### PR TITLE
optimize mentor availability check in mentor list page

### DIFF
--- a/app/controllers/mentor_controller.rb
+++ b/app/controllers/mentor_controller.rb
@@ -7,6 +7,7 @@ class MentorController < ApplicationController
 
   def index
     @mentors = apply_scopes(policy_scope(User)).mentor.has_expertise
+    @taken = @mentors.joins(team_requests: :team).where(team_requests: { approved: true }, teams: { year: Setting.year })
     if current_user and current_user.geocoded?
       @mentors = @mentors.near(current_user, 10000)
     end

--- a/app/views/mentor/index.html.slim
+++ b/app/views/mentor/index.html.slim
@@ -35,7 +35,6 @@ hr
               a href=url_for(m) = m.name
               small
                 '  #{m.school} &mdash; #{m.home_city}, #{ISO3166::Country[m.home_country]}
-                / - unless m.current_team.nil?
             - for exp in User::EXPERTISES
               - if m.send(exp[:sym])
                 - if params[exp[:sym]] == 'true'
@@ -46,6 +45,6 @@ hr
                 .label.label-default= exp[:abbr]
               '
 
-            - if m.current_team.nil?
+            - if @taken.include? m
               .label.label-success data-toggle='tooltip' title='This mentor is not yet on a team and open to mentoring requests'
                 | Teamless


### PR DESCRIPTION
I think this may help speed up the mentor list page, which issues a query per mentor to check if they're on a current team. This alternate way queries for all "taken" mentors once, and then just looks for inclusion in that list which I think will be much faster.

This needs testing to make sure it's correct and doesn't change page behavior.
