### PR TITLE
Fix for #195 to only show this year's events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,9 +2,14 @@ class Event < ActiveRecord::Base
   has_many :teams
   belongs_to :region
 
-  scope :open_for_signup, -> {
+  scope :display_order, -> {
     order("name!='Virtual Judging', name")
   }
+
+  scope :open_for_signup, -> {
+    display_order.where("extract(year from whentooccur) = ?", Setting.year)
+  }
+
   scope :nonconflicting_events, ->(conflict_regions) {
     open_for_signup.where("region_id not in (?) OR region_id=-1 OR region_id IS NULL", (conflict_regions << -1))
   }


### PR DESCRIPTION
If a season ever spanned two years (e.g. started late in 2016 and ran into 2017) this would not work, but because all events are in the same year for now it should be okay.

<!---
@huboard:{"custom_state":"archived"}
-->
