### PR TITLE
Remove submission date from dashboard

### DIFF
--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -31,7 +31,7 @@
     - if Setting.submissionOpen? and not current_user.judge?
       - submissionClose = Setting.get_date('submissionClose')
       li
-        strong Submissions now open for #{submissionClose.year}
+        strong Submissions now open for #{submissionClose.year} through April 21, 5pm PDT
 
     / confirmation
     - unless current_user.confirmed? 


### PR DESCRIPTION
We're changing the submission date to before/after the real date as a way to use it as a switch for opening/closing submissions, which means it's no longer appropriate to show on the dashboard (people think we've extended the deadline). This is a hotfix for that.

<!---
@huboard:{"custom_state":"archived"}
-->
