### PR TITLE
link to eagle web font

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
 
+    <%= stylesheet_link_tag '//cloud.webtype.com/css/fea72f17-6c81-4c13-9e34-58b54a440d85.css', type: 'text/css' %>
+
     <%= favicon_link_tag 'favicons/apple-icon-57x57.png', rel: 'apple-touch-icon', sizes: '57x57' %>
     <%= favicon_link_tag 'favicons/apple-icon-60x60.png', rel: 'apple-touch-icon', sizes: '60x60' %>
     <%= favicon_link_tag 'favicons/apple-icon-72x72.png', rel: 'apple-touch-icon', sizes: '72x72' %>


### PR DESCRIPTION
This just adds a link to Eagle, purchased through Webtype, to our base layout template. The generated line is: `<link href="//cloud.webtype.com/css/fea72f17-6c81-4c13-9e34-58b54a440d85.css" rel="stylesheet" type="text/css" />` but I tried to use the rails helpers... @joemsak sorry if I formatted it incorrectly!

Worth noting here that you have to log in via Webtype and add any used domains for Eagle to work. If I did this correctly, it should show up on technovation-qa.herokuapp.com. Eventually we need to add our wordpress & production site here as well.

<!---
@huboard:{"custom_state":"archived"}
-->
