### PR TITLE
Add curriculum links to Student, Mentor, and RA dashboards

### DIFF
--- a/app/assets/stylesheets/_dashboards.scss
+++ b/app/assets/stylesheets/_dashboards.scss
@@ -1,10 +1,12 @@
-.team-activity {
-  @include span-columns(3);
-  @include omega;
+.dashboard__main {
+  padding: 0 1em 0 0;
+}
+
+.dashboard__sidebar {
+  padding: 3rem 0 0;
 }
 
 .completion-steps {
-  @include span-columns(9);
   list-style-type: decimal;
   margin: 0 0 15px;
 

--- a/app/views/application/_team_invitations.html.erb
+++ b/app/views/application/_team_invitations.html.erb
@@ -1,47 +1,47 @@
-<div class="team-activity">
-  <%= unlocked_content_tag account, send("new_#{account.type_name}_team_search_path"), :div do %>
-    <div class="pending-team-invitations">
-      <h4><%= t("views.application.dashboards.show.pending_team_invitations") %></h4>
+<%= unlocked_content_tag account, send("new_#{account.type_name}_team_search_path"), :div do %>
+  <div class="pending-team-invitations">
 
-      <% if account.pending_team_invitations.any? %>
-        <ul>
-          <% account.pending_team_invitations.each do |invitation| %>
-            <% cache(invitation) do %>
-              <li>
-                <%= invitation.team_name %>&nbsp;&mdash;
-                <%= link_to t("views.application.review"),
-                            send("#{account.type_name}_#{invite_type}_invite_path", invitation) %>
-              </li>
-            <% end %>
+    <h4><%= t("views.application.dashboards.show.pending_team_invitations") %></h4>
+
+    <% if account.pending_team_invitations.any? %>
+      <ul>
+        <% account.pending_team_invitations.each do |invitation| %>
+          <% cache(invitation) do %>
+            <li>
+              <%= invitation.team_name %>&nbsp;&mdash;
+              <%= link_to t("views.application.review"),
+                          send("#{account.type_name}_#{invite_type}_invite_path", invitation) %>
+            </li>
           <% end %>
-        </ul>
-      <% elsif account.can_join_a_team? %>
-        <p><%= t("views.application.dashboards.show.no_pending_team_invitations") %></p>
-      <% else %>
-        <p><%= t("views.application.dashboards.show.no_more_invites") %></p>
-      <% end %>
+        <% end %>
+      </ul>
+    <% elsif account.can_join_a_team? %>
+      <p><%= t("views.application.dashboards.show.no_pending_team_invitations") %></p>
+    <% else %>
+      <p><%= t("views.application.dashboards.show.no_more_invites") %></p>
+    <% end %>
 
-      <hr />
+    <hr />
 
-      <h4><%= t("views.application.dashboards.show.pending_team_requests") %></h4>
+    <h4><%= t("views.application.dashboards.show.pending_team_requests") %></h4>
 
-      <% if account.pending_team_requests.any? %>
-        <ul>
-          <% account.pending_team_requests.each do |team_request| %>
-            <% cache(team_request) do %>
-              <li><%= link_to team_request.joinable_name, team_request.joinable %></li>
-            <% end %>
+    <% if account.pending_team_requests.any? %>
+      <ul>
+        <% account.pending_team_requests.each do |team_request| %>
+          <% cache(team_request) do %>
+            <li><%= link_to team_request.joinable_name, team_request.joinable %></li>
           <% end %>
-        </ul>
-      <% elsif account.can_join_a_team? %>
-        <p><%= t("views.application.dashboards.show.no_pending_team_requests") %></p>
-        <%= unlocked_link_to account,
-                            t("controllers.#{account.type_name}.team_searches.new.link"),
-                            send("new_#{account.type_name}_team_search_path"),
-                            class: "primary-button" %>
-      <% else %>
-        <p><%= t("views.application.dashboards.show.no_more_requests") %></p>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+        <% end %>
+      </ul>
+    <% elsif account.can_join_a_team? %>
+      <p><%= t("views.application.dashboards.show.no_pending_team_requests") %></p>
+      <%= unlocked_link_to account,
+                          t("controllers.#{account.type_name}.team_searches.new.link"),
+                          send("new_#{account.type_name}_team_search_path"),
+                          class: "primary-button" %>
+    <% else %>
+      <p><%= t("views.application.dashboards.show.no_more_requests") %></p>
+    <% end %>
+
+  </div>
+<% end %>

--- a/app/views/mentor/dashboards/_completion_steps.html.erb
+++ b/app/views/mentor/dashboards/_completion_steps.html.erb
@@ -1,10 +1,8 @@
-<div class="completion-steps">
-  <h2><%= t("views.application.complete_your_profile") %></h2>
+<h2><%= t("views.application.complete_your_profile") %></h2>
 
-  <ol class="completion-steps">
-    <%= render 'completion_steps/consent_waiver', account: current_mentor %>
-    <%= render 'completion_steps/background_check', account: current_mentor %>
-    <%= render 'completion_steps/complete_profile', account: current_mentor %>
-    <%= render 'completion_steps/create_join_team', account: current_mentor %>
-  </ol>
-</div>
+<ol class="completion-steps">
+  <%= render 'completion_steps/consent_waiver', account: current_mentor %>
+  <%= render 'completion_steps/background_check', account: current_mentor %>
+  <%= render 'completion_steps/complete_profile', account: current_mentor %>
+  <%= render 'completion_steps/create_join_team', account: current_mentor %>
+</ol>

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -1,3 +1,18 @@
-<%= render 'mentor/dashboards/completion_steps' %>
+<div class="dashboard flex-row">
+  <div class="flex-col-sm-8 dashboard__main">
+    <%= render 'mentor/dashboards/completion_steps' %>
+  </div>
 
-<%= render 'team_invitations', invite_type: :mentor, account: current_mentor %>
+  <div class="flex-col-sm-4 dashboard__sidebar">
+    <%= render 'team_invitations', invite_type: :mentor, account: current_mentor %>
+
+    <% unless current_mentor.background_check_complete? %>
+      <%# TODO: Localize the followings strings. Find a better place to put this. %>
+      <h4>Curriculum</h4>
+      <p>
+        <a href="http://www.technovationchallenge.org/curriculum" target="_blank">Click here</a> to see the 2017 Technovation Curriculum.
+      </p>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/regional_ambassador/dashboards/show.html.erb
+++ b/app/views/regional_ambassador/dashboards/show.html.erb
@@ -2,16 +2,32 @@
 
 <%= render "regional_ambassador/dashboards/#{current_ambassador.status}_next_steps" %>
 
-<%= render 'completion_steps',
-           account: current_ambassador,
-           steps: CompletionSteps.new(current_ambassador),
-           urls: {
-             consent_waiver: {
-               view: new_consent_waiver_path(
-                 token: current_ambassador.consent_token
-               ),
-             },
-             build_profile: {
-               bio: edit_regional_ambassador_account_path(anchor: 'account-profile-details')
-             },
-           } %>
+<div class="dashboard flex-row">
+
+  <div class="dashboard__main flex-col-sm-8">
+    <%= render 'completion_steps',
+               account: current_ambassador,
+               steps: CompletionSteps.new(current_ambassador),
+               urls: {
+                 consent_waiver: {
+                   view: new_consent_waiver_path(
+                     token: current_ambassador.consent_token
+                   ),
+                 },
+                 build_profile: {
+                   bio: edit_regional_ambassador_account_path(anchor: 'account-profile-details')
+                 },
+               } %>
+  </div>
+
+  <div class="dashboard__sidebar flex-col-sm-4">
+    <% if current_ambassador.background_check_complete? %>
+      <%# TODO: Localize the followings strings. Find a better place to put this. %>
+      <h4>Curriculum</h4>
+      <p>
+        <a href="http://www.technovationchallenge.org/curriculum" target="_blank">Click here</a> to see the 2017 Technovation Curriculum.
+      </p>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -1,5 +1,20 @@
-<%= render 'completion_steps',
-            account: current_student,
-            steps: CompletionSteps.new(current_student) %>
+<div class="flex-row dashboard">
+  <div class="flex-col-sm-8 dashboard__main">
+    <%= render 'completion_steps',
+                account: current_student,
+                steps: CompletionSteps.new(current_student) %>
+  </div>
 
-<%= render 'team_invitations', invite_type: :team_member, account: current_student %>
+  <div class="flex-col-sm-4 dashboard__sidebar">
+    <%= render 'team_invitations', invite_type: :team_member, account: current_student %>
+    <% if current_student.parental_consent.present? %>
+      <hr />
+
+      <%# TODO: Localize the followings strings. Find a better place to put this.%>
+      <h4>Curriculum</h4>
+      <p>
+        <a href="http://www.technovationchallenge.org/curriculum" target="_blank">Click here</a> to see the 2017 Technovation Curriculum.
+      </p>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
This adds curriculum links to the dashboard pages. In the interest of time, they're there right now. IMO, they don't belong there, and the link itself could be made into an import, but it's hardcoded and not localized.

If you don't agree with this, please feel free to reject the PR or ask me to make updates. I got the sense this was high priority for tomorrow. FWIW, I want to/will make a lot of UI updates this weekend, this view included.

**IMPORTANT:** The ticket said the following about the links in the RA view => "For RAs: once they are approved by Technovation staff"

I couldn't figure out how to actually do this, so its being displayed when the RA has passed their background check for now.

<!---
@huboard:{"custom_state":"archived"}
-->
