### PR TITLE
Generic, standalone error message page

### DIFF
--- a/public/generic-error-page.html
+++ b/public/generic-error-page.html
@@ -71,7 +71,7 @@
       <p>We're experiencing a temporary issue with our site.</p>
       <p><a href="/">Click here</a> to go back to the homepage.</p>
 
-      <p class="contact">If the problem persists, please contact us at <a href="mailto:#">something@test.com</a></p>
+      <p class="contact">If the problem persists, please contact us at <a href="mailto:#">something@test.com</a>.</p>
 
     </div>
   </div>


### PR DESCRIPTION
So this page is totally standalone and very much MVP. If there is an issue we can't recover from, and we can't identify the error, we can serve this up.

It looks like this => http://codepen.io/dgca/full/30ddeac815d966dddb278c6478dc69be/ (note, that's a private CodePen so only peeps with the link can see it).

I think we _should_ have something like a contact email in there in case someone needs to report a bug, but I don't know who that would go to. For now, it's just a dummy email that links to `mailto:#`.

<!---
@huboard:{"custom_state":"archived"}
-->
