### PR TITLE
Small text on app description paste

### DIFF
--- a/app/assets/javascripts/submissions_page.js
+++ b/app/assets/javascripts/submissions_page.js
@@ -83,6 +83,8 @@
       var nodeName = e.target.dataset.name;
       var wordLimit = e.target.dataset.wordLimit;
 
+      e.preventDefault();
+
       if (
         wordLimit &&
         stringToWordCount(e.target.innerText) > parseInt(wordLimit, 10)
@@ -104,6 +106,8 @@
         }
       } else {
         tempObject[nodeName] = e.target.innerText;
+        var trimmedString = e.target.innerText.trim();
+        e.target.innerHTML =  trimmedString;
       }
 
       if (wordLimit) {


### PR DESCRIPTION
Turns out some rich text editors bring in actual `<style>` tags with them. This updates the content handler to explicitly set the editable content area's area via innerText, essentially using innerText as a HTML tag sanitizer. It also trims all leading and trailing whitespace.

### Please merge #853 before merging this PR