### PR TITLE
Better test handling of BONSAI_URL

### DIFF
--- a/spec/elasticsearch_helper.rb
+++ b/spec/elasticsearch_helper.rb
@@ -1,0 +1,15 @@
+require 'elasticsearch/model'
+
+module ElasticsearchHelper
+  class << self
+    attr_accessor :urls_regex
+    attr_accessor :hosts
+  end
+  client = Elasticsearch::Client.new url: ENV.fetch('BONSAI_URL')
+  hosts_config = client.transport.hosts
+
+  self.hosts = hosts_config.collect {|c| c[:host] }
+
+  urls = hosts_config.map {|c| URI::HTTP.build(c)}
+  self.urls_regex = /#{urls.join("|")}/
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 require 'rspec/rails'
 require 'vcr_helper'
 
+require 'elasticsearch_helper'
 require "geocoder_helper"
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
@@ -36,7 +37,7 @@ RSpec.configure do |config|
   config.before(:each) do |example|
     DatabaseCleaner.strategy = :transaction
     unless example.metadata[:elasticsearch]
-      stub_request(:any, /#{URI(ENV.fetch("BONSAI_URL")).host}/).to_rack(FakeBonsai)
+      stub_request(:any, ElasticsearchHelper.urls_regex).to_rack(FakeBonsai)
     end
   end
 

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -1,10 +1,11 @@
 require 'vcr'
 require 'webmock/rspec'
+require 'elasticsearch_helper'
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/cassettes"
   config.hook_into :webmock # or :fakeweb
   config.configure_rspec_metadata!
   config.ignore_localhost = true
-  config.ignore_hosts URI(ENV.fetch("BONSAI_URL")).host
+  config.ignore_hosts ElasticsearchHelper.hosts
 end


### PR DESCRIPTION
Fix for #961.

This lets `Elasticsearch::Client` handle the parsing of `BONSAI_URL` according to its own standards, and then makes the resulting host(s) info available from a helper that can be used to configure VCR and the test request stubbing.

<!---
@huboard:{"order":965.0965,"milestone_order":962,"custom_state":"archived"}
-->
