### PR TITLE
Fix VCR configuration

### DIFF
--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -7,5 +7,5 @@ VCR.configure do |config|
   config.hook_into :webmock # or :fakeweb
   config.configure_rspec_metadata!
   config.ignore_localhost = true
-  config.ignore_hosts ElasticsearchHelper.hosts
+  config.ignore_hosts *ElasticsearchHelper.hosts
 end


### PR DESCRIPTION
Gotta splat the hosts when configuring VCR. Didn't catch it because localhost is separately configured to be skipped. This should fix the build.

<!---
@huboard:{"custom_state":"archived"}
-->
