### PR TITLE
Add include_blank and required attribues

### DIFF
--- a/app/views/admin/profiles/_mentor_debugging.html.erb
+++ b/app/views/admin/profiles/_mentor_debugging.html.erb
@@ -41,7 +41,7 @@
       <strong> Add this mentor to a team </strong> <br>
       <%= select_tag "team_id",
           options_from_collection_for_select(Team.current, "id", "name"),
-          :include_blank => true,
+          include_blank: true,
           required: true,
           class: "chosen" %>
       <%= submit_tag 'Add', class: "appy-button" %>

--- a/app/views/admin/profiles/_student_debugging.html.erb
+++ b/app/views/admin/profiles/_student_debugging.html.erb
@@ -26,7 +26,7 @@
         <strong> Add this student to a team </strong> <br>
         <%= select_tag "team_id",
             options_from_collection_for_select(Team.current, "id", "name"),
-            :include_blank => true,
+            include_blank: true,
             required: true,
             class: "chosen" %>
         <%= submit_tag 'Add', class: "appy-button" %>


### PR DESCRIPTION
Added blank options for adding mentors and students to team. If you don't include custom text for it, the blank options goes away once you click on the dropdown menu.

<!---
@huboard:{"custom_state":"archived"}
-->
