### PR TITLE
Filter out teams in official RPEs from virtual submission pool

### DIFF
--- a/app/technovation/find_eligible_submission_id.rb
+++ b/app/technovation/find_eligible_submission_id.rb
@@ -29,11 +29,15 @@ module FindEligibleSubmissionId
   def self.random_eligible_id(judge)
     scored_submissions = judge.submission_scores.pluck(:team_submission_id)
     judge_conflicts = judge.team_region_division_names
+    official_rpe_team_ids = RegionalPitchEvent.official.joins(:teams).pluck(:team_id)
     candidates = TeamSubmission.current
       .where.not(
         id: scored_submissions
       )
       .includes(:team)
+      .where.not(
+        teams: { id: official_rpe_team_ids }
+      )
       .select {|sub|
         not judge_conflicts.include?(sub.team.region_division_name)
       }

--- a/spec/technovation/find_eligible_submission_id_spec.rb
+++ b/spec/technovation/find_eligible_submission_id_spec.rb
@@ -39,6 +39,44 @@ RSpec.describe FindEligibleSubmissionId do
     expect(FindEligibleSubmissionId.(judge)).to be_nil
   end
 
+  it "should select submission for an unofficial regional pitch event" do
+    judge = FactoryGirl.create(:judge)
+    team = FactoryGirl.create(:team)
+    team.regional_pitch_events << RegionalPitchEvent.create!({
+      name: "RPE",
+      starts_at: Date.today,
+      ends_at: Date.today + 1.day,
+      division_ids: Division.senior.id,
+      city: "City",
+      venue_address: "123 Street St.",
+      unofficial: true
+    })
+    sub = TeamSubmission.create!({
+      integrity_affirmed: true,
+      team: team,
+    })
+    expect(FindEligibleSubmissionId.(judge)).to eq(sub.id)
+  end
+
+  it "should not select submission for an official regional pitch event" do
+    judge = FactoryGirl.create(:judge)
+    team = FactoryGirl.create(:team)
+    team.regional_pitch_events << RegionalPitchEvent.create!({
+      name: "RPE",
+      starts_at: Date.today,
+      ends_at: Date.today + 1.day,
+      division_ids: Division.senior.id,
+      city: "City",
+      venue_address: "123 Street St.",
+      unofficial: false
+    })
+    sub = TeamSubmission.create!({
+      integrity_affirmed: true,
+      team: team,
+    })
+    expect(FindEligibleSubmissionId.(judge)).to be_nil
+  end
+
   context "judge without team" do
     it "returns submission id" do
       judge = FactoryGirl.create(:judge)


### PR DESCRIPTION
Closes #1002. Grabs ids of teams in official RPEs and filters out submissions from those teams for virtual judging submission selection.

<!---
@huboard:{"custom_state":"archived"}
-->
