### PR TITLE
Limit prepared statements 

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,8 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  # https://devcenter.heroku.com/articles/postgres-logs-errors#ruby-activerecord-and-prepared-statements
+  statement_limit: 200
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5


### PR DESCRIPTION
For #1005 

It seems like rails creates prepared statements that can eat up memory on the database server. It defaults to 1000, this turns that down to see if the OutOfMemory problems go away.

<!---
@huboard:{"custom_state":"archived"}
-->
