### PR TITLE
Explicitly give ActiveRecord the preferred config for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,7 +5,6 @@ Sidekiq.default_worker_options = {
 
 Sidekiq.configure_server do |config|
   if database_url = ENV['DATABASE_URL']
-    ENV['DATABASE_URL'] = "#{database_url}?pool=25"
-    ActiveRecord::Base.establish_connection
+    ActiveRecord::Base.establish_connection "#{database_url}?pool=25"
   end
 end


### PR DESCRIPTION
If I log the pool size with `ActiveRecord::Base.connection_pool.instance_eval { @size }` and run the worker locally with `RAILS_ENV=development DATABASE_URL=postgres://localhost:5432/technovation-app_development heroku local worker` I don't see the pool size of 25 without this change. I'm a little weirded out by that, but... maybe let's try this?

<!---
@huboard:{"custom_state":"archived"}
-->
