### PR TITLE
Remove callbacks to update elasticsearch on anything but deletes

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,6 @@
 class Account < ActiveRecord::Base
   include Elasticsearch::Model
 
-  after_save    { IndexModelJob.perform_later("index", "Account", id) }
   after_destroy { IndexModelJob.perform_later("delete", "Account", id) }
 
   after_save -> {

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -8,9 +8,7 @@ class Team < ActiveRecord::Base
   before_create :update_geocoding
   reverse_geocoded_by :latitude, :longitude
 
-  after_save    { IndexModelJob.perform_later("index", "Team", id) }
   after_destroy { IndexModelJob.perform_later("delete", "Team", id) }
-  after_touch   { IndexModelJob.perform_later("index", "Team", id) }
 
   after_commit :register_to_season, on: :create
 


### PR DESCRIPTION
We're periodically getting throttled by Bonsai with `Elasticsearch::Transport::Transport::ServerError: [429] {"error":"Concurrent request limit exceeded. Please consider batching your requests, or contact support@bonsai.io for help.","status":429} `, and when it happens we get a bunch of those and New Relic gets sad.

This PR paired with a Heroku Scheduler job to run `rake environment elasticsearch:import:all` every hour or 10 minutes or something should hopefully do better. That rake command does a batch update but doesn't delete missing records, which I don't think happens often anyway.

<!---
@huboard:{"custom_state":"archived"}
-->
