### PR TITLE
Include rack-mini-profiler in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rails', '~> 5.0'
 gem 'puma', '~> 3.8'
 gem 'pg', '~> 0.20'
 
+
 gem "paranoia", '~> 2.3'
 
 gem 'uglifier', '~> 3.2'
@@ -80,6 +81,8 @@ end
 group :development do
   gem 'active_record_query_trace', "~> 1.5"
   gem "letter_opener", "~> 1.4"
+  gem 'rack-mini-profiler'
+  gem 'memory_profiler'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    memory_profiler (0.9.8)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -392,6 +393,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
+    rack-mini-profiler (0.10.2)
+      rack (>= 1.2.0)
     rack-protection (2.0.0.rc2)
       rack
     rack-rewrite (1.5.1)
@@ -556,6 +559,7 @@ DEPENDENCIES
   launchy (~> 2.4)
   letter_opener (~> 1.4)
   lodash-rails (~> 4.17)
+  memory_profiler
   mini_magick (~> 4.7)
   newrelic_rpm (~> 3.18)
   nokogiri (~> 1.7)
@@ -567,6 +571,7 @@ DEPENDENCIES
   pry-nav (~> 0.2)
   pry-rails (~> 0.3)
   puma (~> 3.8)
+  rack-mini-profiler
   rack-rewrite (~> 1.5)
   rack-timeout (~> 0.4)
   rails (~> 5.0)


### PR DESCRIPTION
This puts page timing info on the page in dev:

<img width="272" alt="screen shot 2017-05-01 at 1 11 20 pm" src="https://cloud.githubusercontent.com/assets/55319/25586938/bcdc1016-2e6f-11e7-95c0-05b9bb85d8f3.png">
<img width="745" alt="screen shot 2017-05-01 at 1 11 30 pm" src="https://cloud.githubusercontent.com/assets/55319/25586940/be1d4850-2e6f-11e7-82bc-4e813e1719fc.png">

Various memory profiling options are available as well: https://github.com/MiniProfiler/rack-mini-profiler#memory-profiling

Hitting a URL like this, while slow, can help show what's eating up RAM: http://localhost:3000/regional_ambassador/regional_pitch_events/3?pp=profile-memory&memory_profiler_allow_files=technovation-app

<!---
@huboard:{"custom_state":"archived"}
-->
