### PR TITLE
Change RA/admin scores screens to use submissions instead of teams

### DIFF
--- a/app/controllers/admin/scores_controller.rb
+++ b/app/controllers/admin/scores_controller.rb
@@ -9,15 +9,6 @@ module Admin
 
       @division = params[:division] ||= "senior"
 
-      sort = case params.fetch(:sort) { "avg_score_desc" }
-             when "avg_score_desc"
-               "team_submissions.average_score DESC"
-             when "avg_score_asc"
-               "team_submissions.average_score ASC"
-             when "team_name"
-               "teams.name ASC"
-             end
-
       events = RegionalPitchEvent.eager_load(regional_ambassador_profile: :account).all
       virtual_event = Team::VirtualRegionalPitchEvent.new
 
@@ -35,7 +26,7 @@ module Admin
         FriendlyCountry.(e.regional_ambassador_profile.account)
       }
 
-      @teams = get_sorted_paginated_teams_in_requested_division
+      @submissions = get_sorted_paginated_submissions_in_requested_division
     end
 
     def show
@@ -58,26 +49,26 @@ module Admin
     end
 
     private
-    def get_sorted_paginated_teams_in_requested_division(page = params[:page])
-      teams = @event.teams
-        .includes(:regional_pitch_events, team_submissions: :submission_scores)
+    def get_sorted_paginated_submissions_in_requested_division(page = params[:page])
+      submissions = @event.team_submissions
+        .includes(:submission_scores, team: :regional_pitch_events)
         .public_send(params[:division])
-        .select { |t| t.selected_regional_pitch_event.live? or t.submission.complete? }
+        .select { |s| s.team.selected_regional_pitch_event.live? or s.complete? }
         .sort { |a, b|
           case params.fetch(:sort) { "avg_score_desc" }
           when "avg_score_desc"
-            b.submission.average_score <=> a.submission.average_score
+            b.average_score <=> a.average_score
           when "avg_score_asc"
-            a.submission.average_score <=> b.submission.average_score
+            a.average_score <=> b.average_score
           when "team_name"
-            a.name <=> b.name
+            a.team.name <=> b.team.name
           end
         }.paginate(page: page.to_i, per_page: params[:per_page].to_i)
 
-      if teams.empty? and page.to_i != 1
-        get_sorted_paginated_teams_in_requested_division(1)
+      if submissions.empty? and page.to_i != 1
+        get_sorted_paginated_submissions_in_requested_division(1)
       else
-        teams
+        submissions
       end
     end
   end

--- a/app/controllers/regional_ambassador/scores_controller.rb
+++ b/app/controllers/regional_ambassador/scores_controller.rb
@@ -31,7 +31,7 @@ module RegionalAmbassador
         @events = events.sort_by(&:name)
       end
 
-      @teams = get_sorted_paginated_teams_in_requested_division
+      @submissions = get_sorted_paginated_submissions_in_requested_division
     end
 
     def show
@@ -52,28 +52,27 @@ module RegionalAmbassador
     end
 
     private
-    def get_sorted_paginated_teams_in_requested_division(page = params[:page])
-      teams = @event.teams
-        .joins(:team_submissions)
-        .includes(:regional_pitch_events, team_submissions: :submission_scores)
+    def get_sorted_paginated_submissions_in_requested_division(page = params[:page])
+      submissions = @event.team_submissions
+        .includes(:submission_scores, team: :regional_pitch_events)
         .for_ambassador(current_ambassador)
         .public_send(params[:division])
-        .select { |t| t.selected_regional_pitch_event.live? or t.submission.complete? }
+        .select { |s| s.team.selected_regional_pitch_event.live? or s.complete? }
         .sort { |a, b|
           case params.fetch(:sort) { "avg_score_desc" }
           when "avg_score_desc"
-            b.submission.average_score <=> a.submission.average_score
+            b.average_score <=> a.average_score
           when "avg_score_asc"
-            a.submission.average_score <=> b.submission.average_score
+            a.average_score <=> b.average_score
           when "team_name"
-            a.name <=> b.name
+            a.team.name <=> b.team.name
           end
         }.paginate(page: page.to_i, per_page: params[:per_page].to_i)
 
-      if teams.empty? and page.to_i != 1
-        get_sorted_paginated_teams_in_requested_division(1)
+      if submissions.empty? and page.to_i != 1
+        get_sorted_paginated_submissions_in_requested_division(1)
       else
-        teams
+        submissions
       end
     end
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -372,6 +372,12 @@ class Team < ActiveRecord::Base
       Team.not_attending_live_event
     end
 
+    def team_submissions
+      TeamSubmission.includes(team: :regional_pitch_events)
+                    .references(:regional_pitch_events)
+                    .where("regional_pitch_events.id IS NULL")
+    end
+
     def timezone
       "US/Pacific"
     end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -44,6 +44,20 @@ class TeamSubmission < ActiveRecord::Base
     joins(season_registrations: :season).where("seasons.year = ?", Season.current.year)
   }
 
+  scope :for_ambassador, ->(ambassador) {
+    if ambassador.country == "US"
+      joins(:team).where("teams.state_province = ? AND teams.country = 'US'", ambassador.state_province)
+    else
+      joins(:team).where("teams.country = ?", ambassador.country)
+    end
+  }
+
+  Division.names.keys.each do |division_name|
+    scope division_name, -> {
+      joins(team: :division).where("divisions.name = ?", Division.names[division_name])
+    }
+  end
+
   belongs_to :team, touch: true
   has_many :screenshots, -> { order(:sort_position) },
     dependent: :destroy,

--- a/app/views/admin/scores/index.html.erb
+++ b/app/views/admin/scores/index.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <%= render 'regional_ambassador/scores/index',
-    teams: @teams,
+    submissions: @submissions,
     event: @event,
     events: @events,
     division: @division,

--- a/app/views/regional_ambassador/scores/_index.en.html.erb
+++ b/app/views/regional_ambassador/scores/_index.en.html.erb
@@ -63,6 +63,6 @@
   <%= render 'regional_ambassador/scores/list',
     division: division,
     event: event,
-    teams: teams,
+    submissions: submissions,
     scope: scope %>
 </div>

--- a/app/views/regional_ambassador/scores/_list.en.html.erb
+++ b/app/views/regional_ambassador/scores/_list.en.html.erb
@@ -1,4 +1,4 @@
-<% if teams.any? %>
+<% if submissions.any? %>
   <table class="ra-participants-list">
     <thead>
       <tr>
@@ -12,30 +12,30 @@
     </thead>
 
     <tbody>
-      <% teams.each do |team| %>
+      <% submissions.each do |submission| %>
         <tr>
-          <td><%= team.name %></td>
+          <td><%= submission.team.name %></td>
           <td>
-            <%= link_to team.submission.app_name,
-              app_path(team.submission),
+            <%= link_to submission.app_name,
+              app_path(submission),
               target: :_blank %>
           </td>
-          <td><%= team.submission_scores.complete.count %></td>
-          <td><%= team.submission_scores.incomplete.count %></td>
-          <td><%= team.submission.average_score %></td>
+          <td><%= submission.submission_scores.complete.count %></td>
+          <td><%= submission.submission_scores.incomplete.count %></td>
+          <td><%= submission.average_score %></td>
           <td><%= link_to 'View details',
-            send("#{scope}_score_path", team.submission) %></td>
+            send("#{scope}_score_path", submission) %></td>
         </tr>
       <% end %>
     </tbody>
   </table>
 
   <div class="pagination_info" style="padding: 1rem 0 0;">
-    <%= page_entries_info teams,
+    <%= page_entries_info submissions,
       model: "#{division.capitalize}_team" %>
   </div>
 
-  <%= will_paginate teams %>
+  <%= will_paginate submissions %>
 
   <label class="per_page">
     Per page:

--- a/app/views/regional_ambassador/scores/index.en.html.erb
+++ b/app/views/regional_ambassador/scores/index.en.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <%= render 'regional_ambassador/scores/index',
-    teams: @teams,
+    submissions: @submissions,
     event: @event,
     events: @events,
     division: @division,


### PR DESCRIPTION
I think this should be substantially faster. Pulling the submission off of a team was generating one query per team before pagination despite the includes, I think because `team.submission` is actually a method getting the current submission? Not sure.

This eliminates that, and I think future-proofs things a bit in that teams will last year to year whereas a submission is tied to a season, as is an RPE. Plus for semifinals scoring RPEs are irrelevant so driving these pages that way makes it hard to add semifinals scores in. Hopefully this will help make that easier as well.