### PR TITLE
Use a weighted ordering when choosing submissions for judging

### DIFF
--- a/app/technovation/find_eligible_submission_id.rb
+++ b/app/technovation/find_eligible_submission_id.rb
@@ -52,19 +52,20 @@ module FindEligibleSubmissionId
             not judge_conflicts.include?(sub.team.region_division_name))
         }
         .sort { |a, b|
-          x = a.public_send("pending_#{current_round}_official_submission_scores_count") || 0
-          y = b.public_send("pending_#{current_round}_official_submission_scores_count") || 0
-          x <=> y
-        }
-        .sort { |a, b|
-          x = a.public_send("complete_#{current_round}_official_submission_scores_count") || 0
-          y = b.public_send("complete_#{current_round}_official_submission_scores_count") || 0
-          x <=> y
+          a_complete = a.public_send("complete_#{current_round}_official_submission_scores_count") || 0
+          b_complete = b.public_send("complete_#{current_round}_official_submission_scores_count") || 0
+          [weighted(a), a_complete] <=> [weighted(b), b_complete]
         }
 
       sub = candidates.first
 
       sub and sub.id
+    end
+
+    def weighted(sub)
+      pending = sub.public_send("pending_#{current_round}_official_submission_scores_count") || 0
+      complete = sub.public_send("complete_#{current_round}_official_submission_scores_count") || 0
+      pending + 2*complete
     end
 
     def current_round


### PR DESCRIPTION
Offering a tweak on the last-minute submission finding changes.

I didn't fully understand the double sort last night. Now I'm realizing that the algorithm might cycle through all the 0 completed submissions, piling new pending scores on them until they all have 1 completed at least, then it'll cycle through 1 completed submissions, etc. I'm worried if we actually saw a burst of judging, it'll over-assign submissions, letting those with 0 completions build up too many pending scores before moving on to subs with 1 completion.

This tweaks the sorting with a weighted sort score such that it looks at pending and completed, but each completed counts double. Here's a gist of how it would order the remaining pool: https://gist.github.com/stenington/40a584b58a4bef6267ca58af81966f9e

That ordering looks pretty good to me, and I think a burst of new scores would get more evenly spread across the entire pool this way. 

Anyway @joemsak if this makes sense to you, we could try it. If you're more comfortable with what we have that's fine with me too.