### PR TITLE
#1098 User type registration config

### DIFF
--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,7 +1,7 @@
 class SignupsController < ApplicationController
   before_action :require_unauthenticated
 
-  helper_method :admin_permission?
+  helper_method :admin_permission?, :signup_available?
 
   def new
     if not params[:admin_permission_token].blank? and (attempt = SignupAttempt.find_by(
@@ -17,8 +17,12 @@ class SignupsController < ApplicationController
   end
 
   private
+  def signup_available?(type)
+    SeasonToggles.public_send("#{type}_signup?") or admin_permission?
+  end
+
   def admin_permission?
-    token = cookies.fetch(:admin_permission_token) { "" }
-    ENV["ENABLE_ALL_PROFILE_TYPE_SIGNUPS"] or not token.blank?
+    !!cookies[:admin_permission_token]
+    # TODO: check token validity
   end
 end

--- a/app/technovation/season_toggles.rb
+++ b/app/technovation/season_toggles.rb
@@ -46,12 +46,14 @@ class SeasonToggles
     end
     alias :semifinals? :semifinals_judging?
 
-    def student_signup=(value)
-      store.set(:student_signup, with_bool_validation(value))
-    end
+    %w{student mentor judge regional_ambassador}.each do |scope|
+      define_method("#{scope}_signup=") do |value|
+        store.set("#{scope}_signup", with_bool_validation(value))
+      end
 
-    def student_signup?
-      convert_to_bool(store.get(:student_signup))
+      define_method("#{scope}_signup?") do
+        convert_to_bool(store.get("#{scope}_signup"))
+      end
     end
 
     private

--- a/app/views/signups/new.html.erb
+++ b/app/views/signups/new.html.erb
@@ -9,8 +9,8 @@
     <%= t("views.application.instead") %>.
   </p>
 
-  <%= render 'signups/account_type', role: :judge, enabled: true %>
-  <%= render 'signups/account_type', role: :student, enabled: admin_permission? %>
-  <%= render 'signups/account_type', role: :mentor, enabled: admin_permission? %>
-  <%= render 'signups/account_type', role: :regional_ambassador, enabled: admin_permission? %>
+  <%= render 'signups/account_type', role: :judge, enabled: signup_available?(:judge) %>
+  <%= render 'signups/account_type', role: :student, enabled: signup_available?(:student) %>
+  <%= render 'signups/account_type', role: :mentor, enabled: signup_available?(:mentor) %>
+  <%= render 'signups/account_type', role: :regional_ambassador, enabled: signup_available?(:regional_ambassador) %>
 </div>

--- a/spec/features/registration_toggles_spec.rb
+++ b/spec/features/registration_toggles_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.feature "Toggle available user types for registration" do
+  %w{student mentor judge regional_ambassador}.each do |scope|
+    scenario "#{scope} registration is toggled on" do
+      SeasonToggles.public_send("#{scope}_signup=", "on")
+
+      set_signup_token("user@example.com")
+
+      visit signup_path
+
+      href = public_send("#{scope}_signup_path")
+      links = page.all(:css, "a[href='#{href}']")
+
+      expect(links).not_to be_empty
+      links.each do |link|
+        expect(link[:disabled]).to be_nil
+      end
+    end
+
+    scenario "#{scope} registration is toggled off" do
+      SeasonToggles.public_send("#{scope}_signup=", "off")
+
+      set_signup_token("user@example.com")
+
+      visit signup_path
+
+      href = public_send("#{scope}_signup_path")
+      links = page.all(:css, "a[href='#{href}']")
+
+      expect(links).not_to be_empty
+      links.each do |link|
+        expect(link[:disabled]).to eq("disabled")
+      end
+    end
+
+    scenario "#{scope} registration is toggled off, with admin permission" do
+      SeasonToggles.public_send("#{scope}_signup=", "off")
+
+      set_signup_and_permission_token("user@example.com")
+
+      visit signup_path
+
+      href = public_send("#{scope}_signup_path")
+      links = page.all(:css, "a[href='#{href}']")
+
+      expect(links).not_to be_empty
+      links.each do |link|
+        expect(link[:disabled]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/signup_helper.rb
+++ b/spec/support/signup_helper.rb
@@ -3,4 +3,10 @@ module SignupHelper
     token = FactoryGirl.create(:signup_attempt, email: email).signup_token
     page.driver.browser.set_cookie("signup_token=#{token}")
   end
+
+  def set_signup_and_permission_token(email)
+    attempt = FactoryGirl.create(:signup_attempt, email: email)
+    page.driver.browser.set_cookie("signup_token=#{attempt.signup_token}")
+    page.driver.browser.set_cookie("admin_permission_token=#{attempt.admin_permission_token}")
+  end
 end

--- a/spec/technovation/season_toggles_spec.rb
+++ b/spec/technovation/season_toggles_spec.rb
@@ -142,36 +142,40 @@ RSpec.describe SeasonToggles do
     end
   end
 
-  describe "#student_signup=" do
-    context "valid input" do
-      it "allows a collection of 'boolean' words and booleans" do
-        expect_good_input_works(
-          method: :student_signup,
-          valid_input: SeasonToggles::VALID_BOOLS +
-            %i{On oFf yEs nO tRue fAlse}
-        )
-      end
+  %i(student mentor judge regional_ambassador).each do |scope|
 
-      it "reads back a boolean from #student_signup?" do
-        SeasonToggles::VALID_TRUTHY.each do |on|
-          SeasonToggles.student_signup = on
-          expect(SeasonToggles.student_signup?).to be true
+    describe "##{scope}_signup=" do
+      context "valid input" do
+        it "allows a collection of 'boolean' words and booleans" do
+          expect_good_input_works(
+            method: "#{scope}_signup",
+            valid_input: SeasonToggles::VALID_BOOLS +
+              %i{On oFf yEs nO tRue fAlse}
+          )
         end
 
-        SeasonToggles::VALID_FALSEY.each do |off|
-          SeasonToggles.student_signup = off
-          expect(SeasonToggles.student_signup?).to be false
+        it "reads back a boolean from ##{scope}_signup?" do
+          SeasonToggles::VALID_TRUTHY.each do |on|
+            SeasonToggles.public_send("#{scope}_signup=", on)
+            expect(SeasonToggles.public_send("#{scope}_signup?")).to be true
+          end
+
+          SeasonToggles::VALID_FALSEY.each do |off|
+            SeasonToggles.public_send("#{scope}_signup=", off)
+            expect(SeasonToggles.public_send("#{scope}_signup?")).to be false
+          end
+        end
+      end
+
+      context "bad input" do
+        it "raises an exception" do
+          expect_bad_input_raises_error(
+            method: "#{scope}_signup",
+            valid_input: SeasonToggles::VALID_BOOLS.join(' | ')
+          )
         end
       end
     end
 
-    context "bad input" do
-      it "raises an exception" do
-        expect_bad_input_raises_error(
-          method: :student_signup,
-          valid_input: SeasonToggles::VALID_BOOLS.join(' | ')
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
PR for #1098, reopening with squashed commits against `qa`.

<!---
@huboard:{"custom_state":"archived"}
-->
