### PR TITLE
#1107 Add season toggle for displaying scores to mentors and students

### DIFF
--- a/app/controllers/student/dashboards_controller.rb
+++ b/app/controllers/student/dashboards_controller.rb
@@ -7,7 +7,7 @@ module Student
       @quarterfinals_scores = SubmissionScore.none
       @semifinals_scores = SubmissionScore.none
 
-      if current_team.submission.present? and ENV["ENABLE_TEAM_SCORES"]
+      if current_team.submission.present? and SeasonToggles.display_scores?
         @all_scores = current_team.submission.submission_scores.complete
         @quarterfinals_scores = @all_scores.quarterfinals
 

--- a/app/technovation/season_toggles.rb
+++ b/app/technovation/season_toggles.rb
@@ -19,6 +19,14 @@ class SeasonToggles
       convert_to_bool(store.get("select_regional_pitch_event"))
     end
 
+    def display_scores=(value)
+      store.set("display_scores", with_bool_validation(value))
+    end
+
+    def display_scores?
+      convert_to_bool(store.get("display_scores"))
+    end
+
     %w{mentor student}.each do |scope|
       define_method("#{scope}_survey_link=") do |attrs|
         store.set("#{scope}_survey_link", JSON.generate(attrs))

--- a/app/views/mentor/dashboards/_full_access.en.html.erb
+++ b/app/views/mentor/dashboards/_full_access.en.html.erb
@@ -8,7 +8,7 @@
       </div>
     <% end %>
 
-    <% if current_mentor.is_on_team? %>
+    <% if current_mentor.is_on_team? and SeasonToggles.display_scores? %>
       <div class="tab-content flex-row" id="scores">
         <%= render 'mentor/dashboards/full_access_content/scores' %>
       </div>

--- a/app/views/mentor/dashboards/_menu.en.html.erb
+++ b/app/views/mentor/dashboards/_menu.en.html.erb
@@ -10,7 +10,7 @@
     </li>
   <% end %>
 
-  <% if current_mentor.is_on_team? %>
+  <% if current_mentor.is_on_team? and SeasonToggles.display_scores? %>
     <li class="tab-link">
       <button
         role="button"

--- a/app/views/student/dashboards/_full_access.en.html.erb
+++ b/app/views/student/dashboards/_full_access.en.html.erb
@@ -8,7 +8,7 @@
       </div>
     <% end %>
 
-    <% if current_team.submission.present? and ENV["ENABLE_TEAM_SCORES"] %>
+    <% if current_team.submission.present? and SeasonToggles.display_scores? %>
       <div class="tab-content flex-row" id="scores">
         <%= render 'student/dashboards/full_access_content/scores' %>
       </div>

--- a/app/views/student/dashboards/_menu.en.html.erb
+++ b/app/views/student/dashboards/_menu.en.html.erb
@@ -10,7 +10,7 @@
     </li>
   <% end %>
 
-  <% if current_team.submission.present? and ENV["ENABLE_TEAM_SCORES"] %>
+  <% if current_team.submission.present? and SeasonToggles.display_scores? %>
     <li class="tab-link">
       <button
         role="button"

--- a/spec/features/admin/display_scores_toggle_spec.rb
+++ b/spec/features/admin/display_scores_toggle_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.feature "Toggling display of scores" do
+  context "Student dashboard" do
+    let(:user) { FactoryGirl.create(:student) }
+    let(:sub) { FactoryGirl.create(:submission, :complete) }
+    let(:path) { student_dashboard_path }
+
+    before do
+      TeamRosterManaging.add(sub.team, user)
+
+      sign_in(user)
+    end
+
+    scenario "display scores on" do
+      SeasonToggles.display_scores="on"
+      visit path
+
+      expect(page).to have_button("Scores")
+      expect(page).to have_css("div.content div#scores")
+    end
+
+    scenario "display scores off" do
+      SeasonToggles.display_scores="off"
+      visit path
+
+      expect(page).not_to have_button("Scores")
+      expect(page).not_to have_css("div.content div#scores")
+    end
+  end
+
+  context "Mentor dashboard" do
+    let(:user) { FactoryGirl.create(:mentor) }
+    let(:sub) { FactoryGirl.create(:submission, :complete) }
+    let(:path) { mentor_dashboard_path }
+
+    before do
+      TeamRosterManaging.add(sub.team, user)
+
+      sign_in(user)
+    end
+
+    scenario "display scores on" do
+      SeasonToggles.display_scores="on"
+      visit path
+
+      expect(page).to have_button("Scores")
+      expect(page).to have_css("div.content div#scores")
+    end
+
+    scenario "display scores off" do
+      SeasonToggles.display_scores="off"
+      visit path
+
+      expect(page).not_to have_button("Scores")
+      expect(page).not_to have_css("div.content div#scores")
+    end
+  end
+end

--- a/spec/features/mentor/certificates_spec.rb
+++ b/spec/features/mentor/certificates_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Mentor certificates" do
   before do
     @original_certificates = ENV["CERTIFICATES"]
     ENV["CERTIFICATES"] = "any value -- booleans don't work in ENV"
+    SeasonToggles.display_scores="yes"
   end
 
   after do

--- a/spec/features/mentor/view_scores_spec.rb
+++ b/spec/features/mentor/view_scores_spec.rb
@@ -2,16 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Mentors view scores" do
   before do
-    @enable_scores = ENV.fetch("ENABLE_TEAM_SCORES") { false }
-    ENV["ENABLE_TEAM_SCORES"] = "yes"
-  end
-
-  after do
-    if @enable_scores
-      ENV["ENABLE_TEAM_SCORES"] = @enable_scores
-    else
-      ENV.delete("ENABLE_TEAM_SCORES")
-    end
+    SeasonToggles.display_scores="yes"
   end
 
   scenario "view QF scores" do

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -3,18 +3,13 @@ require "rails_helper"
 RSpec.feature "Student certificates" do
   before do
     @original_certificates = ENV["CERTIFICATES"]
-    @original_scores = ENV["ENABLE_TEAM_SCORES"]
     ENV["CERTIFICATES"] = "a truthy value -- booleans don't work"
-    ENV["ENABLE_TEAM_SCORES"] = "truthy"
+    SeasonToggles.display_scores="yes"
   end
 
   after do
     if @original_certificates.blank?
       ENV.delete("CERTIFICATES")
-    end
-
-    if @original_scores.blank?
-      ENV.delete("ENABLE_TEAM_SCORES")
     end
   end
 

--- a/spec/features/student/view_scores_spec.rb
+++ b/spec/features/student/view_scores_spec.rb
@@ -2,16 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Students view scores" do
   before do
-    @enable_scores = ENV.fetch("ENABLE_TEAM_SCORES") { false }
-    ENV["ENABLE_TEAM_SCORES"] = "yes"
-  end
-
-  after do
-    if @enable_scores
-      ENV["ENABLE_TEAM_SCORES"] = @enable_scores
-    else
-      ENV.delete("ENABLE_TEAM_SCORES")
-    end
+    SeasonToggles.display_scores="yes"
   end
 
   scenario "view QF scores" do


### PR DESCRIPTION
For #1107 

This shows/hides scores on the mentor and student dashboards based on `SeasonToggles.display_scores?`, and does away with `ENABLE_TEAM_SCORES` in the env. 

I noticed there's an `ENABLE_RA_SCORES` parameter that can be set, which I have not yet dealt with. It seemed like RAs maybe get to see scores at a different time than everyone else? 

<!---
@huboard:{"milestone_order":1145.0,"order":1145,"custom_state":"archived"}
-->
