### PR TITLE
Remove the incomplete profile case from the team mailer's invitation …

### DIFF
--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -39,8 +39,7 @@ en:
         mentor: "You are invited to be a mentor for a Technovation team — %{name}."
         student: "You've been invited join Technovation as a member of %{name}."
       intro:
-        complete_profile: "You can review and accept or decline your invitation here:"
-        incomplete_profile: "You will need to complete your profile before reviewing this invitation."
+        existing_profile: "You can review and accept or decline your invitation here:"
         no_profile: "Before you can join the team, you'll need to register for Technovation — it's free and it won't take long. You can register at the link below:"
       subject: "You're invited to join a Technovation team!"
     invite_mentor:


### PR DESCRIPTION
- Removes the case in `TeamMailer.invite_member` with variables init'd for incomplete profiles
- No tests failed (oy), so no tests were written, changed, or removed
- New test coverage ought to be required for #1196 
- Small refactor to `TeamMailer.invite_member` to separate the results of the conditional into their own functions

<!---
@huboard:{"custom_state":"archived"}
-->
