### PR TITLE
#1230 log out users from member invite sign up link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,6 +62,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def force_logout
+    remove_cookie(:auth_token)
+  end
+
   def can_generate_certificate?(scope, cert_type)
     @can_generate_certificate ||= {}
 

--- a/app/controllers/student/signups_controller.rb
+++ b/app/controllers/student/signups_controller.rb
@@ -1,6 +1,7 @@
 module Student
   class SignupsController < ApplicationController
-    before_action :require_unauthenticated
+    before_action :require_unauthenticated, except: :new
+    before_action :force_logout, only: :new
 
     before_action -> {
       attempt = (

--- a/spec/features/activate_email_for_signup_spec.rb
+++ b/spec/features/activate_email_for_signup_spec.rb
@@ -113,24 +113,4 @@ RSpec.feature "Activate your email to sign up" do
     expect(signup_attempt.reload).to be_registered
     expect(signup_attempt.account.email).to eq("joe@joesak.com")
   end
-
-  scenario "Register after team invite" do
-    team = FactoryGirl.create(:team)
-    email = "Student@test.com"
-
-    team.team_member_invites.create!(
-      inviter: team.students.first,
-      invitee_email: email,
-    )
-
-    visit student_signup_path(
-      token: SignupAttempt.find_by(email: email).activation_token
-    )
-
-    click_button "Create Your Account"
-
-    within(".student_profile_account_password") {
-      expect(page).to have_css('.error', text: "can't be blank")
-    }
-  end
 end

--- a/spec/features/student/registration_spec.rb
+++ b/spec/features/student/registration_spec.rb
@@ -46,3 +46,40 @@ RSpec.feature "Register as a student" do
     expect(page).not_to have_content("You changed your email address")
   end
 end
+
+RSpec.feature "Register from team invite" do
+  let(:email) { "Student@test.com" }
+  let(:team) { FactoryGirl.create(:team) }
+  let(:inviter) { team.students.first }
+
+  before do
+    team.team_member_invites.create!(
+      inviter: inviter,
+      invitee_email: email,
+    )
+  end
+
+  scenario "No user logged in" do
+    visit student_signup_path(
+      token: SignupAttempt.find_by(email: email).activation_token
+    )
+    expect_profile_creation_page(email)
+  end
+
+  scenario "Other user logged in" do
+    sign_in(inviter)
+    visit student_signup_path(
+      token: SignupAttempt.find_by(email: email).activation_token
+    )
+    expect_profile_creation_page(email)
+  end
+
+  def expect_profile_creation_page(email)
+    within(".navigation") {
+      expect(page).to have_link("Sign in")
+    }
+    within(".new_student_profile") {
+      expect(page).to have_content("Your email address: #{email}")
+    }
+  end
+end


### PR DESCRIPTION
For #1230 

Following a sign up link in an invitation email will now log out any logged in user, instead of taking you to that users dashboard.

<!---
@huboard:{"custom_state":"archived"}
-->
