### PR TITLE
1233 - Request student's location on team search

### DIFF
--- a/app/assets/javascripts/flash-msgs.js
+++ b/app/assets/javascripts/flash-msgs.js
@@ -1,7 +1,5 @@
 (function() {
   document.addEventListener("turbolinks:load", function() {
-    fadeOutExistingFlashes();
-
     $(document).on('click', '.flash .icon-close', function() {
       $(this).closest('.flash').fadeOut('easeout', function() {
         $(this).remove();
@@ -26,16 +24,6 @@
       $flash.hide();
       $("#flash").html($flash);
       $flash.fadeIn();
-
-      fadeOutExistingFlashes();
     }
   });
-
-  function fadeOutExistingFlashes() {
-    setTimeout(function() {
-      $("#flash .flash").fadeOut(function() {
-        $(this).remove();
-      })
-    }, 5000);
-  }
 })();

--- a/app/assets/stylesheets/_flashes.scss
+++ b/app/assets/stylesheets/_flashes.scss
@@ -1,9 +1,6 @@
 #flash {
   width: 100%;
-  position: fixed;
-  left: 0;
-  bottom: 1rem;
-  z-index: $z-modal;
+  margin: 0 0 1rem;
 
   .flash {
     width: 80%;

--- a/app/controllers/student/team_searches_controller.rb
+++ b/app/controllers/student/team_searches_controller.rb
@@ -1,6 +1,11 @@
 module Student
   class TeamSearchesController < StudentController
     def new
+      if current_student.latitude.blank?
+        redirect_to student_location_details_path(return_to: request.fullpath),
+          notice: "Please save your location so that you can search for nearby teams"
+      end
+
       @search_filter = SearchFilter.new(search_params)
       @teams = SearchTeams.(@search_filter).paginate(page: search_params[:page])
     end

--- a/app/views/completion_steps/_location_details.en.html.erb
+++ b/app/views/completion_steps/_location_details.en.html.erb
@@ -19,7 +19,7 @@
         [
           current_scope,
           :location_details,
-          { return: request.fullpath }
+          { return_to: request.fullpath }
         ],
         class: "button" %>
     </div>

--- a/app/views/signups/_location_fields.html.erb
+++ b/app/views/signups/_location_fields.html.erb
@@ -7,7 +7,7 @@
 ) %>
 
 <%= simple_form_for current_profile, url: [current_scope, :profile] do |f| %>
-  <%= hidden_field_tag :return_to, params[:return] %>
+  <%= hidden_field_tag :return_to, params[:return_to] %>
 
   <div class="while-geocoding">
     <%= web_icon "spinner2", class: "spin" %>


### PR DESCRIPTION
When a student hasn't entered their location details, team search doesn't work. Interrupt the flow to have them save that first, and send them on their way.

* Also moves flash messages back to the top of the page and they no longer close automatically
  * Needed to show the student the notice about why they're on this page, it wasn't noticeable at the bottom, and in general they shouldn't disappear on a timer because of ESL. The "X" to close it keeps them in control of when they're done reading it

<!---
@huboard:{"custom_state":"archived"}
-->
