### PR TITLE
1195 teams see onboarding progress of members

### DIFF
--- a/app/assets/stylesheets/_img.scss
+++ b/app/assets/stylesheets/_img.scss
@@ -3,6 +3,11 @@
   float: left;
 }
 
+.thumbnail-sm {
+  max-width: 120px;
+  float: left;
+}
+
 .thumbnail-md {
   max-width: 160px;
   float: left;

--- a/app/assets/stylesheets/_lists.scss
+++ b/app/assets/stylesheets/_lists.scss
@@ -86,11 +86,5 @@ ol {
         padding-right: 0;
       }
     }
-
-    &:hover {
-      [class*="grid__col-"] {
-        background: #ddd;
-      }
-    }
   }
 }

--- a/app/controllers/regional_ambassador/team_memberships_controller.rb
+++ b/app/controllers/regional_ambassador/team_memberships_controller.rb
@@ -4,11 +4,10 @@ module RegionalAmbassador
       team = Team.find(params.fetch(:id))
       account = Account.find(params.fetch(:account_id))
 
-      if account.mentor_profile
-        TeamRosterManaging.remove(team, account.mentor_profile)
-      else
-        TeamRosterManaging.remove(team, account.student_profile)
-      end
+      TeamRosterManaging.remove(
+        team,
+        account.mentor_profile || account.student_profile
+      )
 
       redirect_to regional_ambassador_team_path(team),
         success: "You have removed #{account.full_name} from this team"

--- a/app/controllers/student/team_memberships_controller.rb
+++ b/app/controllers/student/team_memberships_controller.rb
@@ -2,11 +2,16 @@ module Student
   class TeamMembershipsController < StudentController
     def destroy
       team = current_student.teams.find(params.fetch(:id))
-      TeamRosterManaging.remove(team, current_student)
+      member = current_student.team.students.find(params.fetch(:member_id))
+      TeamRosterManaging.remove(team, member)
 
-      redirect_to student_dashboard_path,
-        success: t("controllers.team_memberships.destroy.success",
-                   name: team.name)
+      if member == current_student
+        redirect_to student_dashboard_path,
+          success: "You have removed yourself from #{team.name}"
+      else
+        redirect_to student_team_path(team),
+          success: "#{member.full_name} has been removed from #{team.name}"
+      end
     end
   end
 end

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -188,12 +188,23 @@ class MentorProfile < ActiveRecord::Base
     teams.include? team
   end
 
-  def full_access_enabled?
+  def onboarding?
+    not onboarded?
+  end
+
+  def onboarded?
     account.email_confirmed? and
       consent_signed? and
         background_check_complete? and
           location_confirmed? and
             not bio.blank?
+  end
+
+  def full_access_enabled?
+    ActiveSupport::Deprecation.warn(
+      "#full_access_enabled? is deprecated. Please use #onboarded?"
+    )
+    onboarded?
   end
 
   private

--- a/app/technovation/can_remove_team_member.rb
+++ b/app/technovation/can_remove_team_member.rb
@@ -1,6 +1,7 @@
 module CanRemoveTeamMember
   def self.call(account, member)
     account.admin_profile or
-      account.id == member.account_id
+      member.onboarding? or
+        account.id == member.account_id
   end
 end

--- a/app/views/invites/_registered_invitee.en.html.erb
+++ b/app/views/invites/_registered_invitee.en.html.erb
@@ -1,9 +1,10 @@
 <div class="grid">
-  <div class="grid__col-3 grid__col--bleed-y">
-    <%= image_tag invite.invitee.profile_image_url, class: "grid__cell-img" %>
+  <div class="grid__col-2 grid__col--bleed-y">
+    <%= image_tag invite.invitee.profile_image_url,
+      class: "thumbnail-sm grid__cell-img" %>
   </div>
 
-  <div class="grid__col-9 grid__col--bleed-y">
+  <div class="grid__col-10 grid__col--bleed-y">
     <div class="grid__cell">
       <strong><%= invite.invitee_first_name %></strong><br />
 

--- a/app/views/invites/_unregistered_invitee.en.html.erb
+++ b/app/views/invites/_unregistered_invitee.en.html.erb
@@ -1,10 +1,10 @@
 <div class="grid grid--bleed">
-  <div class="grid__col-3 grid__col--bleed-y">
+  <div class="grid__col-2 grid__col--bleed-y">
     <%= image_tag 'placeholders/placeholder-avatar.svg',
-      class: "placeholder grid__cell-img" %>
+      class: "placeholder thumbnail-sm grid__cell-img" %>
   </div>
 
-  <div class="grid__col-9 grid__col--bleed-y">
+  <div class="grid__col-10 grid__col--bleed-y">
     <div class="grid__cell">
       <strong><%= invite.invitee_email %></strong><br />
 

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-<% if current_student.full_access_enabled? %>
+<% if current_student.onboarded? %>
   <%= render 'student/dashboards/full_access' %>
 <% else %>
   <div class="grid grid--justify-space-around">

--- a/app/views/student/navigation/_global_nav.html.erb
+++ b/app/views/student/navigation/_global_nav.html.erb
@@ -6,7 +6,7 @@
   student_dashboard_path,
   class: al(student_dashboard_path) %>
 
-<% if current_student.full_access_enabled? %>
+<% if current_student.onboarded? %>
   <% if current_student.is_on_team? %>
     <%= link_to t("views.student.navigation.my_team"),
       student_team_path(current_team),

--- a/app/views/teams/_edit_students.en.html.erb
+++ b/app/views/teams/_edit_students.en.html.erb
@@ -1,6 +1,22 @@
 <ul class="reset">
-  <%= render partial: "teams/member", collection: team.students %>
+  <%= render partial: "teams/member",
+    collection: team.students.onboarded %>
 </ul>
+
+<% if team.students.onboarding.any? %>
+  <hr />
+
+  <h3 class="reset">Pending students</h3>
+
+  <p class="hint">
+    These students are listed on your team, but are not yet eligible to compete.
+  </p>
+
+  <ul class="reset">
+    <%= render partial: "teams/onboarding_member",
+      collection: team.students.onboarding %>
+  </ul>
+<% end %>
 
 <%= render "teams/pending_invites",
   preview_method: :invitee_email,

--- a/app/views/teams/_member.html.erb
+++ b/app/views/teams/_member.html.erb
@@ -1,4 +1,5 @@
 <% admin ||= false %>
+
 <% #TODO: fix this admin/profile/user/account stuff %>
 <% path_name = current_scope == "admin" ? "profile" : "user" %>
 
@@ -23,7 +24,7 @@
 
     <% if CanRemoveTeamMember.(current_account, member) %>
       <%= link_to "remove this member",
-        [current_scope, @team, :membership, { account_id: member.account_id }],
+        [current_scope, @team, :membership, { member_id: member.id }],
         data: {
           method: :delete,
           confirm: t("views.teams.show.confirm_leave"),

--- a/app/views/teams/_onboarding_member.en.html.erb
+++ b/app/views/teams/_onboarding_member.en.html.erb
@@ -1,0 +1,32 @@
+<li class="grid">
+  <div class="grid__col-2 grid__col--bleed-x">
+    <%= image_tag onboarding_member.profile_image_url,
+      class: "thumbnail-sm grid__cell-img" %>
+  </div>
+
+  <div class="grid__col-10">
+    <h5 class="reset"><%= onboarding_member.full_name %></h5>
+
+    <p class="reset"><%= mail_to onboarding_member.email %></p>
+
+    <% if CanRemoveTeamMember.(current_account, onboarding_member) %>
+      <%= link_to "remove this member",
+        [current_scope, @team, :membership, { member_id: onboarding_member.id }],
+        data: {
+          method: :delete,
+          confirm: "Are you sure you want to REMOVE #{onboarding_member.full_name} from your team?"
+        },
+        class: "danger small" %>
+    <% end %>
+
+    <div class="help">
+      <h6 class="reset"><%= onboarding_member.first_name %> still needs to:</h6>
+
+      <ul class="reset">
+        <% onboarding_member.actions_needed.each do |action| %>
+          <li><%= action %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</li>

--- a/app/views/teams/_pending_invites.html.erb
+++ b/app/views/teams/_pending_invites.html.erb
@@ -1,4 +1,6 @@
 <% if invites.any? %>
+  <hr />
+
   <div class="grid">
     <div class="grid__col-auto grid__col--bleed-x">
       <h3 class="reset">Invites sent</h1>

--- a/app/views/teams/_pending_requests.html.erb
+++ b/app/views/teams/_pending_requests.html.erb
@@ -1,4 +1,6 @@
 <% if requests.any? %>
+  <hr />
+
   <div class="grid grid--bleed">
     <div class="grid__col-auto">
       <h3 class="reset">Requests from others</h3>
@@ -11,12 +13,12 @@
         <% requests.each do |join_request| %>
           <li class="row">
             <div class="grid">
-              <div class="grid__col-3 grid__col--bleed-y">
+              <div class="grid__col-2 grid__col--bleed-y">
                 <%= image_tag join_request.requestor.profile_image_url,
-                  class: "grid__cell-img" %>
+                  class: "thumbnail-sm grid__cell-img" %>
               </div>
 
-              <div class="grid__col-9 grid__col--bleed-y">
+              <div class="grid__col-10 grid__col--bleed-y">
                 <div class="grid__cell">
                   <strong><%= join_request.requestor_first_name %></strong><br />
                   <small><%= join_request.requestor_scope_name %></small><br />

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,7 @@ if (student = StudentProfile.create(school_name: "John Hughes High",
                                       email_confirmed_at: Time.current,
                                     })).valid?
   SeasonRegistration.register(student.account)
+  Geocoding.perform(student).with_save
   student.create_parental_consent!(FactoryGirl.attributes_for(:parental_consent))
   puts ""
   puts "============================================================="

--- a/spec/controllers/team_memberships_controller_spec.rb
+++ b/spec/controllers/team_memberships_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Team Memberships Controllers" do
 
         sign_in(older_student)
 
-        delete :destroy, params: { id: team.id }
+        delete :destroy, params: { id: team.id, member_id: older_student.id }
 
         expect(team.reload).to be_junior
       end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -276,13 +276,24 @@ RSpec.describe Team do
     expect(heisenberg.reload.id).not_to be_nil
   end
 
-  it "deletes itself when the membership count decrements to zero" do
+  it "deletes itself and pending join requests/invites when membership decrements to zero" do
     team = FactoryGirl.create(:team)
+
+    team.team_member_invites.create!(
+      invitee_email: "will@delete.com",
+      inviter: FactoryGirl.create(:mentor),
+    )
+
+    team.join_requests.create!(
+      requestor: FactoryGirl.create(:student),
+    )
 
     team.members.each do |m|
       TeamRosterManaging.remove(team, m)
     end
 
     expect(team).to be_deleted
+    expect(team.team_member_invites).to be_empty
+    expect(team.join_requests).to be_empty
   end
 end


### PR DESCRIPTION
For card #1195 

Depends on PR #1240 (for card #1162)

* Deprecates `#full_access_enabled?` in favor of `#onboarded?` and `#onboarding?`
* Makes thumbnails of pending students, invites, join requests smaller

<!---
@huboard:{"custom_state":"archived"}
-->
