### PR TITLE
#1229 redirect registered signup attempts when link used again

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,10 @@ class ApplicationController < ActionController::Base
 
     if @profile.errors[:"account.email"]
       .include?("has already been taken")
-      render "signups/email_taken" and return
+      render "signups/email_taken",
+        locals: {
+          email: @profile.email
+        } and return
     end
 
     @profile.errors.clear

--- a/app/controllers/signup_attempt_confirmations_controller.rb
+++ b/app/controllers/signup_attempt_confirmations_controller.rb
@@ -3,6 +3,12 @@ class SignupAttemptConfirmationsController < ApplicationController
 
   def new
     signup_attempt = SignupAttempt.find_by!(activation_token: params.fetch(:token))
+    if signup_attempt.registered?
+      render "signups/email_taken",
+        locals: {
+          email: signup_attempt.email
+        } and return
+    end
     signup_attempt.active!
     cookies[:signup_token] = signup_attempt.signup_token
     redirect_to signup_path, success: t("controllers.signup_attempt_confirmations.new.success")

--- a/app/views/signups/email_taken.en.html.erb
+++ b/app/views/signups/email_taken.en.html.erb
@@ -3,16 +3,16 @@
     <p>
       Hey there!
       The email address
-      <strong><%= @profile.email %></strong>
+      <strong><%= @email %></strong>
       is already registered.
     </p>
 
     <p>
       Have you tried to
-      <%= link_to "sign in", signin_path(email: @profile.email) %>
+      <%= link_to "sign in", signin_path(email: @email) %>
       or
       <%= link_to "reset your password",
-        new_password_reset_path(email: @profile.email) %>
+        new_password_reset_path(email: @email) %>
       instead?
     </p>
   </div>


### PR DESCRIPTION
This fixes #1229. 

@joemsak Not sure how you feel about the `render` call with locals... I see it used in `.erb` files elsewhere in the project but not from a controller.

<!---
@huboard:{"custom_state":"archived"}
-->
