### PR TITLE
#1262 Fix bug during team creation

### DIFF
--- a/app/technovation/team_creating.rb
+++ b/app/technovation/team_creating.rb
@@ -1,7 +1,7 @@
 class TeamCreating
   def self.execute(team, profile, context)
     if team.seasons.empty?
-      RegisterToSeasonJob.perform_later(team)
+      RegisterToSeasonJob.perform_now(team)
     end
 
     TeamRosterManaging.add(team, profile)


### PR DESCRIPTION
The season registration has to happen inline and not in a background job, to avoid the race condition: if the team isn't associated to the current season, it can't be found on your profile

<!---
@huboard:{"custom_state":"archived"}
-->
