### PR TITLE
#1279 Add incoming join requests to dashboard

### DIFF
--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -71,7 +71,6 @@ document.addEventListener("turbolinks:load", function() {
   }
 
   function revealTab($_btn, $_contents, $_links) {
-    console.log($_contents);
     if (!$_btn.data('tab-id'))
       $_btn = $_btn.find('button').first();
 

--- a/app/null_objects/null_team.rb
+++ b/app/null_objects/null_team.rb
@@ -26,4 +26,16 @@ class NullTeam
   def submission
     NullTeamSubmission.new
   end
+
+  def pending_requests
+    []
+  end
+
+  def pending_student_join_requests
+    []
+  end
+
+  def pending_mentor_join_requests
+    []
+  end
 end

--- a/app/views/student/dashboards/_current_actions.html.erb
+++ b/app/views/student/dashboards/_current_actions.html.erb
@@ -14,4 +14,12 @@
     invites: current_student.team_member_invites.pending %>
 
   <%= render "student/dashboards/completion_steps/team_submission" %>
+
+  <%= render "student/dashboards/completion_steps/incoming_join_requests",
+    requests: current_student.team.pending_student_join_requests,
+    scope: :student %>
+
+  <%= render "student/dashboards/completion_steps/incoming_join_requests",
+    requests: current_student.team.pending_mentor_join_requests,
+    scope: :mentor %>
 </ul>

--- a/app/views/student/dashboards/completion_steps/_incoming_join_requests.html.erb
+++ b/app/views/student/dashboards/completion_steps/_incoming_join_requests.html.erb
@@ -1,0 +1,25 @@
+<% if requests.any? %>
+  <li>
+    <div class="flags">
+      <span class="flag flag-team">
+        Form a team
+      </span>
+    </div>
+
+    <h1 class="content-heading"><%= scope.to_s.titleize %> join requests</h1>
+
+    <p>A <%= scope %> wants to join your team!</p>
+
+    <p>
+      You have <strong><%= requests.count %> <%= scope %> request<%= "s" if requests.count > 1 %></strong>
+      waiting for you and your team members.
+    </p>
+
+    <div class="step-actions">
+      <%= link_to "Manage #{scope} requests",
+        student_team_path(current_team, anchor: "!#{scope}s"),
+        class: "button" %>
+    </div>
+  </li>
+<% end %>
+

--- a/app/views/student/dashboards/completion_steps/_start_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/_start_team_submission.html.erb
@@ -1,5 +1,5 @@
 <% if SeasonToggles.team_submissions_editable? %>
-  <h1>Start Your Team Submission</h1>
+  <h1 class="content-heading">Start Your Team Submission</h1>
   <p>
     You and your teammates can begin submitting your app now!
     As you work through the curriculum, you can upload it in parts.
@@ -12,7 +12,7 @@
       class: "button" %>
   </p>
 <% else %>
-  <h1>Your Team Submission</h1>
+  <h1 class="content-heading">Your Team Submission</h1>
   <p>
   Submissions are currently locked. Starting a submission
   is not available at this time.


### PR DESCRIPTION
Looks like this:

![screencapture-localhost-3000-student-dashboard-1506353861849](https://user-images.githubusercontent.com/55319/30817303-8a7eac7e-a1e6-11e7-8040-8e0681c75790.png)

I wanted to start with something less complicated than full controls on the dashboard itself. This will at least notify people and let them know where to go to manage the requests.

<!---
@huboard:{"custom_state":"archived"}
-->
