### PR TITLE
#1295 update mentor invite mailer

### DIFF
--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -73,16 +73,9 @@ class TeamMailer < ApplicationMailer
       "team_mailer.invite_member.greeting.mentor",
       name: invite.team_name
     )
-
-    if invite.invitee.onboarded?
-      @url = mentor_mentor_invite_url(invite)
-      @intro = I18n.translate("team_mailer.invite_member.intro.complete_profile")
-      @link_text = "Review this invitation"
-    else
-      @url = mentor_dashboard_url
-      @intro = I18n.translate("team_mailer.invite_member.intro.incomplete_profile")
-      @link_text = "Complete your profile"
-    end
+    @url = mentor_mentor_invite_url(invite)
+    @intro = I18n.translate("team_mailer.invite_member.intro.existing_profile")
+    @link_text = "Review this invitation"
 
     I18n.with_locale(invite.inviter.locale) do
       mail to: invite.invitee_email, template_name: :invite_member


### PR DESCRIPTION
This updates `invite_mentor` to use the `existing_profile` translation string exclusively, because to my knowledge you can't invite a mentor who hasn't completed their profile, thus making themselves searchable and invitable. 

<!---
@huboard:{"custom_state":"archived"}
-->
