### PR TITLE
#1307 Replace email in URL param for logging in with secure token

### DIFF
--- a/app/controllers/mentor/join_requests_controller.rb
+++ b/app/controllers/mentor/join_requests_controller.rb
@@ -22,7 +22,7 @@ module Mentor
       if reviewer_needs_to_sign_in?
         mentor = @join_request.team.mentors
           .joins(:account)
-          .find_by("accounts.email = ?", params.fetch(:email))
+          .find_by("accounts.mailer_token = ?", params.fetch(:mailer_token))
 
         SignIn.(
           mentor.account,
@@ -60,8 +60,8 @@ module Mentor
     end
 
     def reviewer_needs_to_sign_in?
-      email = params.fetch(:email) { false }
-      email and current_mentor.email != email
+      mailer_token = params.fetch(:mailer_token) { false }
+      mailer_token and current_mentor.mailer_token != mailer_token
     end
 
     def reviewer_is_unauthorized?(join_request)

--- a/app/controllers/student/join_requests_controller.rb
+++ b/app/controllers/student/join_requests_controller.rb
@@ -12,7 +12,7 @@ module Student
       if reviewer_needs_to_sign_in?
         student = @join_request.team.students
           .joins(:account)
-          .find_by("accounts.email = ?", params.fetch(:email))
+          .find_by("accounts.mailer_token = ?", params.fetch(:mailer_token))
 
         SignIn.(
           student.account,
@@ -65,8 +65,8 @@ module Student
     end
 
     def reviewer_needs_to_sign_in?
-      email = params.fetch(:email) { false }
-      email and current_student.email != email
+      mailer_token = params.fetch(:mailer_token) { false }
+      mailer_token and current_student.mailer_token != mailer_token
     end
 
     def reviewer_is_requestor?(join_request)

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -93,7 +93,7 @@ class TeamMailer < ApplicationMailer
     @url = send(
       "#{recipient.scope_name}_join_request_url",
       join_request,
-      email: recipient.email
+      mailer_token: recipient.mailer_token
     )
 
     I18n.with_locale(recipient.locale) do

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -78,6 +78,7 @@ class Account < ActiveRecord::Base
   has_secure_token :consent_token
   has_secure_token :password_reset_token
   has_secure_token :session_token
+  has_secure_token :mailer_token
   has_secure_password
 
   validates :email,

--- a/app/null_objects/null_profile.rb
+++ b/app/null_objects/null_profile.rb
@@ -2,7 +2,8 @@ class NullProfile
   def authenticated?; false; end
   def present?; false; end
   def onboarded?; false; end
-  def email; nil; end
+  def email; false; end
   def is_an_ambassador?; false; end
   def past_teams; Team.none; end
+  def mailer_token; false; end
 end

--- a/db/migrate/20171003154720_add_mailer_token_to_accounts.rb
+++ b/db/migrate/20171003154720_add_mailer_token_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddMailerTokenToAccounts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :accounts, :mailer_token, :string
+  end
+end

--- a/db/migrate/20171003154750_regenerate_null_mailer_tokens_on_accounts.rb
+++ b/db/migrate/20171003154750_regenerate_null_mailer_tokens_on_accounts.rb
@@ -1,0 +1,7 @@
+class RegenerateNullMailerTokensOnAccounts < ActiveRecord::Migration[5.1]
+  def change
+    Account.where(mailer_token: [nil, ""]).find_each do |a|
+      a.regenerate_mailer_token
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171003153733) do
+ActiveRecord::Schema.define(version: 20171003154750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20171003153733) do
     t.datetime "last_logged_in_at"
     t.text "seasons", default: [], array: true
     t.string "session_token"
+    t.string "mailer_token"
     t.index ["auth_token"], name: "index_accounts_on_auth_token", unique: true
     t.index ["consent_token"], name: "index_accounts_on_consent_token", unique: true
     t.index ["email"], name: "index_accounts_on_email", unique: true

--- a/spec/features/student/request_to_join_a_team_spec.rb
+++ b/spec/features/student/request_to_join_a_team_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Students request to join a team",
 
       sign_out
       student = team.students.sample
-      visit student_join_request_path(JoinRequest.last, email: student.email)
+      visit student_join_request_path(JoinRequest.last, mailer_token: student.mailer_token)
       click_button "Approve"
 
       expect(ActionMailer::Base.deliveries.count).not_to be_zero,
@@ -72,7 +72,7 @@ RSpec.feature "Students request to join a team",
 
       sign_out
       mentor = team.mentors.sample
-      visit mentor_join_request_path(JoinRequest.last, email: mentor.email)
+      visit mentor_join_request_path(JoinRequest.last, mailer_token: mentor.mailer_token)
       click_button "Approve"
 
       expect(ActionMailer::Base.deliveries.count).not_to be_zero,
@@ -87,7 +87,7 @@ RSpec.feature "Students request to join a team",
 
       sign_out
       student = team.students.sample
-      visit student_join_request_path(JoinRequest.last, email: student.email)
+      visit student_join_request_path(JoinRequest.last, mailer_token: student.mailer_token)
       click_button "Decline"
 
       expect(ActionMailer::Base.deliveries.count).not_to be_zero,
@@ -107,7 +107,7 @@ RSpec.feature "Students request to join a team",
 
       sign_out
       mentor = team.mentors.sample
-      visit mentor_join_request_path(JoinRequest.last, email: mentor.email)
+      visit mentor_join_request_path(JoinRequest.last, mailer_token: mentor.mailer_token)
       click_button "Decline"
 
       expect(ActionMailer::Base.deliveries.count).not_to be_zero,


### PR DESCRIPTION
Pretty simple: adds `Account#mailer_token` using Rails' built-in `has_secure_token`

This is used in the `TeamMailer`'s join request review email sent to all team members, so the URL knows who to log in. Previously, it was their email, which isn't as secure, and production is configured to filter the email out, so the URL wasn't working anyway.

This should be used in any case where the same URL is sent to multiple people, but the system needs to know who to log in. Otherwise, if the URL is meant for one person, the existing token should suffice to authenticate them.

<!---
@huboard:{"custom_state":"archived"}
-->
