### PR TITLE
Add tests around profanity and sentiment analysis using Algorithmia mock

### DIFF
--- a/app/javascript/judge/scores/QuestionSection.vue
+++ b/app/javascript/judge/scores/QuestionSection.vue
@@ -221,6 +221,22 @@ export default {
     prevBtnTxt () {
       return _.capitalize(this.prevSection)
     },
+
+    shouldRunSentimentAnalysis () {
+      return (
+        this.wordCount > 19 &&
+          (this.wordCount % 5 === 0 ||
+            !this.commentIsSentimentAnalyzed)
+      )
+    },
+
+    shouldRunProfanityAnalysis () {
+      return (
+        this.wordCount > 0 &&
+          (this.wordCount % 2 === 0 ||
+            !this.commentIsProfanityAnalyzed)
+      )
+    },
   },
 
   props: [
@@ -288,13 +304,7 @@ export default {
 
     runSentimentAnalysis () {
       return new Promise((resolve, reject) => {
-        const shouldRunSentimentAnalysis = (
-          this.wordCount > 19 &&
-            (this.wordCount % 5 === 0 ||
-              !this.commentIsSentimentAnalyzed)
-        )
-
-        if (shouldRunSentimentAnalysis) {
+        if (this.shouldRunSentimentAnalysis) {
           Algorithmia.client("sim7BOgNHD5RnLXe/ql+KUc0O0r1")
             .algo("nlp/SocialSentimentAnalysis/0.1.4")
             .pipe({ sentence: this.commentText })
@@ -314,13 +324,7 @@ export default {
 
     runProfanityAnalysis () {
       return new Promise((resolve, reject) => {
-        const shouldRunProfanityAlysis = (
-          this.wordCount > 0 &&
-            (this.wordCount % 2 === 0 ||
-              !this.commentIsProfanityAnalyzed)
-        )
-
-        if (shouldRunProfanityAlysis) {
+        if (this.shouldRunProfanityAnalysis) {
           Algorithmia.client("sim7BOgNHD5RnLXe/ql+KUc0O0r1")
             .algo("nlp/ProfanityDetection/1.0.0")
             .pipe([this.commentText, ['suck', 'sucks'], false])


### PR DESCRIPTION
This pull request adds the following:
- Mock Algorithmia for testing so that we can test the response callbacks
- Alleviate nested `nextTick()` calls with the use of `setImmediate()`. This is a NodeJS function which essentially waits for the queued tasks to finish and then calls the callback. In our case, an expect statement after all the Vue tasks are done.
- I pulled out the `shouldRunProfanityAnalysis` and `shouldRunSentimentAnalysis` into computed properties and wrote unit tests around both functions. This allows for easier mocking in other tests.
- Using the above functionality, I mocked and tested the `setComment` commits that come from the Algorithmia callbacks.