### PR TITLE
Axios mock refactor

### DIFF
--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,0 +1,12 @@
+export default {
+  get: jest.fn((url) => {
+    return Promise.resolve({
+      data: {}
+    })
+  }),
+  post: jest.fn((url) => {
+    return Promise.resolve({
+      data: {}
+    })
+  })
+};

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+describe('axios mock', () => {
+  it('returns the proper mock for GET', (done) => {
+    axios.get('/this/is/a/test/url').then((response) => {
+      expect(axios.get).toHaveBeenCalledWith('/this/is/a/test/url')
+      expect(response).toEqual({ data: {} })
+      done()
+    })
+  })
+
+  it('returns the proper mock for POST', (done) => {
+    axios.post('/this/is/a/test/url').then((response) => {
+      expect(axios.post).toHaveBeenCalledWith('/this/is/a/test/url')
+      expect(response).toEqual({ data: {} })
+      done()
+    })
+  })
+})

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -376,21 +376,4 @@ describe('CertificateButton Vue component', () => {
       })
     })
   })
-
-  // Refactor this test once the logic for populating fileUrl is done
-  xit('contains the proper state once all AJAX requests and job have finished', (done) => {
-    const wrapper = shallow(CertificateButton, {
-      propsData: {
-        teamId: 3,
-        userScope: 'mentor',
-      },
-    })
-
-    setImmediate(() => {
-      expect(wrapper.vm.certificateUrl).toEqual('/mentor/certificates/3')
-      expect(wrapper.vm.jobId).toEqual(5)
-      expect(wrapper.vm.state).toEqual('ready')
-      done()
-    })
-  })
 })

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -7,7 +7,7 @@ import CertificateButton from 'components/CertificateButton'
 describe('CertificateButton Vue component', () => {
   axiosMock.post.mockImplementation(() => {
     return Promise.resolve({
-      data: { jobId: 5, test: 'blah' },
+      data: { jobId: 5 },
     })
   })
   axiosMock.get.mockImplementation(() => {

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -1,21 +1,16 @@
 import { shallow } from '@vue/test-utils'
 
-import axios from 'axios'
+import axiosMock from 'axios'
 import Icon from 'components/Icon'
 import CertificateButton from 'components/CertificateButton'
 
 describe('CertificateButton Vue component', () => {
-  // Mocking this out to prevent console from getting bogged down with warnings
-  // We will want to move this into a proper mock later on
-  axios.get = jest.fn()
-  axios.post = jest.fn()
-
-  axios.post.mockImplementation(() => {
+  axiosMock.post.mockImplementation(() => {
     return Promise.resolve({
-      data: { jobId: 5 },
+      data: { jobId: 5, test: 'blah' },
     })
   })
-  axios.get.mockImplementation(() => {
+  axiosMock.get.mockImplementation(() => {
     return Promise.resolve({
       data: {
         status: 'complete',
@@ -25,8 +20,8 @@ describe('CertificateButton Vue component', () => {
   })
 
   beforeEach(() => {
-    axios.post.mockClear()
-    axios.get.mockClear()
+    axiosMock.post.mockClear()
+    axiosMock.get.mockClear()
   })
 
   describe('props', () => {
@@ -103,9 +98,7 @@ describe('CertificateButton Vue component', () => {
 
     it('displays a link to the certificate if the certificate button URL ' +
         'has finished being generated', (done) => {
-      axios.post.mockClear()
-
-      axios.post.mockImplementationOnce(() => {
+      axiosMock.post.mockImplementationOnce(() => {
         return Promise.resolve({
           data: {
             status: "complete",
@@ -162,13 +155,13 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axios.post.mockClear()
+        axiosMock.post.mockClear()
 
-        expect(axios.post).not.toHaveBeenCalled()
+        expect(axiosMock.post).not.toHaveBeenCalled()
 
         wrapper.vm.requestCertificate()
 
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(axiosMock.post).toHaveBeenCalledWith(
           '/mentor/certificates/',
           { team_id: 42892 },
         )
@@ -253,15 +246,15 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axios.get.mockClear()
+        axiosMock.get.mockClear()
 
-        expect(axios.get).not.toHaveBeenCalled()
+        expect(axiosMock.get).not.toHaveBeenCalled()
 
         wrapper.vm.jobId = 6
 
         wrapper.vm.pollJobQueue()
 
-        expect(axios.get).toHaveBeenCalledWith('/mentor/job_statuses/6')
+        expect(axiosMock.get).toHaveBeenCalledWith('/mentor/job_statuses/6')
       })
 
       it('returns early if the state is already ready', () => {
@@ -271,15 +264,15 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axios.get.mockClear()
+        axiosMock.get.mockClear()
 
-        expect(axios.get).not.toHaveBeenCalled()
+        expect(axiosMock.get).not.toHaveBeenCalled()
 
         wrapper.vm.state = 'ready'
 
         wrapper.vm.pollJobQueue()
 
-        expect(axios.get).not.toHaveBeenCalled()
+        expect(axiosMock.get).not.toHaveBeenCalled()
       })
     })
 


### PR DESCRIPTION
Pulls the `axios` mock out of CertificateButton and puts it in `__mocks__` so it can be reused in other portions of the test suite. Renamed `axios` module to `axiosMock` in the spec so that we know it is being mocked and the implementation is replaced.