### PR TITLE
Convenient axios mocking with axios.mockRequest(method, returnData, options)

### DIFF
--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,7 +1,10 @@
 export default {
-  mockRequest (method, returnData, options) {
+  mockRequest (method, returnData, opts) {
+    const options = Object.assign({}, opts)
+    const promiseState = options.reject ? 'reject' : 'resolve'
+
     this[method].mockImplementation(() => {
-      return Promise.resolve({
+      return Promise[promiseState]({
         data: returnData,
       })
     })

--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,9 +1,13 @@
 export default {
   mockRequest (method, returnData, opts) {
     const options = Object.assign({}, opts)
+
     const promiseState = options.reject ? 'reject' : 'resolve'
 
-    this[method].mockImplementation(() => {
+    const mockImplementationFunc = options.once ?
+      'mockImplementationOnce' : 'mockImplementation'
+
+    this[method][mockImplementationFunc](() => {
       return Promise[promiseState]({
         data: returnData,
       })

--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,9 +1,18 @@
 export default {
+  mockRequest (method, returnData, options) {
+    this[method].mockImplementation(() => {
+      return Promise.resolve({
+        data: returnData,
+      })
+    })
+  },
+
   get: jest.fn((url) => {
     return Promise.resolve({
       data: {}
     })
   }),
+
   post: jest.fn((url) => {
     return Promise.resolve({
       data: {}

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -1,19 +1,25 @@
 import axios from 'axios'
 
 describe('axios mock', () => {
-  it('returns the proper mock for GET', (done) => {
-    axios.get('/this/is/a/test/url').then((response) => {
-      expect(axios.get).toHaveBeenCalledWith('/this/is/a/test/url')
-      expect(response).toEqual({ data: {} })
-      done()
-    })
-  })
+  describe('axios.mockRequest', () => {
+    it('mocks implementations with resolve by default', (done) => {
+      axios.mockRequest('get', {
+        myField: 'myValue',
+      })
 
-  it('returns the proper mock for POST', (done) => {
-    axios.post('/this/is/a/test/url').then((response) => {
-      expect(axios.post).toHaveBeenCalledWith('/this/is/a/test/url')
-      expect(response).toEqual({ data: {} })
-      done()
+      axios.get('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { myField: 'myValue' } })
+        done()
+      })
+    })
+
+    xit('returns the proper mock for POST', (done) => {
+      axios.post('/this/is/a/test/url').then((response) => {
+        expect(axios.post).toHaveBeenCalledWith('/this/is/a/test/url')
+        expect(response).toEqual({ data: {} })
+        done()
+      })
     })
   })
 })

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -32,6 +32,22 @@ describe('axios mock', () => {
       })
     })
 
+    it('mocks implementations once with an option', (done) => {
+      axios.mockRequest('post', { always: 'resolved' })
+      axios.mockRequest('post', { resolved: 'once' }, { once: true })
+
+      axios.post('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { resolved: 'once' } })
+      })
+
+      axios.post('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { always: 'resolved' } })
+        done()
+      })
+    })
+
     it('does not disturb normal boilerplate mocking', (done) => {
       axios.get.mockImplementation(() => {
         return Promise.resolve({ data: { status: 'complete' } })

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -2,10 +2,8 @@ import axios from 'axios'
 
 describe('axios mock', () => {
   describe('axios.mockRequest', () => {
-    it('mocks implementations with resolve by default', (done) => {
-      axios.mockRequest('get', {
-        myField: 'myValue',
-      })
+    it('mocks get implementations with resolve by default', (done) => {
+      axios.mockRequest('get', { myField: 'myValue' })
 
       axios.get('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
@@ -14,10 +12,34 @@ describe('axios mock', () => {
       })
     })
 
-    xit('returns the proper mock for POST', (done) => {
-      axios.post('/this/is/a/test/url').then((response) => {
-        expect(axios.post).toHaveBeenCalledWith('/this/is/a/test/url')
-        expect(response).toEqual({ data: {} })
+    it('mocks post implementations with resolve by default', (done) => {
+      axios.mockRequest('post', { some: 'value' })
+
+      axios.post('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { some: 'value' } })
+        done()
+      })
+    })
+
+    it('mocks implementations with a reject by option', (done) => {
+      axios.mockRequest('post', { rejected: 'value' }, { reject: true })
+
+      axios.post('/test/url').catch((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { rejected: 'value' } })
+        done()
+      })
+    })
+
+    it('does not disturb normal boilerplate mocking', (done) => {
+      axios.get.mockImplementation(() => {
+        return Promise.resolve({ data: { status: 'complete' } })
+      })
+
+      axios.get('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { status: 'complete' } })
         done()
       })
     })

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -10,6 +10,7 @@ describe('CertificateButton Vue component', () => {
       data: { jobId: 5 },
     })
   })
+
   axiosMock.get.mockImplementation(() => {
     return Promise.resolve({
       data: {


### PR DESCRIPTION
This PR adds a convenient method on our axios mock to reduce boilerplate code

```js
axios.mockRequest(method, returnData, options)

// options:
{
  reject: true, // default false
  once: true, // default false
}

// reject option will return a rejected promise instead of a resolved one
// once option will call mockImplementationOnce() instead of mockImplementation()
```

```js
// Example usage

import axios from 'axios'

// Default mocking of GET
axios.mockRequest('get', { returnsThisData: true })

axios.get('/some/url/').then((response) => {
  console.log(response)
  // { data: { returnsThisData: true } }
})

// Default mocking of POST
axios.mockRequest('post', { returnsThisData: true })

axios.post('/some/url/').then((response) => {
  console.log(response)
  // { data: { returnsThisData: true } }
})

// Return a Rejected Promise
axios.mockRequest('get', { returnsThisData: true }, { reject: true })

axios.post('/some/url/').catch((response) => {
  console.log(response)
  // { data: { returnsThisData: true } }
})

// Mock implementation once
axios.mockRequest('get', { returnsThisDataAlways: true }, { once: true })
axios.mockRequest('get', { returnsThisDataOnce: true }, { once: true })

axios.post('/some/url/').then((response) => {
  console.log(response)
  // { data: { returnsThisDataOnce: true } }
})

axios.post('/some/url/').then((response) => {
  console.log(response)
  // { data: { returnsThisDataAlways: true } }
})
```