### PR TITLE
Screenshots refactor and initial tests

### DIFF
--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -1,0 +1,229 @@
+<template>
+  <div id="screenshot-uploader">
+    <template v-if="maxFiles > 0">
+      <label class="label--wraps-file-input">
+        <input type="file" multiple @change="handleFileInput" />
+
+        <span class="button button--small">
+          + Add {{ prefix }} {{ maxFiles }} {{ object }}
+        </span>
+      </label>
+    </template>
+
+    <template v-else>
+      You have uploaded the maximum of {{ maxAllowed }} screenshots.
+      You need to remove some if you want to add others.
+    </template>
+
+    <p v-if="screenshots.length > 1">
+      Sort your screenshots in the order that you want
+      the judges to see them:
+    </p>
+
+    <ol
+      v-dragula
+      id="sortable-list"
+      data-sort-url="sortUrl"
+      class="sortable-list submission-pieces__screenshots"
+    >
+      <li
+        class="sortable-list__item draggable"
+        v-for="screenshot in screenshots"
+        :key="screenshot.id"
+        :data-db-id="screenshot.id"
+      >
+        <img
+          class="submission-pieces__screenshot img-modal"
+          :src="screenshot.src"
+          :alt="screenshot.name"
+          :data-modal-url="screenshot.large_img_url"
+        />
+
+        <div class="sortable-list__item-actions">
+          <i
+            class="icon-remove icon--red"
+            @click="removeScreenshot(screenshot)"
+          ></i>
+        </div>
+      </li>
+
+      <li
+        class="submission-pieces__screenshot-placeholder"
+        v-for="upload in uploads"
+        :key="upload.id"
+      >
+        <i class="icon-spinner2 spin"></i>
+        <span>{{ upload.name }}</span>
+      </li>
+    </ol>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue/dist/vue.common'
+import VueDragula from 'vue-dragula';
+
+Vue.use(VueDragula)
+
+export default {
+  name: 'screenshot-uploader',
+
+  props: {
+    sortUrl: {
+      type: String,
+      required: true,
+    },
+    screenshotsUrl: {
+      type: String,
+      required: true,
+    },
+    teamId: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  data () {
+    return {
+      maxAllowed: 6,
+      screenshots: [],
+      uploads: [],
+    }
+  },
+
+  computed: {
+    maxFiles () {
+      return this.maxAllowed - this.screenshots.length;
+    },
+
+    object () {
+      return this.maxFiles != 1 ? "screenshots" : "screenshot";
+    },
+
+    prefix () {
+      return this.maxFiles != 1 ? "up to" : "";
+    },
+  },
+
+  methods: {
+    removeScreenshot (screenshot) {
+      swal({
+        text: "Are you sure you want to delete the screenshot?",
+        cancelButtonText: "No, go back",
+        confirmButtonText: "Yes, delete it",
+        confirmButtonColor: "#D8000C",
+        showCancelButton: true,
+        reverseButtons: true,
+        focusCancel: true,
+      }).then(
+        () => {
+          var idx = this.screenshots.indexOf(screenshot);
+          this.screenshots.splice(idx, 1);
+          $.ajax({
+            method: "DELETE",
+            url: this.screenshotsUrl +
+                  "/" +
+                  screenshot.id +
+                  "?team_id=" +
+                  this.teamId,
+          });
+        },
+
+        () => { return false; }
+      );
+    },
+
+    handleFileInput (e) {
+      var keep = [].slice.call(e.target.files, 0, this.maxFiles),
+          vm = this;
+
+      [].forEach.call(keep, (file) => {
+        this.uploads.push(file);
+
+        var vm = this,
+            form = new FormData();
+
+        form.append(
+          "team_submission[screenshots_attributes][]image", file
+        );
+
+        form.append("team_id", this.teamId);
+
+        $.ajax({
+          method: "POST",
+          url: this.screenshotsUrl,
+          data: form,
+          contentType: false,
+          processData: false,
+          success: (data) => {
+            vm.screenshots.push({
+              id: data.id,
+              src: data.src,
+              name: data.name,
+              large_img_url: data.large_img_url,
+            });
+
+            var i = vm.uploads.indexOf(file);
+            vm.uploads.splice(i, 1);
+
+            e.target.value = "";
+          },
+        });
+      });
+    },
+  },
+
+  mounted () {
+    var vm = this;
+
+    $.ajax({
+      method: "GET",
+      url: this.screenshotsUrl + "?team_id=" + this.teamId,
+      success: function(data) {
+        vm.screenshots = data;
+      },
+    });
+
+    Vue.vueDragula.eventBus.$on('drop', (args) => {
+      var dropped = args[1],
+          list = args[2];
+
+      var url = $(list).data("sort-url"),
+          items = $(list).find(".sortable-list__item"),
+          form = new FormData();
+
+      [].forEach.call(items, (item) => {
+        form.append(
+          "team_submission[screenshots][]",
+          $(item).data("db-id")
+        );
+      });
+
+      form.append("team_id", this.teamId);
+
+      $.ajax({
+        method: "PATCH",
+        url: url,
+        data: form,
+        contentType: false,
+        processData: false,
+        success: function() {
+          if (window.timeout) {
+            clearTimeout(window.timeout);
+            window.timeout = null;
+          }
+
+          $(dropped).addClass("sortable-list--updated");
+
+          window.timeout = setTimeout(function () {
+            $(dropped).removeClass("sortable-list--updated");
+          }, 100);
+        },
+      });
+    });
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -73,10 +73,12 @@ export default {
       type: String,
       required: true,
     },
+
     screenshotsUrl: {
       type: String,
       required: true,
     },
+
     teamId: {
       type: Number,
       required: true,

--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script>
-import Vue from 'vue/dist/vue.common'
+import Vue from 'vue'
 import VueDragula from 'vue-dragula';
 
 Vue.use(VueDragula)

--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -23,7 +23,6 @@
     <ol
       v-dragula
       id="sortable-list"
-      data-sort-url="sortUrl"
       class="sortable-list submission-pieces__screenshots"
     >
       <li
@@ -60,11 +59,6 @@
 </template>
 
 <script>
-import Vue from 'vue'
-import VueDragula from 'vue-dragula';
-
-Vue.use(VueDragula)
-
 export default {
   name: 'screenshot-uploader',
 
@@ -186,11 +180,11 @@ export default {
       },
     });
 
-    Vue.vueDragula.eventBus.$on('drop', (args) => {
+    window.vueDragula.eventBus.$on('drop', (args) => {
       var dropped = args[1],
           list = args[2];
 
-      var url = $(list).data("sort-url"),
+      var url = this.sortUrl,
           items = $(list).find(".sortable-list__item"),
           form = new FormData();
 

--- a/app/javascript/submissions/screenshots.js
+++ b/app/javascript/submissions/screenshots.js
@@ -1,150 +1,18 @@
+import Vue from 'vue/dist/vue.common'
 import VueDragula from 'vue-dragula';
-import Vue from 'vue/dist/vue.esm'
 
 Vue.use(VueDragula)
 
+import ScreenshotUploader from '../components/ScreenshotUploader'
+
 document.addEventListener('turbolinks:load', () => {
-  const screenshotsUrl = $("#screenshots").data("url"),
-        teamId = $("#screenshots").data("team-id");
+  if (document.getElementById('vue-screenshot-uploader') !== null) {
+    new Vue({
+      el: '#vue-screenshot-uploader',
 
-  const app = new Vue({
-    el: '#app',
-    data: {
-      maxAllowed: 6,
-      screenshots: [],
-      uploads: [],
-    },
-
-    computed: {
-      maxFiles () {
-        return this.maxAllowed - this.screenshots.length;
+      components: {
+        ScreenshotUploader,
       },
-
-      object () {
-        return this.maxFiles != 1 ? "screenshots" : "screenshot";
-      },
-
-      prefix () {
-        return this.maxFiles != 1 ? "up to" : "";
-      },
-    },
-
-    methods: {
-      removeScreenshot (screenshot) {
-        swal({
-          text: "Are you sure you want to delete the screenshot?",
-          cancelButtonText: "No, go back",
-          confirmButtonText: "Yes, delete it",
-          confirmButtonColor: "#D8000C",
-          showCancelButton: true,
-          reverseButtons: true,
-          focusCancel: true,
-        }).then(
-          () => {
-            var idx = this.screenshots.indexOf(screenshot);
-            this.screenshots.splice(idx, 1);
-            $.ajax({
-              method: "DELETE",
-              url: screenshotsUrl +
-                   "/" +
-                   screenshot.id +
-                   "?team_id=" +
-                   teamId,
-            });
-          },
-
-          () => { return false; }
-        );
-      },
-
-      handleFileInput (e) {
-        var keep = [].slice.call(e.target.files, 0, this.maxFiles),
-            vm = this;
-
-        [].forEach.call(keep, (file) => {
-          this.uploads.push(file);
-
-          var vm = this,
-              form = new FormData();
-
-          form.append(
-            "team_submission[screenshots_attributes][]image", file
-          );
-
-          form.append("team_id", teamId);
-
-          $.ajax({
-            method: "POST",
-            url: screenshotsUrl,
-            data: form,
-            contentType: false,
-            processData: false,
-            success: (data) => {
-              vm.screenshots.push({
-                id: data.id,
-                src: data.src,
-                name: data.name,
-                large_img_url: data.large_img_url,
-              });
-
-              var i = vm.uploads.indexOf(file);
-              vm.uploads.splice(i, 1);
-
-              e.target.value = "";
-            },
-          });
-        });
-      },
-    },
-
-    mounted () {
-      var vm = this;
-
-      $.ajax({
-        method: "GET",
-        url: screenshotsUrl + "?team_id=" + teamId,
-        success: function(data) {
-          vm.screenshots = data;
-        },
-      });
-
-      Vue.vueDragula.eventBus.$on('drop', (args) => {
-        var dropped = args[1],
-            list = args[2];
-
-        var url = $(list).data("sort-url"),
-            items = $(list).find(".sortable-list__item"),
-            form = new FormData();
-
-        [].forEach.call(items, (item) => {
-          form.append(
-            "team_submission[screenshots][]",
-            $(item).data("db-id")
-          );
-        });
-
-        form.append("team_id", teamId);
-
-        $.ajax({
-          method: "PATCH",
-          url: url,
-          data: form,
-          contentType: false,
-          processData: false,
-          success: function() {
-            if (window.timeout) {
-              clearTimeout(window.timeout);
-              window.timeout = null;
-            }
-
-            $(dropped).addClass("sortable-list--updated");
-
-            window.timeout = setTimeout(function () {
-              $(dropped).removeClass("sortable-list--updated");
-            }, 100);
-          },
-        });
-      });
-    },
-  })
+    })
+  }
 })

--- a/app/javascript/submissions/screenshots.js
+++ b/app/javascript/submissions/screenshots.js
@@ -7,6 +7,10 @@ import ScreenshotUploader from '../components/ScreenshotUploader'
 
 document.addEventListener('turbolinks:load', () => {
   if (document.getElementById('vue-screenshot-uploader') !== null) {
+    // We have to assign the VueDragula event bus to a global level variable in
+    // order to communicate with sub components.
+    window.vueDragula = Vue.vueDragula
+
     new Vue({
       el: '#vue-screenshot-uploader',
 

--- a/app/views/team_submissions/pieces/screenshots.en.html.erb
+++ b/app/views/team_submissions/pieces/screenshots.en.html.erb
@@ -1,72 +1,20 @@
 <div
   id="screenshots"
-  data-url="<%= send("#{current_scope}_screenshots_path") %>"
-  data-team-id="<%= @team_submission.team_id %>"
   class="panel"
 >
   <h3 class="panel--heading">Screenshots</h3>
 
-  <div id="app">
-    <template v-if="maxFiles > 0">
-      <label class="label--wraps-file-input">
-        <input type="file" multiple @change="handleFileInput" />
-
-        <span class="button button--small">
-          + Add {{ prefix }} {{ maxFiles }} {{ object }}
-        </span>
-      </label>
-    </template>
-
-    <template v-else>
-      You have uploaded the maximum of {{ maxAllowed }} screenshots.
-      You need to remove some if you want to add others.
-    </template>
-
-    <p v-if="screenshots.length > 1">
-      Sort your screenshots in the order that you want
-      the judges to see them:
-    </p>
-
-    <ol
-      v-dragula=""
-      id="sortable-list"
-      data-sort-url="<%=
+  <div id="vue-screenshot-uploader">
+    <screenshot-uploader
+      screenshots-url="<%= send("#{current_scope}_screenshots_path") %>"
+      :team-id="<%= @team_submission.team_id %>"
+      sort-url="<%=
         send(
           "#{current_scope}_team_submission_path",
           @team_submission
         )
       %>"
-      class="sortable-list submission-pieces__screenshots"
-    >
-      <li
-        class="sortable-list__item draggable"
-        v-for="screenshot in screenshots"
-        :key="screenshot.id"
-        :data-db-id="screenshot.id"
-      >
-        <img
-          class="submission-pieces__screenshot img-modal"
-          :src="screenshot.src"
-          :alt="screenshot.name"
-          :data-modal-url="screenshot.large_img_url"
-        />
-
-        <div class="sortable-list__item-actions">
-          <i
-            class="icon-remove icon--red"
-            @click="removeScreenshot(screenshot)"
-          ></i>
-        </div>
-      </li>
-
-      <li
-        class="submission-pieces__screenshot-placeholder"
-        v-for="upload in uploads"
-      >
-        <i class="icon-spinner2 spin"></i>
-        <span>{{ upload.name }}</span>
-      </li>
-    </ol>
+    ><screenshot-uploader>
   </div>
 
   <p class="grid__cell--padding-sm-y">

--- a/spec/javascript/attendee-search.spec.js
+++ b/spec/javascript/attendee-search.spec.js
@@ -1,13 +1,14 @@
-import Vue from "vue";
+import { shallow } from '@vue/test-utils'
+
 import AttendeeSearch from "ra/events/AttendeeSearch";
 
 test('performs remote search when filteredItems is empty', () => {
-  const vm = new Vue(AttendeeSearch).$mount();
-  let spy = jest.spyOn(vm, "fetchRemoteItems");
+  const wrapper = shallow(AttendeeSearch);
+  const fetchRemoteItemsSpy = jest.spyOn(wrapper.vm, "fetchRemoteItems");
 
-  vm.query = "longer than 2 chars";
+  wrapper.vm.query = "longer than 2 chars";
 
   setTimeout(() => {
-    expect(spy).toBeCalledWith({ expandSearch: "1" });
+    expect(fetchRemoteItemsSpy).toBeCalledWith({ expandSearch: "1" });
   }, 300);
 });

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -1,9 +1,13 @@
+import $ from 'jquery'
 import { shallow, createLocalVue } from '@vue/test-utils'
 import VueDragula from 'vue-dragula'
 
+// We need to expose these globally since they are exposed globally in
+// application.js via Ruby
 const localVue = createLocalVue()
 localVue.use(VueDragula)
 window.vueDragula = localVue.vueDragula
+window.$ = $
 
 import ScreenshotUploader from 'components/ScreenshotUploader'
 
@@ -44,7 +48,7 @@ describe('ScreenshotUploader Vue component', () => {
 
   })
 
-  xdescribe('computed properties', () => {
+  describe('computed properties', () => {
 
     it('maxFiles returns the the number of screenshots remaining for upload', () => {
       const wrapper = shallow(ScreenshotUploader, {

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -1,0 +1,73 @@
+import { shallow, createLocalVue } from '@vue/test-utils'
+import VueDragula from 'vue-dragula'
+
+const localVue = createLocalVue()
+localVue.use(VueDragula)
+window.vueDragula = localVue.vueDragula
+
+import ScreenshotUploader from 'components/ScreenshotUploader'
+
+describe('ScreenshotUploader Vue component', () => {
+
+  describe('props', () => {
+
+    it('contains valid sortUrl, screenshotsUrl, and teamId properties', () => {
+      expect(ScreenshotUploader.props).toEqual({
+        sortUrl: {
+          type: String,
+          required: true,
+        },
+
+        screenshotsUrl: {
+          type: String,
+          required: true,
+        },
+
+        teamId: {
+          type: Number,
+          required: true,
+        },
+      })
+    })
+
+  })
+
+  describe('data', () => {
+
+    it('returns an object with the proper initialization', () => {
+      expect(ScreenshotUploader.data()).toEqual({
+        maxAllowed: 6,
+        screenshots: [],
+        uploads: [],
+      })
+    })
+
+  })
+
+  xdescribe('computed properties', () => {
+
+    it('maxFiles returns the the number of screenshots remaining for upload', () => {
+      const wrapper = shallow(ScreenshotUploader, {
+        localVue,
+        propsData: {
+          screenshotsUrl: '/student/screenshots',
+          sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
+          teamId: 1,
+        },
+      })
+
+      for (let i = 1; i <= wrapper.vm.maxAllowed; i += 1) {
+        wrapper.vm.screenshots.push({
+          id: i,
+          src: `https://s3.amazonaws.com/technovation-uploads-dev/${i}.png`,
+          name: null,
+          large_img_url: `https://s3.amazonaws.com/technovation-uploads-dev/large_${i}.png`,
+        })
+
+        expect(wrapper.vm.maxFiles).toEqual(wrapper.vm.maxAllowed - i)
+      }
+    })
+
+  })
+
+})


### PR DESCRIPTION
This is a pretty heavy copy and paste refactor of the screenshot uploading functionality to make it a little more testable. Before, the template was in the `erb` partial for the UI and the component code was in the screenshots.js file. This refactor consolidates the template and Vue instance code into a single component which allows us for simpler, more focused testing. Here is a rundown of all the changed that were implemented:

- Moved screenshots.en.html.erb template into ScreenshotUploader.vue
- Moved the Vue instance code in screenshots.js into ScreenshotUploader.vue
- Moved data attributes that populate `data-sort-url`, `data-url`, and `data-team-id` to the properties on ScreenshotUploader
- Moved the Vue.vueDragula event bus to the global scope so that it can be used in the component. This may need to be looked at for improvements as it is only used within the component, but requires setup outside of it to get the directive to work as far as I can see. I made a note to come back to this.
- Created tests to begin testing the functionality.

**Important Note:** I did not write the tests before the refactor. I took two full hours last night after work to manually test against QA. This isn't ideal, but I felt that testing with the template and instance separate comes with its own issues. We can discuss any of this if you find it problematic. I figured I would get this in front of a set of eyes quickly to see if this workflow is appropriate for these cases where components are spread out.

Thanks! :)