### PR TITLE
Rename axios mock request to mock response

### DIFF
--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,5 +1,5 @@
 export default {
-  mockRequest (method, returnData, opts) {
+  mockResponse (method, returnData, opts) {
     const options = Object.assign({}, opts)
 
     const promiseState = options.reject ? 'reject' : 'resolve'

--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -14,6 +14,11 @@ export default {
     })
   },
 
+  mockResponseOnce (method, returnData, opts) {
+    const options = Object.assign({}, opts, { once: true })
+    this.mockResponse(method, returnData, options)
+  },
+
   get: jest.fn((url) => {
     return Promise.resolve({
       data: {}

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -61,7 +61,7 @@ describe('axios mock', () => {
     })
   })
 
-  describe('axios.mockResponse', () => {
+  describe('axios.mockResponseOnce', () => {
     it('mocks responses once', (done) => {
       axios.mockResponse('get', { resolved: 'always' })
       axios.mockResponseOnce('get', { resolved: 'once' })

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -60,4 +60,22 @@ describe('axios mock', () => {
       })
     })
   })
+
+  describe('axios.mockResponse', () => {
+    it('mocks responses once', (done) => {
+      axios.mockResponse('get', { resolved: 'always' })
+      axios.mockResponseOnce('get', { resolved: 'once' })
+
+      axios.get('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { resolved: 'once' } })
+      })
+
+      axios.get('/test/url').then((response) => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { resolved: 'always' } })
+        done()
+      })
+    })
+  })
 })

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -1,9 +1,9 @@
 import axios from 'axios'
 
 describe('axios mock', () => {
-  describe('axios.mockRequest', () => {
+  describe('axios.mockResponse', () => {
     it('mocks get implementations with resolve by default', (done) => {
-      axios.mockRequest('get', { myField: 'myValue' })
+      axios.mockResponse('get', { myField: 'myValue' })
 
       axios.get('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
@@ -13,7 +13,7 @@ describe('axios mock', () => {
     })
 
     it('mocks post implementations with resolve by default', (done) => {
-      axios.mockRequest('post', { some: 'value' })
+      axios.mockResponse('post', { some: 'value' })
 
       axios.post('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
@@ -23,7 +23,7 @@ describe('axios mock', () => {
     })
 
     it('mocks implementations with a reject by option', (done) => {
-      axios.mockRequest('post', { rejected: 'value' }, { reject: true })
+      axios.mockResponse('post', { rejected: 'value' }, { reject: true })
 
       axios.post('/test/url').catch((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
@@ -33,8 +33,8 @@ describe('axios mock', () => {
     })
 
     it('mocks implementations once with an option', (done) => {
-      axios.mockRequest('post', { always: 'resolved' })
-      axios.mockRequest('post', { resolved: 'once' }, { once: true })
+      axios.mockResponse('post', { always: 'resolved' })
+      axios.mockResponse('post', { resolved: 'once' }, { once: true })
 
       axios.post('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -1,28 +1,17 @@
 import { shallow } from '@vue/test-utils'
 
-import axiosMock from 'axios'
+import axios from 'axios'
 import Icon from 'components/Icon'
 import CertificateButton from 'components/CertificateButton'
 
 describe('CertificateButton Vue component', () => {
-  axiosMock.post.mockImplementation(() => {
-    return Promise.resolve({
-      data: { jobId: 5 },
-    })
-  })
+  axios.mockResponse('post', { jobId: 5 })
 
-  axiosMock.get.mockImplementation(() => {
-    return Promise.resolve({
-      data: {
-        status: 'complete',
-        payload: {},
-      },
-    })
-  })
+  axios.mockResponse('get', { status: 'complete', payload: {} })
 
   beforeEach(() => {
-    axiosMock.post.mockClear()
-    axiosMock.get.mockClear()
+    axios.post.mockClear()
+    axios.get.mockClear()
   })
 
   describe('props', () => {
@@ -99,16 +88,18 @@ describe('CertificateButton Vue component', () => {
 
     it('displays a link to the certificate if the certificate button URL ' +
         'has finished being generated', (done) => {
-      axiosMock.post.mockImplementationOnce(() => {
-        return Promise.resolve({
-          data: {
-            status: "complete",
-            payload: {
-              fileUrl: "some/test/url",
-            },
+      axios.mockResponse(
+       'post',
+       {
+          status: "complete",
+          payload: {
+            fileUrl: "some/test/url",
           },
-        })
-      })
+        },
+        {
+          once: true,
+        }
+      )
 
       const wrapper = shallow(CertificateButton, {
         propsData: {
@@ -156,13 +147,13 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axiosMock.post.mockClear()
+        axios.post.mockClear()
 
-        expect(axiosMock.post).not.toHaveBeenCalled()
+        expect(axios.post).not.toHaveBeenCalled()
 
         wrapper.vm.requestCertificate()
 
-        expect(axiosMock.post).toHaveBeenCalledWith(
+        expect(axios.post).toHaveBeenCalledWith(
           '/mentor/certificates/',
           { team_id: 42892 },
         )
@@ -247,15 +238,15 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axiosMock.get.mockClear()
+        axios.get.mockClear()
 
-        expect(axiosMock.get).not.toHaveBeenCalled()
+        expect(axios.get).not.toHaveBeenCalled()
 
         wrapper.vm.jobId = 6
 
         wrapper.vm.pollJobQueue()
 
-        expect(axiosMock.get).toHaveBeenCalledWith('/mentor/job_statuses/6')
+        expect(axios.get).toHaveBeenCalledWith('/mentor/job_statuses/6')
       })
 
       it('returns early if the state is already ready', () => {
@@ -265,15 +256,15 @@ describe('CertificateButton Vue component', () => {
           },
         })
 
-        axiosMock.get.mockClear()
+        axios.get.mockClear()
 
-        expect(axiosMock.get).not.toHaveBeenCalled()
+        expect(axios.get).not.toHaveBeenCalled()
 
         wrapper.vm.state = 'ready'
 
         wrapper.vm.pollJobQueue()
 
-        expect(axiosMock.get).not.toHaveBeenCalled()
+        expect(axios.get).not.toHaveBeenCalled()
       })
     })
 

--- a/spec/javascript/components/CertificateButton.spec.js
+++ b/spec/javascript/components/CertificateButton.spec.js
@@ -88,16 +88,12 @@ describe('CertificateButton Vue component', () => {
 
     it('displays a link to the certificate if the certificate button URL ' +
         'has finished being generated', (done) => {
-      axios.mockResponse(
-       'post',
+      axios.mockResponseOnce('post',
        {
           status: "complete",
           payload: {
             fileUrl: "some/test/url",
           },
-        },
-        {
-          once: true,
         }
       )
 


### PR DESCRIPTION
Adds:

* Convenience function `mockResponseOnce`

Renames:

* `axios.mockRequest` to `axios.mockResponse`

Changes:

* Usage of axios mock in `CertificateButton.spec.js`