### PR TITLE
Screenshots tests before refactor

### DIFF
--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -62,6 +62,14 @@
 export default {
   name: 'screenshot-uploader',
 
+  data () {
+    return {
+      maxAllowed: 6,
+      screenshots: [],
+      uploads: [],
+    }
+  },
+
   props: {
     sortUrl: {
       type: String,
@@ -79,12 +87,54 @@ export default {
     },
   },
 
-  data () {
-    return {
-      maxAllowed: 6,
-      screenshots: [],
-      uploads: [],
-    }
+  mounted () {
+    var vm = this;
+
+    $.ajax({
+      method: "GET",
+      url: this.screenshotsUrl + "?team_id=" + this.teamId,
+      success: function(data) {
+        vm.screenshots = data;
+      },
+    });
+
+    window.vueDragula.eventBus.$on('drop', (args) => {
+      var dropped = args[1],
+          list = args[2];
+
+      var url = this.sortUrl,
+          items = $(list).find(".sortable-list__item"),
+          form = new FormData();
+
+      [].forEach.call(items, (item) => {
+        form.append(
+          "team_submission[screenshots][]",
+          $(item).data("db-id")
+        );
+      });
+
+      form.append("team_id", this.teamId);
+
+      $.ajax({
+        method: "PATCH",
+        url: url,
+        data: form,
+        contentType: false,
+        processData: false,
+        success: function() {
+          if (window.timeout) {
+            clearTimeout(window.timeout);
+            window.timeout = null;
+          }
+
+          $(dropped).addClass("sortable-list--updated");
+
+          window.timeout = setTimeout(function () {
+            $(dropped).removeClass("sortable-list--updated");
+          }, 100);
+        },
+      });
+    });
   },
 
   computed: {
@@ -167,56 +217,6 @@ export default {
         });
       });
     },
-  },
-
-  mounted () {
-    var vm = this;
-
-    $.ajax({
-      method: "GET",
-      url: this.screenshotsUrl + "?team_id=" + this.teamId,
-      success: function(data) {
-        vm.screenshots = data;
-      },
-    });
-
-    window.vueDragula.eventBus.$on('drop', (args) => {
-      var dropped = args[1],
-          list = args[2];
-
-      var url = this.sortUrl,
-          items = $(list).find(".sortable-list__item"),
-          form = new FormData();
-
-      [].forEach.call(items, (item) => {
-        form.append(
-          "team_submission[screenshots][]",
-          $(item).data("db-id")
-        );
-      });
-
-      form.append("team_id", this.teamId);
-
-      $.ajax({
-        method: "PATCH",
-        url: url,
-        data: form,
-        contentType: false,
-        processData: false,
-        success: function() {
-          if (window.timeout) {
-            clearTimeout(window.timeout);
-            window.timeout = null;
-          }
-
-          $(dropped).addClass("sortable-list--updated");
-
-          window.timeout = setTimeout(function () {
-            $(dropped).removeClass("sortable-list--updated");
-          }, 100);
-        },
-      });
-    });
   },
 }
 </script>

--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -89,15 +89,15 @@ export default {
 
   computed: {
     maxFiles () {
-      return this.maxAllowed - this.screenshots.length;
+      return this.maxAllowed - this.screenshots.length
     },
 
     object () {
-      return this.maxFiles != 1 ? "screenshots" : "screenshot";
+      return this.maxFiles > 1 ? "screenshots" : "screenshot"
     },
 
     prefix () {
-      return this.maxFiles != 1 ? "up to" : "";
+      return this.maxFiles > 1 ? "up to" : ""
     },
   },
 

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -81,16 +81,97 @@ describe('ScreenshotUploader Vue component', () => {
 
   })
 
-  describe('data', () => {
+  describe('mounted lifecycle hook', () => {
 
-    it('returns an object with the proper initialization', () => {
-      expect(ScreenshotUploader.data()).toEqual({
-        maxAllowed: 6,
-        screenshots: [],
-        uploads: [],
-      })
+    beforeAll(() => {
+      jest.useFakeTimers()
     })
 
+    it('loads the previously saved screenshots via AJAX', () => {
+      expect($.ajax).not.toHaveBeenCalled()
+
+      wrapper = shallow(ScreenshotUploader, {
+        localVue,
+        propsData: {
+          screenshotsUrl: '/student/screenshots',
+          sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
+          teamId: 1,
+        },
+      })
+
+      expect($.ajax).toHaveBeenCalledWith({
+        method: 'GET',
+        url: `${wrapper.vm.screenshotsUrl}?team_id=${wrapper.vm.teamId}`,
+        success: expect.any(Function),
+      })
+
+      // Mock the success callback for the AJAX request
+      $.ajax.mock.calls[0][0].success([
+        screenshot,
+        screenshotTwo,
+      ])
+
+      expect(wrapper.vm.screenshots).toEqual([
+        screenshot,
+        screenshotTwo,
+      ])
+    })
+
+    // TODO - Refactor this test into much smaller pieces
+    // First we need to refactor the code into smaller chunks and make sure
+    // this test doesn't break.
+    it('sets up VueDragula drop event handler', (done) => {
+      wrapper.vm.screenshots.push(screenshot)
+      wrapper.vm.screenshots.push(screenshotTwo)
+
+      wrapper.vm.$nextTick(() => {
+        const vueDragulaArgs = [
+          'globalBag',
+          wrapper.find('li.sortable-list__item.draggable:first-child').element,
+          wrapper.find('ol#sortable-list.sortable-list.submission-pieces__screenshots').element,
+          wrapper.find('ol#sortable-list.sortable-list.submission-pieces__screenshots').element,
+          wrapper.find('li.sortable-list__item.draggable:last-child').element,
+        ]
+
+        window.vueDragula.eventBus.$emit('drop', vueDragulaArgs)
+
+        wrapper.vm.$nextTick(() => {
+          const form = new FormData()
+
+          form.append(
+            'team_submission[screenshots][]',
+            vueDragulaArgs[1].dataset.dbId
+          )
+
+          form.append(
+            'team_submission[screenshots][]',
+            vueDragulaArgs[4].dataset.dbId
+          )
+
+          form.append('team_id', wrapper.vm.teamId);
+
+          expect($.ajax).toHaveBeenCalledWith({
+            method: 'PATCH',
+            url: wrapper.vm.sortUrl,
+            data: form,
+            contentType: false,
+            processData: false,
+            success: expect.any(Function),
+          })
+
+          $.ajax.mock.calls[0][0].success()
+
+          expect(vueDragulaArgs[1].classList).toContain('sortable-list--updated')
+
+          jest.advanceTimersByTime(1000)
+
+          expect(vueDragulaArgs[1].classList).not.toContain('sortable-list--updated')
+
+          done()
+        })
+
+      })
+    })
   })
 
   describe('computed properties', () => {

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -28,6 +28,8 @@ describe('ScreenshotUploader Vue component', () => {
         teamId: 1,
       },
     })
+
+    $.ajax.mockClear()
   })
 
   describe('props', () => {

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -17,6 +17,20 @@ import ScreenshotUploader from 'components/ScreenshotUploader'
 
 describe('ScreenshotUploader Vue component', () => {
 
+  const screenshot = {
+    id: 1,
+    src: 'https://s3.amazonaws.com/technovation-uploads-dev/1.png',
+    name: null,
+    large_img_url: 'https://s3.amazonaws.com/technovation-uploads-dev/large_1.png',
+  }
+
+  const screenshotTwo = {
+    id: 2,
+    src: 'https://s3.amazonaws.com/technovation-uploads-dev/2.png',
+    name: null,
+    large_img_url: 'https://s3.amazonaws.com/technovation-uploads-dev/large_2.png',
+  }
+
   let wrapper
 
   beforeEach(() => {

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -46,6 +46,18 @@ describe('ScreenshotUploader Vue component', () => {
     $.ajax.mockClear()
   })
 
+  describe('data', () => {
+
+    it('returns an object with the proper initialization', () => {
+      expect(ScreenshotUploader.data()).toEqual({
+        maxAllowed: 6,
+        screenshots: [],
+        uploads: [],
+      })
+    })
+
+  })
+
   describe('props', () => {
 
     it('contains valid sortUrl, screenshotsUrl, and teamId properties', () => {
@@ -157,20 +169,6 @@ describe('ScreenshotUploader Vue component', () => {
   })
 
   describe('methods', () => {
-
-    const screenshot = {
-      id: 1,
-      src: 'https://s3.amazonaws.com/technovation-uploads-dev/1.png',
-      name: null,
-      large_img_url: 'https://s3.amazonaws.com/technovation-uploads-dev/large_1.png',
-    }
-
-    const screenshotTwo = {
-      id: 2,
-      src: 'https://s3.amazonaws.com/technovation-uploads-dev/2.png',
-      name: null,
-      large_img_url: 'https://s3.amazonaws.com/technovation-uploads-dev/large_2.png',
-    }
 
     describe('removeScreenshot', () => {
 

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -13,6 +13,19 @@ import ScreenshotUploader from 'components/ScreenshotUploader'
 
 describe('ScreenshotUploader Vue component', () => {
 
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallow(ScreenshotUploader, {
+      localVue,
+      propsData: {
+        screenshotsUrl: '/student/screenshots',
+        sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
+        teamId: 1,
+      },
+    })
+  })
+
   describe('props', () => {
 
     it('contains valid sortUrl, screenshotsUrl, and teamId properties', () => {
@@ -50,26 +63,75 @@ describe('ScreenshotUploader Vue component', () => {
 
   describe('computed properties', () => {
 
-    it('maxFiles returns the the number of screenshots remaining for upload', () => {
-      const wrapper = shallow(ScreenshotUploader, {
-        localVue,
-        propsData: {
-          screenshotsUrl: '/student/screenshots',
-          sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
-          teamId: 1,
-        },
+    describe('maxFiles', () => {
+
+      it('returns the the number of screenshots remaining for upload', () => {
+        for (let i = 1; i <= wrapper.vm.maxAllowed; i += 1) {
+          wrapper.vm.screenshots.push({
+            id: i,
+            src: `https://s3.amazonaws.com/technovation-uploads-dev/${i}.png`,
+            name: null,
+            large_img_url: `https://s3.amazonaws.com/technovation-uploads-dev/large_${i}.png`,
+          })
+
+          expect(wrapper.vm.maxFiles).toEqual(wrapper.vm.maxAllowed - i)
+        }
       })
 
-      for (let i = 1; i <= wrapper.vm.maxAllowed; i += 1) {
-        wrapper.vm.screenshots.push({
-          id: i,
-          src: `https://s3.amazonaws.com/technovation-uploads-dev/${i}.png`,
-          name: null,
-          large_img_url: `https://s3.amazonaws.com/technovation-uploads-dev/large_${i}.png`,
+    })
+
+    describe('object', () => {
+
+      it('returns "screenshots" if more than one file upload remains', () => {
+        expect(wrapper.vm.maxFiles).toBeGreaterThan(1)
+        expect(wrapper.vm.object).toEqual('screenshots')
+      })
+
+      it('returns "screenshot" if only one file upload remains', () => {
+        wrapper = shallow(ScreenshotUploader, {
+          localVue,
+          propsData: {
+            screenshotsUrl: '/student/screenshots',
+            sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
+            teamId: 1,
+          },
+          computed: {
+            maxFiles () {
+              return 1
+            },
+          },
         })
 
-        expect(wrapper.vm.maxFiles).toEqual(wrapper.vm.maxAllowed - i)
-      }
+        expect(wrapper.vm.object).toEqual('screenshot')
+      })
+
+    })
+
+    describe('prefix', () => {
+
+      it('returns "up to" if more than one file upload remains', () => {
+        expect(wrapper.vm.maxFiles).toBeGreaterThan(1)
+        expect(wrapper.vm.prefix).toEqual('up to')
+      })
+
+      it('returns "" if only one file upload remains', () => {
+        wrapper = shallow(ScreenshotUploader, {
+          localVue,
+          propsData: {
+            screenshotsUrl: '/student/screenshots',
+            sortUrl: '/student/team_submissions/no-name-yet-by-all-star-team',
+            teamId: 1,
+          },
+          computed: {
+            maxFiles () {
+              return 1
+            },
+          },
+        })
+
+        expect(wrapper.vm.prefix).toEqual('')
+      })
+
     })
 
   })

--- a/spec/javascript/submissions/screenshots.spec.js
+++ b/spec/javascript/submissions/screenshots.spec.js
@@ -181,10 +181,10 @@ describe('ScreenshotUploader Vue component', () => {
         wrapper.vm.removeScreenshot(screenshot)
 
         expect(swal).toHaveBeenCalledWith({
-          text: "Are you sure you want to delete the screenshot?",
-          cancelButtonText: "No, go back",
-          confirmButtonText: "Yes, delete it",
-          confirmButtonColor: "#D8000C",
+          text: 'Are you sure you want to delete the screenshot?',
+          cancelButtonText: 'No, go back',
+          confirmButtonText: 'Yes, delete it',
+          confirmButtonColor: '#D8000C',
           showCancelButton: true,
           reverseButtons: true,
           focusCancel: true,
@@ -211,11 +211,11 @@ describe('ScreenshotUploader Vue component', () => {
 
         setImmediate(() => {
           expect($.ajax).toHaveBeenCalledWith({
-            method: "DELETE",
+            method: 'DELETE',
             url: wrapper.vm.screenshotsUrl +
-                  "/" +
+                  '/' +
                   screenshot.id +
-                  "?team_id=" +
+                  '?team_id=' +
                   wrapper.vm.teamId,
           })
           done()


### PR DESCRIPTION
Addresses the following:
- Move `data` and `mounted` sections to match the organization of `CertificateButton`
- Write tests around all remaining functionality

Please note that some of the tests in this file will need to be refactored as I remove jQuery and implement axios. The way I am currently handling the success callbacks is less than ideal, so please keep in mind that the tests will get a lot cleaner as the code itself gets cleaner. I just wanted to get passing coverage before I started the refactor.

The next PR will cover refactoring.