### PR TITLE
Pie Charts Vue Refactor: Part 2

### DIFF
--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -23,27 +23,23 @@
               'With parental permission – <%= show_percentage(@permitted_students, @students) %>',
               'Without parental permission – <%= show_percentage(@unpermitted_students, @students) %>',
             ],
-            datasets: [
-              {
-                data: [
-                  <%= @permitted_students.count %>,
-                  <%= @unpermitted_students.count %>,
-                ],
-                urls: [
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["student"],
-                      parental_consent: "parental_consented",
-                    }
-                  ) %>',
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["student"],
-                      parental_consent: "not_parental_consented",
-                    }
-                  ) %>',
-                ],
-              },
+            data: [
+              <%= @permitted_students.count %>,
+              <%= @unpermitted_students.count %>,
+            ],
+            urls: [
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["student"],
+                  parental_consent: "parental_consented",
+                }
+              ) %>',
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["student"],
+                  parental_consent: "not_parental_consented",
+                }
+              ) %>',
             ],
           }"
         ></pie-chart>
@@ -68,13 +64,9 @@
               'Returning students – <%= show_percentage(@returning_students, @students) %>',
               'New students – <%= show_percentage(@new_students, @students) %>',
             ],
-            datasets: [
-              {
-                data: [
-                  <%= @returning_students.count %>,
-                  <%= @new_students.count %>,
-                ],
-              },
+            data: [
+              <%= @returning_students.count %>,
+              <%= @new_students.count %>,
             ],
           }"
         ></pie-chart>
@@ -106,45 +98,41 @@
               'Only cleared bg check, if required – <%= show_percentage(@cleared_bg_check_mentors, @mentors) %>',
               'Have done neither – <%= show_percentage(@neither_mentors, @mentors) %>',
             ],
-            datasets: [
-              {
-                data: [
-                  <%= @cleared_mentors.count %>,
-                  <%= @signed_consent_mentors.count %>,
-                  <%= @cleared_bg_check_mentors.count %>,
-                  <%= @neither_mentors.count %>,
-                ],
-                urls: [
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["mentor"],
-                      background_check: "bg_check_clear",
-                      consent_waiver: "consent_signed",
-                    }
-                  ) %>',
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["mentor"],
-                      background_check: "bg_check_submitted",
-                      consent_waiver: "consent_signed",
-                    }
-                  ) %>',
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["mentor"],
-                      background_check: "bg_check_clear",
-                      consent_waiver: "consent_not_signed",
-                    }
-                  ) %>',
-                  '<%= admin_participants_path(
-                    accounts_grid: {
-                      scope_names: ["mentor"],
-                      background_check: "bg_check_unsubmitted",
-                      consent_waiver: "consent_not_signed",
-                    }
-                  ) %>',
-                ],
-              },
+            data: [
+              <%= @cleared_mentors.count %>,
+              <%= @signed_consent_mentors.count %>,
+              <%= @cleared_bg_check_mentors.count %>,
+              <%= @neither_mentors.count %>,
+            ],
+            urls: [
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["mentor"],
+                  background_check: "bg_check_clear",
+                  consent_waiver: "consent_signed",
+                }
+              ) %>',
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["mentor"],
+                  background_check: "bg_check_submitted",
+                  consent_waiver: "consent_signed",
+                }
+              ) %>',
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["mentor"],
+                  background_check: "bg_check_clear",
+                  consent_waiver: "consent_not_signed",
+                }
+              ) %>',
+              '<%= admin_participants_path(
+                accounts_grid: {
+                  scope_names: ["mentor"],
+                  background_check: "bg_check_unsubmitted",
+                  consent_waiver: "consent_not_signed",
+                }
+              ) %>',
             ],
           }"
           :color-range="{
@@ -169,13 +157,9 @@
               'Returning mentors – <%= show_percentage(@returning_mentors, @mentors) %>',
               'New mentors – <%= show_percentage(@new_mentors, @mentors) %>',
             ],
-            datasets: [
-              {
-                data: [
-                  <%= @returning_mentors.count %>,
-                  <%= @new_mentors.count %>,
-                ],
-              },
+            data: [
+              <%= @returning_mentors.count %>,
+              <%= @new_mentors.count %>,
             ],
           }"
           :color-range="{

--- a/app/views/regional_ambassador/dashboards/_quick_view.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/_quick_view.en.html.erb
@@ -38,27 +38,23 @@
             'With parental permission – <%= show_percentage(@permitted_students, @students) %>',
             'Without parental permission – <%= show_percentage(@unpermitted_students, @students) %>',
           ],
-          datasets: [
-            {
-              data: [
-                <%= @permitted_students.count %>,
-                <%= @unpermitted_students.count %>,
-              ],
-              urls: [
-                '<%= regional_ambassador_participants_path(
-                  accounts_grid: {
-                    scope_names: ["student"],
-                    parental_consent: "parental_consented",
-                  }
-                ) %>',
-                '<%= regional_ambassador_participants_path(
-                  accounts_grid: {
-                    scope_names: ["student"],
-                    parental_consent: "not_parental_consented",
-                  }
-                ) %>',
-              ]
-            },
+          data: [
+            <%= @permitted_students.count %>,
+            <%= @unpermitted_students.count %>,
+          ],
+          urls: [
+            '<%= regional_ambassador_participants_path(
+              accounts_grid: {
+                scope_names: ["student"],
+                parental_consent: "parental_consented",
+              }
+            ) %>',
+            '<%= regional_ambassador_participants_path(
+              accounts_grid: {
+                scope_names: ["student"],
+                parental_consent: "not_parental_consented",
+              }
+            ) %>',
           ],
         }"
       ></pie-chart>
@@ -83,13 +79,9 @@
             'Returning students – <%= show_percentage(@returning_students, @students) %>',
             'New students – <%= show_percentage(@new_students, @students) %>',
           ],
-          datasets: [
-            {
-              data: [
-                <%= @returning_students.count %>,
-                <%= @new_students.count %>,
-              ],
-            },
+          data: [
+            <%= @returning_students.count %>,
+            <%= @new_students.count %>,
           ],
         }"
       ></pie-chart>
@@ -134,13 +126,9 @@
             'Returning mentors – <%= show_percentage(@returning_mentors, @mentors) %>',
             'New mentors – <%= show_percentage(@new_mentors, @mentors) %>',
           ],
-          datasets: [
-            {
-              data: [
-                <%= @returning_mentors.count %>,
-                <%= @new_mentors.count %>,
-              ],
-            },
+          data: [
+            <%= @returning_mentors.count %>,
+            <%= @new_mentors.count %>,
           ],
         }"
       ></pie-chart>

--- a/app/views/regional_ambassador/dashboards/quick_view/_international_mentors.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/quick_view/_international_mentors.en.html.erb
@@ -15,27 +15,23 @@
         'Signed consent – <%= show_percentage(@consenting_mentors, @mentors) %>',
         'Has not signed – <%= show_percentage(@unconsenting_mentors, @mentors) %>',
       ],
-      datasets: [
-        {
-          data: [
-            <%= @consenting_mentors.count %>,
-            <%= @unconsenting_mentors.count %>,
-          ],
-          urls: [
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                consent_waiver: "consent_signed",
-              }
-            ) %>',
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                consent_waiver: "consent_not_signed",
-              }
-            ) %>',
-          ],
-        },
+      data: [
+        <%= @consenting_mentors.count %>,
+        <%= @unconsenting_mentors.count %>,
+      ],
+      urls: [
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            consent_waiver: "consent_signed",
+          }
+        ) %>',
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            consent_waiver: "consent_not_signed",
+          }
+        ) %>',
       ],
     }"
   ></pie-chart>

--- a/app/views/regional_ambassador/dashboards/quick_view/_us_mentors.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/quick_view/_us_mentors.en.html.erb
@@ -17,45 +17,41 @@
         'Only cleared bg check – <%= show_percentage(@cleared_bg_check_mentors, @mentors) %>',
         'Have done neither – <%= show_percentage(@neither_mentors, @mentors) %>',
       ],
-      datasets: [
-        {
-          data: [
-            <%= @cleared_mentors.count %>,
-            <%= @signed_consent_mentors.count %>,
-            <%= @cleared_bg_check_mentors.count %>,
-            <%= @neither_mentors.count %>,
-          ],
-          urls: [
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                background_check: "bg_check_clear",
-                consent_waiver: "consent_signed",
-              }
-            ) %>',
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                background_check: "bg_check_submitted",
-                consent_waiver: "consent_signed",
-              }
-            ) %>',
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                background_check: "bg_check_clear",
-                consent_waiver: "consent_not_signed",
-              }
-            ) %>',
-            '<%= regional_ambassador_participants_path(
-              accounts_grid: {
-                scope_names: ["mentor"],
-                background_check: "bg_check_unsubmitted",
-                consent_waiver: "consent_not_signed",
-              }
-            ) %>',
-          ],
-        },
+      data: [
+        <%= @cleared_mentors.count %>,
+        <%= @signed_consent_mentors.count %>,
+        <%= @cleared_bg_check_mentors.count %>,
+        <%= @neither_mentors.count %>,
+      ],
+      urls: [
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            background_check: "bg_check_clear",
+            consent_waiver: "consent_signed",
+          }
+        ) %>',
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            background_check: "bg_check_submitted",
+            consent_waiver: "consent_signed",
+          }
+        ) %>',
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            background_check: "bg_check_clear",
+            consent_waiver: "consent_not_signed",
+          }
+        ) %>',
+        '<%= regional_ambassador_participants_path(
+          accounts_grid: {
+            scope_names: ["mentor"],
+            background_check: "bg_check_unsubmitted",
+            consent_waiver: "consent_not_signed",
+          }
+        ) %>',
       ],
     }"
   ></pie-chart>

--- a/spec/javascript/components/PieChart.spec.js
+++ b/spec/javascript/components/PieChart.spec.js
@@ -139,11 +139,6 @@ describe('PieChart Vue component', () => {
       })
 
       it('returns false if optional urls property is not an array', () => {
-        expect(PieChart.props.chartData.validator(dataWithInvalidLabels))
-          .toBe(false)
-      })
-
-      it('requires optional urls property to be an array', () => {
         expect(PieChart.props.chartData.validator(labelsAndDataWithInvalidUrls))
           .toBe(false)
       })

--- a/spec/javascript/components/PieChart.spec.js
+++ b/spec/javascript/components/PieChart.spec.js
@@ -1,4 +1,5 @@
 import { shallow } from '@vue/test-utils'
+import axios from 'axios'
 
 import PieChart from 'components/PieChart'
 
@@ -11,19 +12,26 @@ describe('PieChart Vue component', () => {
       'With parental permission – (75%)',
       'Without parental permission – (25%)',
     ],
-    datasets: [
-      {
-        data: [
-          3,
-          1,
-        ],
-        urls: [
-          '/with/parental/permission',
-          '/without/parental/permission',
-        ],
-      },
+    data: [
+      3,
+      1,
+    ],
+    urls: [
+      '/with/parental/permission',
+      '/without/parental/permission',
     ],
   }
+
+  const extendedChartData = Object.assign({}, chartData, {
+    backgroundColor: [
+      "rgba(250,250,110,0.7)",
+      "rgba(42,72,88,0.7)",
+    ],
+    hoverBackgroundColor: [
+      "rgba(250,250,110,1)",
+      "rgba(42,72,88,1)",
+    ],
+  })
 
   let wrapper
 
@@ -45,17 +53,18 @@ describe('PieChart Vue component', () => {
       expect(PieChart.props).toEqual({
         chartData: {
           type: Object,
-          required: true,
+          default: expect.any(Function),
+          validator: expect.any(Function),
         },
 
         chartClasses: {
           type: Object,
-          default: expect.any(Function)
+          default: expect.any(Function),
         },
 
         colorRange: {
           type: Object,
-          default: expect.any(Function)
+          default: expect.any(Function),
         },
 
         url: {
@@ -63,6 +72,82 @@ describe('PieChart Vue component', () => {
           default: '',
         },
       })
+    })
+
+    describe('chartData', () => {
+      const labels = [ 'One', 'Two' ]
+      const data = [ 1, 3 ]
+      const urls = [ '/url/one', '/url/two' ]
+
+      const invalidLabels = 'string'
+      const invalidData = 'string'
+      const invalidUrls = 'string'
+
+      const dataWithoutLabels = { data, urls }
+      const labelsWithoutData = { labels, urls }
+      const labelsAndDataWithoutUrls = { labels, data }
+
+      const dataWithInvalidLabels = {
+        data,
+        urls,
+        labels: invalidLabels,
+      }
+
+      const labelsWithInvalidData = {
+        labels,
+        urls,
+        data: invalidData,
+      }
+
+      const labelsAndDataWithInvalidUrls = {
+        labels,
+        data,
+        urls: invalidUrls,
+      }
+
+      it('returns true if it is an empty object (needed for default value)', () => {
+        expect(PieChart.props.chartData.validator({})).toBe(true)
+      })
+
+      it('returns true if label, data, and url props are present and arrays', () => {
+        expect(PieChart.props.chartData.validator(chartData)).toBe(true)
+      })
+
+      it('returns true if label and data props are present and arrays', () => {
+        expect(PieChart.props.chartData.validator(labelsAndDataWithoutUrls))
+          .toBe(true)
+      })
+
+      it('returns false if data is array and labels is not present', () => {
+        expect(PieChart.props.chartData.validator(dataWithoutLabels))
+          .toBe(false)
+      })
+
+      it('returns false if labels is array and data is not present', () => {
+        expect(PieChart.props.chartData.validator(labelsWithoutData))
+          .toBe(false)
+      })
+
+      it('returns false if labels is array and data is not an array', () => {
+        expect(PieChart.props.chartData.validator(labelsWithInvalidData))
+          .toBe(false)
+      })
+
+      it('returns false if data is array and labels is not an array', () => {
+        expect(PieChart.props.chartData.validator(dataWithInvalidLabels))
+          .toBe(false)
+      })
+
+      it('returns false if optional urls property is not an array', () => {
+        expect(PieChart.props.chartData.validator(dataWithInvalidLabels))
+          .toBe(false)
+      })
+
+      it('requires optional urls property to be an array', () => {
+        expect(PieChart.props.chartData.validator(labelsAndDataWithInvalidUrls))
+          .toBe(false)
+      })
+
     })
 
     describe('chartClasses', () => {
@@ -92,7 +177,59 @@ describe('PieChart Vue component', () => {
       expect(PieChart.data()).toEqual({
         chart: null,
         loading: true,
-        mutableChartData: {},
+        extendedChartData: {},
+      })
+    })
+
+  })
+
+  describe('mounted hook', () => {
+    beforeEach(() => {
+      axios.get.mockClear()
+      axios.mockResponseOnce('get', chartData)
+    })
+
+    it('loads the chart data via AJAX if chartData prop is empty and url is present', (done) => {
+      expect(axios.get).not.toHaveBeenCalled()
+
+      wrapper = shallow(PieChart, {
+        propsData: {
+          url: '/test/url',
+          colorRange: {
+            start: '#fafa6e',
+            end: '#2A4858',
+          },
+        },
+      })
+
+      wrapper.vm.$nextTick(() => {
+        expect(axios.get).toHaveBeenCalledWith('/test/url')
+        expect(wrapper.vm.extendedChartData).toEqual(
+          expect.objectContaining(extendedChartData)
+        )
+        done()
+      })
+    })
+
+    it('loads the chart data from chartData prop if url is not present', (done) => {
+      expect(axios.get).not.toHaveBeenCalled()
+
+      wrapper = shallow(PieChart, {
+        propsData: {
+          chartData,
+          colorRange: {
+            start: '#fafa6e',
+            end: '#2A4858',
+          },
+        },
+      })
+
+      wrapper.vm.$nextTick(() => {
+        expect(axios.get).not.toHaveBeenCalled()
+        expect(wrapper.vm.extendedChartData).toEqual(
+          expect.objectContaining(extendedChartData)
+        )
+        done()
       })
     })
 
@@ -112,45 +249,40 @@ describe('PieChart Vue component', () => {
         expect(chartDestroySpy).toHaveBeenCalledTimes(1)
       })
 
-      it('sets the mutableChartData by extending the chartData prop', () => {
-        expect(wrapper.vm.mutableChartData).toEqual({
-          labels: [
-            'With parental permission – (75%)',
-            'Without parental permission – (25%)',
-          ],
-          datasets: [
-            expect.objectContaining({
-              backgroundColor: [
-                "rgba(250,250,110,0.7)",
-                "rgba(42,72,88,0.7)",
-              ],
-              data: [
-                3,
-                1,
-              ],
-              hoverBackgroundColor: [
-                "rgba(250,250,110,1)",
-                "rgba(42,72,88,1)",
-              ],
-              urls: [
-                '/with/parental/permission',
-                '/without/parental/permission',
-              ],
-            })
-          ],
-        })
+      it('sets the extendedChartData by extending the chartData prop', () => {
+        expect(wrapper.vm.extendedChartData).toEqual(
+          expect.objectContaining(extendedChartData)
+        )
       })
 
       it('creates a chart.js instance with the correct settings', () => {
         const chartElement = wrapper.find('canvas').element
         const chartContext = chartElement.getContext('2d')
 
+        const {
+          labels,
+          data,
+          backgroundColor,
+          hoverBackgroundColor,
+          urls
+        } = wrapper.vm.extendedChartData
+
         expect(wrapper.vm.chart.canvas).toEqual(chartElement)
         expect(wrapper.vm.chart.ctx).toEqual(chartContext)
         expect(wrapper.vm.chart.config).toEqual(
           expect.objectContaining({
             type: 'pie',
-            data: wrapper.vm.mutableChartData,
+            data: expect.objectContaining({
+              labels,
+              datasets: [
+                expect.objectContaining({
+                  data,
+                  backgroundColor,
+                  hoverBackgroundColor,
+                  urls,
+                })
+              ],
+            }),
             options: expect.objectContaining({
               legend: expect.objectContaining({
                 position: 'bottom',

--- a/spec/javascript/components/PieChart.spec.js
+++ b/spec/javascript/components/PieChart.spec.js
@@ -6,29 +6,31 @@ require('canvas')
 
 describe('PieChart Vue component', () => {
 
+  const chartData = {
+    labels: [
+      'With parental permission – (75%)',
+      'Without parental permission – (25%)',
+    ],
+    datasets: [
+      {
+        data: [
+          3,
+          1,
+        ],
+        urls: [
+          '/with/parental/permission',
+          '/without/parental/permission',
+        ],
+      },
+    ],
+  }
+
   let wrapper
 
   beforeEach(() => {
     wrapper = shallow(PieChart, {
       propsData: {
-        chartData: {
-          labels: [
-            'With parental permission – (75%)',
-            'Without parental permission – (25%)',
-          ],
-          datasets: [
-            {
-              data: [
-                3,
-                1,
-              ],
-              urls: [
-                '/with/parental/permission',
-                '/without/parental/permission',
-              ],
-            },
-          ],
-        },
+        chartData,
         colorRange: {
           start: '#fafa6e',
           end: '#2A4858',
@@ -54,6 +56,11 @@ describe('PieChart Vue component', () => {
         colorRange: {
           type: Object,
           default: expect.any(Function)
+        },
+
+        url: {
+          type: String,
+          default: '',
         },
       })
     })
@@ -84,6 +91,7 @@ describe('PieChart Vue component', () => {
     it('sets the correct initial state', () => {
       expect(PieChart.data()).toEqual({
         chart: null,
+        loading: true,
         mutableChartData: {},
       })
     })
@@ -99,7 +107,7 @@ describe('PieChart Vue component', () => {
 
         expect(chartDestroySpy).not.toHaveBeenCalled()
 
-        wrapper.vm.initializeChart()
+        wrapper.vm.initializeChart(chartData)
 
         expect(chartDestroySpy).toHaveBeenCalledTimes(1)
       })
@@ -177,6 +185,28 @@ describe('PieChart Vue component', () => {
             'rgba(42,72,88,1)',
           ],
         })
+      })
+
+    })
+
+    describe('isEmptyObject', () => {
+
+      it('returns true if object is empty', () => {
+        const object = {}
+
+        const result = wrapper.vm.isEmptyObject(object)
+
+        expect(result).toBe(true)
+      })
+
+      it('returns false if the object is not empty', () => {
+        const object = {
+          key: 'value'
+        }
+
+        const result = wrapper.vm.isEmptyObject(object)
+
+        expect(result).toBe(false)
       })
 
     })


### PR DESCRIPTION
This pull request gives us the ability to load pie charts via AJAX (axios.get). New additions:

- If `url` prop is supplied and `chartData` prop is empty, it will load via AJAX.
- An event is triggered on chart load so that we can store the state and pass it via props for caching purposes in Part 3.
- Added some chartData prop validation for sanity checks when build out new charts later on.
- Had to tweak Rails templates and our JS tests in order to work with the new JSON structure that will be returned via AJAX.

Please note that the loading animation is a work in progress and will change in the next part. Though if you feel it should be changed now, I am willing to do that. Thanks!