### PR TITLE
Admin Dashboard: hideTotals property

### DIFF
--- a/app/javascript/admin/dashboard/components/DashboardSection.vue
+++ b/app/javascript/admin/dashboard/components/DashboardSection.vue
@@ -27,6 +27,11 @@ export default {
         return {}
       },
     },
+
+    hideTotal: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   created () {

--- a/app/javascript/admin/dashboard/components/MentorsSection.vue
+++ b/app/javascript/admin/dashboard/components/MentorsSection.vue
@@ -2,7 +2,7 @@
   <div id="mentors">
     <h3>
       Mentors
-      <span v-if="getTotal('mentors')">
+      <span v-if="getTotal('mentors') && !hideTotal">
         ({{ getTotal('mentors') }})
       </span>
     </h3>

--- a/app/javascript/admin/dashboard/components/StudentsSection.vue
+++ b/app/javascript/admin/dashboard/components/StudentsSection.vue
@@ -2,7 +2,7 @@
   <div id="students">
     <h3>
       Students
-      <span v-if="getTotal('students')">
+      <span v-if="getTotal('students') && !hideTotal">
         ({{ getTotal('students') }})
       </span>
     </h3>

--- a/app/javascript/admin/dashboard/components/TopCountriesSection.vue
+++ b/app/javascript/admin/dashboard/components/TopCountriesSection.vue
@@ -2,7 +2,7 @@
   <div id="top-countries">
     <h3>
       Top Countries
-      <span v-if="getTotal('top_countries')">
+      <span v-if="getTotal('top_countries') && !hideTotal">
         ({{ getTotal('top_countries') }})
       </span>
     </h3>

--- a/app/javascript/admin/dashboard/routes/index.js
+++ b/app/javascript/admin/dashboard/routes/index.js
@@ -5,10 +5,30 @@ import Students from '../components/StudentsSection'
 import TopCountries from '../components/TopCountriesSection'
 
 export const routes = [
-  { path: '/', redirect: { name: 'students' }},
-  { path: '/students', name: 'students', component: Students },
-  { path: '/mentors', name: 'mentors', component: Mentors },
-  { path: '/top_countries', name: 'top_countries', component: TopCountries },
+  {
+    path: '/',
+    redirect: {
+      name: 'students',
+    },
+  },
+  {
+    path: '/students',
+    name: 'students',
+    component: Students,
+  },
+  {
+    path: '/mentors',
+    name: 'mentors',
+    component: Mentors,
+  },
+  {
+    path: '/top_countries',
+    name: 'top_countries',
+    component: TopCountries,
+    props: {
+      hideTotal: true,
+    },
+  },
 ]
 
 export const router = new VueRouter({

--- a/spec/javascript/admin/dashboard/components/DashboardSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/DashboardSection.spec.js
@@ -61,6 +61,11 @@ describe('Admin Dashboard - DashboardSection component', () => {
           type: Object,
           default: expect.any(Function),
         },
+
+        hideTotal: {
+          type: Boolean,
+          default: false,
+        },
       })
     })
 

--- a/spec/javascript/admin/dashboard/components/MentorsSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/MentorsSection.spec.js
@@ -205,6 +205,14 @@ describe('Admin Dashboard - MentorSection component', () => {
       expect(wrapper.find('h3 span').exists()).toBe(false)
     })
 
+    it('hides the mentors count label if the hideTotal prop is true', () => {
+      wrapper.setProps({
+        hideTotal: true,
+      })
+
+      expect(wrapper.find('h3 span').exists()).toBe(false)
+    })
+
     it('changes the label of the onboarding chart if international changes', () => {
       const onboardingChart = wrapper.findAll('.tab-content').at(0)
 

--- a/spec/javascript/admin/dashboard/components/StudentsSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/StudentsSection.spec.js
@@ -184,6 +184,14 @@ describe('Admin Dashboard - StudentsSection component', () => {
       expect(wrapper.find('h3 span').exists()).toBe(false)
     })
 
+    it('hides the students count label if the hideTotal prop is true', () => {
+      wrapper.setProps({
+        hideTotal: true,
+      })
+
+      expect(wrapper.find('h3 span').exists()).toBe(false)
+    })
+
   })
 
 })

--- a/spec/javascript/admin/dashboard/components/TopCountriesSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/TopCountriesSection.spec.js
@@ -119,8 +119,16 @@ describe('Admin Dashboard - TopCountriesSection component', () => {
       expect(wrapper.find(BarChart).exists()).toBe(true)
     })
 
-    it('hides the students count label if the students total is not found', () => {
+    it('hides the top countries count label if the top countries total is not found', () => {
       wrapper.vm.totals = {}
+
+      expect(wrapper.find('h3 span').exists()).toBe(false)
+    })
+
+    it('hides the top countries count label if the hideTotal prop is true', () => {
+      wrapper.setProps({
+        hideTotal: true,
+      })
 
       expect(wrapper.find('h3 span').exists()).toBe(false)
     })

--- a/spec/javascript/admin/dashboard/routes/index.spec.js
+++ b/spec/javascript/admin/dashboard/routes/index.spec.js
@@ -7,10 +7,30 @@ describe('Admin Dashboard - routes', () => {
 
   it('returns the routes used by the AdminDashboard component', () => {
     expect(routes).toEqual([
-      { path: '/', redirect: { name: 'students' }},
-      { path: '/students', name: 'students', component: Students },
-      { path: '/mentors', name: 'mentors', component: Mentors },
-      { path: '/top_countries', name: 'top_countries', component: TopCountries },
+      {
+        path: '/',
+        redirect: {
+          name: 'students',
+        },
+      },
+      {
+        path: '/students',
+        name: 'students',
+        component: Students,
+      },
+      {
+        path: '/mentors',
+        name: 'mentors',
+        component: Mentors,
+      },
+      {
+        path: '/top_countries',
+        name: 'top_countries',
+        component: TopCountries,
+        props: {
+          hideTotal: true,
+        },
+      },
     ])
   })
 


### PR DESCRIPTION
Implements a hideTotals property on the DashboardSection Vue component so that we can hide the totals in our admin dashboard sections where it makes sense, regardless of whether or not the total is present.

Also removes the total count from the Top Countries section in the admin dashboard.