### PR TITLE
Datagrid Table Layout Improvements

### DIFF
--- a/app/assets/stylesheets/_datagrid.scss
+++ b/app/assets/stylesheets/_datagrid.scss
@@ -1,5 +1,15 @@
 .datagrid {
   background: white;
+
+  td.actions,
+  th.actions {
+    right: 0;
+    position: sticky;
+    top: auto;
+    width: 1%;
+    white-space: nowrap;
+    background: white;
+  }
 }
 
 .filter {

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,3 +1,11 @@
+.table--scrollable {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
 .datagrid {
   width: 100%;
   border-collapse: collapse;
@@ -17,6 +25,8 @@
     position: relative;
     text-align: left;
     padding: 0.5rem;
+    width: 1%;
+    white-space: nowrap;
 
     span {
       &:hover {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,8 @@
 import Vue from 'vue/dist/vue.esm'
 import CertificateButton from '../components/CertificateButton'
 
+import '../utilities/jquery-double-scroll'
+
 import '../config/axios'
 
 document.addEventListener('turbolinks:load', () => {
@@ -23,5 +25,10 @@ document.addEventListener('turbolinks:load', () => {
         CertificateButton,
       },
     })
+  })
+
+  // Scrollable datagrid table dual scrollbars
+  $('.table--scrollable').doubleScroll({
+    resetOnWindowResize: true,
   })
 })

--- a/app/javascript/utilities/jquery-double-scroll.js
+++ b/app/javascript/utilities/jquery-double-scroll.js
@@ -1,0 +1,126 @@
+/*
+ * @name DoubleScroll
+ * @desc displays scroll bar on top and on the bottom of the div
+ * @requires jQuery
+ *
+ * @author Pawel Suwala - http://suwala.eu/
+ * @author Antoine Vianey - http://www.astek.fr/
+ * @version 0.5 (11-11-2015)
+ *
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ * Usage:
+ * https://github.com/avianey/jqDoubleScroll
+ */
+(function( $ ) {
+
+  jQuery.fn.doubleScroll = function(userOptions) {
+
+   // Default options
+   var options = {
+     contentElement: undefined, // Widest element, if not specified first child element will be used
+     scrollCss: {
+       'overflow-x': 'auto',
+       'overflow-y': 'hidden'
+     },
+     contentCss: {
+       'overflow-x': 'auto',
+       'overflow-y': 'hidden'
+     },
+     onlyIfScroll: true, // top scrollbar is not shown if the bottom one is not present
+     resetOnWindowResize: false, // recompute the top ScrollBar requirements when the window is resized
+     timeToWaitForResize: 30 // wait for the last update event (usefull when browser fire resize event constantly during ressing)
+   };
+
+   $.extend(true, options, userOptions);
+
+   // do not modify
+   // internal stuff
+   $.extend(options, {
+     topScrollBarMarkup: '<div class="doubleScroll-scroll-wrapper" style="height: 20px;"><div class="doubleScroll-scroll" style="height: 20px;"></div></div>',
+     topScrollBarWrapperSelector: '.doubleScroll-scroll-wrapper',
+     topScrollBarInnerSelector: '.doubleScroll-scroll'
+   });
+
+   var _showScrollBar = function($self, options) {
+
+     if (options.onlyIfScroll && $self.get(0).scrollWidth <= $self.width()) {
+       // content doesn't scroll
+       // remove any existing occurrence...
+       $self.prev(options.topScrollBarWrapperSelector).remove();
+       return;
+     }
+
+     // add div that will act as an upper scroll only if not already added to the DOM
+     var $topScrollBar = $self.prev(options.topScrollBarWrapperSelector);
+
+     if ($topScrollBar.length == 0) {
+
+       // creating the scrollbar
+       // added before in the DOM
+       $topScrollBar = $(options.topScrollBarMarkup);
+       $self.before($topScrollBar);
+
+       // apply the css
+       $topScrollBar.css(options.scrollCss);
+       $self.css(options.contentCss);
+
+       // bind upper scroll to bottom scroll
+       $topScrollBar.bind('scroll.doubleScroll', function() {
+         $self.scrollLeft($topScrollBar.scrollLeft());
+       });
+
+       // bind bottom scroll to upper scroll
+       var selfScrollHandler = function() {
+         $topScrollBar.scrollLeft($self.scrollLeft());
+       };
+       $self.bind('scroll.doubleScroll', selfScrollHandler);
+     }
+
+     // find the content element (should be the widest one)
+     var $contentElement;
+
+     if (options.contentElement !== undefined && $self.find(options.contentElement).length !== 0) {
+       $contentElement = $self.find(options.contentElement);
+     } else {
+       $contentElement = $self.find('>:first-child');
+     }
+
+     // set the width of the wrappers
+     $(options.topScrollBarInnerSelector, $topScrollBar).width($contentElement.outerWidth());
+     $topScrollBar.width($self.width());
+     $topScrollBar.scrollLeft($self.scrollLeft());
+
+   }
+
+   return this.each(function() {
+
+     var $self = $(this);
+
+     _showScrollBar($self, options);
+
+     // bind the resize handler
+     // do it once
+     if (options.resetOnWindowResize) {
+
+       var id;
+       var handler = function(e) {
+         _showScrollBar($self, options);
+       };
+
+       $(window).bind('resize.doubleScroll', function() {
+         // adding/removing/replacing the scrollbar might resize the window
+         // so the resizing flag will avoid the infinite loop here...
+         clearTimeout(id);
+         id = setTimeout(handler, options.timeToWaitForResize);
+       });
+
+     }
+
+   });
+
+ }
+
+}( jQuery ));

--- a/app/views/datagrid/_datagrid.en.html.erb
+++ b/app/views/datagrid/_datagrid.en.html.erb
@@ -30,7 +30,9 @@
     </p>
   <% end %>
 
-  <%= datagrid_table(grid) %>
+  <div class="table--scrollable">
+    <%= datagrid_table(grid) %>
+  </div>
 
   <%= will_paginate grid.assets %>
 </div>


### PR DESCRIPTION
- Datagrid tables that become larger horizontally than the viewing area get scrollbars on the top and bottom so that they don't bleed over.
- The Actions column in the datagrids are now sticky and float to the right when the scrollbars appear.
- Header columns now display without being wrapped to keep them smaller and more readable.