### PR TITLE
Bar Chart UI Bugfix

### DIFF
--- a/app/models/data_analysis.rb
+++ b/app/models/data_analysis.rb
@@ -361,6 +361,12 @@ class TopCountriesDataAnalysis < DataAnalysis
       .group(:country)
       .order('country desc')
       .count
+
+    @top_countries.each {|key, value| @top_countries[key] = 0 }
+
+    @top_students = @top_countries.merge(@top_students)
+    @top_mentors = @top_countries.merge(@top_mentors)
+    @top_judges = @top_countries.merge(@top_judges)
   end
 
   def totals


### PR DESCRIPTION
Right now in the UI, because the datasets don't always have the same amount of data values, the UI sorting functionality is failing upon reload. This fix addresses that issue by padding the datasets to have zero values for hash keys that are not found.