### PR TITLE
IE11 Fixes

### DIFF
--- a/app/assets/javascripts/rails-ujs-overrides.js
+++ b/app/assets/javascripts/rails-ujs-overrides.js
@@ -25,7 +25,7 @@ $.rails.showConfirmationDialog = function(link) {
     showCancelButton: true,
     reverseButtons: true,
     focusCancel: true,
-  }).then(result => {
+  }).then(function(result) {
     if (result.value) {
       $.rails.confirmed(link);
     }

--- a/app/assets/stylesheets/_datagrid.scss
+++ b/app/assets/stylesheets/_datagrid.scss
@@ -9,6 +9,7 @@
     width: 1%;
     white-space: nowrap;
     background: white;
+    background-clip: padding-box;
   }
 }
 

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -18,6 +18,7 @@
 
   tr:hover > td {
     background: #ddd;
+    background-clip: padding-box;
   }
 
   > thead th {

--- a/app/javascript/utilities/jquery-double-scroll.js
+++ b/app/javascript/utilities/jquery-double-scroll.js
@@ -16,7 +16,7 @@
  */
 (function( $ ) {
 
-  jQuery.fn.doubleScroll = function(userOptions) {
+  $.fn.doubleScroll = function(userOptions) {
 
    // Default options
    var options = {
@@ -123,4 +123,4 @@
 
  }
 
-}( jQuery ));
+}( $ ));


### PR DESCRIPTION
Please see commits for details. There may be subsequent fixes that go in, but I want to see how many errors the two of these clear up.

- Global `jQuery` was not present due to scoping and initialization, so it has been converted to `$` which was available in doubleScroll.
- Converted ES6 fat arrow function over to standard function as it was throwing errors in IE11. https://caniuse.com/#feat=arrow-functions
- Fixed table styles for FF and Edge browsers for floating Actions column in datagrids.

We may want to go through our non-webpacker compiled JS and convert anything over from ES6 to something more backwards compatible friendly.