### PR TITLE
IE11 Fixes Round Two

### DIFF
--- a/app/assets/javascripts/flash-msgs.js
+++ b/app/assets/javascripts/flash-msgs.js
@@ -8,7 +8,7 @@ $(document).on('click', '.flash .icon-close', function() {
 document.addEventListener("turbolinks:load", function() {
   $(document).ajaxComplete(function(_, xhr) {
     if (xhr.status === 200) {
-      let res = false
+      var res = false
 
       try {
         res = JSON.parse(xhr.responseText)

--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -1,8 +1,8 @@
 //= require application
 //= require toggling-select
 
-$(document).on("click", ".screenshot-nav__item", evt => {
-  let goToIdx
+$(document).on("click", ".screenshot-nav__item", function(evt) {
+  var goToIdx
 
   if (evt.target.nodeName === "IMG") {
     goToIdx = $(evt.target.parentElement).data('goTo')

--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -78,7 +78,7 @@ $(document).on("ready turbolinks:load", function() {
 });
 
 $(document).on("click", ".img-modal", function(e) {
-  let html, animation
+  var html, animation
 
   if (typeof $(e.target).data("modalIdx") !== 'undefined') {
     const last = parseInt($("#screenshots-nav").data("modalLast"))

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,3 +1,5 @@
 const environment = require('./environment')
 
+environment.plugins.get("UglifyJs").options.uglifyOptions.ecma = 5
+
 module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
- Convert ES6 functionality over to ES5 for IE11 compatibility in static JS asset files
- Make production webpacker JS uglifier use ES5 instead of ES8 for IE11 compatibility