### PR TITLE
Add ES6 Promise polyfill support for IE11 and axios

### DIFF
--- a/app/javascript/config/axios.js
+++ b/app/javascript/config/axios.js
@@ -1,4 +1,10 @@
+import PromisePolyfill from 'es6-promise'
 import axios from 'axios'
+
+// Polyfill Promise for IE11 to support axios
+if (typeof Promise === 'undefined') {
+  PromisePolyfill.polyfill()
+}
 
 window.axios = axios
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chart.js": "^2.7.2",
     "chroma-js": "^1.3.7",
     "element-ui": "^2.2.0",
+    "es6-promise": "^4.2.4",
     "escape-string-regexp": "^1.0.5",
     "flatpickr": "^4.2.4",
     "lodash": "^4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,6 +2240,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
+es6-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"


### PR DESCRIPTION
Axios used to polyfill `Promise` for use in IE11, but newer versions do not. So I had to add a polyfill for it to get our charts working in IE11.

https://caniuse.com/#feat=promises