### PR TITLE
Fix ScreenshotUploader

### DIFF
--- a/app/javascript/packs/submissions.js
+++ b/app/javascript/packs/submissions.js
@@ -1,6 +1,8 @@
 import TurbolinksAdapter from 'vue-turbolinks';
 import Vue from 'vue/dist/vue.esm'
 
+import '../config/axios'
+
 Vue.use(TurbolinksAdapter)
 
 import '../submissions/screenshots'


### PR DESCRIPTION
After the move to the `config/axios` import in our `application.js` pack, the submissions screenshot uploader was not working as the `ScreenshotUploader` Vue component was not able to find `window.axios`. This addresses that issue by including it in the submissions pack file as well.