### PR TITLE
Remove deprecated tabs classes throughout the application

### DIFF
--- a/app/assets/javascripts/season-schedule.js
+++ b/app/assets/javascripts/season-schedule.js
@@ -10,7 +10,7 @@ document.addEventListener("turbolinks:load", function() {
   }
 
   function handleJudgingRoundChanges($choices) {
-    const $container = $choices.closest('.tab-content'),
+    const $container = $choices.closest('.tabs__tab-content'),
 
           $blockedByJudging = $('[data-blocked-by-judging=true]'),
           originalTextColor = $blockedByJudging.css('color'),
@@ -99,7 +99,7 @@ document.addEventListener("turbolinks:load", function() {
           .not('.user-notified')
           .each(function() {
 
-          const $tab = $(this).closest('.tab-content');
+          const $tab = $(this).closest('.tabs__tab-content');
 
           var $notice = $('<div>');
 
@@ -112,7 +112,7 @@ document.addEventListener("turbolinks:load", function() {
 
           $(this).next('label').after($notice);
 
-          const $menuItem = $('.tab-menu').find(
+          const $menuItem = $('.tabs__menu').find(
             '[data-tab-id=' + $tab.prop('id') + ']'
           );
 
@@ -185,7 +185,7 @@ document.addEventListener("turbolinks:load", function() {
 
           appendLabels(
             $panel,
-            $(this).closest('.tab-content').find('label')
+            $(this).closest('.tabs__tab-content').find('label')
           );
         })
 

--- a/app/assets/javascripts/tabs.js
+++ b/app/assets/javascripts/tabs.js
@@ -1,22 +1,22 @@
 $(document).on("turbolinks:load", function() {
   $('.tabs').not('.tabs--css-only').each(function() {
-    var $links = $(this).find('.tab-menu, .tabs__menu')
+    var $links = $(this).find('.tabs__menu')
                         .first()
-                        .find('.tab-link, .tabs__menu-link'),
+                        .find('.tabs__menu-link'),
 
-        $contents = $(this).find('.content, .tabs__content')
+        $contents = $(this).find('.tabs__content')
                            .first()
-                           .find('> .tab-content, > .tabs__tab-content');
+                           .find('> .tabs__tab-content');
 
     // possible col--sticky
     if ($contents.length === 0)
-      $contents = $(this).find('.content .col--sticky')
+      $contents = $(this).find('.tabs__content .col--sticky')
                          .first()
-                         .find('> .tab-content');
+                         .find('> .tabs__tab-content');
 
-    // possible tabs-vertical layout
+    // Possible tabs--vertical layout
     if ($contents.length === 0)
-      $contents = $('#' + $(this).prop('id') + ' + .content .tab-content');
+      $contents = $('#' + $(this).prop('id') + ' + .tabs__content .tabs__tab-content');
 
     $links.filter(":visible")
       .first()
@@ -29,7 +29,7 @@ $(document).on("turbolinks:load", function() {
 
     if (intendedTab.length === 0)
       intendedTab = $links.filter(":visible").first()
-        .find(".tab-button, .tabs__menu-button")
+        .find(".tabs__menu-button")
         .data("tab-id");
 
     $links.each(function() {
@@ -56,10 +56,10 @@ $(document).on("turbolinks:load", function() {
     openTabMenu.bind(this)();
   });
 
-  $(".content, .tabs__content").on("click", closeTabMenu);
+  $(".tabs__content").on("click", closeTabMenu);
 
   function closeTabMenu() {
-    var $menu = $(this).closest(".tabs").find(".tab-menu, .tabs__menu");
+    var $menu = $(this).closest(".tabs").find(".tabs__menu");
 
     if ($menu.data("open")) {
       $menu
@@ -73,7 +73,7 @@ $(document).on("turbolinks:load", function() {
   }
 
   function openTabMenu() {
-    var $menu = $(this).closest(".tabs").find(".tab-menu, .tabs__menu");
+    var $menu = $(this).closest(".tabs").find(".tabs__menu");
 
     if ($menu.data("closed")) {
       $menu
@@ -99,13 +99,13 @@ $(document).on("turbolinks:load", function() {
     $_contents.addClass('hidden');
     $_links.removeClass('tabs__menu-link--active');
 
-    $_btn.closest('.tab-link, .tabs__menu-link')
+    $_btn.closest('.tabs__menu-link')
       .addClass('tabs__menu-link--active');
 
     var $revealEl = $('#' + $_btn.data('tab-id'));
     $revealEl.removeClass('hidden');
 
-    var $parentTab = $_btn.closest('.tab-content, .tabs__tab-content');
+    var $parentTab = $_btn.closest('.tabs__tab-content');
 
     if ($parentTab.length !== 0) {
       var $parentBtn = $('[data-tab-id]').filter(function() {
@@ -117,21 +117,14 @@ $(document).on("turbolinks:load", function() {
       revealTab($parentBtn, $_contents, $_links);
     }
 
-    var $links = $revealEl.find('.tab-menu, .tabs__menu')
+    var $links = $revealEl.find('.tabs__menu')
                           .first()
-                          .find('.tab-link, .tabs__menu-link'),
-        $contents = $revealEl.find('.content, .tabs__content')
+                          .find('.tabs__menu-link'),
+        $contents = $revealEl.find('.tabs__content')
                              .first()
-                             .find('> .tab-content, > .tabs__tab-content');
+                             .find('> .tabs__tab-content');
 
-    // possible tabs-vertical layout
-    if ($contents.length === 0)
-      $contents = $(
-        '#' +
-        $revealEl.prop('id') +
-        ' + .content .tab-content'
-      );
-
+    // Possible tabs--vertical layout
     if ($contents.length === 0)
       $contents = $(
         '#' +

--- a/app/assets/stylesheets/_season_schedule.scss
+++ b/app/assets/stylesheets/_season_schedule.scss
@@ -3,7 +3,7 @@
     color: $alert-txt;
   }
 
-  .tab-button {
+  .tabs__menu-button {
     [class^="icon-"], [class*=" icon-"] {
       display: none;
     }
@@ -15,7 +15,7 @@
     }
   }
 
-  .tab-content {
+  .tabs__tab-content {
     margin: 0 0 1rem;
     padding: 0 1rem;
     background: white;

--- a/app/assets/stylesheets/_tabs.scss
+++ b/app/assets/stylesheets/_tabs.scss
@@ -1,5 +1,4 @@
 .tabs {
-  .tab-menu,
   .tabs__menu {
     display: flex;
     flex-direction: row;
@@ -7,7 +6,6 @@
     padding: 0 0 0 1rem;
     list-style: none;
 
-    .tab-link,
     .tabs__menu-link {
       background: #ddd;
       border-top: 3px solid #999;
@@ -18,7 +16,6 @@
       position: relative;
       z-index: 0;
 
-      .tab-button,
       .tabs__menu-button {
         display: block;
         width: 100%;
@@ -28,7 +25,6 @@
         background: white;
         border-color: $primary;
 
-        .tab-button,
         .tabs__menu-button {
           color: black;
         }
@@ -36,45 +32,37 @@
     }
   }
 
-  &.tabs-vertical,
   &.tabs--vertical {
     padding: 0;
     background: white;
 
-    .tab-menu,
     .tabs__menu {
       display: block;
       background: white;
     }
 
-    .tab-link,
     .tabs__menu-link {
       background: inherit;
       border: 0;
       margin: 0;
       box-shadow: none;
 
-      .tab-button,
       .tabs__menu-button {
         font-size: 1rem;
         color: #999;
       }
     }
 
-    .tab-content,
     .tabs__tab-content {
       margin: 0;
       padding: 1rem;
     }
 
-    .content,
     .tabs__content,
-    + .content,
     + .tabs__content {
       border-left: 1px solid #ddd;
     }
 
-    .tab-button,
     .tabs__menu-button {
       color: #666;
       font-weight: normal;
@@ -90,7 +78,6 @@
     }
   }
 
-  .tab-content,
   .tabs__tab-content {
     position: relative;
     margin-top: -2px;
@@ -113,7 +100,6 @@
   }
 }
 
-.tab-button,
 .tabs__menu-button {
   cursor: pointer;
   border-radius: 0;
@@ -133,7 +119,6 @@
   .tabs {
     -webkit-font-smoothing: antialiased;
 
-    &.tabs-vertical,
     &.tabs--vertical {
       position: relative;
 
@@ -151,12 +136,10 @@
         padding: 0.5rem;
       }
 
-      .tab-content,
       .tabs__tab-content {
         padding: 0;
       }
 
-      .tab-menu,
       .tabs__menu {
         position: absolute;
         left: -100%;
@@ -168,9 +151,7 @@
         transition: left 0.5s;
         opacity: 0.9;
 
-        .tab-link,
         .tabs__menu-link {
-          .tab-button,
           .tabs__menu-button {
             padding: 0.75rem 2rem;
             font-size: 1.5rem;

--- a/app/javascript/admin/dashboard/components/AdminDashboard.vue
+++ b/app/javascript/admin/dashboard/components/AdminDashboard.vue
@@ -35,7 +35,7 @@
       </router-link>
     </ul>
 
-    <router-view class="content grid__col-md-9"></router-view>
+    <router-view class="tabs__content grid__col-md-9"></router-view>
   </div>
 </template>
 

--- a/app/javascript/admin/dashboard/components/MentorsSection.vue
+++ b/app/javascript/admin/dashboard/components/MentorsSection.vue
@@ -7,7 +7,7 @@
       </span>
     </h3>
 
-    <div class="tab-content">
+    <div class="tabs__tab-content">
       <h6 v-if="international">Consent waivers</h6>
       <h6 v-else>Background check / consent waivers</h6>
 
@@ -18,7 +18,7 @@
       />
     </div>
 
-    <div class="tab-content">
+    <div class="tabs__tab-content">
       <h6>New vs. Returning</h6>
 
       <pie-chart

--- a/app/javascript/admin/dashboard/components/StudentsSection.vue
+++ b/app/javascript/admin/dashboard/components/StudentsSection.vue
@@ -7,7 +7,7 @@
       </span>
     </h3>
 
-    <div class="tab-content">
+    <div class="tabs__tab-content">
       <h6>Parental permission</h6>
 
       <pie-chart
@@ -17,7 +17,7 @@
       />
     </div>
 
-    <div class="tab-content">
+    <div class="tabs__tab-content">
       <h6>New vs. Returning</h6>
 
       <pie-chart

--- a/app/javascript/admin/dashboard/components/TopCountriesSection.vue
+++ b/app/javascript/admin/dashboard/components/TopCountriesSection.vue
@@ -7,7 +7,7 @@
       </span>
     </h3>
 
-    <div class="tab-content">
+    <div class="tabs__tab-content">
       <bar-chart
         :url="topCountriesEndpoint"
         :chart-data="topCountriesChartData"

--- a/app/javascript/admin/review-requests/App.vue
+++ b/app/javascript/admin/review-requests/App.vue
@@ -53,7 +53,7 @@
         </router-link>
       </ul>
 
-      <div class="content">
+      <div class="tabs__content">
         <div class="tabs__tab-content panel">
           <router-view />
         </div>

--- a/app/views/admin/season_schedule_settings/edit.html.erb
+++ b/app/views/admin/season_schedule_settings/edit.html.erb
@@ -8,74 +8,74 @@
               url: admin_season_schedule_settings_path,
               local: true,
               method: :patch) do |f| %>
-  <div class="tabs tabs-vertical grid" id="admin-season-schedule">
-    <ul class="tab-menu grid__col-4">
-      <li class="tab-link">
+  <div class="tabs tabs--vertical grid" id="admin-season-schedule">
+    <ul class="tabs__menu grid__col-4">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="user-reg">
           <%= web_icon "exclamation-circle", text: "Registration" %>
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="notices">
           Notices
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="surveys">
           Surveys
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="teams">
           <%= web_icon "exclamation-circle", text: "Teams & Submissions" %>
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="events">
           <%= web_icon "exclamation-circle", text: "Events" %>
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="judging">
           Judging
         </button>
       </li>
 
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="scores">
           <%= web_icon "exclamation-circle", text: "Scores & Certificates" %>
         </button>
       </li>
     </ul>
 
-    <div class="content grid__col-8">
-      <div class="tab-content" id="user-reg">
+    <div class="tabs__content grid__col-8">
+      <div class="tabs__tab-content" id="user-reg">
         <h4>User Registrations</h4>
 
         <% %w{student mentor}.each do |scope| %>
@@ -93,7 +93,7 @@
         <% end %>
       </div>
 
-      <div class="tab-content" id="notices">
+      <div class="tabs__tab-content" id="notices">
         <h4>Dashboard Notices</h4>
 
         <div class="notice info hint">
@@ -113,7 +113,7 @@
         <% end %>
       </div>
 
-      <div class="tab-content" id="surveys">
+      <div class="tabs__tab-content" id="surveys">
         <h4>Survey Links</h4>
 
         <div class="notice info hint">
@@ -151,7 +151,7 @@
         <% end %>
       </div>
 
-      <div class="tab-content" id="teams">
+      <div class="tabs__tab-content" id="teams">
         <h4>Teams & Submissions</h4>
 
         <p class="inline-checkbox">
@@ -181,7 +181,7 @@
         </p>
       </div>
 
-      <div class="tab-content" id="events">
+      <div class="tabs__tab-content" id="events">
         <h4>Regional Pitch Events</h4>
 
         <p class="inline-checkbox">
@@ -199,7 +199,7 @@
         </p>
       </div>
 
-      <div class="tab-content" id="judging">
+      <div class="tabs__tab-content" id="judging">
         <h4>Judging Round</h4>
 
         <p>
@@ -222,7 +222,7 @@
         </p>
       </div>
 
-      <div class="tab-content" id="scores">
+      <div class="tabs__tab-content" id="scores">
         <h4>Scores & Certificates</h4>
 
         <p class="inline-checkbox">

--- a/app/views/admin/semifinals_scores/show.html.erb
+++ b/app/views/admin/semifinals_scores/show.html.erb
@@ -23,13 +23,13 @@
     No completed scores are available for this submission.
   </p>
 <% else %>
-  <div id="ra-scores-detail" class="flex-row tabs tabs-vertical">
-    <ul class="flex-col-md-3 tab-menu">
+  <div id="ra-scores-detail" class="flex-row tabs tabs--vertical">
+    <ul class="flex-col-md-3 tabs__menu">
       <% @scores.each do |score| %>
-        <li class="tab-link">
+        <li class="tabs__menu-link">
           <button
             role="button"
-            class="tab-button"
+            class="tabs__menu-button"
             data-tab-id="ra-scores-score-<%= score.id %>">
             <%= score.judge_profile.full_name %><br />
             <small style="color: #999; font-style: italic;">
@@ -40,9 +40,9 @@
       <% end %>
     </ul>
 
-    <div class="content flex-col-md-9">
+    <div class="tabs__content flex-col-md-9">
       <% @scores.each do |score| %>
-        <div class="tab-content" id="ra-scores-score-<%= score.id %>">
+        <div class="tabs__tab-content" id="ra-scores-score-<%= score.id %>">
           <%= render 'regional_ambassador/scores/detail_summary',
             score: score,
             team: @team %>

--- a/app/views/judge/dashboards/_menu.en.html.erb
+++ b/app/views/judge/dashboards/_menu.en.html.erb
@@ -1,30 +1,30 @@
-<ul class="tab-menu">
+<ul class="tabs__menu">
   <% if SeasonToggles.judging_enabled? %>
     <% if quarterfinals? and current_judge.selected_regional_pitch_event.live? %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="scores">
           Live Event Scores
         </button>
       </li>
     <% end %>
 
-    <li class="tab-link">
+    <li class="tabs__menu-link">
       <button
         role="button"
-        class="tab-button"
+        class="tabs__menu-button"
         data-tab-id="virtual-scores">
         Virtual Scores
       </button>
     </li>
   <% end %>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="pitch-events">
       Pitch Events
     </button>

--- a/app/views/judge/profiles/_menu.en.html.erb
+++ b/app/views/judge/profiles/_menu.en.html.erb
@@ -1,61 +1,61 @@
 <%= web_icon "close", class: "hidden-sm hidden-md hidden-lg close-tab-menu" %>
 <%= web_icon "navicon", class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="hidden-sm hidden-md hidden-lg tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="avatar"
     >
       Profile image
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="basic"
     >
       Basic
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="survey-answers"
     >
       Survey Answers
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="location"
     >
       Location
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-email"
     >
       Change email
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-password"
     >
       Change password

--- a/app/views/judge/profiles/show.html.erb
+++ b/app/views/judge/profiles/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "My profile" %>
 
-<div id="judge-profile-tabs" class="grid tabs tabs-vertical">
+<div id="judge-profile-tabs" class="grid tabs tabs--vertical">
   <div class="grid__col-sm-3">
     <div class="hidden-xs hidden-xxs">
       <h3><%= current_judge.full_name %></h3>
@@ -22,12 +22,12 @@
     <%= render 'judge/profiles/menu' %>
   </div>
 
-  <div class="content grid__col-sm-9">
-    <div class="tab-content" id="basic">
+  <div class="tabs__content grid__col-sm-9">
+    <div class="tabs__tab-content" id="basic">
       <%= render 'judge/profiles/basic' %>
     </div>
 
-    <div class="hidden-sm hidden-md hidden-lg tab-content" id="avatar">
+    <div class="hidden-sm hidden-md hidden-lg tabs__tab-content" id="avatar">
       <%= image_tag current_judge.profile_image_url,
         class: "grid__cell-img" %>
 
@@ -42,19 +42,19 @@
         size: "300x300" %>
     </div>
 
-    <div class="tab-content" id="survey-answers">
+    <div class="tabs__tab-content" id="survey-answers">
       <%= render 'judge/profiles/survey_answers' %>
     </div>
 
-    <div class="tab-content" id="location">
+    <div class="tabs__tab-content" id="location">
       <%= render 'judge/profiles/location' %>
     </div>
 
-    <div class="tab-content" id="change-email">
+    <div class="tabs__tab-content" id="change-email">
       <%= render 'profiles/email' %>
     </div>
 
-    <div class="tab-content" id="change-password">
+    <div class="tabs__tab-content" id="change-password">
       <%= render 'profiles/password' %>
     </div>
   </div>

--- a/app/views/mentor/dashboards/_menu.en.html.erb
+++ b/app/views/mentor/dashboards/_menu.en.html.erb
@@ -1,9 +1,9 @@
-<ul class="tab-menu">
+<ul class="tabs__menu">
   <% if current_mentor.mentor_invites.pending.any? %>
-    <li class="tab-link">
+    <li class="tabs__menu-link">
       <button
         role="button"
-        class="tab-button"
+        class="tabs__menu-button"
         data-tab-id="invitations">
         Invitations
       </button>
@@ -11,29 +11,29 @@
   <% end %>
 
   <% if current_mentor.is_on_team? and SeasonToggles.display_scores? %>
-    <li class="tab-link">
+    <li class="tabs__menu-link">
       <button
         role="button"
-        class="tab-button"
+        class="tabs__menu-button"
         data-tab-id="scores">
         Scores
       </button>
     </li>
   <% end %>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="submissions">
       Team Submissions
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="pitch-events">
       Pitch Events
     </button>

--- a/app/views/mentor/dashboards/_onboarded.en.html.erb
+++ b/app/views/mentor/dashboards/_onboarded.en.html.erb
@@ -1,29 +1,29 @@
 <div id="mentor-dashboard-menu" class="tabs">
   <%= render 'mentor/dashboards/menu' %>
 
-  <div class="content">
+  <div class="tabs__content">
     <% if current_mentor.mentor_invites.pending.any? %>
-      <div class="tab-content" id="invitations">
+      <div class="tabs__tab-content" id="invitations">
         <%= render 'dashboards/invitations',
           invites: current_mentor.mentor_invites.pending %>
       </div>
     <% end %>
 
     <% if current_mentor.is_on_team? and SeasonToggles.display_scores? %>
-      <div class="tab-content" id="scores">
+      <div class="tabs__tab-content" id="scores">
         <%= render 'mentor/dashboards/onboarded/scores' %>
       </div>
     <% end %>
 
-    <div class="tab-content" id="scores">
+    <div class="tabs__tab-content" id="scores">
       <%= render 'mentor/dashboards/onboarded/scores' %>
     </div>
 
-    <div class="tab-content grid" id="submissions">
+    <div class="tabs__tab-content grid" id="submissions">
       <%= render 'mentor/dashboards/onboarded/submissions' %>
     </div>
 
-    <div class="tab-content grid" id="pitch-events">
+    <div class="tabs__tab-content grid" id="pitch-events">
       <%= render 'mentor/dashboards/onboarded/pitch_events' %>
     </div>
   </div>

--- a/app/views/mentor/dashboards/onboarded/_submissions.en.html.erb
+++ b/app/views/mentor/dashboards/onboarded/_submissions.en.html.erb
@@ -3,15 +3,15 @@
     <% if current_mentor.is_on_team? %>
       <div class="grid">
         <div
-          class="gird__col-sm-3 tabs tabs-vertical"
+          class="gird__col-sm-3 tabs tabs--vertical"
           id="team-submissions-team-list"
         >
-          <ul class="tab-menu">
+          <ul class="tabs__menu">
             <% @teams.each do |team| %>
-              <li class="tab-link">
+              <li class="tabs__menu-link">
                 <button
                   role="button"
-                  class="tab-button"
+                  class="tabs__menu-button"
                   data-tab-id="submissions-team-<%= team.id %>">
                   <%= team.name %>
                 </button>
@@ -20,11 +20,11 @@
           </ul>
         </div>
 
-        <div class="grid__col-sm-9 content">
+        <div class="grid__col-sm-9 tabs__content">
           <% @teams.each do |team| %>
             <div
               id="submissions-team-<%= team.id %>"
-              class="tab-content"
+              class="tabs__tab-content"
             >
               <div class="grid">
                 <dl class="grid__col-sm-6">

--- a/app/views/mentor/profiles/_menu.en.html.erb
+++ b/app/views/mentor/profiles/_menu.en.html.erb
@@ -1,51 +1,51 @@
 <%= web_icon "close", class: "hidden-sm hidden-md hidden-lg close-tab-menu" %>
 <%= web_icon "navicon", class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="hidden-sm hidden-md hidden-lg tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="avatar"
     >
       Profile image
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="basic"
     >
       Basic
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="location"
     >
       Location
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-email"
     >
       Change email
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-password"
     >
       Change password

--- a/app/views/mentor/profiles/show.html.erb
+++ b/app/views/mentor/profiles/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "My profile" %>
 
-<div class="grid tabs tabs-vertical">
+<div class="grid tabs tabs--vertical">
   <div class="grid__col-sm-3 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
@@ -26,14 +26,14 @@
     </div>
   </div>
 
-  <div class="content grid__col-sm-9 col--sticky-parent">
+  <div class="tabs__content grid__col-sm-9 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
-        <div class="tab-content" id="basic">
+        <div class="tabs__tab-content" id="basic">
           <%= render 'mentor/profiles/basic' %>
         </div>
 
-        <div class="hidden-sm hidden-md hidden-lg tab-content" id="avatar">
+        <div class="hidden-sm hidden-md hidden-lg tabs__tab-content" id="avatar">
           <%= image_tag current_mentor.profile_image_url, class: "grid__cell-img" %>
 
           <%= render 'image_upload',
@@ -42,15 +42,15 @@
             size: "300x300" %>
         </div>
 
-        <div class="tab-content" id="location">
+        <div class="tabs__tab-content" id="location">
           <%= render 'mentor/profiles/location' %>
         </div>
 
-        <div class="tab-content" id="change-email">
+        <div class="tabs__tab-content" id="change-email">
           <%= render 'profiles/email' %>
         </div>
 
-        <div class="tab-content" id="change-password">
+        <div class="tabs__tab-content" id="change-password">
           <%= render 'profiles/password' %>
         </div>
       </div>

--- a/app/views/regional_ambassador/dashboards/_menu.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/_menu.en.html.erb
@@ -1,61 +1,61 @@
 <%= web_icon "close", class: "hidden-sm hidden-md hidden-lg close-tab-menu" %>
 <%= web_icon "navicon", class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="students"
     >
       Students
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="mentors"
     >
       Mentors
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="inactivity"
     >
       Inactivity notices
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="recent-activity"
     >
       Recent activity
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="ra-info"
     >
       Regional program introduction
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="resources"
     >
       RA resources

--- a/app/views/regional_ambassador/dashboards/show_approved.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/show_approved.en.html.erb
@@ -1,7 +1,7 @@
 <% if current_ambassador.onboarding? %>
   <%= render "regional_ambassador/dashboards/onboarding" %>
 <% else %>
-  <div class="grid tabs tabs-vertical">
+  <div class="grid tabs tabs--vertical">
     <div class="grid__col-sm-3 col--sticky-parent">
       <div class="col--sticky-spacer">
         <div class="col--sticky">
@@ -25,10 +25,10 @@
       </div>
     </div>
 
-    <div class="content grid__col-sm-9 col--sticky-parent">
+    <div class="tabs__content grid__col-sm-9 col--sticky-parent">
       <div class="col--sticky-spacer">
         <div class="col--sticky">
-          <div class="tab-content" id="students">
+          <div class="tabs__tab-content" id="students">
             <%= SeasonToggles.dashboard_text(:regional_ambassador) %>
 
             <% if current_ambassador.needs_intro_prompt? %>
@@ -38,7 +38,7 @@
             <% end %>
           </div>
 
-          <div class="tab-content" id="mentors">
+          <div class="tabs__tab-content" id="mentors">
             <%= SeasonToggles.dashboard_text(:regional_ambassador) %>
 
             <% if current_ambassador.needs_intro_prompt? %>
@@ -48,7 +48,7 @@
             <% end %>
           </div>
 
-          <div class="tab-content" id="inactivity">
+          <div class="tabs__tab-content" id="inactivity">
             <% if current_ambassador.needs_intro_prompt? %>
               <p>Please fill in your regional program introduction to access this section</p>
             <% else %>
@@ -56,7 +56,7 @@
             <% end %>
           </div>
 
-          <div class="tab-content" id="recent-activity">
+          <div class="tabs__tab-content" id="recent-activity">
             <% if current_ambassador.needs_intro_prompt? %>
               <p>Please fill in your regional program introduction to access this section</p>
             <% else %>
@@ -64,7 +64,7 @@
             <% end %>
           </div>
 
-          <div class="tab-content" id="ra-info">
+          <div class="tabs__tab-content" id="ra-info">
             <% if current_ambassador.needs_intro_prompt? %>
               <h4>
                 New this year: Introduce your region to your program!
@@ -88,7 +88,7 @@
             <% end %>
           </div>
 
-          <div class="tab-content" id="resources">
+          <div class="tabs__tab-content" id="resources">
             <%= render "regional_ambassador/dashboards/info_sidebar" %>
           </div>
         </div>

--- a/app/views/regional_ambassador/profiles/_menu.en.html.erb
+++ b/app/views/regional_ambassador/profiles/_menu.en.html.erb
@@ -1,51 +1,51 @@
 <%= web_icon "close", class: "hidden-sm hidden-md hidden-lg close-tab-menu" %>
 <%= web_icon "navicon", class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="hidden-sm hidden-md hidden-lg tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="avatar"
     >
       Profile image
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="basic"
     >
       Basic
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="location"
     >
       Location
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-email"
     >
       Change email
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-password"
     >
       Change password

--- a/app/views/regional_ambassador/profiles/show.en.html.erb
+++ b/app/views/regional_ambassador/profiles/show.en.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "My profile" %>
 
-<div id="ra-profile-tabs" class="grid tabs tabs-vertical">
+<div id="ra-profile-tabs" class="grid tabs tabs--vertical">
   <div class="grid__col-sm-3 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
@@ -21,14 +21,14 @@
     </div>
   </div>
 
-  <div class="content grid__col-sm-9 col--sticky-parent">
+  <div class="tabs__content grid__col-sm-9 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
-        <div class="tab-content" id="basic">
+        <div class="tabs__tab-content" id="basic">
           <%= render 'regional_ambassador/profiles/basic' %>
         </div>
 
-        <div class="hidden-sm hidden-md hidden-lg tab-content" id="avatar">
+        <div class="hidden-sm hidden-md hidden-lg tabs__tab-content" id="avatar">
           <%= image_tag current_ambassador.profile_image_url,
             class: "grid__cell-img" %>
 
@@ -38,15 +38,15 @@
             size: "300x300" %>
         </div>
 
-        <div class="tab-content" id="location">
+        <div class="tabs__tab-content" id="location">
           <%= render 'regional_ambassador/profiles/location' %>
         </div>
 
-        <div class="tab-content" id="change-email">
+        <div class="tabs__tab-content" id="change-email">
           <%= render 'profiles/email' %>
         </div>
 
-        <div class="tab-content" id="change-password">
+        <div class="tabs__tab-content" id="change-password">
           <%= render 'profiles/password' %>
         </div>
       </div>

--- a/app/views/regional_ambassador/scores/_divisions.en.html.erb
+++ b/app/views/regional_ambassador/scores/_divisions.en.html.erb
@@ -1,11 +1,11 @@
 <div id="ra-event-<%= event.id %>-divisions"
-      class="flex-col-md-2 card__body tabs tabs-vertical">
-  <ul class="tab-menu">
+      class="flex-col-md-2 card__body tabs tabs--vertical">
+  <ul class="tabs__menu">
     <% if event.divisions.include?(Division.senior) %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="ra-event-<%= event.id %>-senior">
           Senior Division
         </button>
@@ -13,10 +13,10 @@
     <% end %>
 
     <% if event.divisions.include?(Division.junior) %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
           role="button"
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="ra-event-<%= event.id %>-junior">
           Junior Division
         </button>

--- a/app/views/regional_ambassador/scores/show.en.html.erb
+++ b/app/views/regional_ambassador/scores/show.en.html.erb
@@ -37,13 +37,13 @@
     No completed scores are available for this submission.
   </p>
 <% else %>
-  <div id="ra-scores-detail" class="flex-row tabs tabs-vertical">
-    <ul class="flex-col-md-3 tab-menu">
+  <div id="ra-scores-detail" class="flex-row tabs tabs--vertical">
+    <ul class="flex-col-md-3 tabs__menu">
       <% @scores.each do |score| %>
-        <li class="tab-link">
+        <li class="tabs__menu-link">
           <button
             role="button"
-            class="tab-button"
+            class="tabs__menu-button"
             data-tab-id="ra-scores-score-<%= score.id %>">
             <%= score.judge_profile.full_name %><br />
             <small style="color: #999; font-style: italic;">
@@ -55,9 +55,9 @@
       <% end %>
     </ul>
 
-    <div class="content flex-col-md-9">
+    <div class="tabs__content flex-col-md-9">
       <% @scores.each do |score| %>
-        <div class="tab-content" id="ra-scores-score-<%= score.id %>">
+        <div class="tabs__tab-content" id="ra-scores-score-<%= score.id %>">
           <%= render 'regional_ambassador/scores/detail_summary',
             score: score,
             team: @team %>

--- a/app/views/student/profiles/_menu.en.html.erb
+++ b/app/views/student/profiles/_menu.en.html.erb
@@ -4,61 +4,61 @@
 <%= web_icon "navicon",
   class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="hidden-sm hidden-md hidden-lg tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="avatar"
     >
       Profile image
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="basic"
     >
       Basic
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="parent"
     >
       Parental Consent
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="location"
     >
       Location
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-email"
     >
       Change email
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="change-password"
     >
       Change password

--- a/app/views/student/profiles/show.html.erb
+++ b/app/views/student/profiles/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "My profile" %>
 
-<div id="student-profile-tabs" class="grid tabs tabs-vertical">
+<div id="student-profile-tabs" class="grid tabs tabs--vertical">
   <div class="grid__col-sm-3 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
@@ -24,14 +24,14 @@
     </div>
   </div>
 
-  <div class="content grid__col-sm-9 col--sticky-parent">
+  <div class="tabs__content grid__col-sm-9 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
-        <div class="tab-content" id="basic">
+        <div class="tabs__tab-content" id="basic">
           <%= render 'student/profiles/basic' %>
         </div>
 
-        <div class="hidden-sm hidden-md hidden-lg tab-content" id="avatar">
+        <div class="hidden-sm hidden-md hidden-lg tabs__tab-content" id="avatar">
           <%= image_tag current_student.profile_image_url,
             id: "profile-image-xs",
             class: "grid__cell-img" %>
@@ -45,19 +45,19 @@
             size: "300x300" %>
         </div>
 
-        <div class="tab-content" id="parent">
+        <div class="tabs__tab-content" id="parent">
           <%= render 'student/profiles/parent' %>
         </div>
 
-        <div class="tab-content" id="location">
+        <div class="tabs__tab-content" id="location">
           <%= render 'student/profiles/location' %>
         </div>
 
-        <div class="tab-content" id="change-email">
+        <div class="tabs__tab-content" id="change-email">
           <%= render 'profiles/email' %>
         </div>
 
-        <div class="tab-content" id="change-password">
+        <div class="tabs__tab-content" id="change-password">
           <%= render 'profiles/password' %>
         </div>
       </div>

--- a/app/views/student/scores/index.html.erb
+++ b/app/views/student/scores/index.html.erb
@@ -1,45 +1,45 @@
 <h3 class="heading--page">View your Scores and Certificate</h3>
 
 <div id="student-scores-tabs" class="tabs">
-  <ul class="score-tabs-menu tab-menu">
+  <ul class="score-tabs-menu tabs__menu">
     <% if @quarterfinals_scores.official.any? %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="quarterfinal"
         >Quarterfinals</button>
       </li>
     <% end %>
 
     <% if @quarterfinals_scores.unofficial.any? %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="unofficial"
         >Celebration Scores</button>
       </li>
     <% end %>
 
     <% if @semifinals_scores.any? %>
-      <li class="tab-link">
+      <li class="tabs__menu-link">
         <button
-          class="tab-button"
+          class="tabs__menu-button"
           data-tab-id="semifinal"
         >Semifinals</button>
       </li>
     <% end %>
 
-    <li class="tab-link">
+    <li class="tabs__menu-link">
       <button
-        class="tab-button"
+        class="tabs__menu-button"
         data-tab-id="certificates"
       >Certificate</button>
     </li>
   </ul>
 
-  <div class="score-tab-content content">
+  <div class="score-tab-content tabs__content">
     <% if @quarterfinals_scores.official.any? %>
-      <div class="score-tab tab-content" id="quarterfinal">
+      <div class="score-tab tabs__tab-content" id="quarterfinal">
         <%= render "student/scores/scores",
           round: :quarterfinals,
           scores: @quarterfinals_scores.official %>
@@ -47,7 +47,7 @@
     <% end %>
 
     <% if @quarterfinals_scores.unofficial.any? %>
-      <div class="score-tab tab-content" id="unofficial">
+      <div class="score-tab tabs__tab-content" id="unofficial">
         <%= render "student/scores/scores",
           round: UnofficialJudgingRound.new,
           scores: @quarterfinals_scores.unofficial %>
@@ -55,14 +55,14 @@
     <% end %>
 
     <% if @semifinals_scores.any? %>
-      <div class="score-tab tab-content" id="semifinal">
+      <div class="score-tab tabs__tab-content" id="semifinal">
         <%= render "student/scores/scores",
           round: :semifinals,
           scores: @semifinals_scores %>
       </div>
     <% end %>
 
-    <div class="score-tab tab-content" id="certificates">
+    <div class="score-tab tabs__tab-content" id="certificates">
       <h2>Congratulations on all your hard work!</h2>
 
       <p>

--- a/app/views/teams/_edit_menu.en.html.erb
+++ b/app/views/teams/_edit_menu.en.html.erb
@@ -1,61 +1,61 @@
 <%= web_icon "close", class: "hidden-sm hidden-md hidden-lg close-tab-menu" %>
 <%= web_icon "navicon", class: "hidden-sm hidden-md hidden-lg open-tab-menu" %>
 
-<ul class="tab-menu" data-closed="true">
-  <li class="tab-link">
+<ul class="tabs__menu" data-closed="true">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="students"
     >
       Students
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="mentors"
     >
       Mentors
     </button>
   </li>
 
-  <li class="hidden-sm hidden-md hidden-lg tab-link">
+  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="photo"
     >
       Team photo
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="description"
     >
       Summary
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="location"
     >
       Location
     </button>
   </li>
 
-  <li class="tab-link">
+  <li class="tabs__menu-link">
     <button
       role="button"
-      class="tab-button"
+      class="tabs__menu-button"
       data-tab-id="division"
     >
       Division

--- a/app/views/teams/_show.html.erb
+++ b/app/views/teams/_show.html.erb
@@ -1,6 +1,6 @@
 <% admin_ra ||= false %>
 
-<div class="grid tabs tabs-vertical">
+<div class="grid tabs tabs--vertical">
   <div class="grid__col-sm-3 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
@@ -15,10 +15,10 @@
     </div>
   </div>
 
-  <div class="content grid__col-sm-9 col--sticky-parent">
+  <div class="tabs__content grid__col-sm-9 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
-        <div class="tab-content" id="students">
+        <div class="tabs__tab-content" id="students">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -30,7 +30,7 @@
             team: team %>
         </div>
 
-        <div class="tab-content" id="mentors">
+        <div class="tabs__tab-content" id="mentors">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -42,7 +42,7 @@
             team: team %>
         </div>
 
-        <div class="tab-content hidden-md hidden-lg hidden-sm" id="photo">
+        <div class="tabs__tab-content hidden-md hidden-lg hidden-sm" id="photo">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -55,7 +55,7 @@
             team: team %>
         </div>
 
-        <div class="tab-content" id="description">
+        <div class="tabs__tab-content" id="description">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -65,7 +65,7 @@
           <%= render 'teams/edit_description', team: team %>
         </div>
 
-        <div class="tab-content" id="location">
+        <div class="tabs__tab-content" id="location">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -75,7 +75,7 @@
           <%= render 'teams/location', team: team %>
         </div>
 
-        <div class="tab-content" id="division">
+        <div class="tabs__tab-content" id="division">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>

--- a/spec/javascript/admin/dashboard/components/MentorsSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/MentorsSection.spec.js
@@ -186,7 +186,7 @@ describe('Admin Dashboard - MentorSection component', () => {
 
       expect(wrapper.find('h3 span').text()).toEqual('(402)')
 
-      const charts = wrapper.findAll('.tab-content')
+      const charts = wrapper.findAll('.tabs__tab-content')
       const onboardingChart = charts.at(0)
       const returningChart = charts.at(1)
 
@@ -214,7 +214,7 @@ describe('Admin Dashboard - MentorSection component', () => {
     })
 
     it('changes the label of the onboarding chart if international changes', () => {
-      const onboardingChart = wrapper.findAll('.tab-content').at(0)
+      const onboardingChart = wrapper.findAll('.tabs__tab-content').at(0)
 
       wrapper.setProps({ international: false })
 

--- a/spec/javascript/admin/dashboard/components/StudentsSection.spec.js
+++ b/spec/javascript/admin/dashboard/components/StudentsSection.spec.js
@@ -165,7 +165,7 @@ describe('Admin Dashboard - StudentsSection component', () => {
 
       expect(wrapper.find('h3 span').text()).toEqual('(854)')
 
-      const charts = wrapper.findAll('.tab-content')
+      const charts = wrapper.findAll('.tabs__tab-content')
       const onboardingChart = charts.at(0)
       const returningChart = charts.at(1)
 


### PR DESCRIPTION
This converts all non-BEM tabs classes throughout the application over to their non-deprecated BEM versions. I thoroughly tested the UIs to make sure that the javascript edits I made didn't break anything, and to confirm that things were styled correctly. I know this is a large pull request and it grew very large after I started in on this, so I apologize in advance for the pot of coffee you might have to consume to make sure all of this works haha.