### PR TITLE
Debounce Utility

### DIFF
--- a/app/javascript/judge/scores/QuestionSection.vue
+++ b/app/javascript/judge/scores/QuestionSection.vue
@@ -96,6 +96,7 @@
 import _ from 'lodash'
 import { mapState, mapGetters } from 'vuex'
 
+import { debounce } from '../../utilities/utilities'
 import ScoreEntry from './ScoreEntry'
 
 export default {
@@ -363,7 +364,9 @@ export default {
   },
 
   created () {
-    this.debouncedCommentWatcher = _.debounce(this.handleCommentChange, 500)
+    this.debouncedCommentWatcher = debounce(() => {
+      this.handleCommentChange()
+    }, 500)
   }
 }
 </script>

--- a/app/javascript/utilities/utilities.js
+++ b/app/javascript/utilities/utilities.js
@@ -1,3 +1,15 @@
 export const isEmptyObject = (object) => {
   return Object.keys(object).length === 0 && object.constructor === Object
 }
+
+export const debounce = function (func, wait = 500) {
+  let timeout
+
+  return function(...args) {
+    clearTimeout(timeout)
+
+    timeout = setTimeout(() => {
+      func.apply(this, args)
+    }, wait)
+  }
+}

--- a/spec/javascript/judge/scores/QuestionSection.spec.js
+++ b/spec/javascript/judge/scores/QuestionSection.spec.js
@@ -108,6 +108,34 @@ describe('Question comments section', () => {
     })
   })
 
+  test('debouncedCommentWatcher calls handleCommentChange', () => {
+    jest.useFakeTimers()
+
+    wrapper = shallowMount(
+      QuestionSection, {
+        store: storeMocks.store,
+        localVue,
+        propsData: {
+          section: 'ideation',
+        },
+        computed: {
+          shouldRunSentimentAnalysis: () => true,
+          shouldRunProfanityAnalysis: () => true,
+        },
+      }
+    )
+
+    const handleCommentChangeSpy = jest.spyOn(wrapper.vm, 'handleCommentChange')
+
+    expect(handleCommentChangeSpy).not.toHaveBeenCalled()
+
+    wrapper.vm.debouncedCommentWatcher()
+
+    jest.runAllTimers()
+
+    expect(handleCommentChangeSpy).toHaveBeenCalled()
+  })
+
   test('saves comments after changes, if analysis is run', (done) => {
     wrapper = shallowMount(
       QuestionSection, {

--- a/spec/javascript/utilities/utilities.spec.js
+++ b/spec/javascript/utilities/utilities.spec.js
@@ -24,4 +24,51 @@ describe('Helper Utilities', () => {
 
   })
 
+  describe('debounce', () => {
+
+    let booleanVariable
+    let debouncedFunction
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      booleanVariable = false
+    })
+
+    it('calls function after 500ms when no wait parameter is present', () => {
+      debouncedFunction = Utils.debounce(() => {
+        booleanVariable = true
+      })
+
+      expect(booleanVariable).toBe(false)
+
+      debouncedFunction()
+
+      jest.advanceTimersByTime(250)
+
+      expect(booleanVariable).toBe(false)
+
+      jest.advanceTimersByTime(251)
+
+      expect(booleanVariable).toBe(true)
+    })
+
+    it('calls function after 1000ms when wait is set to 1000', () => {
+      debouncedFunction = Utils.debounce(() => {
+        booleanVariable = true
+      }, 1000)
+
+      expect(booleanVariable).toBe(false)
+
+      debouncedFunction()
+
+      jest.advanceTimersByTime(600)
+
+      expect(booleanVariable).toBe(false)
+
+      jest.advanceTimersByTime(401)
+
+      expect(booleanVariable).toBe(true)
+    })
+  })
+
 })


### PR DESCRIPTION
Because lodash debounce is so difficult to test using integration tests, I took it upon myself to write a utility function that performs a trailing edge debounce that can be used with Jest mock timers. You should be able to just replace the `_.debounce` calls with this. This will allow us to also make sure that our implementations of debounced functions are working. Please see `QuestionSection.spec.js` for details.

Please note that anything within the debounce needs to be wrapped in an anonymous function, otherwise it will not work properly due to scoping.

**Bad**
```
this.debouncedCommentWatcher = debounce(this.handleCommentChange, 500)
```

**Good**
```
this.debouncedCommentWatcher = debounce(() => {
  this.handleCommentChange()
}, 500)
```