### PR TITLE
Resolve JS aliases for import paths in application and Jest

### DIFF
--- a/app/javascript/admin/dashboard/components/DashboardSection.vue
+++ b/app/javascript/admin/dashboard/components/DashboardSection.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import BarChart from '../../../components/BarChart'
-import PieChart from '../../../components/PieChart'
+import BarChart from '@appjs/components/BarChart'
+import PieChart from '@appjs/components/PieChart'
 
 export default {
   name: 'dashboard-section',

--- a/app/javascript/admin/dashboard/index.js
+++ b/app/javascript/admin/dashboard/index.js
@@ -4,7 +4,7 @@ import VueRouter from 'vue-router'
 import AdminDashboard from './components/AdminDashboard'
 import StudentsSection from './components/StudentsSection'
 import MentorsSection from './components/MentorsSection'
-import PieChart from '../../components/PieChart'
+import PieChart from '@appjs/components/PieChart'
 
 Vue.use(VueRouter)
 

--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+module.exports = {
+  resolve: {
+    alias: {
+      '@appjs': path.resolve(__dirname, '..', '..', 'app/javascript'),
+      '@assetsjs': path.resolve(__dirname, '..', '..', 'app/assets/javascripts'),
+      '@vendorjs': path.resolve(__dirname, '..', '..', 'vendor/assets/javascripts'),
+    }
+  }
+}

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,9 @@
 const { environment } = require('@rails/webpacker')
+const customConfig = require('./custom')
 const vue =  require('./loaders/vue')
 
 environment.loaders.append('vue', vue)
+
+environment.config.merge(customConfig)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
       "json",
       "vue"
     ],
+    "moduleNameMapper": {
+      "@appjs(.*)$": "<rootDir>/app/javascript/$1",
+      "@assetsjs(.*)$": "<rootDir>/app/assets/javascripts/$1",
+      "@vendorjs(.*)$": "<rootDir>/vendor/assets/javascripts/$1"
+    },
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"


### PR DESCRIPTION
You can now use the following aliases when importing modules in order to eliminate the need for most relative paths:
- `@appjs/` - `<rootDir>/app/javascript/`
- `@assetsjs/` - `<rootDir>/app/assets/javascripts/`
- `@vendorjs/` - `<rootDir>/vendor/assets/javascripts/`