### PR TITLE
New mentors should not be able to switch to judge mode

### DIFF
--- a/app/controllers/judge/dashboards_controller.rb
+++ b/app/controllers/judge/dashboards_controller.rb
@@ -15,20 +15,6 @@ module Judge
     end
 
     private
-    def create_mentor_judge_on_dashboard
-      return if current_session.authenticated?
-        # RA/Admin Logged in as someone else
-
-      if CreateJudgeProfile.(current_account)
-        flash.now[:success] = t(
-          "controllers.judge.dashboards.show.judge_profile_created"
-        )
-      elsif current_account.authenticated? and is_not_and_cannot_be_judge?
-        redirect_to root_path,
-          alert: "You don't have permission to go there!"
-      end
-    end
-
     def is_not_and_cannot_be_judge?
       not current_account.judge_profile.present? and
         not current_account.can_be_a_judge?

--- a/app/controllers/judge_controller.rb
+++ b/app/controllers/judge_controller.rb
@@ -1,5 +1,4 @@
 class JudgeController < ApplicationController
-  before_action :create_mentor_judge_on_dashboard
   include Authenticated
 
   layout "judge"
@@ -31,10 +30,6 @@ class JudgeController < ApplicationController
 
   def current_profile
     current_judge
-  end
-
-  def create_mentor_judge_on_dashboard
-    # Implemented in Judge::DashboardsController
   end
 
   def back_from_event_path

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -536,6 +536,10 @@ class Account < ActiveRecord::Base
           mentor_profile.present?
   end
 
+  def is_a_judge?
+    judge_profile.present?
+  end
+
   def is_not_a_judge?
     not judge_profile.present?
   end

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -4,9 +4,11 @@
       <h1 class="page-heading">
         <%= t("views.application.mentor_dashboard") %>
 
-        <small>
-          <%= link_to "Switch to Judge mode", judge_dashboard_path %>
-        </small>
+        <% if current_mentor.is_a_judge? %>
+          <small>
+            <%= link_to "Switch to Judge mode", judge_dashboard_path %>
+          </small>
+        <% end %>
 
         <% if current_mentor.is_an_ambassador? %>
           <small>

--- a/app/views/regional_ambassador/_navigation.en.html.erb
+++ b/app/views/regional_ambassador/_navigation.en.html.erb
@@ -51,7 +51,9 @@
     mentor_dashboard_path,
     data: { turbolinks: false } %>
 
-  <%= link_to "Judge Mode",
-    judge_dashboard_path,
-    data: { turbolinks: false } %>
+  <% if current_ambassador.is_a_judge? %>
+    <%= link_to "Judge Mode",
+      judge_dashboard_path,
+      data: { turbolinks: false } %>
+  <% end %>
 </nav>

--- a/spec/factories/ambassadors.rb
+++ b/spec/factories/ambassadors.rb
@@ -87,5 +87,11 @@ FactoryBot.define do
       state_province "Bahia"
       city "Salvador"
     end
+
+    trait :has_judge_profile do
+      after(:create) do |ambassador|
+        CreateJudgeProfile.(ambassador.account)
+      end
+    end
   end
 end

--- a/spec/factories/mentors.rb
+++ b/spec/factories/mentors.rb
@@ -143,6 +143,12 @@ FactoryBot.define do
       end
     end
 
+    trait :has_judge_profile do
+      after(:create) do |mentor|
+        CreateJudgeProfile.(mentor.account)
+      end
+    end
+
     factory :onboarded_mentor
   end
 end

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -15,17 +15,6 @@ RSpec.feature "Mentors switch to judging mode" do
     expect(current_path).to eq(mentor_dashboard_path)
   end
 
-  scenario "mentors with a judge profile can browse to judge profile" do
-    mentor = FactoryBot.create(:mentor, :has_judge_profile)
-
-    sign_in(mentor)
-
-    visit judge_dashboard_path
-
-    expect(current_path).to eq(judge_dashboard_path)
-    expect(page).to have_link("Switch to Mentor mode")
-  end
-
   scenario "mentors without a judge profile do not see a judge mode link" do
     mentor = FactoryBot.create(:mentor)
 

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -1,11 +1,24 @@
 require "rails_helper"
 
 RSpec.feature "Mentors switch to judging mode" do
-  scenario "mentors can switch to judge mode" do
-    mentor = FactoryBot.create(:mentor)
+  scenario "mentors with a judge profile can switch to judge mode" do
+    mentor = FactoryBot.create(:mentor, :has_judge_profile)
+
     sign_in(mentor)
+
+    expect(mentor.is_a_judge?).to be_truthy
 
     click_link "Switch to Judge mode"
     expect(current_path).to eq(judge_dashboard_path)
+  end
+
+  scenario "mentors without a judge profile do not see a judge mode link" do
+    mentor = FactoryBot.create(:mentor)
+
+    sign_in(mentor)
+
+    expect(mentor.is_a_judge?).to be_falsey
+
+    expect(page).not_to have_link("Switch to Judge mode")
   end
 end

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -12,6 +12,16 @@ RSpec.feature "Mentors switch to judging mode" do
     expect(current_path).to eq(judge_dashboard_path)
   end
 
+  scenario "mentors with a judge profile can browse to judge profile" do
+    mentor = FactoryBot.create(:mentor, :has_judge_profile)
+
+    sign_in(mentor)
+
+    visit judge_dashboard_path
+
+    expect(current_path).to eq(judge_dashboard_path)
+  end
+
   scenario "mentors without a judge profile do not see a judge mode link" do
     mentor = FactoryBot.create(:mentor)
 
@@ -20,5 +30,16 @@ RSpec.feature "Mentors switch to judging mode" do
     expect(mentor.is_a_judge?).to be_falsey
 
     expect(page).not_to have_link("Switch to Judge mode")
+  end
+
+  scenario "mentors without a judge profile cannot browse to judge profile" do
+    mentor = FactoryBot.create(:mentor)
+
+    sign_in(mentor)
+
+    visit judge_dashboard_path
+
+    expect(current_path).to eq(mentor_dashboard_path)
+    expect(page).to have_content("You don't have permission to go there!")
   end
 end

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -10,6 +10,9 @@ RSpec.feature "Mentors switch to judging mode" do
 
     click_link "Switch to Judge mode"
     expect(current_path).to eq(judge_dashboard_path)
+
+    click_link "Switch to Mentor mode"
+    expect(current_path).to eq(mentor_dashboard_path)
   end
 
   scenario "mentors with a judge profile can browse to judge profile" do
@@ -20,6 +23,7 @@ RSpec.feature "Mentors switch to judging mode" do
     visit judge_dashboard_path
 
     expect(current_path).to eq(judge_dashboard_path)
+    expect(page).to have_link("Switch to Mentor mode")
   end
 
   scenario "mentors without a judge profile do not see a judge mode link" do

--- a/spec/features/regional_ambassador/switch_to_mentor_spec.rb
+++ b/spec/features/regional_ambassador/switch_to_mentor_spec.rb
@@ -53,17 +53,6 @@ RSpec.feature "RAs switch to mentor mode" do
     expect(current_path).to eq(regional_ambassador_dashboard_path)
   end
 
-  scenario "RAs with a judge profile can browse to judge profile" do
-    regional_ambassador = FactoryBot.create(:regional_ambassador, :approved, :has_judge_profile)
-
-    sign_in(regional_ambassador)
-
-    visit judge_dashboard_path
-
-    expect(current_path).to eq(judge_dashboard_path)
-    expect(page).to have_link("Switch to RA mode")
-  end
-
   scenario "RAs without a judge profile do not see a judge mode link" do
     regional_ambassador = FactoryBot.create(:regional_ambassador, :approved)
 

--- a/spec/features/regional_ambassador/switch_to_mentor_spec.rb
+++ b/spec/features/regional_ambassador/switch_to_mentor_spec.rb
@@ -38,4 +38,50 @@ RSpec.feature "RAs switch to mentor mode" do
     visit regional_ambassador_dashboard_path
     expect(current_path).to eq(mentor_dashboard_path)
   end
+
+  scenario "RAs with a judge profile can switch to judge mode" do
+    regional_ambassador = FactoryBot.create(:regional_ambassador, :approved, :has_judge_profile)
+
+    sign_in(regional_ambassador)
+
+    expect(regional_ambassador.is_a_judge?).to be_truthy
+
+    click_link "Judge Mode"
+    expect(current_path).to eq(judge_dashboard_path)
+
+    click_link "Switch to RA mode"
+    expect(current_path).to eq(regional_ambassador_dashboard_path)
+  end
+
+  scenario "RAs with a judge profile can browse to judge profile" do
+    regional_ambassador = FactoryBot.create(:regional_ambassador, :approved, :has_judge_profile)
+
+    sign_in(regional_ambassador)
+
+    visit judge_dashboard_path
+
+    expect(current_path).to eq(judge_dashboard_path)
+    expect(page).to have_link("Switch to RA mode")
+  end
+
+  scenario "RAs without a judge profile do not see a judge mode link" do
+    regional_ambassador = FactoryBot.create(:regional_ambassador, :approved)
+
+    sign_in(regional_ambassador)
+
+    expect(regional_ambassador.is_a_judge?).to be_falsey
+
+    expect(page).not_to have_link("Switch to Judge mode")
+  end
+
+  scenario "RAs without a judge profile cannot browse to judge profile" do
+    regional_ambassador = FactoryBot.create(:regional_ambassador, :approved)
+
+    sign_in(regional_ambassador)
+
+    visit judge_dashboard_path
+
+    expect(current_path).to eq(regional_ambassador_dashboard_path)
+    expect(page).to have_content("You don't have permission to go there!")
+  end
 end


### PR DESCRIPTION
Addresses the needs in #1571. Meets the following acceptance criteria:
- New Mentors/RAs, or Mentors/RAs who do not already have judge profiles, should not be able to switch to judge mode.
- Existing judges should be able to switch.

Approach:
- Removed the judge profile creation hook and controller functionality so that judge profiles aren't created for Mentors/RAs visiting the judge profile section without a judge profile.
- Added logic so that the judge profile link does not appear for Mentors/RAs unless they have a judge profile already.
- Confirmed that removing the judge creation hook forces a redirect when a Mentor/RA visits the judge dashboard without access.

I also added rspec tests around the link visibility functionality and no-access redirects.