### PR TITLE
Disable team invites during judging

### DIFF
--- a/app/controllers/mentor/join_requests_controller.rb
+++ b/app/controllers/mentor/join_requests_controller.rb
@@ -2,16 +2,26 @@ module Mentor
   class JoinRequestsController < MentorController
     def new
       @team = Team.find(params.fetch(:team_id))
+
+      if SeasonToggles.judging_enabled_or_between?
+        redirect_to mentor_team_path(@team),
+          alert: t("views.team_member_invites.show.invites_disabled_by_judging")
+      end
     end
 
     def create
       @team = Team.find(params.fetch(:team_id))
 
-      join_request = current_mentor.join_requests.find_or_create_by!(team: @team)
+      if SeasonToggles.judging_enabled_or_between?
+        redirect_to mentor_team_path(@team),
+          alert: t("views.team_member_invites.show.invites_disabled_by_judging")
+      elsif
+        join_request = current_mentor.join_requests.find_or_create_by!(team: @team)
 
-      redirect_to mentor_join_request_path(join_request),
-        success: t("controllers.mentor.join_requests.create.success",
-                  name: @team.name)
+        redirect_to mentor_join_request_path(join_request),
+          success: t("controllers.mentor.join_requests.create.success",
+                    name: @team.name)
+      end
     end
 
     def show
@@ -19,7 +29,13 @@ module Mentor
         review_token: params.fetch(:id)
       ) || ::NullJoinRequest.new
 
-      if reviewer_is_requestor?(@join_request)
+      if SeasonToggles.judging_enabled_or_between?
+        redirect_to mentor_team_path(
+          @join_request.team,
+          anchor: @join_request.requestor_scope_name.pluralize
+        ),
+          alert: t("views.team_member_invites.show.invites_disabled_by_judging")
+      elsif reviewer_is_requestor?(@join_request)
         render template: "join_requests/show_requestor_#{@join_request.status}"
       elsif reviewer_is_unauthorized?(@join_request)
         redirect_to mentor_dashboard_path,
@@ -35,15 +51,23 @@ module Mentor
       join_request = JoinRequest.find_by(review_token: params.fetch(:id)) ||
         ::NullJoinRequest.new
 
-      "join_request_#{status}".camelize.constantize.(join_request)
+      if SeasonToggles.judging_enabled_or_between?
+        redirect_to mentor_team_path(
+          join_request.team,
+          anchor: join_request.requestor_scope_name.pluralize
+        ),
+          alert: t("views.team_member_invites.show.invites_disabled_by_judging")
+      elsif
+        "join_request_#{status}".camelize.constantize.(join_request)
 
-      redirect_to params[:back] || mentor_team_path(
-        join_request.team,
-        anchor: join_request.requestor_scope_name.pluralize
-      ),
-      success: t("controllers.mentor.join_requests.update.success",
-                 name: join_request.requestor_first_name,
-                 status: status)
+        redirect_to params[:back] || mentor_team_path(
+          join_request.team,
+          anchor: join_request.requestor_scope_name.pluralize
+        ),
+        success: t("controllers.mentor.join_requests.update.success",
+                  name: join_request.requestor_first_name,
+                  status: status)
+      end
     end
 
     private

--- a/app/views/completion_steps/_join_requests.en.html.erb
+++ b/app/views/completion_steps/_join_requests.en.html.erb
@@ -1,7 +1,11 @@
 <% unless hidden ||= false %>
   <h1 class="content-heading">Join a team</h1>
 
-  <% if requests.any? %>
+  <% if SeasonToggles.judging_enabled_or_between? %>
+    <p>
+      <%= t("views.team_member_invites.show.join_team_disabled_by_judging") %>
+    </p>
+  <% elsif requests.any? %>
     <p>You have asked to join a team!</p>
 
     <% requests.each do |join_request| %>

--- a/app/views/teams/_edit_students.en.html.erb
+++ b/app/views/teams/_edit_students.en.html.erb
@@ -39,7 +39,7 @@
 
 <div class="grid grid--bleed">
   <div class="grid__col-auto">
-    <% if SeasonToggles.team_building_enabled? %>
+    <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
       <% if !admin_ra && team.current? && team.spot_available? %>
         <%= render "team_member_invites/form" %>
 

--- a/app/views/teams/_pending_requests.html.erb
+++ b/app/views/teams/_pending_requests.html.erb
@@ -5,9 +5,16 @@
     <div class="grid__col-auto">
       <h3 class="reset">Requests from others</h3>
 
-      <p class="hint">
-        These people are waiting for your team's response
-      </p>
+      <% if SeasonToggles.judging_enabled_or_between? %>
+        <p class="hint">
+          Judging has begun or we are in between judging rounds, so you cannot
+          approve or decline these invitations.
+        </p>
+      <% else %>
+        <p class="hint">
+          These people are waiting for your team's response
+        </p>
+      <% end %>
 
       <ul class="reset">
         <% requests.each do |join_request| %>
@@ -35,38 +42,40 @@
                       )
                     ) %>
 
-                  <p class="buttons">
-                    <%= link_to t("views.application.approved"),
-                      [
-                        current_scope,
-                        join_request,
-                        join_request: { status: :approved },
-                      ],
+                  <% if !SeasonToggles.judging_enabled_or_between? %>
+                    <p class="buttons">
+                      <%= link_to t("views.application.approved"),
+                        [
+                          current_scope,
+                          join_request,
+                          join_request: { status: :approved },
+                        ],
 
-                      class: "button small",
+                        class: "button small",
 
-                      data: {
-                        method: :put,
-                        confirm: t("views.application.confirm_approved",
-                                  name: join_request.requestor_first_name),
-                        positive: true,
-                      } %>
+                        data: {
+                          method: :put,
+                          confirm: t("views.application.confirm_approved",
+                                    name: join_request.requestor_first_name),
+                          positive: true,
+                        } %>
 
-                    <%= link_to t("views.application.declined"),
-                      [
-                        current_scope,
-                        join_request,
-                        join_request: { status: :declined },
-                      ],
+                      <%= link_to t("views.application.declined"),
+                        [
+                          current_scope,
+                          join_request,
+                          join_request: { status: :declined },
+                        ],
 
-                      class: "button small danger",
+                        class: "button small danger",
 
-                      data: {
-                        method: :put,
-                        confirm: t("views.application.confirm_declined",
-                                  name: join_request.requestor_first_name),
-                      } %>
-                  </p>
+                        data: {
+                          method: :put,
+                          confirm: t("views.application.confirm_declined",
+                                    name: join_request.requestor_first_name),
+                        } %>
+                    </p>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -351,6 +351,7 @@ en:
         message: "Review this team and respond below"
         missing: "We're sorry, but this invitation appears to be missing. Either the token is incorrect, or the invitation was removed by the team."
         invites_disabled_by_judging: "Sorry, but team invitations are currently disabled because judging has already begun."
+        join_team_disabled_by_judging: "Sorry, but you cannot join a team because judging has already begun."
 
     team_searches:
       new:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -350,7 +350,7 @@ en:
         greeting: "You've been invited to join %{name}!"
         message: "Review this team and respond below"
         missing: "We're sorry, but this invitation appears to be missing. Either the token is incorrect, or the invitation was removed by the team."
-        invites_disabled_by_judging: "Sorry, but accepting invites is currently disabled because judging has already begun."
+        invites_disabled_by_judging: "Sorry, but team invitations are currently disabled because judging has already begun."
 
     team_searches:
       new:

--- a/spec/controllers/mentor/join_requests_controller_spec.rb
+++ b/spec/controllers/mentor/join_requests_controller_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Mentor::JoinRequestsController do
+  describe "POST #new" do
+    let(:team) { FactoryBot.create(:team, members_count: 2) }
+    let(:mentor) { FactoryBot.create(:mentor) }
+
+    before do
+      sign_in(mentor)
+    end
+
+    it "redirects and displays alert if judging is enabled or between rounds" do
+      SeasonToggles.judging_round = :qf
+
+      post :new, params: { team_id: team.id }
+
+      expect(response).to redirect_to mentor_team_path(team)
+      expect(flash[:alert]).to eq(
+        "Sorry, but team invitations are currently disabled because judging has already begun."
+      )
+    end
+  end
+
   describe "POST #create" do
     let(:team) { FactoryBot.create(:team, members_count: 2) }
     let(:mentor) { FactoryBot.create(:mentor) }
@@ -8,6 +28,10 @@ RSpec.describe Mentor::JoinRequestsController do
     before do
       sign_in(mentor)
       post :create, params: { team_id: team.id }
+    end
+
+    before(:each) do
+      SeasonToggles.judging_round = :off
     end
 
     it "redirects gracefully on dupe" do
@@ -43,6 +67,103 @@ RSpec.describe Mentor::JoinRequestsController do
       )
 
       expect(bodies.sample.to_s).to include("href=\"#{url}")
+    end
+
+    it "redirects and displays alert if judging is enabled or between rounds" do
+      SeasonToggles.judging_round = :qf
+
+      post :create, params: { team_id: team.id }
+
+      expect(response).to redirect_to mentor_team_path(team)
+      expect(flash[:alert]).to eq(
+        "Sorry, but team invitations are currently disabled because judging has already begun."
+      )
+    end
+  end
+
+  describe "POST #show" do
+    let(:team) { FactoryBot.create(:team, :with_mentor, members_count: 2) }
+    let(:student) { FactoryBot.create(:student) }
+    let(:join_request) {
+      FactoryBot.create(
+        :join_request,
+        team: team,
+        requestor: student
+      )
+    }
+
+    before do
+      sign_in(team.mentors.sample)
+    end
+
+    it "redirects and displays alert if judging is enabled or between rounds" do
+      SeasonToggles.judging_round = :qf
+
+      post :show, params: { id: join_request.review_token }
+
+      expect(response).to redirect_to mentor_team_path(
+        team,
+        anchor: join_request.requestor_scope_name.pluralize
+      )
+
+      expect(flash[:alert]).to eq(
+        "Sorry, but team invitations are currently disabled because judging has already begun."
+      )
+    end
+  end
+
+  describe "PUT #update" do
+    let(:team) { FactoryBot.create(:team, :with_mentor, members_count: 2) }
+    let(:student) { FactoryBot.create(:student) }
+    let(:join_request) {
+      FactoryBot.create(
+        :join_request,
+        team: team,
+        requestor: student
+      )
+    }
+
+    before do
+      sign_in(team.mentors.sample)
+      request.env["HTTP_REFERER"] = "/somewhere"
+    end
+
+    context "judging is enabled or between judging rounds" do
+      before(:each) do
+        SeasonToggles.judging_round = :qf
+      end
+
+      it "redirects and displays alert if approved" do
+        put :update, params: {
+          id: join_request.review_token,
+          join_request: { status: :approved },
+        }
+
+        expect(response).to redirect_to mentor_team_path(
+          team,
+          anchor: join_request.requestor_scope_name.pluralize
+        )
+
+        expect(flash[:alert]).to eq(
+          "Sorry, but team invitations are currently disabled because judging has already begun."
+        )
+      end
+
+      it "redirects and displays alert if denied" do
+        put :update, params: {
+          id: join_request.review_token,
+          join_request: { status: :declined },
+        }
+
+        expect(response).to redirect_to mentor_team_path(
+          team,
+          anchor: join_request.requestor_scope_name.pluralize
+        )
+
+        expect(flash[:alert]).to eq(
+          "Sorry, but team invitations are currently disabled because judging has already begun."
+        )
+      end
     end
   end
 end

--- a/spec/controllers/student/team_member_invites_controller_spec.rb
+++ b/spec/controllers/student/team_member_invites_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Student::TeamMemberInvitesController do
 
       expect(response).to redirect_to student_dashboard_path
       expect(flash[:alert]).to eq(
-        "Sorry, but accepting invites is currently disabled because judging has already begun."
+        "Sorry, but team invitations are currently disabled because judging has already begun."
       )
       expect(invite.reload).to be_pending
     end
@@ -129,7 +129,7 @@ RSpec.describe Student::TeamMemberInvitesController do
 
         expect(response).to redirect_to student_dashboard_path
         expect(flash[:alert]).to eq(
-          "Sorry, but accepting invites is currently disabled because judging has already begun."
+          "Sorry, but team invitations are currently disabled because judging has already begun."
         )
         expect(invite.reload).to be_pending
       end


### PR DESCRIPTION
Adds additional rules to lock-down sending new invites and accepting/rejecting invite requests sent when a user asks to join a team.