### PR TITLE
Chunking Improvements

### DIFF
--- a/app/javascript/admin/content-settings/index.js
+++ b/app/javascript/admin/content-settings/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 import AdminContentSettings from './components/AdminContentSettings'

--- a/app/javascript/admin/content-settings/store/index.js
+++ b/app/javascript/admin/content-settings/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/admin/dashboard/index.js
+++ b/app/javascript/admin/dashboard/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 import AdminDashboard from './components/AdminDashboard'

--- a/app/javascript/admin/dashboard/store/index.js
+++ b/app/javascript/admin/dashboard/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/admin/review-requests/index.js
+++ b/app/javascript/admin/review-requests/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import store from './store'
 import router from './router'

--- a/app/javascript/admin/review-requests/store/index.js
+++ b/app/javascript/admin/review-requests/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/admin/scores/index.js
+++ b/app/javascript/admin/scores/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import store from './store'
 import { router } from './routes'

--- a/app/javascript/admin/scores/routes/index.js
+++ b/app/javascript/admin/scores/routes/index.js
@@ -1,4 +1,3 @@
-import Vue from 'vue/dist/vue.esm';
 import VueRouter from 'vue-router'
 
 import SuspiciousScoresList from '../suspicious_scores/list'

--- a/app/javascript/admin/scores/store/index.js
+++ b/app/javascript/admin/scores/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 Vue.use(Vuex)

--- a/app/javascript/components/EventBus.js
+++ b/app/javascript/components/EventBus.js
@@ -1,3 +1,3 @@
-import Vue from "vue";
+import Vue from 'vue'
 
 export default new Vue({ });

--- a/app/javascript/components/job_process/index.js
+++ b/app/javascript/components/job_process/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import JpTemplate from './template'
 

--- a/app/javascript/datagrids/scores/index.js
+++ b/app/javascript/datagrids/scores/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 document.addEventListener('turbolinks:load', () => {
   const table = document.querySelector("table.scored_submissions_grid")

--- a/app/javascript/judge/dashboards/index.js
+++ b/app/javascript/judge/dashboards/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import store from './scores/store'
 import { router } from './scores/routes'

--- a/app/javascript/judge/dashboards/scores/routes.js
+++ b/app/javascript/judge/dashboards/scores/routes.js
@@ -1,4 +1,3 @@
-import Vue from 'vue/dist/vue.esm'
 import VueRouter from 'vue-router'
 
 import FinishedScoresList from './FinishedScoresList'

--- a/app/javascript/judge/dashboards/scores/store.js
+++ b/app/javascript/judge/dashboards/scores/store.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm';
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 Vue.use(Vuex)

--- a/app/javascript/judge/scores/index.js
+++ b/app/javascript/judge/scores/index.js
@@ -1,5 +1,5 @@
 import URLSearchParams from 'url-search-params'
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import store from './store'
 import { router } from './routes'

--- a/app/javascript/judge/scores/routes.js
+++ b/app/javascript/judge/scores/routes.js
@@ -1,4 +1,3 @@
-import Vue from 'vue/dist/vue.esm';
 import VueRouter from 'vue-router'
 
 import ReviewSubmission from './sections/ReviewSubmission'

--- a/app/javascript/judge/scores/stepper.js
+++ b/app/javascript/judge/scores/stepper.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import store from './store'
 import { router } from './routes'

--- a/app/javascript/judge/scores/store/actions.js
+++ b/app/javascript/judge/scores/store/actions.js
@@ -14,7 +14,9 @@ export const validateScore = ({ commit, state }) => {
     }
   })
 
-  _.each(state.score.comments, (comment, section) => {
+  Object.keys(state.score.comments).forEach((section) => {
+    const comment = state.score.comments[section]
+
     if (state.team.division === 'junior' && section === 'entrepreneurship') {
       return true
     } else if (comment.word_count < 40 ||

--- a/app/javascript/judge/scores/store/index.js
+++ b/app/javascript/judge/scores/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/judge/scores/store/mutations.js
+++ b/app/javascript/judge/scores/store/mutations.js
@@ -74,7 +74,7 @@ export const saveComment = (state, sectionName) => {
 }
 
 export const updateScores = (state, qData) => {
-  let question = _.find(state.questions, q => {
+  const question = state.questions.find((q) => {
     return q.section === qData.section && q.idx === qData.idx
   })
 

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -270,7 +270,7 @@ export default {
 
   computed: {
     countryDetectedInStateOptionalList () {
-      if (!this.country.length)
+      if (!this.country || !this.country.length)
         return false
 
       return this.country.match(/^\s*(hong\s*kong|hk)\s*$/i) ||

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import VueRouter from 'vue-router'
 import TurbolinksAdapter from 'vue-turbolinks'

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,7 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import TurbolinksAdapter from 'vue-turbolinks'
 
 import AutocompleteInput from '../components/AutocompleteInput'

--- a/app/javascript/packs/job_process.js
+++ b/app/javascript/packs/job_process.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import VueRouter from 'vue-router'
 import TurbolinksAdapter from 'vue-turbolinks'

--- a/app/javascript/packs/judge.js
+++ b/app/javascript/packs/judge.js
@@ -1,5 +1,5 @@
 import "babel-polyfill"
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import VueRouter from 'vue-router'
 import TurbolinksAdapter from 'vue-turbolinks'

--- a/app/javascript/packs/ra.js
+++ b/app/javascript/packs/ra.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import VueRouter from 'vue-router'
 import TurbolinksAdapter from 'vue-turbolinks'

--- a/app/javascript/packs/student.js
+++ b/app/javascript/packs/student.js
@@ -1,5 +1,5 @@
 import "babel-polyfill"
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 import VueRouter from 'vue-router'
 import TurbolinksAdapter from 'vue-turbolinks'

--- a/app/javascript/packs/submissions.js
+++ b/app/javascript/packs/submissions.js
@@ -1,5 +1,5 @@
-import TurbolinksAdapter from 'vue-turbolinks';
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
+import TurbolinksAdapter from 'vue-turbolinks'
 
 import '../config/axios'
 

--- a/app/javascript/ra/events/EventsTable.vue
+++ b/app/javascript/ra/events/EventsTable.vue
@@ -141,7 +141,10 @@
       },
 
       editingOne () {
-        return this.formActive || _.some(this.events, "editing");
+        const editingEvent = this.events.some((event) => {
+          return Boolean(event.editing)
+        })
+        return this.formActive || editingEvent
       },
     },
 
@@ -162,7 +165,7 @@
 
       editEvent (event) {
         event.editing = true;
-        _.each(this.events, (e) => { e.managing = false });
+        this.events.forEach((e) => { e.managing = false })
         EventBus.$emit("EventsTable.editEvent", event);
       },
 
@@ -206,7 +209,7 @@
 
       EventBus.$on("EventForm.reset", () => {
         this.formActive = false;
-        _.each(this.events, (e) => { e.editing = false; });
+        this.events.forEach((e) => { e.editing = false; })
       });
 
       EventBus.$on("EventForm.active", () => {
@@ -217,8 +220,7 @@
         method: "GET",
         url: this.fetchUrl,
         success: (resp) => {
-          _.each(resp, (event) => {
-
+          Array.from(resp).forEach((event) => {
             event.fetchTeamsUrlRoot = this.teamsListUrl;
             event.fetchJudgesUrlRoot = this.judgesListUrl;
 

--- a/app/javascript/ra/events/index.js
+++ b/app/javascript/ra/events/index.js
@@ -1,11 +1,11 @@
-import Vue from 'vue/dist/vue.esm';
+import Vue from 'vue'
 import Vuex from 'vuex'
 
-import EventsTable from './EventsTable';
-import EventForm from './EventForm';
+import EventsTable from './EventsTable'
+import EventForm from './EventForm'
 
-import "flatpickr/dist/themes/material_green.css";
-import "../../components/tooltip.scss";
+import "flatpickr/dist/themes/material_green.css"
+import "../../components/tooltip.scss"
 
 Vue.use(Vuex)
 

--- a/app/javascript/ra/events/index.js
+++ b/app/javascript/ra/events/index.js
@@ -16,7 +16,7 @@ const store = new Vuex.Store({
 
   mutations: {
     addTeam (state, team) {
-      const idx = _.findIndex(state.teams, t => {
+      const idx = state.teams.findIndex((t) => {
         return t.id === team.id
       })
 
@@ -25,7 +25,7 @@ const store = new Vuex.Store({
     },
 
     removeTeam (state, team) {
-      const idx = _.findIndex(state.teams, t => {
+      const idx = state.teams.findIndex((t) => {
         return t.id === team.id
       })
 

--- a/app/javascript/registration/index.js
+++ b/app/javascript/registration/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vue2Filters from 'vue2-filters'
 
 import router from './routes'

--- a/app/javascript/registration/routes/index.js
+++ b/app/javascript/registration/routes/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 import store from '../store'

--- a/app/javascript/registration/store/index.js
+++ b/app/javascript/registration/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/student/index.js
+++ b/app/javascript/student/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vue2Filters from 'vue2-filters'
 
 import router from './routes'

--- a/app/javascript/student/routes/index.js
+++ b/app/javascript/student/routes/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import VueRouter from 'vue-router'
 
 import RegistrationApp from 'registration/App'

--- a/app/javascript/student/routes/judging.js
+++ b/app/javascript/student/routes/judging.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 const JudgingStep = Vue.component('judging-step', {
   template: `<div><slot :name="$route.name">slot named {{ $route.name }}</slot></div>`,

--- a/app/javascript/student/routes/scores.js
+++ b/app/javascript/student/routes/scores.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 const ScoreStep = Vue.component('score-step', {
   template: `<div><slot :name="$route.name">slot named {{ $route.name }}</slot></div>`,

--- a/app/javascript/student/routes/teams.js
+++ b/app/javascript/student/routes/teams.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 const TeamBuildingStep = Vue.component('team-building-step', {
   template: `<div><slot :name="$route.name">add App.vue and TeamBuilding.vue slots for route named {{ $route.name }}</slot></div>`,

--- a/app/javascript/student/store/index.js
+++ b/app/javascript/student/store/index.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import Vuex from 'vuex'
 
 import state from './state'

--- a/app/javascript/student/store/mutations.js
+++ b/app/javascript/student/store/mutations.js
@@ -1,4 +1,4 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 
 export default {
   refs (state, value) {

--- a/app/javascript/submissions/screenshots.js
+++ b/app/javascript/submissions/screenshots.js
@@ -1,5 +1,5 @@
-import Vue from 'vue/dist/vue.common'
-import VueDragula from 'vue-dragula';
+import Vue from 'vue'
+import VueDragula from 'vue-dragula'
 
 Vue.use(VueDragula)
 

--- a/app/javascript/utilities/vuex-mock-store.js
+++ b/app/javascript/utilities/vuex-mock-store.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 import Vue from 'vue'
 import Vuex from 'vuex'

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -30,6 +30,9 @@
     <%= javascript_include_tag determine_manifest,
       'data-turbolinks-track' => true %>
 
+    <%= javascript_pack_tag "manifest" %>
+    <%= javascript_pack_tag "vendor" %>
+    <%= javascript_pack_tag "application" %>
     <%= javascript_pack_tag("submissions") %>
 
     <%= yield :js %>

--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -6,6 +6,7 @@ module.exports = {
       '@appjs': path.resolve(__dirname, '..', '..', 'app/javascript'),
       '@assetsjs': path.resolve(__dirname, '..', '..', 'app/assets/javascripts'),
       '@vendorjs': path.resolve(__dirname, '..', '..', 'vendor/assets/javascripts'),
+      'vue$': 'vue/dist/vue.esm.js' // Use the full build
     }
   }
 }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,6 @@
 const { environment } = require('@rails/webpacker')
 const customConfig = require('./custom')
-const vue =  require('./loaders/vue')
+const vue = require('./loaders/vue')
 
 environment.loaders.append('vue', vue)
 

--- a/spec/javascript/attendee.spec.js
+++ b/spec/javascript/attendee.spec.js
@@ -1,6 +1,4 @@
-import _ from "lodash";
-
-import Attendee from 'ra/events/Attendee';
+import Attendee from 'ra/events/Attendee'
 
 test('assignedTeamFoundInEvent adds teams to assignedTeams list', () => {
   const team = new Attendee({ id: 1 })
@@ -8,6 +6,6 @@ test('assignedTeamFoundInEvent adds teams to assignedTeams list', () => {
 
   judge.assignedTeamFoundInEvent(team)
 
-  expect(_.map(judge.assignedTeams, 'id')).toEqual([1])
-  expect(_.map(team.assignedJudges, 'id')).toEqual([2])
+  expect(judge.assignedTeams.map((team) => team.id)).toEqual([1])
+  expect(team.assignedJudges.map((judge) => judge.id)).toEqual([2])
 })

--- a/spec/javascript/event.spec.js
+++ b/spec/javascript/event.spec.js
@@ -1,7 +1,5 @@
-import _ from "lodash";
-
-import Event from 'ra/events/Event';
-import Attendee from 'ra/events/Attendee';
+import Event from 'ra/events/Event'
+import Attendee from 'ra/events/Attendee'
 
 test('resultReadyForList ignores double entry', () => {
   let event = new Event({ id: 1 })
@@ -10,7 +8,7 @@ test('resultReadyForList ignores double entry', () => {
   event.resultReadyForList(teamResp, event.selectedTeams)
   event.resultReadyForList(teamResp, event.selectedTeams)
 
-  expect(_.map(event.selectedTeams, "id")).toEqual([1])
+  expect(event.selectedTeams.map((team) => team.id)).toEqual([1])
 })
 
 test('resultReadyForList appends assignments', () => {
@@ -25,55 +23,55 @@ test('resultReadyForList appends assignments', () => {
   const team = event.selectedTeams[0]
   const judge = event.selectedJudges[0]
 
-  expect(_.map(team.assignedJudges, "id")).toEqual([2])
-  expect(_.map(judge.assignedTeams, "id")).toEqual([1])
+  expect(team.assignedJudges.map((judge) => judge.id)).toEqual([2])
+  expect(judge.assignedTeams.map((team) => team.id)).toEqual([1])
 })
 
 test('addTeam adds new teams', () => {
-  let event = new Event({ id: 1 });
+  let event = new Event({ id: 1 })
 
-  const team1 = new Attendee({ id: "1" });
-  event.addTeam(team1);
+  const team1 = new Attendee({ id: "1" })
+  event.addTeam(team1)
 
-  const team2 = new Attendee({ id: "2" });
-  event.addTeam(team2);
+  const team2 = new Attendee({ id: "2" })
+  event.addTeam(team2)
 
-  expect(_.map(event.selectedTeams, "id")).toEqual([1, 2]);
-});
+  expect(event.selectedTeams.map((team) => team.id)).toEqual([1, 2])
+})
 
 test('addTeam ignores already added teams', () => {
-  let event = new Event({ id: 1 });
+  let event = new Event({ id: 1 })
 
-  const team = new Attendee({ id: "1" });
-  event.addTeam(team);
-  event.addTeam(team);
+  const team = new Attendee({ id: "1" })
+  event.addTeam(team)
+  event.addTeam(team)
 
-  expect(_.map(event.selectedTeams, "id")).toEqual([1]);
-});
+  expect(event.selectedTeams.map((team) => team.id)).toEqual([1])
+})
 
 test('removeTeam removes specified team', () => {
-  let event = new Event({ id: 1 });
+  let event = new Event({ id: 1 })
 
-  const remove = new Attendee({ id: "1" });
-  event.addTeam(remove);
+  const remove = new Attendee({ id: "1" })
+  event.addTeam(remove)
 
-  const keep = new Attendee({ id: "2" });
-  event.addTeam(keep);
+  const keep = new Attendee({ id: "2" })
+  event.addTeam(keep)
 
-  event.removeTeam(remove);
-  expect(_.map(event.selectedTeams, "id")).toEqual([2]);
-});
+  event.removeTeam(remove)
+  expect(event.selectedTeams.map((team) => team.id)).toEqual([2])
+})
 
 test('addTeam/removeTeam notifies teams of the action', () => {
-  let event = new Event({ id: 1 });
-  const team = new Attendee({ id: "1" });
+  let event = new Event({ id: 1 })
+  const team = new Attendee({ id: "1" })
 
-  event.addTeam(team);
-  expect(team.selected).toBe(true);
+  event.addTeam(team)
+  expect(team.selected).toBe(true)
 
-  event.removeTeam(team);
-  expect(team.selected).toBe(false);
-});
+  event.removeTeam(team)
+  expect(team.selected).toBe(false)
+})
 
 describe('findTeam', () => {
   let event


### PR DESCRIPTION
Gets us from 3.24 MB to 2.81 MB total vendor.js size by streamlining all Vue imports to use the correct version, and removing lodash in various spots. Additionally, this fixes some broken functionality that occurred during initial passthrough when removing lodash functionality.

Going forward we can just import Vue via: `import Vue from 'vue'`