### PR TITLE
Screenshot uploader preview bugfix

### DIFF
--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -35,7 +35,7 @@
           class="submission-pieces__screenshot img-modal"
           :src="screenshot.src"
           :alt="screenshot.name"
-          :data-modal-url="screenshot.large_img_url"
+          :data-modal-url="screenshot.largeImgUrl"
         />
 
         <div class="sortable-list__item-actions">
@@ -185,12 +185,7 @@ export default {
 
         window.axios.post(this.screenshotsUrl, form)
           .then(({data}) => {
-            this.screenshots.push({
-              id: data.id,
-              src: data.src,
-              name: data.name,
-              large_img_url: data.large_img_url,
-            })
+            this.screenshots.push(data)
 
             const i = this.uploads.indexOf(file)
             this.uploads.splice(i, 1)


### PR DESCRIPTION
Addresses bug found in issue #1651. You can now preview the screenshots in the uploader. `axios-case-converter` caused issues with the response. This has been fixed and screenshots are now working.