### PR TITLE
Add point count to code checklist

### DIFF
--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -125,7 +125,9 @@
         <%= link_to submission_progress_web_icon(
           submission,
           :code_checklist,
-          "Code checklist*"
+          submission.code_checklist_points > 0 ?
+            "Code checklist* (#{submission.code_checklist_points}/10)" :
+              "Code checklist*"
         ),
         [current_scope, submission, piece: :code_checklist] %>
 


### PR DESCRIPTION
Addresses issue #1652.

Adds a point count with total to the code checklist link in the submission area if the code checklist has been started and progress has been saved.