### PR TITLE
Vue saturation proof of concept

### DIFF
--- a/app/javascript/components/Tabs.vue
+++ b/app/javascript/components/Tabs.vue
@@ -1,0 +1,31 @@
+<script>
+  export default {
+    props: {
+      section: {
+        type: String,
+        default: '',
+      }
+    },
+
+    data () {
+      return {
+        mutableSection: '',
+      }
+    },
+
+    created () {
+      this.setSection(this.section)
+    },
+
+    methods: {
+      isSection (section) {
+        return this.mutableSection === section
+      },
+
+      setSection (section) {
+        this.mutableSection = section
+        history.replaceState(history.state, '', `#!${this.mutableSection}`)
+      },
+    }
+  }
+</script>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ import TurbolinksAdapter from 'vue-turbolinks'
 import AutocompleteInput from 'components/AutocompleteInput'
 import CertificateButton from 'components/CertificateButton'
 import LocationForm from '../location/components/LocationForm'
+import Tabs from 'components/Tabs'
 
 Vue.use(TurbolinksAdapter)
 
@@ -67,6 +68,18 @@ document.addEventListener('turbolinks:load', function () {
 
       components: {
         AutocompleteInput,
+      },
+    })
+  }
+
+  const tabElements = document.querySelectorAll('.vue-enable-tabs')
+
+  for (let i = 0; i < tabElements.length; i += 1) {
+    new Vue({
+      el: tabElements[i],
+      extends: Tabs,
+      propsData: {
+        section: 'students',
       },
     })
   }

--- a/app/views/teams/_edit_menu.en.html.erb
+++ b/app/views/teams/_edit_menu.en.html.erb
@@ -1,19 +1,29 @@
 <ul class="tabs__menu" data-closed="true">
-  <li class="tabs__menu-link">
+  <li
+    class="tabs__menu-link"
+    :class="{
+      'tabs__menu-link--active': isSection('students')
+    }"
+  >
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="students"
+      @click.stop.prevent="setSection('students')"
     >
       Students
     </button>
   </li>
 
-  <li class="tabs__menu-link">
+  <li
+    class="tabs__menu-link"
+    :class="{
+      'tabs__menu-link--active': isSection('mentors')
+    }"
+  >
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="mentors"
+      @click.stop.prevent="setSection('mentors')"
     >
       Mentors
     </button>
@@ -23,37 +33,52 @@
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="photo"
+      @click.stop.prevent="setSection('photo')"
     >
       Team photo
     </button>
   </li>
 
-  <li class="tabs__menu-link">
+  <li
+    class="tabs__menu-link"
+    :class="{
+      'tabs__menu-link--active': isSection('description')
+    }"
+  >
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="description"
+      @click.stop.prevent="setSection('description')"
     >
       Summary
     </button>
   </li>
 
-  <li class="tabs__menu-link">
+  <li
+    class="tabs__menu-link"
+    :class="{
+      'tabs__menu-link--active': isSection('location')
+    }"
+  >
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="location"
+      @click.stop.prevent="setSection('location')"
     >
       Location
     </button>
   </li>
 
-  <li class="tabs__menu-link">
+  <li
+    class="tabs__menu-link"
+    :class="{
+      'tabs__menu-link--active': isSection('division')
+    }"
+  >
     <button
       role="button"
       class="tabs__menu-button"
-      data-tab-id="division"
+      @click.stop.prevent="setSection('division')"
     >
       Division
     </button>

--- a/app/views/teams/_show.html.erb
+++ b/app/views/teams/_show.html.erb
@@ -1,6 +1,6 @@
 <% admin_ra ||= false %>
 
-<div class="grid tabs tabs--vertical">
+<div class="grid tabs tabs--vertical tabs--css-only vue-enable-tabs">
   <div class="grid__col-sm-3 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
@@ -18,7 +18,7 @@
   <div class="tabs__content grid__col-sm-9 col--sticky-parent">
     <div class="col--sticky-spacer">
       <div class="col--sticky">
-        <div class="tabs__tab-content" id="students">
+        <div class="tabs__tab-content" v-show="isSection('students')">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -30,7 +30,7 @@
             team: team %>
         </div>
 
-        <div class="tabs__tab-content" id="mentors">
+        <div class="tabs__tab-content" v-show="isSection('mentors')">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -55,7 +55,7 @@
             team: team %>
         </div>
 
-        <div class="tabs__tab-content" id="description">
+        <div class="tabs__tab-content" v-show="isSection('description')">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -65,7 +65,7 @@
           <%= render 'teams/edit_description', team: team %>
         </div>
 
-        <div class="tabs__tab-content" id="location">
+        <div class="tabs__tab-content" v-show="isSection('location')">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>
@@ -75,7 +75,7 @@
           <%= render 'teams/location', team: team %>
         </div>
 
-        <div class="tabs__tab-content" id="division">
+        <div class="tabs__tab-content" v-show="isSection('division')">
           <div class="grid grid--bleed">
             <div class="grid__col-auto">
               <h1 class="content-heading"><%= team.name %></h1>

--- a/spec/javascript/components/Tabs.spec.js
+++ b/spec/javascript/components/Tabs.spec.js
@@ -114,18 +114,20 @@ describe('Tabs Vue component', () => {
         expect(result).toBe(false)
       })
     })
+
+    describe('setSection', () => {
+      it('sets the current section', () => {
+        const historyState = history.state
+        const historySpy = spyOn(history, 'replaceState').and.callThrough()
+
+        expect(historySpy).not.toHaveBeenCalled()
+
+        wrapper.vm.setSection('mentors')
+
+        expect(wrapper.vm.mutableSection).toEqual('mentors')
+        expect(historySpy)
+          .toHaveBeenCalledWith(historyState, '', `#!mentors`)
+      })
+    })
   })
 })
-/*
-<script>
-  export default {
-
-
-      setSection (section) {
-        this.mutableSection = section
-        history.replaceState(history.state, '', `#!${this.mutableSection}`)
-      },
-    }
-  }
-</script>
-*/

--- a/spec/javascript/components/Tabs.spec.js
+++ b/spec/javascript/components/Tabs.spec.js
@@ -1,0 +1,131 @@
+import { shallowMount } from '@vue/test-utils'
+
+import Tabs from 'components/Tabs'
+
+describe('Tabs Vue component', () => {
+  // Set a template for the component to prevent console errors.
+  // This can also be used to test DOM behaviors should that be desired.
+  // Or simplified if not: Tabs.template='<div></div>'
+  Tabs.template = `
+    <div id="tabs-app">
+      <ul class="tabs_menu">
+        <li
+          class="tabs__menu-link"
+          :class="{
+            'tabs__menu-link--active': isSection('students')
+          }"
+        >
+          <button
+            role="button"
+            class="tabs__menu-button"
+            @click.stop.prevent="setSection('students')"
+          >
+            Students
+          </button>
+        </li>
+
+        <li
+          class="tabs__menu-link"
+          :class="{
+            'tabs__menu-link--active': isSection('mentors')
+          }"
+        >
+          <button
+            role="button"
+            class="tabs__menu-button"
+            @click.stop.prevent="setSection('mentors')"
+          >
+            Mentors
+          </button>
+        </li>
+      </ul>
+
+      <div class="tabs__content">
+        <div class="tabs__tab-content" v-show="isSection('students')">
+          <h1 class="content-heading">Students</h1>
+        </div>
+
+        <div class="tabs__tab-content" v-show="isSection('mentors')">
+          <h1 class="content-heading">Mentors</h1>
+        </div>
+      </div>
+    </div>
+  `
+
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(Tabs, {
+      propsData: {
+        section: 'students',
+      },
+    })
+  })
+
+  describe('props', () => {
+    it('contains a valid list of props', () => {
+      expect(Tabs.props).toEqual({
+        section: {
+          type: String,
+          default: '',
+        }
+      })
+    })
+  })
+
+  describe('data', () => {
+    it('contains correct initial data state', () => {
+      expect(Tabs.data()).toEqual({
+        mutableSection: '',
+      })
+    })
+  })
+
+  describe('created hook', () => {
+    it('sets the current section', () => {
+      wrapper.destroy()
+
+      const historyState = history.state
+      const historySpy = spyOn(history, 'replaceState').and.callThrough()
+
+      expect(historySpy).not.toHaveBeenCalled()
+
+      wrapper = shallowMount(Tabs, {
+        propsData: {
+          section: 'mentors',
+        },
+      })
+
+      expect(wrapper.vm.mutableSection).toEqual('mentors')
+      expect(historySpy)
+        .toHaveBeenCalledWith(historyState, '', `#!mentors`)
+    })
+  })
+
+  describe('methods', () => {
+    describe('isSection', () => {
+      it('returns true if section parameter matches the current section', () => {
+        const result = wrapper.vm.isSection('students')
+        expect(result).toBe(true)
+      })
+
+      it('returns false if section parameter does not match the current section', () => {
+        const result = wrapper.vm.isSection('mentors')
+        expect(result).toBe(false)
+      })
+    })
+  })
+})
+/*
+<script>
+  export default {
+
+
+      setSection (section) {
+        this.mutableSection = section
+        history.replaceState(history.state, '', `#!${this.mutableSection}`)
+      },
+    }
+  }
+</script>
+*/


### PR DESCRIPTION
Proof of concept to show how we could rewrite existing JavaScript functionality using Vue without a template. Vue takes a standard Rails template and then lays its own functionality on top, saturating the existing DOM with Vue goodness. I used Vue extends to organize things a bit, and the tests require a small shift in one's thought process, so I included a complete example with some comments.

You can view the working tabs at: `/student/teams/<team-id>`

If this looks good and tests pass, this can be merged safely without breaking any current tabs functionality if we want to pull the proof into QA. This functionality mimics that found in `app/assets/javascripts/tabs.js` and can be used to replace the functionality in other spots throughout the application.