### PR TITLE
Location Form UI/JS Test Coverage

### DIFF
--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -475,7 +475,6 @@ export default {
             matched && matched.length &&
               countries.length === countrySensitivityList.length &&
                 countries.sort().every((value, index) => value === countrySensitivityList.sort()[index])
-
         ) {
           const result = {
             id: Math.floor(Math.random()*16777215).toString(16),

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -28,7 +28,7 @@
           We have saved {{ subjectPossessive }} region as:
         </p>
 
-        <div ref="savedRegionTable">
+        <div ref="savedLocationTable">
           <div class="Rtable Rtable--3cols">
             <div class="Rtable-cell padding--t-b-none padding--r-l-large">
               <h6 class="margin--none">City</h6>
@@ -43,7 +43,7 @@
             </div>
           </div>
 
-          <div class="Rtable Rtable--3cols">
+          <div class="Rtable Rtable--3cols" ref="savedLocationTableRow">
             <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
               {{ savedLocation.city || "(no city)" }}
             </div>

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -28,58 +28,62 @@
           We have saved {{ subjectPossessive }} region as:
         </p>
 
-        <div class="Rtable Rtable--3cols">
-          <div class="Rtable-cell padding--t-b-none padding--r-l-large">
-            <h6 class="margin--none">City</h6>
+        <div ref="savedRegionTable">
+          <div class="Rtable Rtable--3cols">
+            <div class="Rtable-cell padding--t-b-none padding--r-l-large">
+              <h6 class="margin--none">City</h6>
+            </div>
+
+            <div class="Rtable-cell padding--t-b-none padding--r-l-large">
+              <h6 class="margin--none">State / Province</h6>
+            </div>
+
+            <div class="Rtable-cell padding--t-b-none padding--r-l-large">
+              <h6 class="margin--none">Country / Territory</h6>
+            </div>
           </div>
 
-          <div class="Rtable-cell padding--t-b-none padding--r-l-large">
-            <h6 class="margin--none">State / Province</h6>
-          </div>
+          <div class="Rtable Rtable--3cols">
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ savedLocation.city || "(no city)" }}
+            </div>
 
-          <div class="Rtable-cell padding--t-b-none padding--r-l-large">
-            <h6 class="margin--none">Country / Territory</h6>
-          </div>
-        </div>
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ savedLocation.state || "(no state/province)" }}
+            </div>
 
-        <div class="Rtable Rtable--3cols">
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ savedLocation.city || "(no city)" }}
-          </div>
-
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ savedLocation.state || "(no state/province)" }}
-          </div>
-
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ savedLocation.country || "(no country)" }}
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ savedLocation.country || "(no country)" }}
+            </div>
           </div>
         </div>
       </template>
 
       <template v-if="suggestions.length">
-        <div class="Rtable Rtable--3cols">
-          <div class="Rtable-cell padding--t-b-none"><h6>City</h6></div>
-          <div class="Rtable-cell padding--t-b-none"><h6>State / Province</h6></div>
-          <div class="Rtable-cell padding--t-b-none"><h6>Country / Territory</h6></div>
-        </div>
-
-        <div
-          class="Rtable Rtable--3cols suggestion"
-          v-for="suggestion in suggestions"
-          :key="suggestion.id"
-          @click="handleSuggestionClick(suggestion)"
-        >
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ suggestion.city || "(no city)" }}
+        <div ref="suggestionsTable">
+          <div class="Rtable Rtable--3cols">
+            <div class="Rtable-cell padding--t-b-none"><h6>City</h6></div>
+            <div class="Rtable-cell padding--t-b-none"><h6>State / Province</h6></div>
+            <div class="Rtable-cell padding--t-b-none"><h6>Country / Territory</h6></div>
           </div>
 
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ suggestion.state || "(no state/province)" }}
-          </div>
+          <div
+            class="Rtable Rtable--3cols suggestion"
+            v-for="suggestion in suggestions"
+            :key="suggestion.id"
+            @click="handleSuggestionClick(suggestion)"
+          >
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ suggestion.city || "(no city)" }}
+            </div>
 
-          <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
-            {{ suggestion.country || "(no country)" }}
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ suggestion.state || "(no state/province)" }}
+            </div>
+
+            <div class="Rtable-cell padding--t-b-medium padding--r-l-large">
+              {{ suggestion.country || "(no country)" }}
+            </div>
           </div>
         </div>
       </template>

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -108,25 +108,27 @@
           <label>Please choose the correct terrritory:</label>
 
           <p class="inline-checkbox">
-            <input
-              type="radio"
-              name="location_country"
-              value="Israel"
-              v-model="country"
-              @click="confirmCountry('Israel')"
-            />
-            <label>Israel</label>
+            <label>
+              <input
+                type="radio"
+                name="location_country"
+                value="Israel"
+                v-model="country"
+                @click="confirmCountry('Israel')"
+              /> Israel
+            </label>
           </p>
 
           <p class="inline-checkbox">
-            <input
-              type="radio"
-              name="location_country"
-              value="Palestine"
-              v-model="country"
-              @click="confirmCountry('Palestine')"
-            />
-            <label>Palestine</label>
+            <label>
+              <input
+                type="radio"
+                name="location_country"
+                value="Palestine"
+                v-model="country"
+                @click="confirmCountry('Palestine')"
+              /> Palestine
+            </label>
           </p>
         </template>
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,6 +19,8 @@ Vue.use(TurbolinksAdapter)
 import '../config/axios'
 import '../registration'
 
+import { urlHelpers } from 'utilities/utilities'
+
 document.addEventListener('turbolinks:load', function () {
   const buttonElems = document.querySelectorAll('.vue-enable-certificate-btn')
 
@@ -40,6 +42,17 @@ document.addEventListener('turbolinks:load', function () {
 
       components: {
         LocationForm,
+      },
+
+      methods: {
+        goBack() {
+          const returnTo = urlHelpers.fetchGetParameterValue('return_to')
+          if (!!returnTo) {
+            window.location.href = returnTo
+          } else {
+            window.history.back()
+          }
+        },
       },
     })
   }

--- a/app/views/judge/profiles/_location.en.html.erb
+++ b/app/views/judge/profiles/_location.en.html.erb
@@ -5,6 +5,8 @@
 
 <p>
   <%= link_to "Change your location",
-    judge_location_details_path,
+    judge_location_details_path(
+      return_to: judge_profile_path(anchor: '!location')
+    ),
     class: "button" %>
 </p>

--- a/app/views/mentor/profiles/_location.en.html.erb
+++ b/app/views/mentor/profiles/_location.en.html.erb
@@ -2,7 +2,9 @@
   <% if current_mentor.address_details.blank? %>
     <p>
       <%= link_to "Set your location",
-        mentor_location_details_path,
+        mentor_location_details_path(
+          return_to: mentor_profile_path(anchor: '!location')
+        ),
         class: "button" %>
     </p>
   <% else %>
@@ -25,7 +27,9 @@
 
   <p>
     <%= link_to "Change your location",
-      mentor_location_details_path,
+      mentor_location_details_path(
+        return_to: mentor_profile_path(anchor: '!location')
+      ),
       class: "button" %>
   </p>
 <% end %>

--- a/app/views/signups/_location_fields.html.erb
+++ b/app/views/signups/_location_fields.html.erb
@@ -8,6 +8,7 @@
     scope-name="<%= current_scope %>"
     :account-id="<%= account_id %>"
     :team-id="<%= team_id %>"
+    :handle-confirm="goBack"
   >
   </location-form>
 </div>

--- a/app/views/student/profiles/_location.en.html.erb
+++ b/app/views/student/profiles/_location.en.html.erb
@@ -5,6 +5,8 @@
 
 <p>
   <%= link_to "Change your location",
-    student_location_details_path,
+    student_location_details_path(
+      return_to: student_profile_path(anchor: '!location')
+    ),
     class: "button" %>
 </p>

--- a/spec/javascript/__mocks__/axios.js
+++ b/spec/javascript/__mocks__/axios.js
@@ -1,6 +1,6 @@
 const mockedAxios = {
   mockResponse (method, returnData, opts) {
-    const options = Object.assign({}, opts)
+    const options = Object.assign({ status: 200 }, opts)
 
     const promiseState = options.reject ? 'reject' : 'resolve'
 
@@ -10,6 +10,7 @@ const mockedAxios = {
     this[method][mockImplementationFunc](() => {
       return Promise[promiseState]({
         data: returnData,
+        status: options.status
       })
     })
   },

--- a/spec/javascript/axios.spec.js
+++ b/spec/javascript/axios.spec.js
@@ -14,7 +14,7 @@ describe('axios mock', () => {
 
       axios.get('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { myField: 'myValue' } })
+        expect(response).toEqual({ data: { myField: 'myValue' }, status: 200 })
         done()
       })
     })
@@ -24,7 +24,7 @@ describe('axios mock', () => {
 
       axios.post('/test/url').then((response) => {
         expect(axios.post).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { some: 'value' } })
+        expect(response).toEqual({ data: { some: 'value' }, status: 200 })
         done()
       })
     })
@@ -34,7 +34,7 @@ describe('axios mock', () => {
 
       axios.delete('/test/url').then((response) => {
         expect(axios.delete).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { some: 'value' } })
+        expect(response).toEqual({ data: { some: 'value' }, status: 200 })
         done()
       })
     })
@@ -44,7 +44,7 @@ describe('axios mock', () => {
 
       axios.patch('/test/url').then((response) => {
         expect(axios.patch).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { some: 'value' } })
+        expect(response).toEqual({ data: { some: 'value' }, status: 200 })
         done()
       })
     })
@@ -54,7 +54,7 @@ describe('axios mock', () => {
 
       axios.post('/test/url').catch((response) => {
         expect(axios.post).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { rejected: 'value' } })
+        expect(response).toEqual({ data: { rejected: 'value' }, status: 200 })
         done()
       })
     })
@@ -65,13 +65,13 @@ describe('axios mock', () => {
 
       axios.post('/test/url').then((response) => {
         expect(axios.post).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { resolved: 'once' } })
-      })
+        expect(response).toEqual({ data: { resolved: 'once' }, status: 200 })
 
-      axios.post('/test/url').then((response) => {
-        expect(axios.post).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { always: 'resolved' } })
-        done()
+        axios.post('/test/url').then((response) => {
+          expect(axios.post).toHaveBeenCalledWith('/test/url')
+          expect(response).toEqual({ data: { always: 'resolved' }, status: 200 })
+          done()
+        })
       })
     })
 
@@ -86,6 +86,16 @@ describe('axios mock', () => {
         done()
       })
     })
+
+    it('takes a status option to return a specific status code', (done) => {
+      axios.mockResponse('post', { resolved: 'once' }, { status: 300 })
+
+      axios.post('/test/url').then((response) => {
+        expect(axios.post).toHaveBeenCalledWith('/test/url')
+        expect(response).toEqual({ data: { resolved: 'once' }, status: 300 })
+        done()
+      })
+    })
   })
 
   describe('axios.mockResponseOnce', () => {
@@ -95,12 +105,12 @@ describe('axios mock', () => {
 
       axios.get('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { resolved: 'once' } })
+        expect(response).toEqual({ data: { resolved: 'once' }, status: 200 })
       })
 
       axios.get('/test/url').then((response) => {
         expect(axios.get).toHaveBeenCalledWith('/test/url')
-        expect(response).toEqual({ data: { resolved: 'always' } })
+        expect(response).toEqual({ data: { resolved: 'always' }, status: 200 })
         done()
       })
     })

--- a/spec/javascript/location/LocationForm.spec.js
+++ b/spec/javascript/location/LocationForm.spec.js
@@ -66,4 +66,155 @@ describe('location/components/LocationForm', () => {
       done()
     })
   })
+
+  describe('suggestions table', () => {
+    let wrapper
+    let handleSuggestionClickSpy
+
+    beforeEach(() => {
+      handleSuggestionClickSpy = jest.fn(() => {})
+
+      wrapper = shallowMount(LocationForm, {
+        localVue,
+        propsData: {
+          teamId: 1,
+          scopeName: "admin",
+        },
+        methods: {
+          handleSuggestionClick: handleSuggestionClickSpy,
+        },
+      })
+
+      wrapper.setData({
+        suggestions: [
+          { id: 1, city: 'Kansas City', state: 'Missouri', country: 'United States' },
+          { id: 2, city: 'KC', state: 'MO', country: 'United States' },
+          { id: 3, city: null, state: null, country: null },
+        ],
+      })
+    })
+
+    it('appears if there are suggestions present', () => {
+      const suggestionsTable = wrapper.find({ ref: 'suggestionsTable' })
+
+      expect(suggestionsTable.exists()).toBe(true)
+
+      const suggestions = wrapper.findAll('.suggestion')
+
+      expect(suggestions.length).toEqual(3)
+    })
+
+    it('is not visible if there are no suggestions present', () => {
+      wrapper.setData({ suggestions: [] })
+
+      const suggestionsTable = wrapper.find({ ref: 'suggestionsTable' })
+
+      expect(suggestionsTable.exists()).toBe(false)
+
+      const suggestions = wrapper.findAll('.suggestion')
+
+      expect(suggestions.length).toEqual(0)
+    })
+
+    it('contains a row for each suggestion present', () => {
+      const suggestions = wrapper.findAll('.suggestion')
+
+      let suggestionText = suggestions.at(0).text()
+
+      expect(suggestionText).toContain('Kansas City')
+      expect(suggestionText).toContain('Missouri')
+      expect(suggestionText).toContain('United States')
+
+      suggestionText = suggestions.at(1).text()
+
+      expect(suggestionText).toContain('KC')
+      expect(suggestionText).toContain('MO')
+      expect(suggestionText).toContain('United States')
+
+      suggestionText = suggestions.at(2).text()
+
+      expect(suggestionText).toContain('(no city)')
+      expect(suggestionText).toContain('(no state/province)')
+      expect(suggestionText).toContain('(no country)')
+    })
+
+    it('calls handleSuggestionClick when a suggestion row is clicked', () => {
+      const suggestions = wrapper.findAll('.suggestion')
+
+      suggestions.at(0).element.click()
+
+      expect(handleSuggestionClickSpy).toHaveBeenCalledTimes(1)
+      expect(handleSuggestionClickSpy).toHaveBeenCalledWith({
+        id: 1,
+        city: 'Kansas City',
+        state: 'Missouri',
+        country: 'United States',
+      })
+
+      suggestions.at(1).element.click()
+
+      expect(handleSuggestionClickSpy).toHaveBeenCalledTimes(2)
+      expect(handleSuggestionClickSpy).toHaveBeenCalledWith({
+        id: 2,
+        city: 'KC',
+        state: 'MO',
+        country: 'United States',
+      })
+
+      suggestions.at(2).element.click()
+
+      expect(handleSuggestionClickSpy).toHaveBeenCalledTimes(3)
+      expect(handleSuggestionClickSpy).toHaveBeenCalledWith({
+        id: 3,
+        city: null,
+        state: null,
+        country: null,
+      })
+    })
+  })
+
+  describe('methods', () => {
+    describe('handleSuggestionClick', () => {
+      let wrapper
+      let handleSubmitSpy
+      const suggestion = {
+        id: 1,
+        city: 'Kansas City',
+        state: 'Missouri',
+        country: 'United States'
+      }
+
+      beforeEach(() => {
+        handleSubmitSpy = jest.fn(() => {})
+
+        wrapper = shallowMount(LocationForm, {
+          localVue,
+          propsData: {
+            teamId: 1,
+            scopeName: "admin",
+          },
+          methods: {
+            handleSubmit: handleSubmitSpy,
+          },
+        })
+      })
+
+      it('should set the city, state, and country information in the component data', () => {
+        wrapper.vm.handleSuggestionClick(suggestion)
+
+        expect(wrapper.vm.city).toEqual(suggestion.city)
+        expect(wrapper.vm.state).toEqual(suggestion.state)
+        expect(wrapper.vm.country).toEqual(suggestion.country)
+        expect(wrapper.vm.countryConfirmed).toBe(true)
+      })
+
+      it('should call handleSubmit', () => {
+        expect(handleSubmitSpy).not.toHaveBeenCalled()
+
+        wrapper.vm.handleSuggestionClick(suggestion)
+
+        expect(handleSubmitSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
 })

--- a/spec/javascript/location/LocationForm.spec.js
+++ b/spec/javascript/location/LocationForm.spec.js
@@ -174,6 +174,54 @@ describe('location/components/LocationForm', () => {
     })
   })
 
+  describe('saved locations table', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = shallowMount(LocationForm, {
+        localVue,
+        propsData: {
+          teamId: 1,
+          scopeName: 'admin',
+        },
+      })
+
+      wrapper.setData({
+        savedLocation: {
+          id: 1,
+          city: 'Kansas City',
+          state: 'Missouri',
+          country: 'United States'
+        },
+      })
+    })
+
+    it('appears if there is a saved location present', () => {
+      const savedLocationTable = wrapper.find({ ref: 'savedLocationTable' })
+
+      expect(savedLocationTable.exists()).toBe(true)
+
+      const savedLocationText = wrapper.find({ ref: 'savedLocationTableRow' })
+        .text()
+
+      expect(savedLocationText).toContain('Kansas City')
+      expect(savedLocationText).toContain('Missouri')
+      expect(savedLocationText).toContain('United States')
+    })
+
+    it('is not visible if there is no saved location', () => {
+      wrapper.setData({ savedLocation: null })
+
+      const savedLocationTable = wrapper.find({ ref: 'savedLocationTable' })
+
+      expect(savedLocationTable.exists()).toBe(false)
+
+      const savedLocationRow = wrapper.find({ ref: 'savedLocationTableRow' })
+
+      expect(savedLocationRow.exists()).toBe(false)
+    })
+  })
+
   describe('methods', () => {
     describe('handleSuggestionClick', () => {
       let wrapper


### PR DESCRIPTION
Test golden path and markup to prepare for potential refactors. May need a bit more coverage, but that can come as we begin refactoring. We can write more specific cases as we move things around.

Also addresses the following:
- Adds `status` codes to axios mock responses for those times when the response status is important to the logic.
- Fixes a bug where clicking Confirm to redirect back after saving the location was not reloading the interface correctly and old data was showing up.