### PR TITLE
Fix for email being erased on slow networks

### DIFF
--- a/app/javascript/registration/components/EmailInput.vue
+++ b/app/javascript/registration/components/EmailInput.vue
@@ -168,25 +168,27 @@ export default {
     },
 
     validateEmailInput () {
-      this.saveEmail({ email: this.email })
+      const saveEmail = this.saveEmail({ email: this.email })
 
-      let url = "/public/email_validations/new?address="
-      url += encodeURIComponent(this.email)
+      saveEmail.then(() => {
+        let url = "/public/email_validations/new?address="
+        url += encodeURIComponent(this.email)
 
-      axios.get(url).then(({ data }) => {
-        const attributes = Object.assign({}, data.data).attributes
-        const resp = Object.assign({}, attributes)
+        axios.get(url).then(({ data }) => {
+          const attributes = Object.assign({}, data.data).attributes
+          const resp = Object.assign({}, attributes)
 
-        this.emailHasBeenChecked = true
-        this.emailNeedsValidation = false
+          this.emailHasBeenChecked = true
+          this.emailNeedsValidation = false
 
-        this.emailIsValid = resp.isValid
-        this.isDisposableAddress = resp.isDisposableAddress
-        this.didYouMean = resp.didYouMean
-        this.mailboxVerification = resp.mailboxVerification
-        this.emailIsTaken = resp.isTaken
-      }).catch(err => {
-        console.error(err)
+          this.emailIsValid = resp.isValid
+          this.isDisposableAddress = resp.isDisposableAddress
+          this.didYouMean = resp.didYouMean
+          this.mailboxVerification = resp.mailboxVerification
+          this.emailIsTaken = resp.isTaken
+        }).catch(err => {
+          console.error(err)
+        })
       })
     },
 

--- a/app/javascript/registration/store/actions.js
+++ b/app/javascript/registration/store/actions.js
@@ -61,15 +61,11 @@ export default {
   },
 
   saveEmail ({ commit, state }, { email }) {
-    commit('email', email)
-
     axios.post('/registration/email', {
       email: {
         email,
         wizardToken: state.wizardToken,
       }
-    }).then(({ data: { data: { attributes }} }) => {
-      commit('email', attributes.email)
     }).catch(err => console.error(err))
   },
 

--- a/spec/javascript/registration/components/EmailInput.spec.js
+++ b/spec/javascript/registration/components/EmailInput.spec.js
@@ -70,7 +70,13 @@ describe('EmailInput Vue component', () => {
 
   describe('#validateEmailInput()', () => {
     it('calls the validation service with the email', (done) => {
-      const defaultStore = mockStore.createMocks()
+      const defaultStore = mockStore.createMocks({
+        actions: {
+          saveEmail: jest.fn(() => {
+            return Promise.resolve()
+          }),
+        },
+      })
 
       const wrapper = shallowMount(
         EmailInput,
@@ -91,13 +97,13 @@ describe('EmailInput Vue component', () => {
         }
       )
 
-      wrapper.vm.email = 'joe@joesak.com'
+      wrapper.setData({ email: 'joe@joesak.com' })
+
+      axios.mockResponseOnce('get', {})
+
+      wrapper.vm.validateEmailInput()
 
       setImmediate(() => {
-        axios.mockResponseOnce('get', {})
-
-        wrapper.vm.validateEmailInput()
-
         expect(axios.get).toHaveBeenCalledWith(
           `/public/email_validations/new?address=${encodeURIComponent('joe@joesak.com')}`
         )


### PR DESCRIPTION
Addresses #1736.

I was able to reproduce the issue locally using Chrome's network throttling. A fix has been applied. We were basically overwriting the store by using the Rails DB as our source of truth, which had side-effects when on slow networks.

Since we are already committing to the store in the component, I have removed the offending superfluous action commits in the Vuex store. We should be good to go now. We may need to audit the rest of the registration section for these same conditions and rework that functionality at some point, but I feel like we should wait for end-users to QA that section for us.