### PR TITLE
Dropzone styling issues

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -251,6 +251,6 @@ form[data-remote] {
 }
 
 .dz-success-mark {
-  background: $secondary;
+  background: $primary;
   border-radius: 100px;
 }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -254,3 +254,7 @@ form[data-remote] {
   background: $primary;
   border-radius: 100px;
 }
+
+.dz-error-message {
+  margin-top: 1em;
+}


### PR DESCRIPTION
Addresses #1719 and #1728.

When dragging and dropping an incorrect file type into the dropzone uploader, the tooltip error message now longer covers the `Remove file` link.

The success checkmark when uploading a valid PDF file for the business plan dropzone uploader is now green instead of red.