### PR TITLE
Background check bugfixes

### DIFF
--- a/app/javascript/mentor/App.vue
+++ b/app/javascript/mentor/App.vue
@@ -111,6 +111,18 @@ export default {
       },
     },
   },
+
+  computed: {
+    location () {
+      return this.$store.getters['registration/getLocation']
+    },
+  },
+
+  watch: {
+    location (newLocation) {
+      this.$store.commit('authenticated/location', newLocation)
+    }
+  },
 }
 </script>
 

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -78,9 +78,9 @@ export default {
     return compareYear - year - extraYear
   },
 
-  isBackgroundCheckWaived (state) {
+  isBackgroundCheckWaived (state, getters) {
     const isCountryUS = digStateAttributes(state, 'currentAccount', 'countryCode', code => code == 'US')
-    const isAgeAppropriate = digStateAttributes(state, 'currentAccount', 'age', age => parseInt(age) >= 18)
+    const isAgeAppropriate = getters.getAge() >= 18
     return !isCountryUS || !isAgeAppropriate
   },
 

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -59,6 +59,25 @@ export default {
     return digStateAttributes(state, 'backgroundCheck', 'isClear')
   },
 
+  getAge: (state) => (compareDate = new Date()) => {
+    const year = digStateAttributes(state, 'currentAccount', 'birthYear', age => parseInt(age))
+    const month = digStateAttributes(state, 'currentAccount', 'birthMonth', age => parseInt(age))
+    const day = digStateAttributes(state, 'currentAccount', 'birthDay', age => parseInt(age))
+
+    if (!year || !month || !day) return false
+
+    const compareYear = compareDate.getFullYear()
+    const compareMonth = compareDate.getMonth() + 1
+    const compareDay = compareDate.getDate()
+
+    const extraYear = (
+      compareMonth > month ||
+        (compareMonth === month && compareDay >= day)
+    ) ? 0 : 1
+
+    return compareYear - year - extraYear
+  },
+
   isBackgroundCheckWaived (state) {
     const isCountryUS = digStateAttributes(state, 'currentAccount', 'countryCode', code => code == 'US')
     const isAgeAppropriate = digStateAttributes(state, 'currentAccount', 'age', age => parseInt(age) >= 18)

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -79,7 +79,7 @@ export default {
   },
 
   isBackgroundCheckWaived (state, getters) {
-    const isCountryUS = digStateAttributes(state, 'currentAccount', 'countryCode', code => code == 'US')
+    const isCountryUS = digStateAttributes(state, 'currentAccount', 'country', code => code == 'United States')
     const isAgeAppropriate = getters.getAge() >= 18
     return !isCountryUS || !isAgeAppropriate
   },

--- a/app/javascript/mentor/store/mutations.js
+++ b/app/javascript/mentor/store/mutations.js
@@ -16,4 +16,12 @@ export default {
     if (dataset.currentTeams)
       Vue.set(state, 'currentTeams', JSON.parse(dataset.currentTeams).data)
   },
+
+  location (state, attributes) {
+    state.currentAccount.data.attributes.city = attributes.city
+    state.currentAccount.data.attributes.state = attributes.state
+    state.currentAccount.data.attributes.country = attributes.country
+    state.currentAccount.data.attributes.countryCode = attributes.countryCode || null
+    state.currentAccount.data.attributes.stateCode = attributes.stateCode || null
+  },
 }

--- a/app/javascript/registration/components/Location.vue
+++ b/app/javascript/registration/components/Location.vue
@@ -16,7 +16,7 @@ import { createNamespacedHelpers } from 'vuex'
 import { debounce } from 'utilities/utilities'
 import LocationForm from 'location/components/LocationForm'
 
-const { mapActions, mapState } = createNamespacedHelpers('registration')
+const { mapState } = createNamespacedHelpers('registration')
 
 export default {
   name: 'location',
@@ -25,18 +25,12 @@ export default {
     LocationForm,
   },
 
-  created() {
-    this.debouncedLocationUpdate = debounce(newLocation => {
-      this.updateLocation(newLocation)
-    }, 500)
-  },
-
   computed: {
     ...mapState(['wizardToken', 'apiRoot']),
 
     locationData: {
       get() {
-        return this.$store.getters.getLocation
+        return this.$store.getters['registration/getLocation']
       },
 
       set(location) {
@@ -46,24 +40,12 @@ export default {
   },
 
   methods: {
-    ...mapActions(['updateLocation']),
-
     handleBack () {
       this.$router.push({ name: 'data-use' })
     },
 
     handleConfirm () {
       this.$router.push({ name: 'age' })
-    },
-  },
-
-  watch: {
-    locationData (newLocation, oldLocation) {
-      const locationChanged = Object.keys(newLocation).some((key) => {
-        return newLocation[key] !== oldLocation[key]
-      })
-
-      if (locationChanged) this.debouncedLocationUpdate(newLocation)
     },
   },
 }

--- a/app/javascript/registration/store/actions.js
+++ b/app/javascript/registration/store/actions.js
@@ -102,25 +102,6 @@ export default {
     }).catch(err => console.error(err))
   },
 
-  updateLocation ({ commit, state }, attrs) {
-    const data = Object.assign({}, {
-      city: state.city,
-      state: state.state,
-      country: state.country,
-    }, attrs)
-
-    commit('location', data)
-
-    axios.post(`/${state.apiRoot}/location`, {
-      location: {
-        ...data,
-        token: state.token,
-      },
-    }).then(({ data: { data: { attributes }} }) => {
-      commit('location', attributes)
-    }).catch(err => console.error(err))
-  },
-
   updateBasicProfile ({ commit, state }, attrs) {
     const data = Object.assign({}, {
       firstName: state.firstName,

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -4,9 +4,9 @@ class AccountSerializer
 
   set_id :random_id
 
-  attributes :name, :email, :date_of_birth, :city, :state, :country, :state_code,
-    :country_code, :latitude, :longitude, :first_name, :last_name, :gender,
-    :referred_by, :referred_by_other
+  attributes :name, :email, :date_of_birth, :age, :age_by_cutoff, :city, :state,
+    :country, :state_code, :country_code, :latitude, :longitude, :first_name,
+    :last_name, :gender, :referred_by, :referred_by_other
 
   attribute(:api_root) do |account|
     "#{account.scope_name}"

--- a/app/serializers/mentor_profile_serializer.rb
+++ b/app/serializers/mentor_profile_serializer.rb
@@ -10,6 +10,10 @@ class MentorProfileSerializer
 
   attribute(:is_training_complete, &:training_complete?)
 
+  attribute(:requires_background_check, &:requires_background_check?)
+
+  attribute(:background_check_complete, &:background_check_complete?)
+
   attribute(:next_onboarding_step) do |mentor|
     case mentor.onboarding_steps.first
     when :consent_signed?

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -1,6 +1,69 @@
+import cloneDeep from 'lodash/cloneDeep'
 import getters from 'mentor/store/getters'
 
 describe("mentor/store/getters.js", () => {
+  describe('getAge', () => {
+    const today = new Date()
+
+    const initialState = {
+      currentAccount: {
+        data: {
+          attributes: {
+            birthYear: today.getFullYear() - 18,
+            birthMonth: today.getMonth(),
+            birthDay: today.getDate(),
+          },
+        },
+      },
+    }
+
+    let mockState
+
+    beforeEach(() => {
+      mockState = cloneDeep(initialState)
+    })
+
+    it('returns false if currentAccount.birthYear is not present', () => {
+      delete mockState.currentAccount.data.attributes.birthYear
+
+      const getAge = getters.getAge(mockState)
+
+      expect(getAge()).toBe(false)
+    })
+
+    it('returns false if currentAccount.birthMonth is not present', () => {
+      delete mockState.currentAccount.data.attributes.birthMonth
+
+      const getAge = getters.getAge(mockState)
+
+      expect(getAge()).toBe(false)
+    })
+
+    it('returns false if currentAccount.birthDay is not present', () => {
+      delete mockState.currentAccount.data.attributes.birthDay
+
+      const getAge = getters.getAge(mockState)
+
+      expect(getAge()).toBe(false)
+    })
+
+    it('returns numeric age if year, month, and day are present', () => {
+      expect(getters.getAge(mockState).call()).toEqual(18)
+    })
+
+    it('returns numeric age based on compareDate passed in', () => {
+      const twoYearsAgo = new Date(
+        today.getFullYear() - 2,
+        today.getMonth(),
+        today.getDay()
+      )
+
+      const getAge = getters.getAge(mockState)
+
+      expect(getAge(twoYearsAgo)).toEqual(16)
+    })
+  })
+
   describe("isBackgroundCheckWaived", () => {
     it("is true when currentAccount.countryCode is not US", () => {
       const state = {

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -69,7 +69,7 @@ describe("mentor/store/getters.js", () => {
       currentAccount: {
         data: {
           attributes: {
-            countryCode: "BR",
+            country: "Brazil",
           },
         },
       },
@@ -86,13 +86,13 @@ describe("mentor/store/getters.js", () => {
     })
 
     it('is false when currentAccount.countryCode is US', () => {
-      mockState.currentAccount.data.attributes.countryCode = 'US'
+      mockState.currentAccount.data.attributes.country = 'United States'
 
       expect(getters.isBackgroundCheckWaived(mockState, mockGetters)).toBe(false)
     })
 
     it('is true when currentAccount.age is under 18', () => {
-      mockState.currentAccount.data.attributes.countryCode = 'US'
+      mockState.currentAccount.data.attributes.country = 'United States'
       mockGetters.getAge = jest.fn(() => {
         return 17
       })

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -65,49 +65,39 @@ describe("mentor/store/getters.js", () => {
   })
 
   describe("isBackgroundCheckWaived", () => {
-    it("is true when currentAccount.countryCode is not US", () => {
-      const state = {
-        currentAccount: {
-          data: {
-            attributes: {
-              countryCode: "BR",
-              age: 18,
-            },
+    const mockState = {
+      currentAccount: {
+        data: {
+          attributes: {
+            countryCode: "BR",
           },
         },
-      }
+      },
+    }
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(true)
+    const mockGetters = {
+      getAge: jest.fn(() => {
+        return 18
+      })
+    }
+
+    it('is true when currentAccount.countryCode is not US', () => {
+      expect(getters.isBackgroundCheckWaived(mockState, mockGetters)).toBe(true)
     })
 
-    it("is false when currentAccount.countryCode is US", () => {
-      const state = {
-        currentAccount: {
-          data: {
-            attributes: {
-              countryCode: "US",
-              age: 18,
-            },
-          },
-        },
-      }
+    it('is false when currentAccount.countryCode is US', () => {
+      mockState.currentAccount.data.attributes.countryCode = 'US'
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(false)
+      expect(getters.isBackgroundCheckWaived(mockState, mockGetters)).toBe(false)
     })
 
-    it("is true when currentAccount.age is under 18", () => {
-      const state = {
-        currentAccount: {
-          data: {
-            attributes: {
-              countryCode: "US",
-              age: "17",
-            },
-          },
-        },
-      }
+    it('is true when currentAccount.age is under 18', () => {
+      mockState.currentAccount.data.attributes.countryCode = 'US'
+      mockGetters.getAge = jest.fn(() => {
+        return 17
+      })
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(true)
+      expect(getters.isBackgroundCheckWaived(mockState, mockGetters)).toBe(true)
     })
   })
 

--- a/spec/javascript/mentor/store/mutations.spec.js
+++ b/spec/javascript/mentor/store/mutations.spec.js
@@ -1,0 +1,35 @@
+import mutations from 'mentor/store/mutations'
+
+describe('Mentor store - mutations', () => {
+  describe('location', () => {
+    it('sets the authenticated module state location data', () => {
+      const state = {
+        currentAccount: {
+          data: {
+            attributes: {
+              city: 'Calgary',
+              country: 'Canada',
+              countryCode: 'CA',
+              state: 'Alberta',
+              stateCode: 'AB',
+            },
+          },
+        },
+      }
+
+      mutations.location(state, {
+        city: 'Kansas City',
+        country: 'United States',
+        state: 'Missouri',
+      })
+
+      expect(state.currentAccount.data.attributes).toEqual({
+        city: 'Kansas City',
+        country: 'United States',
+        countryCode: null,
+        state: 'Missouri',
+        stateCode: null,
+      })
+    })
+  })
+})

--- a/spec/javascript/registration/components/Location.spec.js
+++ b/spec/javascript/registration/components/Location.spec.js
@@ -13,11 +13,7 @@ describe("Registration::Components::Location.vue", () => {
   let defaultWrapper
 
   beforeEach(() => {
-    const defaultStore = mockStore.createMocks({
-      actions: {
-        updateLocation: jest.fn(() => {})
-      },
-    })
+    const defaultStore = mockStore.createMocks()
 
     defaultWrapper = mount(
       LocationComponent,


### PR DESCRIPTION
Addresses #1740.

This bugfix was pretty far reaching and required tweaking of tests in order to get everything working properly.

- I removed an unused `updateLocation` function from the registration Vuex store actions and the Location component. I also removed tests around that functionality.
- Added a mutation for mentor `authenticated/location` to update the `currentAccount` data in the store state. Before it was read-only. This is to dynamically change the background check required status.
- Added a `getAge` getter method for the mentor authenticated store namespace to properly calculate a mentor's age in `isBackgroundCheckWaived`.
- Updated `isBackgroundCheckWaived` to work properly.
- Updated specs where necessary to work with new functionality.