### PR TITLE
Source code validation

### DIFF
--- a/app/assets/javascripts/image-uploaders.js
+++ b/app/assets/javascripts/image-uploaders.js
@@ -88,3 +88,35 @@ $(document).on("click", ".save-icon", function() {
     },
   });
 });
+
+$(document).on('change', '.source-code-uploader__file', function (event) {
+  var validFileUploaded = false;
+
+  var validFileTypes = [
+    'application/zip',
+    'application/vnd.android.package-archive', //apk
+  ];
+
+  var validFileExtensions = ['.aia', '.apk', '.zip'];
+
+  for (var i = 0; i < event.target.files.length; i += 1) {
+    var file = event.target.files[i];
+    var extension = file.name.slice(-4);
+
+    if (
+      validFileTypes.indexOf(file.type) !== -1 ||
+      validFileExtensions.indexOf(extension) !== -1
+    ) {
+      validFileUploaded = true;
+      break;
+    }
+  }
+
+  if (!validFileUploaded) {
+    $('.source-code-uploader__submit-button').prop('disabled', true);
+    $('.source-code-uploader__error').removeClass('hidden');
+  } else {
+    $('.source-code-uploader__submit-button').prop('disabled', false);
+    $('.source-code-uploader__error').addClass('hidden');
+  }
+});

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -31,7 +31,12 @@
 
     <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
       <%= f.label :file, "Upload your app's source code" %>
-      <%= f.file_field :file, accept: ".aia,.apk,.zip", class: 'source-code-uploader__file' %>
+      <%= f.file_field :file, class: 'source-code-uploader__file' %>
+
+      <div class="flash flash--alert source-code-uploader__error hidden">
+        Sorry, you tried to upload an invalid file type.
+      </div>
+
       <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
     <% end %>
 

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -27,12 +27,12 @@
          embedded: true,
       } %>
   <% else %>
-    <p class="hint">File types allowed: *.zip or *.aia</p>
+    <p class="hint">File types allowed: *.zip, *.aia, or *.apk</p>
 
-    <%= direct_upload_form_for @source_code_uploader, html: { multipart: true } do |f| %>
+    <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
       <%= f.label :file, "Upload your app's source code" %>
-      <%= f.file_field :file %>
-      <%= f.submit "Upload", class: "button" %>
+      <%= f.file_field :file, accept: ".aia,.apk,.zip", class: 'source-code-uploader__file' %>
+      <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
     <% end %>
 
     <p class="grid__cell--padding-sm-y">

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -31,7 +31,7 @@
 
     <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
       <%= f.label :file, "Upload your app's source code" %>
-      <%= f.file_field :file, class: 'source-code-uploader__file' %>
+      <%= f.file_field :file, accept: ".aia,.apk,.zip", class: 'source-code-uploader__file' %>
 
       <div class="flash flash--alert source-code-uploader__error hidden">
         Sorry, you tried to upload an invalid file type.

--- a/spec/support/uploads/example.aia
+++ b/spec/support/uploads/example.aia
@@ -1,0 +1,1 @@
+Example AIA File. The MIME type will not be correct. We will want to replace this with a real AIA at some point.

--- a/spec/support/uploads/example.apk
+++ b/spec/support/uploads/example.apk
@@ -1,0 +1,1 @@
+Example APK File. The MIME type will not be correct. We will want to replace this with a real APK at some point.

--- a/spec/support/uploads/example.txt
+++ b/spec/support/uploads/example.txt
@@ -1,0 +1,1 @@
+TESTING

--- a/spec/system/submissions/upload_screenshots_spec.rb
+++ b/spec/system/submissions/upload_screenshots_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe "Uploading screenshots to submissions", :js do
   before { SeasonToggles.team_submissions_editable! }
 
   it "does not allow invalid file types" do
-    skip "Why isn't this working in tests, it works in the browser"
-
     student = FactoryBot.create(:student, :onboarded, :on_team)
     submission = student.team.create_submission!(integrity_affirmed: true)
     sign_in(student)
@@ -15,7 +13,7 @@ RSpec.describe "Uploading screenshots to submissions", :js do
     ['jpg', 'jpeg', 'gif', 'png'].each do |good_file|
       attach_file(
         "attach-screenshots",
-        File.open("./spec/support/uploads/example.#{good_file}"),
+        File.absolute_path("./spec/support/uploads/example.#{good_file}"),
         make_visible: true
       )
       expect(page).not_to have_css(".flash.flash--alert")
@@ -25,7 +23,7 @@ RSpec.describe "Uploading screenshots to submissions", :js do
     ['bmp', 'docx', 'pdf', 'zip'].each do |bad_file|
       attach_file(
         "attach-screenshots",
-        File.open("./spec/support/uploads/example.#{bad_file}"),
+        File.absolute_path("./spec/support/uploads/example.#{bad_file}"),
         make_visible: true
       )
       expect(page).to have_css(".flash.flash--alert", text: "invalid file type")
@@ -34,8 +32,6 @@ RSpec.describe "Uploading screenshots to submissions", :js do
   end
 
   it "does not allow invalid file types for mentors" do
-    skip "Why isn't this working in tests, it works in the browser"
-
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team)
     submission = mentor.teams.last.create_submission!(integrity_affirmed: true)
     sign_in(mentor)
@@ -45,7 +41,7 @@ RSpec.describe "Uploading screenshots to submissions", :js do
     ['jpg', 'jpeg', 'gif', 'png'].each do |good_file|
       attach_file(
         "attach-screenshots",
-        File.open("./spec/support/uploads/example.#{good_file}"),
+        File.absolute_path("./spec/support/uploads/example.#{good_file}"),
         make_visible: true
       )
       expect(page).not_to have_css(".flash.flash--alert")
@@ -55,7 +51,7 @@ RSpec.describe "Uploading screenshots to submissions", :js do
     ['bmp', 'docx', 'pdf', 'zip'].each do |bad_file|
       attach_file(
         "attach-screenshots",
-        File.open("./spec/support/uploads/example.#{bad_file}"),
+        File.absolute_path("./spec/support/uploads/example.#{bad_file}"),
         make_visible: true
       )
       expect(page).to have_css(".flash.flash--alert", text: "invalid file type")

--- a/spec/system/submissions/upload_source_code_spec.rb
+++ b/spec/system/submissions/upload_source_code_spec.rb
@@ -23,9 +23,38 @@ RSpec.describe "Uploading source code to submissions", :js do
           TeamSubmission.last.update!(development_platform: "Swift or XCode")
         end
 
-        it "displays a file upload field to the #{scope}" do
-          click_link "Upload your source code"
-          expect(page).to have_css('input[type=file]')
+        context "and a valid file is uploaded" do
+          it "allows the form to be submitted without issue" do
+            click_link "Upload your source code"
+            expect(page).to have_css('input[type=file]')
+
+            ['aia', 'apk', 'zip'].each do |good_file|
+              attach_file(
+                "file",
+                File.absolute_path("./spec/support/uploads/example.#{good_file}"),
+                class: "source-code-uploader__file"
+              )
+
+              expect(page).to have_selector(".source-code-uploader__error", visible: false)
+              expect(page).to have_button("Upload", disabled: false)
+            end
+          end
+        end
+
+        context "and an invalid file is uploaded" do
+          it "allows the form to be submitted without issue" do
+            click_link "Upload your source code"
+            expect(page).to have_css('input[type=file]')
+
+            attach_file(
+              "file",
+              File.absolute_path("./spec/support/uploads/example.txt"),
+              class: "source-code-uploader__file"
+            )
+
+            expect(page).to have_selector(".source-code-uploader__error", visible: true)
+            expect(page).to have_button("Upload", disabled: true)
+          end
         end
       end
 


### PR DESCRIPTION
Addresses #1718.

Displays a message if a file that is not a .zip, .aia, or .apk file is uploaded and disables the upload button. Otherwise it removes the message and enables the upload button. It also locks down the input file selector to just those valid file types.

Additionally fixes and enables the screenshot uploader specs.