### PR TITLE
Make sticky header dynamically adjust based on viewport width

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -147,6 +147,8 @@ h1.page-heading .ra-intro,
 }
 
 .header-container {
+  position: fixed;
+  width: 100%;
   z-index: $z-under-shade;
 }
 

--- a/app/javascript/application/sticky-header.js
+++ b/app/javascript/application/sticky-header.js
@@ -1,0 +1,19 @@
+(function () {
+  function setStickyNav () {
+    const header = document.querySelector('.header-container')
+
+    // Make sure this isn't a sticky-kit header
+    if (header !== null && !header.classList.contains('col--sticky')) {
+      const content = document.querySelector('.main-container')
+      const headerHeight = parseInt(header.offsetHeight, 10)
+
+      content.style.paddingTop = `${headerHeight}px`
+    }
+  }
+
+  window.addEventListener('resize', setStickyNav)
+
+  document.addEventListener('turbolinks:load', function () {
+    setStickyNav()
+  });
+})()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,6 +21,8 @@ import '../registration'
 
 import { urlHelpers } from 'utilities/utilities'
 
+import '../application/sticky-header'
+
 document.addEventListener('turbolinks:load', function () {
   const buttonElems = document.querySelectorAll('.vue-enable-certificate-btn')
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,15 +40,13 @@
     <%= yield :js %>
   </head>
 
-  <body class="col--sticky-parent">
-    <div class="col--sticky-spacer">
-      <div class="header-container col--sticky">
-        <%= yield :session_bar %>
+  <body>
+    <div class="header-container">
+      <%= yield :session_bar %>
 
-        <%= render 'application/navigation' %>
+      <%= render 'application/navigation' %>
 
-        <%= yield :subnav %>
-      </div>
+      <%= yield :subnav %>
     </div>
 
     <div class="main-container">


### PR DESCRIPTION
Created a new sticky header utility that allows the header width to be dynamically resized with the viewport so that it doesn't look off when the window is resized. This replaces the `sticky-kit` functionality. Sticky-kit sets the width for the elements so I have rolled an alternative solution. This doesn't replace the sticky sidebars throughout the site.