### PR TITLE
Add mentor training status on admin profile view

### DIFF
--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -11,6 +11,15 @@
   </p>
 
   <dl>
+    <dt>Mentor training</dt>
+    <dd class="mentor-training">
+      <% if profile.training_complete? %>
+        <%= web_icon("check-circle icon-green", text: "Complete") %>
+      <% else %>
+        <%= web_icon("exclamation-circle icon-red", text: "Incomplete") %>
+      <% end %>
+    </dd>
+
     <dt>Consent waiver</dt>
     <dd>
       <% if profile.consent_signed? %>

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -15,8 +15,10 @@
     <dd class="mentor-training">
       <% if profile.training_complete? %>
         <%= web_icon("check-circle icon-green", text: "Complete") %>
-      <% else %>
+      <% elsif profile.training_required? %>
         <%= web_icon("exclamation-circle icon-red", text: "Incomplete") %>
+      <% else %>
+        <%= web_icon("exclamation-circle", text: "Not required") %>
       <% end %>
     </dd>
 

--- a/spec/system/admin/review_mentors_spec.rb
+++ b/spec/system/admin/review_mentors_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Admins reviewing mentors" do
+  describe "training completion status" do
+    it "displays on their debugging page" do
+      untrained = FactoryBot.create(:mentor, :onboarding)
+      trained = FactoryBot.create(:mentor, :onboarded)
+
+      sign_in(:admin)
+      click_link "Participants"
+
+      within("#account_#{untrained.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Incomplete")
+
+      click_link "Participants"
+
+      within("#account_#{trained.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Complete")
+    end
+  end
+end

--- a/spec/system/admin/review_mentors_spec.rb
+++ b/spec/system/admin/review_mentors_spec.rb
@@ -23,5 +23,22 @@ RSpec.describe "Admins reviewing mentors" do
 
       expect(page).to have_css(".mentor-training", text: "Complete")
     end
+
+    it "displays not required for mentors who signed up before the training date" do
+      mentor = FactoryBot.create(:mentor, :onboarding)
+      mentor.account.update(
+        season_registered_at: ImportantDates.mentor_training_required_since - 1.day
+      )
+
+      sign_in(:admin)
+
+      click_link "Participants"
+
+      within("#account_#{mentor.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Not required")
+    end
   end
 end

--- a/spec/system/regional_ambassador/review_mentors_spec.rb
+++ b/spec/system/regional_ambassador/review_mentors_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "RAs reviewing mentors" do
+  let(:ra) { FactoryBot.create(:ra, :approved) }
+
+  describe "training completion status" do
+    it "displays on their debugging page" do
+      untrained = FactoryBot.create(:mentor, :onboarding)
+      trained = FactoryBot.create(:mentor, :onboarded)
+
+      sign_in(ra)
+      click_link "Participants"
+
+      within("#account_#{untrained.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Incomplete")
+
+      click_link "Participants"
+
+      within("#account_#{trained.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Complete")
+    end
+
+    it "displays not required for mentors who signed up before the training date" do
+      mentor = FactoryBot.create(:mentor, :onboarding)
+      mentor.account.update(
+        season_registered_at: ImportantDates.mentor_training_required_since - 1.day
+      )
+
+      sign_in(ra)
+
+      click_link "Participants"
+
+      within("#account_#{mentor.account_id}") do
+        click_link "view"
+      end
+
+      expect(page).to have_css(".mentor-training", text: "Not required")
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses #1791 which currently has the AC of only showing the status of the mentor's training on the Admin view of mentor profiles

However, due to the shared code, it already appears on the RA view as well, so if that AC is added, it should not require more work. I will add tests though, if need be.

This card may also be pending an addition to a mentor search filter for training completion - I can't remember if that has already been done. Tests will be added if needed.