### PR TITLE
Test and implement thunkable project URLs standing in for source code during submission review

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -11,4 +11,26 @@ module SubmissionsHelper
       end
     end
   end
+
+  def link_to_submission_source_code(submission)
+    if submission.developed_on?("Thunkable")
+      text = "Open this project in Thunkable"
+      url = submission.thunkable_project_url
+    else
+      text = "Download the source code"
+      url = submission.source_code_url
+    end
+
+    link_to(
+      web_icon(
+        "code",
+        remote: true,
+        size: 12,
+        color: "5ABF94",
+        text: text,
+      ),
+      url,
+      target: :_blank,
+    )
+  end
 end

--- a/app/views/team_submissions/published.en.html.erb
+++ b/app/views/team_submissions/published.en.html.erb
@@ -85,18 +85,10 @@
         </div>
       </div>
 
-      <div class="grid__col-6 grid__col--bleed-y">
+      <div class="grid__col-6 grid__col--bleed-y source-code">
         <h3>Code</h3>
 
-        <%= link_to web_icon(
-            "code",
-            text: "Download the source code",
-            remote: true,
-            size: 12,
-            color: "5ABF94",
-          ),
-          @team_submission.source_code_url,
-          target: :_blank %>
+        <%= link_to_submission_source_code(@team_submission) %>
       </div>
 
       <div class="grid__col-6 grid__col--bleed-y">

--- a/spec/factories/team_submissions.rb
+++ b/spec/factories/team_submissions.rb
@@ -54,6 +54,12 @@ FactoryBot.define do
       end
     end
 
+    trait :thunkable do
+      development_platform { "Thunkable" }
+      thunkable_account_email { "user@thunkable.com" }
+      thunkable_project_url { "https://x.thunkable.com/copy/abc123" }
+    end
+
     trait :semifinalist do
       contest_rank { :semifinalist }
     end

--- a/spec/system/submissions/final_step_publish_spec.rb
+++ b/spec/system/submissions/final_step_publish_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe "Publishing a submission from the dashboard" do
         href: student_published_team_submission_path(submission)
       )
     end
+
+    context "who is reviewing the submission" do
+      it "displays a thunkable URL for the source code" do
+        student = FactoryBot.create(:student, :onboarded, :on_team)
+        submission = FactoryBot.create(:submission, :complete, :thunkable, team: student.team)
+        submission.update(published_at: nil)
+
+        sign_in(student)
+
+        click_link "Review and submit now!"
+
+        within(".source-code") do
+          expect(page).to have_link(
+            "Open this project in Thunkable",
+            href: submission.thunkable_project_url
+          )
+        end
+      end
+    end
   end
 
   context "as a mentor" do
@@ -34,7 +53,31 @@ RSpec.describe "Publishing a submission from the dashboard" do
           "Review and submit now!",
           href: mentor_published_team_submission_path(submission)
         )
+      end
     end
+
+    context "who is reviewing the submission" do
+      it "displays a thunkable URL for the source code" do
+        student = FactoryBot.create(:student, :onboarded, :on_team)
+        mentor = FactoryBot.create(:mentor, :onboarded)
+
+        TeamRosterManaging.add(student.team, mentor)
+        submission = FactoryBot.create(:submission, :complete, :thunkable, team: student.team)
+        submission.update(published_at: nil)
+
+        sign_in(mentor)
+
+        within("#find-team") do
+          click_link "Review and submit now!"
+        end
+
+        within(".source-code") do
+          expect(page).to have_link(
+            "Open this project in Thunkable",
+            href: submission.thunkable_project_url
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR addresses #1812 

It adds 2 system tests both for mentors and students reviewing their submission during the publishing workflow, that a thunkable URL is used in the 'source-code' portion of the page.