### PR TITLE
Add mutation observer to header container

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -152,6 +152,12 @@ h1.page-heading .ra-intro,
   z-index: $z-under-shade;
 }
 
+.header-container-spacer {
+  position: relative;
+  width: 100%;
+  display: block;
+}
+
 .col--sticky {
   &.is_stuck:not(.header-container) {
     margin: 92px 0 0;

--- a/app/javascript/application/sticky-header.js
+++ b/app/javascript/application/sticky-header.js
@@ -4,15 +4,16 @@
 
     // Make sure this isn't a sticky-kit header
     if (header !== null && !header.classList.contains('col--sticky')) {
-      const content = document.querySelector('.main-container')
-      const sessionBar = document.getElementById('session-bar')
       let headerHeight = parseInt(header.offsetHeight, 10)
+      let spacer = document.querySelector('.header-container-spacer')
 
-      if (sessionBar !== null) {
-        headerHeight += parseInt(sessionBar.offsetHeight, 10)
+      if (!spacer) {
+        spacer = document.createElement('div')
+        spacer.classList.add('header-container-spacer')
+        header.parentNode.insertBefore(spacer, header.nextSibling)
       }
 
-      content.style.paddingTop = `${headerHeight}px`
+      spacer.style.height = `${headerHeight}px`
     }
   }
 
@@ -20,5 +21,17 @@
 
   document.addEventListener('turbolinks:load', function () {
     setStickyNav()
+
+    const header = document.querySelector('.header-container')
+
+    // Create an observer instance linked to the callback function
+    const observer = new MutationObserver(setStickyNav)
+
+    // Start observing the header for configured mutations
+    observer.observe(header, {
+      attributes: true,
+      childList: true,
+      subtree: true
+    });
   });
 })()


### PR DESCRIPTION
Use a mutation observer in order to check for Vue component changes (and other dynamic changes) in the `.header-container` in order to dynamically change the sticky navigation spacing as the layout is resized.
