### PR TITLE
Bypass email validation for @qq.com

### DIFF
--- a/app/controllers/public/email_validations_controller.rb
+++ b/app/controllers/public/email_validations_controller.rb
@@ -17,6 +17,8 @@ module Public
 
       if !!account
         MailgunResponse.new(email_taken_response)
+      elsif address.match(/@qq.com\z/)
+        MailgunResponse.new(bypassed_response)
       else
         MailgunResponse.new(get_mailgun_response(address))
       end
@@ -27,6 +29,14 @@ module Public
         is_valid: true,
         mailbox_verification: "true",
         is_taken: true,
+      }
+    end
+
+    def bypassed_response
+      {
+        is_valid: true,
+        mailbox_verification: "true",
+        is_taken: false,
       }
     end
 

--- a/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_a_qq_com_email/always_returns_valid.yml
+++ b/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_a_qq_com_email/always_returns_valid.yml
@@ -1,0 +1,148 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/private/validate?address=1@qq.com&mailbox_verification=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YXBpOmtleS0zMmY4NzMwZDY5ODliY2FmZTY1ZTU3NzIwZGQ0OTIxMA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Nov 2018 14:19:04 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '241'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address": "1@qq.com", "did_you_mean": null, "is_disposable_address":
+        false, "is_role_address": false, "is_valid": true, "mailbox_verification":
+        "true", "parts": {"display_name": null, "domain": "qq.com", "local_part":
+        "1"}, "reason": null}'
+    http_version: 
+  recorded_at: Wed, 07 Nov 2018 14:19:03 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/private/validate?address=@qq.com&mailbox_verification=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YXBpOmtleS0zMmY4NzMwZDY5ODliY2FmZTY1ZTU3NzIwZGQ0OTIxMA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Nov 2018 14:19:15 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '320'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address": "@qq.com", "did_you_mean": null, "is_disposable_address":
+        false, "is_role_address": false, "is_valid": false, "mailbox_verification":
+        "unknown", "parts": {"display_name": null, "domain": null, "local_part": null},
+        "reason": "Validation failed for ''@qq.com'', reason: ''malformed address;
+        failed parse checks''"}'
+    http_version: 
+  recorded_at: Wed, 07 Nov 2018 14:19:14 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/private/validate?address=3409186790@qq.com&mailbox_verification=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YXBpOmtleS0zMmY4NzMwZDY5ODliY2FmZTY1ZTU3NzIwZGQ0OTIxMA==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 07 Nov 2018 14:23:58 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '261'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address": "3409186790@qq.com", "did_you_mean": null, "is_disposable_address":
+        false, "is_role_address": false, "is_valid": false, "mailbox_verification":
+        "false", "parts": {"display_name": null, "domain": "qq.com", "local_part":
+        "3409186790"}, "reason": null}'
+    http_version: 
+  recorded_at: Wed, 07 Nov 2018 14:23:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_a_qq_com_email/returns_valid.yml
+++ b/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_a_qq_com_email/returns_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.mailgun.net/v3/address/private/validate?address=joe@joesak.com%20&mailbox_verification=true
+    uri: https://api.mailgun.net/v3/address/private/validate?address=12345678@qq.com&mailbox_verification=true
     body:
       encoding: US-ASCII
       string: ''
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Jul 2018 17:34:35 GMT
+      - Wed, 07 Nov 2018 14:18:15 GMT
       Server:
       - nginx
       Content-Length:
@@ -42,15 +42,15 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"address": "joe@joesak.com ", "did_you_mean": null, "is_disposable_address":
+      string: '{"address": "12345678@qq.com", "did_you_mean": null, "is_disposable_address":
         false, "is_role_address": false, "is_valid": true, "mailbox_verification":
-        "false", "parts": {"display_name": null, "domain": "joesak.com", "local_part":
-        "joe"}, "reason": null}'
+        "true", "parts": {"display_name": null, "domain": "qq.com", "local_part":
+        "12345678"}, "reason": null}'
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 17:34:35 GMT
+  recorded_at: Wed, 07 Nov 2018 14:18:15 GMT
 - request:
     method: get
-    uri: https://api.mailgun.net/v3/address/private/validate?address=joe@joesak.com&mailbox_verification=true
+    uri: https://api.mailgun.net/v3/address/private/validate?address=99999999@qq.com&mailbox_verification=true
     body:
       encoding: US-ASCII
       string: ''
@@ -81,19 +81,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 07 Nov 2018 14:17:31 GMT
+      - Wed, 07 Nov 2018 14:18:42 GMT
       Server:
       - nginx
       Content-Length:
-      - '253'
+      - '255'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"address": "joe@joesak.com", "did_you_mean": null, "is_disposable_address":
+      string: '{"address": "99999999@qq.com", "did_you_mean": null, "is_disposable_address":
         false, "is_role_address": false, "is_valid": true, "mailbox_verification":
-        "true", "parts": {"display_name": null, "domain": "joesak.com", "local_part":
-        "joe"}, "reason": null}'
+        "true", "parts": {"display_name": null, "domain": "qq.com", "local_part":
+        "99999999"}, "reason": null}'
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 14:17:31 GMT
+  recorded_at: Wed, 07 Nov 2018 14:18:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_valid/renders_the_email_is_valid.yml
+++ b/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_valid/renders_the_email_is_valid.yml
@@ -81,7 +81,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Jul 2018 17:55:36 GMT
+      - Wed, 07 Nov 2018 14:17:32 GMT
       Server:
       - nginx
       Content-Length:
@@ -95,5 +95,5 @@ http_interactions:
         "true", "parts": {"display_name": null, "domain": "joesak.com", "local_part":
         "joe"}, "reason": null}'
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 17:55:36 GMT
+  recorded_at: Wed, 07 Nov 2018 14:17:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_valid/renders_the_mailbox_verification_is_true.yml
+++ b/spec/cassettes/Public_EmailValidationsController/GET_new/when_the_email_is_new/and_it_is_valid/renders_the_mailbox_verification_is_true.yml
@@ -81,7 +81,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Jul 2018 17:54:17 GMT
+      - Wed, 07 Nov 2018 14:17:32 GMT
       Server:
       - nginx
       Content-Length:
@@ -95,5 +95,5 @@ http_interactions:
         "true", "parts": {"display_name": null, "domain": "joesak.com", "local_part":
         "joe"}, "reason": null}'
     http_version: 
-  recorded_at: Tue, 24 Jul 2018 17:54:17 GMT
+  recorded_at: Wed, 07 Nov 2018 14:17:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/requests/public/email_validations_spec.rb
+++ b/spec/requests/public/email_validations_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe Public::EmailValidationsController do
           expect(json['is_taken']).to be(nil)
         end
       end
+
+      context "and it is a @qq.com email" do
+        let(:email) { URI.encode('3409186790@qq.com') }
+        let(:json) { JSON.parse(response.body)['data']['attributes'] }
+
+        before do
+          get "/public/email_validations/new?address=#{email}"
+        end
+
+        it "always returns valid" do
+          expect(json['is_valid']).to be(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Addressing #1790 - Mailgun confirms there is a bug on their side but have no ETA for when they will fix it - we confirmed in sprint planning that this is currently our best option.