### PR TITLE
Fix 500 errors when managing teams and judges in RA events section

### DIFF
--- a/app/controllers/regional_ambassador/judge_lists_controller.rb
+++ b/app/controllers/regional_ambassador/judge_lists_controller.rb
@@ -9,7 +9,7 @@ module RegionalAmbassador
         context: self,
       )
 
-      render json: AttendeesSerializer.new(attendees).serialized_json
+      render json: AttendeesSerializer.new(attendees, is_collection: true).serialized_json
     end
   end
 end

--- a/app/controllers/regional_ambassador/possible_event_attendees_controller.rb
+++ b/app/controllers/regional_ambassador/possible_event_attendees_controller.rb
@@ -10,7 +10,7 @@ module RegionalAmbassador
         context: self,
       )
 
-      render json: AttendeesSerializer.new(possible_attendees).serialized_json
+      render json: AttendeesSerializer.new(possible_attendees, is_collection: true).serialized_json
     end
 
     private

--- a/app/controllers/regional_ambassador/team_lists_controller.rb
+++ b/app/controllers/regional_ambassador/team_lists_controller.rb
@@ -9,7 +9,7 @@ module RegionalAmbassador
         context: self,
       )
 
-      render json: AttendeesSerializer.new(attendees).serialized_json
+      render json: AttendeesSerializer.new(attendees, is_collection: true).serialized_json
     end
   end
 end

--- a/app/javascript/application/sticky-header.js
+++ b/app/javascript/application/sticky-header.js
@@ -24,14 +24,16 @@
 
     const header = document.querySelector('.header-container')
 
-    // Create an observer instance linked to the callback function
-    const observer = new MutationObserver(setStickyNav)
+    if (header !== null) {
+      // Create an observer instance linked to the callback function
+      const observer = new MutationObserver(setStickyNav)
 
-    // Start observing the header for configured mutations
-    observer.observe(header, {
-      attributes: true,
-      childList: true,
-      subtree: true
-    });
+      // Start observing the header for configured mutations
+      observer.observe(header, {
+        attributes: true,
+        childList: true,
+        subtree: true
+      });
+    }
   });
 })()

--- a/app/javascript/ra/events/EventsTable.vue
+++ b/app/javascript/ra/events/EventsTable.vue
@@ -200,6 +200,9 @@
           return e.id === event.id;
         });
 
+        event.fetchTeamsUrlRoot = this.teamsListUrl;
+        event.fetchJudgesUrlRoot = this.judgesListUrl;
+
         if (idx !== -1) {
           this.events.splice(idx, 1, event);
         } else {

--- a/app/serializers/attendees_serializer.rb
+++ b/app/serializers/attendees_serializer.rb
@@ -1,8 +1,7 @@
 class AttendeesSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :id,
-    :name,
+  attributes :name,
     :scope,
     :status,
     :human_status,


### PR DESCRIPTION
Addresses #1804.

This is not finished. I am passing this to @joemsak so he can fix the back-end serializer issues that are causing the actual 500 errors when the correct back-end endpoint is hit.

Please note that the fix to `app/javascript/application/sticky-header.js` is not needed for this, but it is a necessary addition I am squeezing in.