### PR TITLE
Fix broken certificate buttons in the mentor dashboard scores section

### DIFF
--- a/app/javascript/components/CertificateButton.vue
+++ b/app/javascript/components/CertificateButton.vue
@@ -119,7 +119,7 @@ export default {
     },
 
     handleJobRequest (response) {
-      return new Promise((resolve, _reject) => {
+      return new Promise((resolve) => {
         if (Boolean(response.data.jobId)) {
           this.jobId = response.data.jobId
           this.state = 'generating'

--- a/app/javascript/mentor/index.js
+++ b/app/javascript/mentor/index.js
@@ -5,6 +5,7 @@ import router from './routes'
 import store from './store'
 
 import App from './App'
+import CertificateButton from 'components/CertificateButton'
 
 Vue.use(Vue2Filters)
 
@@ -33,6 +34,7 @@ document.addEventListener('turbolinks:load', () => {
         router,
         components: {
           App,
+          CertificateButton,
         },
 
         mounted () {

--- a/app/views/mentor/dashboards/onboarded/_scores.html.erb
+++ b/app/views/mentor/dashboards/onboarded/_scores.html.erb
@@ -63,11 +63,9 @@
       <% end %>
     <% end %>
 
-    <p class="vue-enable-certificate-btn">
-      <certificate-button
-        :team-id="<%= team.id %>"
-        user-scope="mentor"
-      />
-    </p>
+    <certificate-button
+      :team-id="<%= team.id %>"
+      user-scope="mentor"
+    />
   </div>
 <% end %>


### PR DESCRIPTION
Move certificate initialization for mentor scores to within Vue app initialization to prevent multiple Vue instance problems.

Previously the certificate button was wrapped in a `p.vue-enable-certificate-btn` element targeted by a global Vue initialization instance. This got initialized properly (which was confirmed by console and breakpoints), but then it was inserted into another Vue app via slots for the mentor dashboard. The functionality broke because it was then overwritten by the mentor dashboard instance, causing the certificate button to stop being saturated by the global Vue instance.