### PR TITLE
Events Attendee models missing ids

### DIFF
--- a/app/javascript/ra/events/AttendeeSearch.vue
+++ b/app/javascript/ra/events/AttendeeSearch.vue
@@ -175,6 +175,8 @@
 
           success: (json) => {
             Array.from(json.data || []).forEach(obj => {
+              // Need to massage this data since serializers modify the JSON structure
+              obj.attributes.id = obj.id
               const item = new Attendee(obj.attributes)
               let idx
 

--- a/app/javascript/ra/events/Event.js
+++ b/app/javascript/ra/events/Event.js
@@ -206,6 +206,8 @@ export default function (event) {
 
           success (resp) {
             Array.from(resp.data || []).forEach(result => {
+              // Need to massage this data since serializers modify the JSON structure
+              result.attributes.id = result.id
               opts.event.resultReadyForList(result.attributes, opts.list)
             })
             resolve(resp)

--- a/app/javascript/ra/events/EventJudgeList.vue
+++ b/app/javascript/ra/events/EventJudgeList.vue
@@ -207,7 +207,7 @@
       },
 
       hoverJudge (judge) {
-        Array.from(this.event.selectedJudges || []).forEach(j => jehovering = false)
+        Array.from(this.event.selectedJudges || []).forEach(j => j.hovering = false)
         judge.hovering = true
       },
 


### PR DESCRIPTION
Addresses #1831 and #1832.

Basically the switch to fastJSON API and serializers caused the IDs to not be on the same level as the attendee attributes, so the Attendee JavaScript model objects weren't populating correctly (the had `NaN` as their ids). This in turn made the Vue loops crash and burn, and therefore everything blew up violently.