### PR TITLE
Update event time pickers to use flatpickr

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -252,3 +252,13 @@ form[data-remote] {
 .dz-error-message {
   margin-top: 1em;
 }
+
+.flatpickr-calendar.hasTime.noCalendar.arrowTop {
+  &:after {
+    border-bottom-color: #fff;
+  }
+
+  input:focus {
+    box-shadow: none;
+  }
+}

--- a/app/javascript/components/DatetimeInput.vue
+++ b/app/javascript/components/DatetimeInput.vue
@@ -22,6 +22,10 @@
     props: ["value", "options"],
 
     watch: {
+      value (newValue) {
+        this.flatpickrValue = newValue;
+      },
+
       flatpickrValue () {
         this.$emit("input", this.flatpickrValue);
       },

--- a/app/javascript/ra/events/EventForm.vue
+++ b/app/javascript/ra/events/EventForm.vue
@@ -80,7 +80,7 @@
             From
             <datetime-input
               v-model="eventStartTime"
-              :options="timeOpts"
+              :options="startDateInputOptions"
             />
           </label>
 
@@ -189,6 +189,20 @@
 
       time () {
         return this.event.time;
+      },
+
+      startDateInputOptions () {
+        return Object.assign({}, this.timeOpts, {
+          onClose: (_selectedDates, dateStr, instance) => {
+            if (this.eventEndTime !== "") {
+              const startTime = this.createTimeFromString(dateStr);
+              const endTime = this.createTimeFromString(this.eventEndTime);
+              if (startTime > endTime) {
+                this.eventEndTime = "";
+              }
+            }
+          }
+        });
       },
     },
 
@@ -318,6 +332,18 @@
           },
         });
       },
+
+      createTimeFromString(twentyFourHourTime) {
+        const newTime = new Date();
+        const timeParts = twentyFourHourTime.split(':');
+        newTime.setHours(
+          parseInt(timeParts[0], 10),
+          parseInt(timeParts[1], 10),
+          0
+        );
+        console.log('createTimeFromString called for', twentyFourHourTime, newTime);
+        return newTime;
+      }
     },
 
     components: {

--- a/app/javascript/ra/events/EventForm.vue
+++ b/app/javascript/ra/events/EventForm.vue
@@ -90,7 +90,7 @@
             To
             <datetime-input
               v-model="eventEndTime"
-              :options="timeOpts"
+              :options="endDateInputOptions"
             />
           </label>
 
@@ -204,6 +204,27 @@
           }
         });
       },
+
+      endDateInputOptions () {
+        return Object.assign({}, this.timeOpts, {
+          onOpen: (_selectedDates, _dateStr, instance) => {
+            if (this.eventStartTime !== "") {
+              const startTime = this.createTimeFromString(this.eventStartTime);
+
+              let endTime = 0;
+              if (this.eventEndTime !== "") {
+                endTime = this.createTimeFromString(this.eventEndTime);
+              }
+
+              if (startTime > endTime) {
+                this.eventEndTime = this.eventStartTime;
+              }
+
+              instance.set('minTime', startTime);
+            }
+          },
+        });
+      }
     },
 
     watch: {

--- a/app/javascript/ra/events/EventForm.vue
+++ b/app/javascript/ra/events/EventForm.vue
@@ -362,7 +362,6 @@
           parseInt(timeParts[1], 10),
           0
         );
-        console.log('createTimeFromString called for', twentyFourHourTime, newTime);
         return newTime;
       }
     },

--- a/app/javascript/ra/events/EventForm.vue
+++ b/app/javascript/ra/events/EventForm.vue
@@ -78,15 +78,9 @@
         <div class="grid__col-6">
           <label>
             From
-            <input
+            <datetime-input
               v-model="eventStartTime"
-              :picker-options="{
-                start: '07:00',
-                step: '00:15',
-                end: '23:30',
-                format: 'HH:mm A',
-              }"
-              placeholder="Select start time"
+              :options="timeOpts"
             />
           </label>
 
@@ -94,16 +88,9 @@
 
           <label>
             To
-            <input
+            <datetime-input
               v-model="eventEndTime"
-              :picker-options="{
-                start: '07:00',
-                step: '00:15',
-                end: '23:30',
-                format: 'HH:mm A',
-                minTime: eventStartTime,
-              }"
-              placeholder="Select start time"
+              :options="timeOpts"
             />
           </label>
 
@@ -168,7 +155,7 @@
           dateFormat: "H:i",
           minuteIncrement: 15,
           minTime: "07:00",
-          maxTime: "22:00",
+          maxTime: "23:30",
         },
 
         httpMethod: "POST",


### PR DESCRIPTION
Addresses #1826.

When `element-ui` was removed for pull request #1632, we didn’t update the time pickers to use a different library. I have implemented the time pickers using flatpickr. I have also added some functionality to prevent end-users from adding a start time after the end time to improve the UX a bit and prevent potential errors.