### PR TITLE
1816 fix searchable mentors who require training

### DIFF
--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -3,13 +3,13 @@ module ImportantDates
     year = Integer(ENV.fetch("DATES_MENTOR_TRAINING_YEAR"))
     month = Integer(ENV.fetch("DATES_MENTOR_TRAINING_MONTH"))
     day = Integer(ENV.fetch("DATES_MENTOR_TRAINING_DAY"))
-    Date.new(year, month, day)
+    Time.zone.local(year, month, day)
   end
 
   def self.registration_opens
     year = Integer(ENV.fetch("DATES_REGISTRATION_OPENS_YEAR"))
     month = Integer(ENV.fetch("DATES_REGISTRATION_OPENS_MONTH"))
     day = Integer(ENV.fetch("DATES_REGISTRATION_OPENS_DAY"))
-    Date.new(year, month, day)
+    Time.zone.local(year, month, day)
   end
 end

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -191,7 +191,8 @@ class MentorProfile < ActiveRecord::Base
     end
 
     if season_registered_at
-      season_registered_at.to_date >= ImportantDates.mentor_training_required_since
+      season_registered_at.to_date >=
+        ImportantDates.mentor_training_required_since.to_date
     else
       false
     end

--- a/db/migrate/20181115163525_fix_un_searchable_mentors.rb
+++ b/db/migrate/20181115163525_fix_un_searchable_mentors.rb
@@ -1,0 +1,7 @@
+class FixUnSearchableMentors < ActiveRecord::Migration[5.1]
+  def up
+    MentorProfile.current.searchable.find_each do |mentor|
+      mentor.save
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,20 +37,6 @@ COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs
 
 
 --
--- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
-
-
---
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -117,6 +103,7 @@ CREATE TABLE public.accounts (
     os_name character varying,
     os_version character varying,
     email_confirmed_at timestamp without time zone,
+    deleted_at timestamp without time zone,
     last_logged_in_at timestamp without time zone,
     seasons text[] DEFAULT '{}'::text[],
     session_token character varying,
@@ -127,7 +114,6 @@ CREATE TABLE public.accounts (
     reminded_about_survey_at timestamp without time zone,
     reminded_about_survey_count integer DEFAULT 0 NOT NULL,
     season_registered_at timestamp without time zone,
-    deleted_at timestamp without time zone,
     override_certificate_type integer,
     admin_status integer DEFAULT 0 NOT NULL,
     admin_invitation_token character varying,
@@ -143,6 +129,7 @@ CREATE TABLE public.accounts (
 --
 
 CREATE SEQUENCE public.accounts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -181,6 +168,7 @@ CREATE TABLE public.activities (
 --
 
 CREATE SEQUENCE public.activities_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -212,6 +200,7 @@ CREATE TABLE public.admin_profiles (
 --
 
 CREATE SEQUENCE public.admin_profiles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -258,6 +247,7 @@ CREATE TABLE public.background_checks (
 --
 
 CREATE SEQUENCE public.background_checks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -290,6 +280,7 @@ CREATE TABLE public.business_plans (
 --
 
 CREATE SEQUENCE public.business_plans_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -358,6 +349,7 @@ CREATE TABLE public.consent_waivers (
 --
 
 CREATE SEQUENCE public.consent_waivers_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -389,6 +381,7 @@ CREATE TABLE public.divisions (
 --
 
 CREATE SEQUENCE public.divisions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -430,6 +423,7 @@ CREATE TABLE public.expertises (
 --
 
 CREATE SEQUENCE public.expertises_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -466,6 +460,7 @@ CREATE TABLE public.exports (
 --
 
 CREATE SEQUENCE public.exports_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -532,6 +527,7 @@ CREATE TABLE public.honor_code_agreements (
 --
 
 CREATE SEQUENCE public.honor_code_agreements_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -567,6 +563,7 @@ CREATE TABLE public.jobs (
 --
 
 CREATE SEQUENCE public.jobs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -587,8 +584,8 @@ ALTER SEQUENCE public.jobs_id_seq OWNED BY public.jobs.id;
 
 CREATE TABLE public.join_requests (
     id integer NOT NULL,
-    requestor_id integer NOT NULL,
     requestor_type character varying NOT NULL,
+    requestor_id integer NOT NULL,
     team_id integer NOT NULL,
     accepted_at timestamp without time zone,
     declined_at timestamp without time zone,
@@ -604,6 +601,7 @@ CREATE TABLE public.join_requests (
 --
 
 CREATE SEQUENCE public.join_requests_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -638,6 +636,7 @@ CREATE TABLE public.judge_assignments (
 --
 
 CREATE SEQUENCE public.judge_assignments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -683,6 +682,7 @@ CREATE TABLE public.judge_profiles (
 --
 
 CREATE SEQUENCE public.judge_profiles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -713,8 +713,8 @@ CREATE TABLE public.judge_profiles_regional_pitch_events (
 
 CREATE TABLE public.memberships (
     id integer NOT NULL,
-    member_id integer NOT NULL,
     member_type character varying NOT NULL,
+    member_id integer NOT NULL,
     team_id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -726,6 +726,7 @@ CREATE TABLE public.memberships (
 --
 
 CREATE SEQUENCE public.memberships_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -759,6 +760,7 @@ CREATE TABLE public.mentor_profile_expertises (
 --
 
 CREATE SEQUENCE public.mentor_profile_expertises_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -800,6 +802,7 @@ CREATE TABLE public.mentor_profiles (
 --
 
 CREATE SEQUENCE public.mentor_profiles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -828,8 +831,8 @@ CREATE TABLE public.messages (
     body text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    regarding_id integer,
     regarding_type character varying,
+    regarding_id integer,
     sent_at timestamp without time zone,
     delivered_at timestamp without time zone
 );
@@ -840,6 +843,7 @@ CREATE TABLE public.messages (
 --
 
 CREATE SEQUENCE public.messages_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -860,10 +864,10 @@ ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
 
 CREATE TABLE public.multi_messages (
     id integer NOT NULL,
-    sender_id integer NOT NULL,
     sender_type character varying NOT NULL,
-    regarding_id integer NOT NULL,
+    sender_id integer NOT NULL,
     regarding_type character varying NOT NULL,
+    regarding_id integer NOT NULL,
     recipients public.hstore NOT NULL,
     subject character varying,
     body text NOT NULL,
@@ -879,6 +883,7 @@ CREATE TABLE public.multi_messages (
 --
 
 CREATE SEQUENCE public.multi_messages_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -914,6 +919,7 @@ CREATE TABLE public.parental_consents (
 --
 
 CREATE SEQUENCE public.parental_consents_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -946,6 +952,7 @@ CREATE TABLE public.pitch_presentations (
 --
 
 CREATE SEQUENCE public.pitch_presentations_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -985,6 +992,7 @@ CREATE TABLE public.regional_ambassador_profiles (
 --
 
 CREATE SEQUENCE public.regional_ambassador_profiles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1060,6 +1068,7 @@ CREATE TABLE public.regional_pitch_events (
 --
 
 CREATE SEQUENCE public.regional_pitch_events_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1131,6 +1140,7 @@ CREATE TABLE public.regions (
 --
 
 CREATE SEQUENCE public.regions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1247,6 +1257,7 @@ CREATE TABLE public.screenshots (
 --
 
 CREATE SEQUENCE public.screenshots_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1304,6 +1315,7 @@ CREATE TABLE public.signup_attempts (
 --
 
 CREATE SEQUENCE public.signup_attempts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1339,6 +1351,7 @@ CREATE TABLE public.student_profiles (
 --
 
 CREATE SEQUENCE public.student_profiles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1361,6 +1374,7 @@ CREATE TABLE public.submission_scores (
     id integer NOT NULL,
     team_submission_id integer,
     judge_profile_id integer,
+    sdg_alignment integer DEFAULT 0,
     evidence_of_problem integer DEFAULT 0,
     problem_addressed integer DEFAULT 0,
     app_functional integer DEFAULT 0,
@@ -1390,7 +1404,6 @@ CREATE TABLE public.submission_scores (
     deleted_at timestamp without time zone,
     round integer DEFAULT 0 NOT NULL,
     official boolean DEFAULT true,
-    sdg_alignment integer DEFAULT 0,
     seasons text[] DEFAULT '{}'::text[],
     ideation_comment_positivity numeric(4,3) DEFAULT 0,
     ideation_comment_negativity numeric(4,3) DEFAULT 0,
@@ -1429,6 +1442,7 @@ CREATE TABLE public.submission_scores (
 --
 
 CREATE SEQUENCE public.submission_scores_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1467,6 +1481,7 @@ CREATE TABLE public.team_member_invites (
 --
 
 CREATE SEQUENCE public.team_member_invites_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1515,12 +1530,12 @@ CREATE TABLE public.team_submissions (
     pending_semifinals_official_submission_scores_count integer DEFAULT 0 NOT NULL,
     pending_quarterfinals_official_submission_scores_count integer DEFAULT 0 NOT NULL,
     deleted_at timestamp without time zone,
+    percent_complete integer DEFAULT 0 NOT NULL,
     seasons text[] DEFAULT '{}'::text[],
     app_inventor_app_name character varying,
     app_inventor_gmail character varying,
     published_at timestamp without time zone,
     business_plan character varying,
-    percent_complete integer DEFAULT 0 NOT NULL,
     pitch_presentation character varying,
     lowest_score_dropped_at timestamp without time zone,
     thunkable_account_email character varying,
@@ -1534,6 +1549,7 @@ CREATE TABLE public.team_submissions (
 --
 
 CREATE SEQUENCE public.team_submissions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1565,11 +1581,11 @@ CREATE TABLE public.teams (
     accepting_mentor_requests boolean DEFAULT true NOT NULL,
     latitude double precision,
     longitude double precision,
+    seasons text[] DEFAULT '{}'::text[],
     city character varying,
     state_province character varying,
     country character varying,
     deleted_at timestamp without time zone,
-    seasons text[] DEFAULT '{}'::text[],
     has_students boolean DEFAULT false NOT NULL,
     has_mentor boolean DEFAULT false NOT NULL,
     all_students_onboarded boolean DEFAULT false
@@ -1581,6 +1597,7 @@ CREATE TABLE public.teams (
 --
 
 CREATE SEQUENCE public.teams_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1648,6 +1665,7 @@ CREATE TABLE public.technical_checklists (
 --
 
 CREATE SEQUENCE public.technical_checklists_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2260,6 +2278,14 @@ ALTER TABLE ONLY public.saved_searches
 
 
 --
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
 -- Name: screenshots screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2732,13 +2758,6 @@ CREATE UNIQUE INDEX uniq_students_accounts ON public.student_profiles USING btre
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
-
-
---
 -- Name: divisions_regional_pitch_events fk_rails_1064d06b86; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3055,7 +3074,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171018170002'),
 ('20171018184701'),
 ('20171019162859'),
-('20171019230759'),
 ('20171019230800'),
 ('20171020085320'),
 ('20171020135709'),
@@ -3070,7 +3088,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171107225231'),
 ('20171107233018'),
 ('20171108140911'),
-('20171110224550'),
 ('20171113170115'),
 ('20171113170150'),
 ('20171113215850'),
@@ -3098,7 +3115,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180129165533'),
 ('20180129165702'),
 ('20180202143954'),
-('20180202145104'),
 ('20180202145820'),
 ('20180206152207'),
 ('20180206184914'),
@@ -3111,7 +3127,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180301140524'),
 ('20180313204753'),
 ('20180314144804'),
-('20180316182251'),
 ('20180322201531'),
 ('20180328171732'),
 ('20180409220653'),
@@ -3153,7 +3168,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180925143744'),
 ('20180925184416'),
 ('20180926192206'),
+('20180927235304'),
+('20180927235305'),
 ('20181001181253'),
-('20181108210955');
+('20181108210955'),
+('20181115163525');
 
 

--- a/spec/models/mentor_profile_spec.rb
+++ b/spec/models/mentor_profile_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe MentorProfile do
     end
   end
 
+  describe ".searchable" do
+    it "does not list mentors who have not completed training (and are required to)" do
+      mentor = FactoryBot.create(:mentor, :onboarded)
+      mentor.account.update(
+        season_registered_at: ImportantDates.mentor_training_required_since
+      )
+
+      expect(mentor.reload).to be_searchable
+      expect(MentorProfile.searchable).to include(mentor)
+
+      mentor.update(training_completed_at: nil)
+
+      expect(mentor.reload).not_to be_training_complete
+      expect(mentor).to be_training_required
+      expect(mentor).not_to be_searchable
+      expect(MentorProfile.searchable).not_to include(mentor)
+    end
+  end
+
   describe ".onboarded" do
     it "lists mentors who require training and have completed it" do
       mentor = FactoryBot.create(:mentor, :onboarded)


### PR DESCRIPTION
This PR addresses #1816 in the following ways:

* Fixes the logic for comparing `season_registered_at` date against the `mentor_training_required_since` date when setting mentor `searchable` attribute

* Runs an update on existing `current` and `searchable` mentors to run the logic and update the `searchable` attribute
  * (the way the model is coded is to run the logic as a callback on updates, so just calling `#save` does the trick - this is standard rails stuff)