### PR TITLE
Fix the RA's link to the team's submission in the debugging area

### DIFF
--- a/app/views/admin/teams/_debugging.html.erb
+++ b/app/views/admin/teams/_debugging.html.erb
@@ -7,8 +7,7 @@
     <p>
       View this team's submission:
 
-      <%= link_to team.submission.app_name,
-        admin_team_submission_path(team.submission) %>
+      <%= link_to team.submission.app_name, [current_scope, team.submission] %>
     </p>
 
     <%= submission_progress_bar(team.submission) %>

--- a/spec/system/regional_ambassador/view_team_submission_from_team_page_spec.rb
+++ b/spec/system/regional_ambassador/view_team_submission_from_team_page_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "RAs visiting a team page" do
+  describe "Clicking through to the submission" do
+    it "works" do
+      team = FactoryBot.create(:team, :submitted)
+
+      sign_in(:ra)
+      visit regional_ambassador_team_path(team)
+      click_link team.submission.app_name
+
+      expect(current_path).to eq(regional_ambassador_team_submission_path(team.submission))
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses #1854 by:

* Adding a system spec (regression test) for the RA clicking on the link from the team debugging area
* Using the rails convention of putting route names together with an array, and the custom helper method of `current_scope` which knows if you're logged in as an RA, admin, mentor, etc...