### PR TITLE
[WIP] Add the password reset script

### DIFF
--- a/lib/reset_vulnerable_passwords.rb
+++ b/lib/reset_vulnerable_passwords.rb
@@ -1,0 +1,13 @@
+class ResetVulnerablePasswords
+  def self.perform!
+    accounts = Account.not_admin.where(
+      "created_at::date BETWEEN '2018-10-01' AND '2018-11-13'"
+    )
+
+    accounts.find_each do |account|
+      account.skip_existing_password = true
+      account.password = SecureRandom.base58(48)
+      account.regenerate_auth_token
+    end
+  end
+end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :account do
-    sequence(:email) { |n| "account#{n}@example.com" }
+    sequence(:email) { |n| "account-#{n}@example.com" }
     password { "secret1234" }
     email_confirmed_at { Time.current }
 
@@ -42,7 +42,7 @@ FactoryBot.define do
       country { "BR" }
     end
 
-    after :create do |a|
+    after(:create) do |a|
       if a.seasons.empty?
         RegisterToCurrentSeasonJob.perform_now(a)
       end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -6,12 +6,13 @@ FactoryBot.define do
 
     transient do
       first_name { "Student" }
+      last_name { "FactoryBot" }
       city { "Chicago" }
       state_province { "IL" }
       country { "US" }
       date_of_birth { Date.today - 14.years }
       sequence(:email) { |n| "factory-student-#{n}@example.com" }
-      password { nil }
+      password { "secret1234" }
       not_onboarded { false }
     end
 
@@ -150,18 +151,17 @@ FactoryBot.define do
         )
       end
 
-      attrs = FactoryBot.attributes_for(:account)
-
-      attrs.merge(
+      {
         skip_existing_password: true,
         first_name: e.first_name,
+        last_name: e.last_name,
         city: e.city,
         state_province: e.state_province,
         country: e.country,
         date_of_birth: e.date_of_birth,
-        email: e.email || attrs[:email],
-        password: e.password || attrs[:password],
-      ).each do |k, v|
+        email: e.email,
+        password: e.password,
+      }.each do |k, v|
         s.account.send("#{k}=", v)
       end
     end

--- a/spec/lib/reset_vulnerable_passwords_spec.rb
+++ b/spec/lib/reset_vulnerable_passwords_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+require "reset_vulnerable_passwords"
+
+RSpec.describe ResetVulnerablePasswords do
+  let(:dates) {
+    [
+      Time.new(2018, 10, 1),
+      Time.new(2018, 11, 13)
+    ]
+  }
+
+  let!(:student) {
+    FactoryBot.create(
+      :student,
+      account: FactoryBot.create(:account, created_at: dates.sample)
+    )
+  }
+
+  let!(:mentor) {
+    FactoryBot.create(
+      :mentor,
+      account: FactoryBot.create(:account, created_at: dates.sample)
+    )
+  }
+
+  let!(:judge) {
+    FactoryBot.create(
+      :judge,
+      account: FactoryBot.create(:account, created_at: dates.sample)
+    )
+  }
+
+  let!(:ra) {
+    FactoryBot.create(
+      :ra,
+      account: FactoryBot.create(:account, created_at: dates.sample)
+    )
+  }
+
+  describe ".perform!" do
+    it "resets passwords to a secure string" do
+      expect {
+        ResetVulnerablePasswords.perform!
+      }.to change {
+        student.reload.password_digest
+      }.and change {
+        mentor.reload.password_digest
+      }.and change {
+        judge.reload.password_digest
+      }.and change {
+        ra.reload.password_digest
+      }
+    end
+
+    it "regenerates auth tokens" do
+      expect {
+        ResetVulnerablePasswords.perform!
+      }.to change {
+        student.reload.auth_token
+      }.and change {
+        mentor.reload.auth_token
+      }.and change {
+        judge.reload.auth_token
+      }.and change {
+        ra.reload.auth_token
+      }
+    end
+
+
+    it "affects ONLY accounts signed up between Oct 1 2018 and Nov 13, 2018" do
+      profiles = [:student, :judge, :mentor, :ra]
+
+      my_dates = [
+        Time.new(2018, 9, 30),
+        Time.new(2018, 11, 14),
+      ]
+
+      account = FactoryBot.create(profiles.sample, created_at: my_dates.sample)
+
+      expect {
+        ResetVulnerablePasswords.perform!
+      }.to not_change {
+        account.reload.password_digest
+      }.and not_change {
+        account.reload.auth_token
+      }
+    end
+
+    it "does not affect admins" do
+      account = FactoryBot.create(
+        :admin,
+        account: FactoryBot.create(:account, created_at: dates.sample)
+      )
+
+      expect {
+        ResetVulnerablePasswords.perform!
+      }.to not_change {
+        account.reload.password_digest
+      }.and not_change {
+        account.reload.auth_token
+      }
+    end
+  end
+end


### PR DESCRIPTION
Still WIP but here are the highlights so far:

* Adds `/lib/reset_vulnerable_passwords.rb` which will collect all users who were `created_at` between Oct 1 2018 and Nov 13 2018 (meaning on both of those days, too) - it sets their password to a random secure hash, and regenerates their auth token

TODO:

* Create the rake task which runs this script
* Coordinate testing the old and new accounts with QA

@Allicolyer anyone who will do the testing on QA can create the new signups on QA today, though, no need to wait on this PR. Thanks!