### PR TITLE
Darken flatpickr calendar day selection links

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -262,3 +262,24 @@ form[data-remote] {
     box-shadow: none;
   }
 }
+
+.flatpickr-calendar {
+  .flatpickr-day.disabled,
+  .flatpickr-day.disabled:hover,
+  .flatpickr-day.prevMonthDay,
+  .flatpickr-day.nextMonthDay,
+  .flatpickr-day.notAllowed,
+  .flatpickr-day.notAllowed.prevMonthDay,
+  .flatpickr-day.notAllowed.nextMonthDay {
+    color: rgba(72, 72, 72, .5);
+    background: transparent;
+    border-color: transparent;
+    cursor: default;
+  }
+
+  .flatpickr-day.disabled,
+  .flatpickr-day.disabled:hover {
+    cursor: not-allowed;
+    color: rgba(72, 72, 72, .1);
+  }
+}


### PR DESCRIPTION
Darken next and previous month days for flatpickr for better color contrast. Addresses Alli's comments on #1802.
