### PR TITLE
Update rack dependency to 2.0.6 to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
       railties (>= 3.0.0)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rack-proxy (0.6.5)


### PR DESCRIPTION
This addresses the vulnerability that shows up on Github. I didn't see anything glaring that this would cause issues with upon first glance when looking at the `rack` repository when comparing the versions. But I thought I would have you check as well.

Please see the following for more details: https://github.com/rack/rack/compare/2.0.5...2.0.6