### PR TITLE
#1793 add admin and ra mentor training status filter

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -297,6 +297,20 @@ class AccountsGrid
       send(value)
     end
 
+  filter :mentor_training,
+    :enum,
+    header: "Mentor training (mentors only)",
+    select: [
+      ['Training complete or not required', 'mentor_training_complete_or_not_required'],
+      ['Training required, and incomplete', 'mentor_training_required'],
+    ],
+    filter_group: "common",
+    if: ->(g) {
+      (%w{judge student regional_ambassador} & (g.scope_names || [])).empty?
+    } do |value|
+      send(value)
+    end
+
   filter :onboarded_judges,
     :enum,
     select: [

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -153,6 +153,26 @@ class Account < ActiveRecord::Base
       .where("judge_profiles.completed_training_at" => nil)
   }
 
+  scope :mentor_training_required, -> () {
+    includes(:mentor_profile)
+      .references(:mentor_profile)
+      .where(
+        "training_completed_at IS NULL AND " +
+          "date(season_registered_at) >= ?",
+        ImportantDates.mentor_training_required_since
+      ) 
+  }
+
+  scope :mentor_training_complete_or_not_required, -> () {
+    includes(:mentor_profile)
+      .references(:mentor_profile)
+      .where(
+        "training_completed_at IS NOT NULL OR " +
+          "date(season_registered_at) < ?",
+        ImportantDates.mentor_training_required_since
+      ) 
+  }
+
   scope :live_event_eligible, ->(event) {
     includes(:judge_profile)
       .references(:judge_profiles)


### PR DESCRIPTION
Adds an admin and RA Participants page filter to find either mentors who require training and have not completed it, or mentors who either don't require it or have completed it.

This should resolve #1793. 