### PR TITLE
[WIP] Report potential carmen updates

### DIFF
--- a/lib/tasks/report_carmen_updates.rake
+++ b/lib/tasks/report_carmen_updates.rake
@@ -1,0 +1,44 @@
+desc "Dry-run only - create report of how data would change in Carmen update"
+task dry_run_carmen: :environment do
+  CSV.open("./tmp/carmen-dry-run.csv", "wb") do |rows|
+    rows << [
+      "ID",
+      "Name",
+      "Email",
+      "Old State",
+      "New State",
+    ]
+
+    accounts = Account.current.where("length(state_province) > 4")
+    puts "Dry run on #{accounts.count} accounts..."
+    accounts.each.with_index do |account, i|
+      row = [
+        account.id,
+        account.name,
+        account.email,
+        account[:state_province],
+      ]
+
+
+      country = Carmen::Country.coded(account[:country])
+
+      case account[:state_province]
+      when /madrid/i
+        state = country.subregions.named("Madrid", fuzzy: true)
+      when /valencia/i
+        state = country.subregions.named("Valencia", fuzzy: true)
+      else
+        state = country.subregions.named(account[:state_province], fuzzy: true)
+      end
+
+      account.state_province = state && state.code
+
+      row << account.state_code
+
+      rows << row
+      puts i + 1
+    end
+    puts "Done!"
+    puts "Find the report in ./tmp/carmen-dry-run.csv"
+  end
+end

--- a/lib/tasks/report_carmen_updates.rake
+++ b/lib/tasks/report_carmen_updates.rake
@@ -21,7 +21,6 @@ task dry_run_carmen: :environment do
         account[:state_province],
       ]
 
-
       country = Carmen::Country.coded(account[:country])
 
       case account[:state_province]

--- a/lib/tasks/report_carmen_updates.rake
+++ b/lib/tasks/report_carmen_updates.rake
@@ -25,8 +25,6 @@ task dry_run_carmen: :environment do
       country = Carmen::Country.coded(account[:country])
 
       case account[:state_province]
-      when /madrid/i
-        state = country.subregions.named("Madrid", fuzzy: true)
       when /valencia/i
         state = country.subregions.named("Valencia", fuzzy: true)
       when /baba/i
@@ -34,7 +32,18 @@ task dry_run_carmen: :environment do
       when /cairo/i
         state = country.subregions.named(/hirah/i, regex: true)
       else
-        state = country.subregions.named(account[:state_province], fuzzy: true)
+        name = account[:state_province].sub("Región de ", "")
+        name = name.sub("Región del ", "")
+        name = name.sub("Región ", "")
+        name = name.sub("Departamento de ", "")
+        name = name.sub("Comunidad de ", "")
+        name = name.sub("Community of ", "")
+        name = name.sub("Gouvernorat de ", "")
+        name = name.sub(" Province", "")
+        name = name.sub(" County", "")
+        name = name.sub(" Governorate", "")
+
+        state = country.subregions.named(name, fuzzy: true)
       end
 
       account.state_province = state && state.code

--- a/lib/tasks/report_carmen_updates.rake
+++ b/lib/tasks/report_carmen_updates.rake
@@ -5,6 +5,7 @@ task dry_run_carmen: :environment do
       "ID",
       "Name",
       "Email",
+      "Country",
       "Old State",
       "New State",
     ]
@@ -16,6 +17,7 @@ task dry_run_carmen: :environment do
         account.id,
         account.name,
         account.email,
+        account[:country],
         account[:state_province],
       ]
 
@@ -27,6 +29,10 @@ task dry_run_carmen: :environment do
         state = country.subregions.named("Madrid", fuzzy: true)
       when /valencia/i
         state = country.subregions.named("Valencia", fuzzy: true)
+      when /baba/i
+        state = country.subregions.named(/beba/i, regex: true)
+      when /cairo/i
+        state = country.subregions.named(/hirah/i, regex: true)
       else
         state = country.subregions.named(account[:state_province], fuzzy: true)
       end


### PR DESCRIPTION
This rake task performs a dry-run on changing full state names to their codes (as dictated by Carmen)

Key points:

* Only considers states with a string length greater than four
  * Having it set at 3 pulled in legitimate data that doesn't need to change
  * None of the data when looking for country string lengths greater than 3 produced records with such country data, so it's not needed
* Seems the best way to go about this is stick in cases for the biggest groups to be fixed one at a time (see the case/switch conditional in the task script)