### PR TITLE
Update ActiveGeocoded country function to use full country name

### DIFF
--- a/app/models/concerns/active_geocoded.rb
+++ b/app/models/concerns/active_geocoded.rb
@@ -124,7 +124,10 @@ module ActiveGeocoded
 
   def country
     if valid_address?
-      me = OpenStruct.new(address_details: [city, state_code, country_code].join(", "))
+      country = Carmen::Country.coded(country_code) ||
+        Carmen::Country.named(country_code)
+
+      me = OpenStruct.new(address_details: [city, state_code, country].join(", "))
       FriendlyCountry.new(me).country_name
     else
       super rescue country_code


### PR DESCRIPTION
Correct `country` function in the `ActiveGeocoded` class to use the full country name for more reliable functionality. Previously it was just concatenating the address details together, and when it encounters a country short code, it seems to bomb out and default to the United States. This should fix that issue. I tested using the acceptance criteria in the #1924 ticket, and things look good and lat/long is saving correctly for each of those.

I am tagging @stenington to make sure that I did not miss anything or overlooked some detail on this. Mike, this needs to be deployed to production as soon as possible, so if you could take a look at this soon, I would appreciate it. Without this change Ophelie and I are manually changing locations for Barcelona, Spain residents. Thanks!

Addresses #1924.