### PR TITLE
Change sign up age to 10 by World Pitch cutoff

### DIFF
--- a/app/javascript/registration/components/ChooseProfile.vue
+++ b/app/javascript/registration/components/ChooseProfile.vue
@@ -42,7 +42,7 @@
     <div class="panel__content" v-else-if="!profileOptions.length">
       <div class="grid grid--justify-space-around">
         <div class="grid__col-12">
-          You must be at least 10 years old to sign up.
+          You must be at least 10 years old by World Pitch to sign up.
         </div>
       </div>
     </div>
@@ -114,7 +114,7 @@ export default {
     },
 
     profileOptions () {
-      if (this.getAge() < 10) {
+      if (this.getAgeByCutoff < 10) {
         this.profileChoice = null
         return []
       }

--- a/spec/javascript/registration/components/ChooseProfile.spec.js
+++ b/spec/javascript/registration/components/ChooseProfile.spec.js
@@ -104,13 +104,22 @@ describe("Registration::Components::ChooseProfile.vue", () => {
         expect(wrapper.vm.profileChoice).toEqual(null)
       })
 
-      it('returns an empty array and sets profile choice to null if age < 10', () => {
+      it('returns an empty array and sets profile choice to null if age by cutoff < 10', () => {
         const wrapper = createWrapperWithAge(9)
 
         expect(wrapper.vm.getAge()).toEqual(9)
         expect(wrapper.vm.getAgeByCutoff).toEqual(9)
         expect(wrapper.vm.profileOptions).toEqual([])
         expect(wrapper.vm.profileChoice).toEqual(null)
+      })
+
+      it('returns student and sets profile choice to student if age is 9 but age by cutoff is 10', () => {
+        const wrapper = createWrapperWithAge(9, 10)
+
+        expect(wrapper.vm.getAge()).toEqual(9)
+        expect(wrapper.vm.getAgeByCutoff).toEqual(10)
+        expect(wrapper.vm.profileOptions).toEqual(['student'])
+        expect(wrapper.vm.profileChoice).toEqual('student')
       })
 
       it('returns student and sets profile choice to student if age < 18', () => {


### PR DESCRIPTION
Change sign up age to 10 by World Pitch cutoff as opposed to the age at the time of sign up.

Addresses #1849.

