### PR TITLE
Location form fixes

### DIFF
--- a/app/models/concerns/active_geocoded.rb
+++ b/app/models/concerns/active_geocoded.rb
@@ -127,7 +127,8 @@ module ActiveGeocoded
       country = Carmen::Country.coded(country_code) ||
         Carmen::Country.named(country_code)
 
-      state_for_country = country.subregions.coded(state_code)
+      state_for_country = country.subregions.coded(state_code) ||
+        country.subregions.named(state_code)
 
       me = OpenStruct.new(address_details: [city, state_for_country, country].join(", "))
       FriendlyCountry.new(me).country_name

--- a/app/models/concerns/active_geocoded.rb
+++ b/app/models/concerns/active_geocoded.rb
@@ -127,7 +127,9 @@ module ActiveGeocoded
       country = Carmen::Country.coded(country_code) ||
         Carmen::Country.named(country_code)
 
-      me = OpenStruct.new(address_details: [city, state_code, country].join(", "))
+      state_for_country = country.subregions.coded(state_code)
+
+      me = OpenStruct.new(address_details: [city, state_for_country, country].join(", "))
       FriendlyCountry.new(me).country_name
     else
       super rescue country_code

--- a/spec/geocoder_helper.rb
+++ b/spec/geocoder_helper.rb
@@ -125,6 +125,7 @@ RSpec.configure do |config|
       "Dhurma, Riyadh Province",
       "Dhurma, Riyadh Province, Saudi Arabia",
       "Dhurma, Riyadh Province, SA",
+      "Dhurma, , Saudi Arabia",
       [24.6769697, 46.2431716],
     ].each do |loc|
       Geocoder::Lookup::Test.add_stub(
@@ -146,6 +147,7 @@ RSpec.configure do |config|
       "Najran",
       "Najran, Najran Province, Saudi Arabia",
       "Najran, Najran Province",
+      "Najran, , Saudi Arabia",
       [17.6004128, 44.2933307],
     ].each do |loc|
       Geocoder::Lookup::Test.add_stub(
@@ -198,7 +200,13 @@ RSpec.configure do |config|
       )
     end
 
-    ["Tel Aviv, IL-TA, IL", "Tel Aviv, Tel Aviv, IL", "Tel Aviv, Tel Aviv, Israel", [32.146611, 34.8519761]].each do |loc|
+    [
+      "Tel Aviv, IL-TA, IL",
+      "Tel Aviv, Tel Aviv, IL",
+      "Tel Aviv, Tel Aviv, Israel",
+      "Tel Aviv, , Israel",
+      [32.146611, 34.8519761]
+    ].each do |loc|
       Geocoder::Lookup::Test.add_stub(
         loc, [{
           "latitude" => 32.146611,


### PR DESCRIPTION
Addresses #1924. We needed to add the fully qualified state/province name to the search in ActiveGeocoded.