### PR TITLE
Country data missing from Teams section in Admin UI

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -177,11 +177,11 @@ class AccountsGrid
   column :city
 
   column :state_province, header: "State" do |account, _grid|
-    FriendlySubregion.(account)
+    FriendlySubregion.(account, prefix: false)
   end
 
   column :country do |account, _grid|
-    FriendlyCountry.(account)
+    FriendlyCountry.new(account).country_name
   end
 
   column :geolocation, header: "Geolocation", if: ->(g) {

--- a/app/data_grids/events_grid.rb
+++ b/app/data_grids/events_grid.rb
@@ -29,13 +29,15 @@ class EventsGrid
 
   column :time
 
-  column :country do
-    FriendlyCountry.(self)
-  end
-
   column :city
 
-  column :state_province, header: "State"
+  column :state_province, header: "State" do
+    FriendlySubregion.(self, prefix: false)
+  end
+
+  column :country do
+    Carmen::Country.coded(country) || Carmen::Country.named(country)
+  end
 
   column :judge_count do
     judge_list.size

--- a/app/data_grids/judges_grid.rb
+++ b/app/data_grids/judges_grid.rb
@@ -72,12 +72,15 @@ class JudgesGrid
   end
 
   column :age, order: "accounts.date_of_birth desc"
+
   column :city
-  column :state_province, header: "State"
+
+  column :state_province, header: "State" do
+    FriendlySubregion.(self, prefix: false)
+  end
+
   column :country do
-    if found_country = Carmen::Country.coded(country)
-      found_country.name
-    end
+    FriendlyCountry.new(self).country_name
   end
 
   column :referred_by do

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -54,13 +54,14 @@ class SubmissionsGrid
     team.city
   end
 
-  column :state_province, header: "State"
+  column :state_province, header: "State" do
+    FriendlySubregion.(team, prefix: false)
+  end
 
   column :country do
-    if found_country = Carmen::Country.coded(country)
-      found_country.name
-    end
+    FriendlyCountry.new(team).country_name
   end
+
 
   column :complete? do
     complete? ? "yes" : "NO"

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -49,12 +49,12 @@ class TeamsGrid
 
   column :city
 
-  column :state_province, header: "State"
+  column :state_province, header: "State" do
+    FriendlySubregion.(self, prefix: false)
+  end
 
   column :country do
-    if found_country = Carmen::Country.coded(country)
-      found_country.name
-    end
+    FriendlyCountry.new(self).country_name
   end
 
   column :created_at, header: "Created" do


### PR DESCRIPTION
Use FriendlyCountry and FriendlySubregion to populate our grid views country and state/region columns.

Addresses #1789.