### PR TITLE
#1956 Add thunkable promo page and a link on the development platform page

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -176,3 +176,18 @@ h1.page-heading .ra-intro,
 .antialias {
   -webkit-font-smoothing: antialiased;
 }
+
+.responsive-video {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+
+  iframe {
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+}

--- a/app/controllers/thunkable_promo_controller.rb
+++ b/app/controllers/thunkable_promo_controller.rb
@@ -1,0 +1,9 @@
+class ThunkablePromoController < ApplicationController
+  include Authenticated
+
+  def show
+    @thunkable_promo_image = ENV.fetch("THUNKABLE_PROMO_IMAGE")
+
+    render "general_info/get_started_with_thunkable"
+  end
+end

--- a/app/controllers/thunkable_promo_controller.rb
+++ b/app/controllers/thunkable_promo_controller.rb
@@ -1,9 +1,19 @@
 class ThunkablePromoController < ApplicationController
-  include Authenticated
+  before_action :unauthenticated!, if: -> {
+    not current_account.authenticated?
+  }
 
   def show
     @thunkable_promo_image = ENV.fetch("THUNKABLE_PROMO_IMAGE")
 
     render "general_info/get_started_with_thunkable"
+  end
+
+  private
+  def unauthenticated!
+    save_redirected_path
+
+    redirect_to signin_path,
+      notice: t("controllers.application.generic_unauthenticated")
   end
 end

--- a/app/views/general_info/get_started_with_thunkable.html.erb
+++ b/app/views/general_info/get_started_with_thunkable.html.erb
@@ -1,0 +1,59 @@
+<div class="grid grid--justify-space-around">
+<div class="grid__col-12 grid__col-md-10">
+<div class="panel">
+  <h3>Getting started with Thunkable</h3>
+
+  <p>
+    If you are using Thunkable to build your project, follow these instructions
+    to get started using it to build your app! Here's a video to help you get
+    started setting up Thunkable.
+  </p>
+
+  <div class="grid">
+    <div class="grid__col-md-8">
+      <div class="responsive-video">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/qOCADZbknNE"
+          frameborder="0"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+    </div>
+  </div>
+
+  <p>You can get a year of Thunkable PRO by following these steps:</p>
+
+  <p>
+    <ol>
+      <li>
+        Go to
+        <a href="https://x.thunkable.com/event/5bc11dbb1c9d440000725286" target="_blank">
+          https://x.thunkable.com/event/5bc11dbb1c9d440000725286
+        </a>
+      </li>
+      <li>Log in with your gmail account. If you don’t have one, you should make one now.</li>
+      <li>
+        Type in the code in this picture:
+        <br>
+        <%= image_tag @thunkable_promo_image %>
+      </li>
+    </ol>
+  </p>
+
+  <p>
+    This code will give you a free trial of Thunkable PRO. Thunkable PRO allows
+    you to create private projects, that way you can keep your apps secret
+    during the Technovation Challenge. If you decide not to purchase Thunkable
+    PRO, no worries, just please note that your apps will become public after
+    the competition.
+  </p>
+
+  <p class="padding--t-large">
+    <%= link_to "Go Back", :back, class: "button" %>
+  </p>
+</div>
+</div>
+</div>

--- a/app/views/general_info/get_started_with_thunkable.html.erb
+++ b/app/views/general_info/get_started_with_thunkable.html.erb
@@ -1,59 +1,59 @@
 <div class="grid grid--justify-space-around">
-<div class="grid__col-12 grid__col-md-10">
-<div class="panel">
-  <h3>Getting started with Thunkable</h3>
+  <div class="grid__col-12 grid__col-md-10">
+    <div class="panel">
+      <h3>Getting started with Thunkable</h3>
 
-  <p>
-    If you are using Thunkable to build your project, follow these instructions
-    to get started using it to build your app! Here's a video to help you get
-    started setting up Thunkable.
-  </p>
+      <p>
+        If you are using Thunkable to build your project, follow these instructions
+        to get started using it to build your app! Here's a video to help you get
+        started setting up Thunkable.
+      </p>
 
-  <div class="grid">
-    <div class="grid__col-md-8">
-      <div class="responsive-video">
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/qOCADZbknNE"
-          frameborder="0"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-        ></iframe>
+      <div class="grid">
+        <div class="grid__col-md-8">
+          <div class="responsive-video">
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/qOCADZbknNE"
+              frameborder="0"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          </div>
+        </div>
       </div>
+
+      <p>You can get a year of Thunkable PRO by following these steps:</p>
+
+      <p>
+        <ol>
+          <li>
+            Go to
+            <a href="https://x.thunkable.com/event/5bc11dbb1c9d440000725286" target="_blank">
+              https://x.thunkable.com/event/5bc11dbb1c9d440000725286
+            </a>
+          </li>
+          <li>Log in with your gmail account. If you don’t have one, you should make one now.</li>
+          <li>
+            Type in the code in this picture:
+            <br>
+            <%= image_tag @thunkable_promo_image %>
+          </li>
+        </ol>
+      </p>
+
+      <p>
+        This code will give you a free trial of Thunkable PRO. Thunkable PRO allows
+        you to create private projects, that way you can keep your apps secret
+        during the Technovation Challenge. If you decide not to purchase Thunkable
+        PRO, no worries, just please note that your apps will become public after
+        the competition.
+      </p>
+
+      <p class="padding--t-large">
+        <%= link_to "Go Back", :back, class: "button" %>
+      </p>
     </div>
   </div>
-
-  <p>You can get a year of Thunkable PRO by following these steps:</p>
-
-  <p>
-    <ol>
-      <li>
-        Go to
-        <a href="https://x.thunkable.com/event/5bc11dbb1c9d440000725286" target="_blank">
-          https://x.thunkable.com/event/5bc11dbb1c9d440000725286
-        </a>
-      </li>
-      <li>Log in with your gmail account. If you don’t have one, you should make one now.</li>
-      <li>
-        Type in the code in this picture:
-        <br>
-        <%= image_tag @thunkable_promo_image %>
-      </li>
-    </ol>
-  </p>
-
-  <p>
-    This code will give you a free trial of Thunkable PRO. Thunkable PRO allows
-    you to create private projects, that way you can keep your apps secret
-    during the Technovation Challenge. If you decide not to purchase Thunkable
-    PRO, no worries, just please note that your apps will become public after
-    the competition.
-  </p>
-
-  <p class="padding--t-large">
-    <%= link_to "Go Back", :back, class: "button" %>
-  </p>
-</div>
-</div>
 </div>

--- a/app/views/team_submissions/pieces/development_platform.en.html.erb
+++ b/app/views/team_submissions/pieces/development_platform.en.html.erb
@@ -71,6 +71,14 @@
         We want to ask you two questions about your use of Thunkable.
       </p>
 
+      <p class="flash flash-info">
+        For more information on how to get started with Thunkable and a free
+        trial of Thunkable PRO, click
+        <%= link_to "here",
+          :general_info_get_started_with_thunkable,
+          role: "url" %>.
+      </p>
+
       <%= f.label :thunkable_account_email,
         "What is the email address of your team's Thunkable account?" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -344,6 +344,8 @@ Rails.application.routes.draw do
 
   resources :geolocation_results, only: :index
 
+  get '/general_info/get_started_with_thunkable', to: 'thunkable_promo#show'
+
   get 'login', to: 'signins#new', as: :login
   get 'signin', to: 'signins#new', as: :signin
 


### PR DESCRIPTION
Addresses #1956.

What this doesn't address is the link on the WordPress side of things. That will need to happen with coordination with the WordPress team after this code has gone live.