### PR TITLE
#1951 Add scores datagrid column from QA feedback

### DIFF
--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -75,6 +75,15 @@ class ScoredSubmissionsGrid
     submission.semifinals_score_range
   end
 
+  column :quarterfinals_official_judging do |submission|
+    if submission.team.selected_regional_pitch_event.live? &&
+         submission.team.selected_regional_pitch_event.official?
+      "live"
+    else
+      "virtual"
+    end
+  end
+
   column :view, mandatory: true, html: true do |submission, grid|
     html = link_to(
       web_icon('list-ul', size: 16, remote: true),


### PR DESCRIPTION
Adds a column to say whether a team's QF official scoring was live or virtual. 

