### PR TITLE
#1985 try another approach to caching team counts on events

### DIFF
--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -190,17 +190,8 @@ class RegionalPitchEvent < ActiveRecord::Base
     "#{FriendlyCountry.(ambassador.account)} - #{name}"
   end
 
-  def update_teams_count
+  def update_teams_count(team = nil)
     update_attributes(teams_count: teams.count)
-  end
-
-  private
-  def inc_teams_count(team)
-    RegionalPitchEvent.increment_counter('teams_count', id)
-  end
-
-  def dec_teams_count(team)
-    RegionalPitchEvent.decrement_counter('teams_count', id)
   end
 end
 

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -48,8 +48,8 @@ class RegionalPitchEvent < ActiveRecord::Base
 
   has_and_belongs_to_many :teams,
     -> { joins(:team_submissions) },
-    before_add: :inc_teams_count,
-    before_remove: :dec_teams_count
+    before_add: :update_teams_count,
+    before_remove: :update_teams_count
 
   has_many :team_submissions, through: :teams
 
@@ -188,6 +188,10 @@ class RegionalPitchEvent < ActiveRecord::Base
 
   def name_with_friendly_country_prefix
     "#{FriendlyCountry.(ambassador.account)} - #{name}"
+  end
+
+  def update_teams_count
+    update_attributes(teams_count: teams.count)
   end
 
   private

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -48,8 +48,8 @@ class RegionalPitchEvent < ActiveRecord::Base
 
   has_and_belongs_to_many :teams,
     -> { joins(:team_submissions) },
-    before_add: :update_teams_count,
-    before_remove: :update_teams_count
+    after_add: :update_teams_count,
+    after_remove: :update_teams_count
 
   has_many :team_submissions, through: :teams
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -243,8 +243,14 @@ class Team < ActiveRecord::Base
 
   has_and_belongs_to_many :events, -> { current },
     class_name: "RegionalPitchEvent",
-    after_add: ->(team, event) { team.submission.touch },
-    after_remove: ->(team, event) { team.submission.touch }
+    after_add: ->(team, event) {
+      team.submission.touch
+      event.update_teams_count
+    },
+    after_remove: ->(team, event) {
+      team.submission.touch
+      event.update_teams_count
+    }
 
   has_and_belongs_to_many :current_official_events, -> { current.official },
     class_name: "RegionalPitchEvent",

--- a/app/technovation/add_team_to_regional_event.rb
+++ b/app/technovation/add_team_to_regional_event.rb
@@ -1,23 +1,23 @@
 class AddTeamToRegionalEvent
   def self.call(event, team)
-    if event.divisions.include?(team.division)
-      InvalidateExistingJudgeData.(team)
-
-      if event.at_team_capacity?
-        raise EventAtTeamCapacityError,
-          "This team cannot attend the event as it is currently full"
-      else
-        event.teams << team
-
-        SendPitchEventRSVPNotifications.perform_later(
-          team.id,
-          joining_event_id: event.id
-        )
-      end
-    else
+    if event.divisions.exclude?(team.division)
       raise IncompatibleDivisionError,
         "This team is not in the correct division for this event"
     end
+
+    if event.at_team_capacity?
+      raise EventAtTeamCapacityError,
+        "This team cannot attend the event as it is currently full"
+    end
+
+    InvalidateExistingJudgeData.(team)
+
+    event.teams << team
+
+    SendPitchEventRSVPNotifications.perform_later(
+      team.id,
+      joining_event_id: event.id
+    )
   end
 
   class RemoveIncompatibleDivisionTeams


### PR DESCRIPTION
Rails seems to have the concept of a counter cache, but it doesn't work with `has_and_belongs_to_many` so I think incrementing/decrementing the count through callbacks here was essentially trying to roll our own counter cache. 

I believe it was getting out of sync because it was only set up to fire from one side of the equation. If you did something like `event.teams.delete(team)` it would have worked (I think) but the app is coming at it the other way [on this line](https://github.com/Iridescent-CM/technovation-app/blob/qa/app/technovation/invalidate_existing_judge_data.rb#L20), where `participant` is sometimes a team. 

I thought about trying to turn that statement around, but the problem is that `participant` is also sometimes a judge, so that makes it more complicated.

Incidentally, the datagrid also includes a judge count [that's calculated, not cached](https://github.com/Iridescent-CM/technovation-app/blob/qa/app/data_grids/events_grid.rb#L42) but it's an optional field, so I'm less worried about what happens if all the extra queries become to slow.

So my proposed solution in this PR does two things:
* it adds a recalculation of `teams_count` from the `Team` side of things so that previously referenced line should cause a recalculation
* it also switches from using `increment_counter` and `decrement_counter` to `update_attributes` and querying for the count, which I think may be slightly slower since it involves an extra query, but slightly more robust