### PR TITLE
Fix one type of sporadic test failure

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,9 @@ RSpec.configure do |config|
   config.include AccountFormHelpers, type: :feature
   config.include AccountFormHelpers, type: :system
 
+  config.include DatagridHelpers, type: :feature
+  config.include DatagridHelpers, type: :system
+
   config.include JudgingHelper
   config.include WebMock::API
 

--- a/spec/support/datagrid_helpers.rb
+++ b/spec/support/datagrid_helpers.rb
@@ -1,0 +1,11 @@
+module DatagridHelpers
+  def within_results_page_with(selector, &block)
+    while has_no_selector?(selector) do
+      find(".next_page").click
+    end
+
+    within(selector) do
+      block.call
+    end
+  end
+end

--- a/spec/system/admin/judge_certificates_spec.rb
+++ b/spec/system/admin/judge_certificates_spec.rb
@@ -8,6 +8,10 @@ RSpec.feature "Admins viewing past judge certificates" do
 
     click_link "Participants"
 
+    while has_no_selector?("#account_#{judge.account_id}") do
+      find(".next_page").click
+    end
+
     within("#account_#{judge.account_id}") do
       click_link "view"
     end
@@ -28,6 +32,10 @@ RSpec.feature "Admins viewing past judge certificates" do
 
     click_link "Participants"
 
+    while has_no_selector?("#account_#{judge.account_id}") do
+      find(".next_page").click
+    end
+
     within("#account_#{judge.account_id}") do
       click_link "view"
     end
@@ -47,6 +55,10 @@ RSpec.feature "Admins viewing past judge certificates" do
       sign_in(:admin)
 
       click_link "Participants"
+
+      while has_no_selector?("#account_#{judge.account_id}") do
+        find(".next_page").click
+      end
 
       within("#account_#{judge.account_id}") do
         click_link "view"
@@ -80,6 +92,10 @@ RSpec.feature "Admins viewing past judge certificates" do
 
         click_link "Participants"
 
+        while has_no_selector?("#account_#{judge.account_id}") do
+          find(".next_page").click
+        end
+
         within("#account_#{judge.account_id}") do
           click_link "view"
         end
@@ -112,6 +128,10 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
+      while has_no_selector?("#account_#{judge.account_id}") do
+        find(".next_page").click
+      end
+
       within("#account_#{judge.account_id}") do
         click_link "view"
       end
@@ -142,6 +162,10 @@ RSpec.feature "Admins viewing past judge certificates" do
       sign_in(:admin)
 
       click_link "Participants"
+
+      while has_no_selector?("#account_#{judge.account_id}") do
+        find(".next_page").click
+      end
 
       within("#account_#{judge.account_id}") do
         click_link "view"
@@ -176,6 +200,10 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
+      while has_no_selector?("#account_#{judge.account_id}") do
+        find(".next_page").click
+      end
+
       within("#account_#{judge.account_id}") do
         click_link "view"
       end
@@ -208,6 +236,10 @@ RSpec.feature "Admins viewing past judge certificates" do
       sign_in(:admin)
 
       click_link "Participants"
+
+      while has_no_selector?("#account_#{judge.account_id}") do
+        find(".next_page").click
+      end
 
       within("#account_#{judge.account_id}") do
         click_link "view"

--- a/spec/system/admin/judge_certificates_spec.rb
+++ b/spec/system/admin/judge_certificates_spec.rb
@@ -8,11 +8,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
     click_link "Participants"
 
-    while has_no_selector?("#account_#{judge.account_id}") do
-      find(".next_page").click
-    end
-
-    within("#account_#{judge.account_id}") do
+    within_results_page_with("#account_#{judge.account_id}") do
       click_link "view"
     end
 
@@ -32,11 +28,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
     click_link "Participants"
 
-    while has_no_selector?("#account_#{judge.account_id}") do
-      find(".next_page").click
-    end
-
-    within("#account_#{judge.account_id}") do
+    within_results_page_with("#account_#{judge.account_id}") do
       click_link "view"
     end
 
@@ -56,11 +48,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
-      while has_no_selector?("#account_#{judge.account_id}") do
-        find(".next_page").click
-      end
-
-      within("#account_#{judge.account_id}") do
+      within_results_page_with("#account_#{judge.account_id}") do
         click_link "view"
       end
     }.to change {
@@ -92,11 +80,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
         click_link "Participants"
 
-        while has_no_selector?("#account_#{judge.account_id}") do
-          find(".next_page").click
-        end
-
-        within("#account_#{judge.account_id}") do
+        within_results_page_with("#account_#{judge.account_id}") do
           click_link "view"
         end
       }.to change {
@@ -128,11 +112,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
-      while has_no_selector?("#account_#{judge.account_id}") do
-        find(".next_page").click
-      end
-
-      within("#account_#{judge.account_id}") do
+      within_results_page_with("#account_#{judge.account_id}") do
         click_link "view"
       end
     }.to change {
@@ -163,11 +143,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
-      while has_no_selector?("#account_#{judge.account_id}") do
-        find(".next_page").click
-      end
-
-      within("#account_#{judge.account_id}") do
+      within_results_page_with("#account_#{judge.account_id}") do
         click_link "view"
       end
     }.to change {
@@ -200,11 +176,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
-      while has_no_selector?("#account_#{judge.account_id}") do
-        find(".next_page").click
-      end
-
-      within("#account_#{judge.account_id}") do
+      within_results_page_with("#account_#{judge.account_id}") do
         click_link "view"
       end
     }.to change {
@@ -237,11 +209,7 @@ RSpec.feature "Admins viewing past judge certificates" do
 
       click_link "Participants"
 
-      while has_no_selector?("#account_#{judge.account_id}") do
-        find(".next_page").click
-      end
-
-      within("#account_#{judge.account_id}") do
+      within_results_page_with("#account_#{judge.account_id}") do
         click_link "view"
       end
     }.to change {

--- a/spec/system/admin/review_mentors_spec.rb
+++ b/spec/system/admin/review_mentors_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Admins reviewing mentors" do
       sign_in(:admin)
       click_link "Participants"
 
-      within("#account_#{untrained.account_id}") do
+      within_results_page_with("#account_#{untrained.account_id}") do
         click_link "view"
       end
 
@@ -17,7 +17,7 @@ RSpec.describe "Admins reviewing mentors" do
 
       click_link "Participants"
 
-      within("#account_#{trained.account_id}") do
+      within_results_page_with("#account_#{trained.account_id}") do
         click_link "view"
       end
 
@@ -34,7 +34,7 @@ RSpec.describe "Admins reviewing mentors" do
 
       click_link "Participants"
 
-      within("#account_#{mentor.account_id}") do
+      within_results_page_with("#account_#{mentor.account_id}") do
         click_link "view"
       end
 


### PR DESCRIPTION
Sometimes admin tests fail because they assume a user has shown up on the first page of results when they haven't. This should fix that problem.