### PR TITLE
#1944 Only show RAs virtual qf and sf scores after score display toggle is set

### DIFF
--- a/app/controllers/regional_ambassador/scores_controller.rb
+++ b/app/controllers/regional_ambassador/scores_controller.rb
@@ -29,13 +29,15 @@ module RegionalAmbassador
 
     private
     def grid_params
+      grid = params[:scored_submissions_grid] ||= {}
+
       if SeasonToggles.display_scores?
-        round = params[:scored_submissions_grid].fetch(:round) { 'quarterfinals' }
+        round = grid.fetch(:round) { 'quarterfinals' }
       else
         round = 'quarterfinals'
       end
 
-      grid = (params[:scored_submissions_grid] ||= {}).merge(
+      grid.merge(
         admin: false,
         allow_state_search: current_ambassador.country_code != "US",
         country: [current_ambassador.country_code],
@@ -48,9 +50,6 @@ module RegionalAmbassador
         ),
         current_account: current_account,
         round: round,
-      )
-
-      grid.merge(
         column_names: detect_extra_columns(grid),
       )
     end

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -62,7 +62,9 @@ class ScoredSubmissionsGrid
     str += "/#{submission.total_possible_score}"
   end
 
-  column :semifinals_average, order: :semifinals_average_score, mandatory: true do |submission|
+  column :semifinals_average, order: :semifinals_average_score, mandatory: true, if: ->(g) {
+    g.admin || SeasonToggles.display_scores?
+  } do |submission|
     str = submission.semifinals_average_score.to_s
     str += "/#{submission.total_possible_score}"
   end
@@ -71,7 +73,9 @@ class ScoredSubmissionsGrid
     submission.quarterfinals_score_range
   end
 
-  column :semifinals_range, order: :semifinals_score_range do |submission|
+  column :semifinals_range, order: :semifinals_score_range, if: ->(g) {
+    g.admin || SeasonToggles.display_scores?
+  } do |submission|
     submission.semifinals_score_range
   end
 

--- a/app/views/regional_ambassador/score_details/show.en.html.erb
+++ b/app/views/regional_ambassador/score_details/show.en.html.erb
@@ -8,9 +8,11 @@
     <dt>Event:</dt>
     <dd><%= @submission.team.event.name %></dd>
 
-    <% if @submission.semifinalist? %>
-      <dt>Semifinals average:</dt>
-      <dd><%= @submission.semifinals_average_score %></dd>
+    <% if current_account.is_admin? or SeasonToggles.display_scores? %>
+      <% if @submission.semifinalist? %>
+        <dt>Semifinals average:</dt>
+        <dd><%= @submission.semifinals_average_score %></dd>
+      <% end %>
     <% end %>
 
     <dt>Quarterfinals average:</dt>
@@ -32,17 +34,21 @@
     for their code checklist.
   </p>
 
-  <%= render 'regional_ambassador/score_details/scores_table',
-    scores: @submission.scores,
-    round: :semifinals,
-    status: :complete
-  %>
+  <% if current_account.is_admin? or SeasonToggles.display_scores? %>
 
-  <%= render 'regional_ambassador/score_details/scores_table',
-    scores: @submission.scores,
-    round: :semifinals,
-    status: :incomplete
-  %>
+    <%= render 'regional_ambassador/score_details/scores_table',
+      scores: @submission.scores,
+      round: :semifinals,
+      status: :complete
+    %>
+
+    <%= render 'regional_ambassador/score_details/scores_table',
+      scores: @submission.scores,
+      round: :semifinals,
+      status: :incomplete
+    %>
+
+  <% end %>
 
   <%= render 'regional_ambassador/score_details/scores_table',
     scores: @submission.scores,

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -2,60 +2,178 @@ require "rails_helper"
 
 RSpec.feature "Regional Ambassador views scores" do
   before do
-    SeasonToggles.display_scores_on!
     ra = FactoryBot.create(:regional_ambassador, :approved)
     sign_in(ra)
   end
 
-  scenario "RA can't pick finals scores, as there is no such thing" do
-    click_link "Scores"
-    options = page.find("[name='scored_submissions_grid[round]']").all('option')
-    expect(options.map(&:value)).not_to include("finals")
-  end
+  context "after scores set to display" do
 
-  scenario "view QF scores" do
-    submission = FactoryBot.create(
-      :submission,
-      :complete,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
-    )
-
-    FactoryBot.create(:submission_score, :complete, team_submission: submission)
-
-    click_link "Scores"
-    within_results_page_with("#team_submission_#{submission.id}") do
-      find('a.view-details').click
+    before do
+      SeasonToggles.display_scores_on!
     end
 
-    expect(page).to have_content("earned 2 points")
-  end
-
-  scenario "view SF scores" do
-    submission = FactoryBot.create(
-      :submission,
-      :complete,
-      :semifinalist,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
-    )
-
-    FactoryBot.create(
-      :score,
-      :complete,
-      round: :semifinals,
-      team_submission: submission
-    )
-
-    visit regional_ambassador_scores_path(scored_submissions_grid: { round: :semifinals })
-    within_results_page_with("#team_submission_#{submission.id}") do
-      find('a.view-details').click
+    scenario "RA can't pick finals scores, as there is no such thing" do
+      click_link "Scores"
+      options = page.find("[name='scored_submissions_grid[round]']").all('option')
+      expect(options.map(&:value)).not_to include("finals")
     end
 
-    expect(page).to have_content("earned 2 points")
+    scenario "can view virtual QF scores" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      FactoryBot.create(:submission_score, :complete, team_submission: submission)
+
+      click_link "Scores"
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find('a.view-details').click
+      end
+
+      expect(page).to have_content("earned 2 points")
+    end
+
+    scenario "can view SF scores" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        :semifinalist,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      FactoryBot.create(
+        :score,
+        :complete,
+        round: :semifinals,
+        team_submission: submission
+      )
+
+      visit regional_ambassador_scores_path(scored_submissions_grid: { round: :semifinals })
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find('a.view-details').click
+      end
+
+      expect(page).to have_content("earned 2 points")
+    end
+
+    scenario "can see SF columns and data" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        :semifinalist,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      FactoryBot.create(:submission_score, :complete, team_submission: submission)
+      FactoryBot.create(
+        :score,
+        :complete,
+        round: :semifinals,
+        team_submission: submission
+      )
+
+      click_link "Scores"
+
+      expect(page).to have_selector(".semifinals_average")
+
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find('a.view-details').click
+      end
+
+      expect(page).to have_content("Semifinals average")
+    end
+  end
+
+  context "before scores set to display" do
+
+    before do
+      SeasonToggles.display_scores_off!
+    end
+
+    scenario "can view live QF scores" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      FactoryBot.create(:submission_score, :complete, team_submission: submission)
+
+      rpe = FactoryBot.create(:rpe)
+
+      rpe.teams << submission.team
+
+      click_link "Scores"
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find('a.view-details').click
+      end
+
+      expect(page).to have_content("earned 2 points")
+    end
+
+    scenario "can not view virtual QF scores" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      FactoryBot.create(:submission_score, :complete, team_submission: submission)
+
+      click_link "Scores"
+      expect(page).to have_no_selector("#team_submission_#{submission.id}")
+      expect(page).to have_no_selector(".next_page")
+    end
+
+    scenario "can not see SF columns and data" do
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        :semifinalist,
+        technical_checklist_attributes: {
+          used_camera: true,
+          used_camera_explanation: "We did it...",
+        }
+      )
+
+      rpe = FactoryBot.create(:rpe)
+
+      rpe.teams << submission.team
+
+      FactoryBot.create(:submission_score, :complete, team_submission: submission)
+      FactoryBot.create(
+        :score,
+        :complete,
+        round: :semifinals,
+        team_submission: submission
+      )
+
+      click_link "Scores"
+
+      expect(page).to have_no_selector(".semifinals_average")
+
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find('a.view-details').click
+      end
+
+      expect(page).not_to have_content("Semifinals average")
+    end
   end
 end

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Regional Ambassador views scores" do
   before do
+    SeasonToggles.display_scores_on!
     ra = FactoryBot.create(:regional_ambassador, :approved)
     sign_in(ra)
   end
@@ -25,7 +26,9 @@ RSpec.feature "Regional Ambassador views scores" do
     FactoryBot.create(:submission_score, :complete, team_submission: submission)
 
     click_link "Scores"
-    find('a.view-details').click
+    within_results_page_with("#team_submission_#{submission.id}") do
+      find('a.view-details').click
+    end
 
     expect(page).to have_content("earned 2 points")
   end
@@ -48,8 +51,10 @@ RSpec.feature "Regional Ambassador views scores" do
       team_submission: submission
     )
 
-    visit regional_ambassador_scores_path(round: :semifinals)
-    find('a.view-details').click
+    visit regional_ambassador_scores_path(scored_submissions_grid: { round: :semifinals })
+    within_results_page_with("#team_submission_#{submission.id}") do
+      find('a.view-details').click
+    end
 
     expect(page).to have_content("earned 2 points")
   end


### PR DESCRIPTION
I think this will prevent RAs from seeing quarterfinals virtual scores and any semifinals scores until scores are displayed by setting the admin setting.