### PR TITLE
Use Timecop to set appropriate date for tests failing between rounds

### DIFF
--- a/spec/controllers/mentor/join_requests_controller_spec.rb
+++ b/spec/controllers/mentor/join_requests_controller_spec.rb
@@ -26,8 +26,13 @@ RSpec.describe Mentor::JoinRequestsController do
     let(:mentor) { FactoryBot.create(:mentor, :onboarded) }
 
     before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       sign_in(mentor)
       post :create, params: { team_id: team.id }
+    end
+
+    after do
+      Timecop.return
     end
 
     before(:each) do

--- a/spec/controllers/student/join_requests_controller_spec.rb
+++ b/spec/controllers/student/join_requests_controller_spec.rb
@@ -58,9 +58,14 @@ RSpec.describe Student::JoinRequestsController do
     let(:mentor) { FactoryBot.create(:mentor, :onboarded) }
 
     before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       TeamRosterManaging.add(team, mentor)
       sign_in(student)
       request.env["HTTP_REFERER"] = "/somewhere"
+    end
+
+    after do
+      Timecop.return
     end
 
     before(:each) do
@@ -117,8 +122,13 @@ RSpec.describe Student::JoinRequestsController do
     }
 
     before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       sign_in(team.students.sample)
       request.env["HTTP_REFERER"] = "/somewhere"
+    end
+
+    after do
+      Timecop.return
     end
 
     context "accepting the request" do

--- a/spec/controllers/student/team_member_invites_controller_spec.rb
+++ b/spec/controllers/student/team_member_invites_controller_spec.rb
@@ -57,7 +57,12 @@ RSpec.describe Student::TeamMemberInvitesController do
     let!(:invite) { FactoryBot.create(:team_member_invite, invitee: student) }
 
     before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       sign_in(student)
+    end
+
+    after do
+      Timecop.return
     end
 
     it "accepts the team member invite" do

--- a/spec/features/admin/team_building_toggle_spec.rb
+++ b/spec/features/admin/team_building_toggle_spec.rb
@@ -60,7 +60,14 @@ RSpec.feature "Team submissions editable toggles team roster controls" do
     let(:path) { new_student_join_request_path(team_id: team.id) }
     let(:action) { student_join_requests_path(team_id: team.id) }
 
-    before { sign_in(user) }
+    before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+      sign_in(user)
+    end
+
+    after do
+      Timecop.return
+    end
 
     scenario "Toggle on" do
       toggle_on
@@ -81,7 +88,14 @@ RSpec.feature "Team submissions editable toggles team roster controls" do
     let(:path) { student_team_path(team) }
     let(:action) { student_team_member_invites_path }
 
-    before { sign_in(user) }
+    before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+      sign_in(user)
+    end
+
+    after do
+      Timecop.return
+    end
 
     scenario "Toggle on" do
       toggle_on
@@ -161,7 +175,14 @@ RSpec.feature "Team submissions editable toggles team roster controls" do
     let(:path) { new_mentor_join_request_path(team_id: team.id) }
     let(:action) { mentor_join_requests_path(team_id: team.id) }
 
-    before { sign_in(user) }
+    before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+      sign_in(user)
+    end
+
+    after do
+      Timecop.return
+    end
 
     scenario "Toggle on" do
       toggle_on
@@ -182,10 +203,15 @@ RSpec.feature "Team submissions editable toggles team roster controls" do
     let(:path) { mentor_team_path(team) }
     let(:action) { mentor_team_member_invites_path }
 
-    before {
+    before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       TeamRosterManaging.add(team, user)
       sign_in(user)
-    }
+    end
+
+    after do
+      Timecop.return
+    end
 
     scenario "Toggle on" do
       toggle_on

--- a/spec/features/mailer_token_logins_spec.rb
+++ b/spec/features/mailer_token_logins_spec.rb
@@ -35,48 +35,52 @@ RSpec.feature "Auto-login to the site with your mailer token" do
     end
 
     scenario "#{scope} on join request review" do
-      profile = FactoryBot.create(scope, :on_team)
-      join_request = FactoryBot.create(:join_request, team: profile.teams.first)
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+        profile = FactoryBot.create(scope, :on_team)
+        join_request = FactoryBot.create(:join_request, team: profile.teams.first)
 
-      visit send(
-        "#{scope}_join_request_path",
-        join_request,
-        mailer_token: profile.mailer_token
-      )
+        visit send(
+          "#{scope}_join_request_path",
+          join_request,
+          mailer_token: profile.mailer_token
+        )
 
-      expect(current_path).to eq(send("#{scope}_join_request_path", join_request))
+        expect(current_path).to eq(send("#{scope}_join_request_path", join_request))
 
-      expect(page).to have_css(
-        ".flash",
-        text: I18n.t("controllers.signins.create.success")
-      )
+        expect(page).to have_css(
+          ".flash",
+          text: I18n.t("controllers.signins.create.success")
+        )
+      end
     end
 
     scenario "#{scope} on invite review" do
-      invite_type = scope == :student ? "team_member" : "mentor"
-      trait = scope == :mentor ? :onboarded : :onboarding
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+        invite_type = scope == :student ? "team_member" : "mentor"
+        trait = scope == :mentor ? :onboarded : :onboarding
 
-      profile = FactoryBot.create(scope, trait)
+        profile = FactoryBot.create(scope, trait)
 
-      invite = FactoryBot.create(
-        "#{invite_type}_invite",
-        invitee_email: profile.email
-      )
+        invite = FactoryBot.create(
+          "#{invite_type}_invite",
+          invitee_email: profile.email
+        )
 
-      visit send(
-        "#{scope}_#{invite_type}_invite_path",
-        invite,
-        mailer_token: profile.mailer_token
-      )
+        visit send(
+          "#{scope}_#{invite_type}_invite_path",
+          invite,
+          mailer_token: profile.mailer_token
+        )
 
-      expect(current_path).to eq(
-        send("#{scope}_#{invite_type}_invite_path", invite)
-      )
+        expect(current_path).to eq(
+          send("#{scope}_#{invite_type}_invite_path", invite)
+        )
 
-      expect(page).to have_css(
-        ".flash",
-        text: I18n.t("controllers.signins.create.success")
-      )
+        expect(page).to have_css(
+          ".flash",
+          text: I18n.t("controllers.signins.create.success")
+        )
+      end
     end
   end
 end

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -6,8 +6,13 @@ RSpec.feature "Mentors find a team" do
   } # City is Chicago
 
   before do
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
     mentor = FactoryBot.create(:mentor, :onboarded, :geocoded) # City is Chicago
     sign_in(mentor)
+  end
+
+  after do
+    Timecop.return
   end
 
   scenario "only see current mentors" do

--- a/spec/features/mentor/find_a_team_spec.rb
+++ b/spec/features/mentor/find_a_team_spec.rb
@@ -112,36 +112,40 @@ RSpec.feature "Mentors find a team" do
   end
 
   scenario "request to join a team" do
-    within('#find-team') { click_link "Find a team" }
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+      within('#find-team') { click_link "Find a team" }
 
-    click_link "Ask to join"
-    click_button "Ask to be a mentor for #{available_team.name}"
+      click_link "Ask to join"
+      click_button "Ask to be a mentor for #{available_team.name}"
 
-    join_request = JoinRequest.last
+      join_request = JoinRequest.last
 
-    expect(current_path).to eq(mentor_join_request_path(join_request))
-    expect(page).to have_content(join_request.team_name)
-    expect(page).to have_content(
-      "You have requested to be a mentor for #{available_team.name}"
-    )
-    expect(page).to have_content("You have requested to join this team")
+      expect(current_path).to eq(mentor_join_request_path(join_request))
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content(
+        "You have requested to be a mentor for #{available_team.name}"
+      )
+      expect(page).to have_content("You have requested to join this team")
+    end
   end
 
   scenario "request to join the same team again, even if you deleted an earlier request" do
-    join_request = JoinRequest.create!({
-      requestor: mentor,
-      team: available_team,
-    })
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+      join_request = JoinRequest.create!({
+        requestor: mentor,
+        team: available_team,
+      })
 
-    join_request.deleted!
+      join_request.deleted!
 
-    within('#find-team') { click_link "Find a team" }
+      within('#find-team') { click_link "Find a team" }
 
-    click_link "Ask to join"
-    click_button "Ask to be a mentor for #{available_team.name}"
+      click_link "Ask to join"
+      click_button "Ask to be a mentor for #{available_team.name}"
 
-    expect(current_path).to eq(mentor_join_request_path(join_request))
-    expect(page).to have_content("You have requested to join this team")
-    expect(page).to have_content(join_request.team_name)
+      expect(current_path).to eq(mentor_join_request_path(join_request))
+      expect(page).to have_content("You have requested to join this team")
+      expect(page).to have_content(join_request.team_name)
+    end
   end
 end

--- a/spec/features/mentor/invitations_spec.rb
+++ b/spec/features/mentor/invitations_spec.rb
@@ -2,22 +2,24 @@ require "rails_helper"
 
 RSpec.feature "Mentors and invitations" do
   scenario "A mentor accepts an invitation" do
-    team = FactoryBot.create(:team)
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+      team = FactoryBot.create(:team)
 
-    mentor = FactoryBot.create(:mentor, :onboarded)
+      mentor = FactoryBot.create(:mentor, :onboarded)
 
-    invite = FactoryBot.create(
-      :mentor_invite,
-      team: team,
-      invitee: mentor,
-      invitee_email: mentor.email
-    )
+      invite = FactoryBot.create(
+        :mentor_invite,
+        team: team,
+        invitee: mentor,
+        invitee_email: mentor.email
+      )
 
-    sign_in(mentor)
-    visit mentor_mentor_invite_path(invite, mailer_token: mentor.mailer_token)
+      sign_in(mentor)
+      visit mentor_mentor_invite_path(invite, mailer_token: mentor.mailer_token)
 
-    click_button "Accept"
+      click_button "Accept"
 
-    expect(team.reload.mentors).to eq([mentor])
+      expect(team.reload.mentors).to eq([mentor])
+    end
   end
 end

--- a/spec/features/mentor/invite_member_to_team_spec.rb
+++ b/spec/features/mentor/invite_member_to_team_spec.rb
@@ -1,7 +1,14 @@
 require "rails_helper"
 
 RSpec.feature "Invite a member to a team" do
-  before { SeasonToggles.team_building_enabled! }
+  before do
+    SeasonToggles.team_building_enabled!
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+  end
+
+  after do
+    Timecop.return
+  end
 
   let(:mentor) { FactoryBot.create(:mentor, :onboarded, :on_team) }
 

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -29,33 +29,37 @@ RSpec.feature "Students find a team" do
   end
 
   scenario "request to join a team" do
-    within (".navigation") { click_link "Find a team" }
-    click_link "Ask to join"
-    click_button "Ask to join #{available_team.name}"
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+      within (".navigation") { click_link "Find a team" }
+      click_link "Ask to join"
+      click_button "Ask to join #{available_team.name}"
 
-    join_request = JoinRequest.last
+      join_request = JoinRequest.last
 
-    expect(current_path).to eq(student_dashboard_path)
-    expect(page).to have_content(join_request.team_name)
-    expect(page).to have_content("You have asked to join")
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content("You have asked to join")
+    end
   end
 
   scenario "onboarded student sees pending requests" do
-    sign_out
+    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+      sign_out
 
-    onboarded = FactoryBot.create(:student, :geocoded)
+      onboarded = FactoryBot.create(:student, :geocoded)
 
-    sign_in(onboarded)
+      sign_in(onboarded)
 
-    within(".navigation") { click_link "Find a team" }
+      within(".navigation") { click_link "Find a team" }
 
-    click_link "Ask to join"
-    click_button "Ask to join #{available_team.name}"
+      click_link "Ask to join"
+      click_button "Ask to join #{available_team.name}"
 
-    join_request = JoinRequest.last
+      join_request = JoinRequest.last
 
-    expect(current_path).to eq(student_dashboard_path)
-    expect(page).to have_content(join_request.team_name)
-    expect(page).to have_content("You have asked to join")
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content("You have asked to join")
+    end
   end
 end

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -44,10 +44,15 @@ RSpec.describe "Students request to join a team",
       # Default Chicago
 
     before do
+      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
       ActionMailer::Base.deliveries.clear
       sign_in(student)
       visit new_student_join_request_path(team_id: team.id)
       click_button "Ask to join #{team.name}"
+    end
+
+    after do
+      Timecop.return
     end
 
     it "students not on a team request to join an available team" do


### PR DESCRIPTION
@adrichey I think this fixes all the tests that would otherwise fail between rounds. I didn't do anything particularly clever, just used Timecop to specify the day before QFs starts.