### PR TITLE
#1999 School/Company Name drop-down improvements

### DIFF
--- a/app/javascript/registration/components/BasicProfile.vue
+++ b/app/javascript/registration/components/BasicProfile.vue
@@ -51,7 +51,10 @@
             v-model="schoolCompanyName"
             url="/registration/top_companies"
           />
-          <span>If your company is not part of the options, type the name of your company then press "Enter" or "Tab"</span>
+          <p class="hint">
+            If your company is not part of the options,
+            type the name of your company then press "Enter" or "Tab"
+          </p>
         </template>
       </p>
 

--- a/app/views/signups/_judge_profile_fields.html.erb
+++ b/app/views/signups/_judge_profile_fields.html.erb
@@ -1,15 +1,21 @@
 <%= f.fields_for :account do |a| %>
   <%= a.input :gender,
     label: t('models.account.gender'),
-    collection: Account.genders.keys %>
+    collection: Account.genders.keys,
+    input_html: { class: "margin--b-large" } %>
 <% end %>
 
 <%= f.input :company_name, {
+  label: "School or company name",
   as: :autocomplete,
   input_html: {
     url: registration_top_companies_path,
     no_options_text: "Please begin typing to select your company from a list or add your own"
   }
 } %>
+<p class="hint">
+  If your school or company is not part of the options,
+  type the name of your company then press "Enter" or "Tab"
+</p>
 
 <%= f.input :job_title %>

--- a/app/views/signups/_mentor_profile_fields.html.erb
+++ b/app/views/signups/_mentor_profile_fields.html.erb
@@ -12,6 +12,10 @@
     no_options_text: "Please begin typing to select your school/company from a list or add your own"
   }
 } %>
+<p class="hint">
+  If your school or company is not part of the options,
+  type the name of your company then press "Enter" or "Tab"
+</p>
 
 <%= f.input :job_title %>
 

--- a/app/views/signups/_regional_ambassador_profile_fields.html.erb
+++ b/app/views/signups/_regional_ambassador_profile_fields.html.erb
@@ -11,6 +11,10 @@
     url: registration_top_companies_path,
     no_options_text: "Please begin typing to select your company from a list or add your own"
   } %>
+<p class="hint">
+  If your organization or company is not part of the options,
+  type the name of your company then press "Enter" or "Tab"
+</p>
 
 <%= f.input :job_title,
   label: t("models.regional_ambassador_profile.job_title") %>

--- a/spec/system/location/sensitive_locations_spec.rb
+++ b/spec/system/location/sensitive_locations_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe "Saving a location in a geopolitically sensitive area", :js do
   end
 
   it "saves the changes in the database" do
-    page.find(".suggestion", text: "Israel").click
+    within(".suggestions") do
+      find(".suggestion", text: "Israel").click
+    end
+
     click_button "Confirm"
     expect(current_path).to eq(student_dashboard_path)
     visit student_profile_path


### PR DESCRIPTION
Addresses #1999.

Adding helper text we created in #1921, to the other sign-up areas for judges, mentors, and RAs.