### PR TITLE
#1984 give unprocessed uploads a unique directory

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -13,6 +13,10 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # CarrierWaveDirect::Uploader puts raw uploaded files in this directory on S3 as a first step
   def store_dir
-    "unprocessed_uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    if model.nil?
+      "unprocessed_uploads"
+    else
+      "unprocessed_uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    end
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -13,6 +13,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # CarrierWaveDirect::Uploader puts raw uploaded files in this directory on S3 as a first step
   def store_dir
-    "unprocessed_uploads"
+    "unprocessed_uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 end


### PR DESCRIPTION
Fix for #1984, copied from https://github.com/carrierwaveuploader/carrierwave/blob/f15f4ba71dd2c78e8df494bf65938bbaf13960f9/lib/generators/templates/uploader.rb#L12

I think unprocessed uploads were all overwriting each other on S3 😱 