### PR TITLE
#2017 fix admin scores export message

### DIFF
--- a/app/controllers/admin/scores_controller.rb
+++ b/app/controllers/admin/scores_controller.rb
@@ -8,7 +8,7 @@ module Admin
 
     before_action -> {
       unless request.xhr?
-        @scores = SubmissionScore.current.public_send(grid_params[:round])
+        @round = grid_params[:round]
       end
     }, only: :index
 

--- a/app/views/admin/scores/index.html.erb
+++ b/app/views/admin/scores/index.html.erb
@@ -21,4 +21,4 @@
   model_name: "submission",
   scope: :admin,
   verb: "scored",
-  extra_count: "Exports #{number_with_delimiter(@scores.count)} #{grid_params[:round]} scores" %>
+  extra_count: "Exports #{number_with_delimiter(@scored_submissions_grid.assets.count)} scored #{grid_params[:round]} submissions" %>

--- a/spec/controllers/admin/scores_controller_spec.rb
+++ b/spec/controllers/admin/scores_controller_spec.rb
@@ -3,41 +3,32 @@ require "rails_helper"
 RSpec.describe Admin::ScoresController do
   describe "GET #index" do
     it "provides a default grid_params[:round] of quarterfinals" do
-      qf_score = FactoryBot.create(:score, :quarterfinals)
-      sf_score = FactoryBot.create(:score, :semifinals)
-
       admin = FactoryBot.create(:admin)
       sign_in(admin)
 
       get :index, params: { "scored_submissions_grid": { "round": "" } }
 
-      expect(assigns[:scores]).to eq([qf_score])
+      expect(assigns[:round]).to eq("quarterfinals")
     end
 
     it "provides a default grid_params[:round] of quarterfinals when judging is off" do
       SeasonToggles.judging_round_off!
-
-      qf_score = FactoryBot.create(:score, :quarterfinals)
-      sf_score = FactoryBot.create(:score, :semifinals)
 
       admin = FactoryBot.create(:admin)
       sign_in(admin)
 
       get :index
 
-      expect(assigns[:scores]).to eq([qf_score])
+      expect(assigns[:round]).to eq("quarterfinals")
     end
 
     it "accepts a passed in round" do
-      qf_score = FactoryBot.create(:score, :quarterfinals)
-      sf_score = FactoryBot.create(:score, :semifinals)
-
       admin = FactoryBot.create(:admin)
       sign_in(admin)
 
       get :index, params: { "scored_submissions_grid": { "round": "semifinals" } }
 
-      expect(assigns[:scores]).to eq([sf_score])
+      expect(assigns[:round]).to eq("semifinals")
     end
   end
 end


### PR DESCRIPTION
The admin scores page used to show submissions, but export scores. Now that it shows and exports submissions, this updates the message shown by the export button to reflect that.