### PR TITLE
Add parental consent "present?" check to prevent errors

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -136,7 +136,7 @@ class AccountsGrid
   end
 
   column :parental_consent do |account, grid|
-    if account.student_profile.present?
+    if account.student_profile.present? and account.parental_consent(grid.season).present?
       account.parental_consent(grid.season).status
     else
       "-"


### PR DESCRIPTION
Add parental consent check to prevent errors from being thrown on parental consent exports.

Randi reported that she had an export hanging forever. I checked the dead jobs and traced it down to an issue where `status` was being called on a nilClass object. The parental consent was missing for a student being exported because this `present?` check wasn't happening. The check was removed a while back, so this puts it back in so that we aren't throwing errors on those exports.

This was also reported by Ophelie and is causing issues for RAs, so once this is approved and merged in, I will hotfix it to production.