### PR TITLE
Fix badge levels bug in BadgeRecipient class

### DIFF
--- a/app/models/badge_recipient.rb
+++ b/app/models/badge_recipient.rb
@@ -1,3 +1,5 @@
+require "./app/constants/badge_levels"
+
 class BadgeRecipient
   attr_reader :judge, :scores, :season
 


### PR DESCRIPTION
Add badge levels constants to BadgeRecipient class to prevent errors from being thrown when applying judge rank column in judge grid in admin UI participants view.

This was discovered while doing exploratory research around certificates and badges.

