### PR TITLE
#2039 QA fix: judges don't have current_team in event templates

### DIFF
--- a/app/views/regional_pitch_events/_event.en.html.erb
+++ b/app/views/regional_pitch_events/_event.en.html.erb
@@ -1,7 +1,8 @@
 <div class="panel">
   <div class="grid">
-    <% if event.at_team_capacity? and
-      not current_team.attending_event?(event) %>
+    <% if current_scope != "judge" and
+          event.at_team_capacity? and
+            not current_team.attending_event?(event) %>
         <div class="grid__col-12">
           <div class="flash flash-info margin--none">
             This event is currently full.


### PR DESCRIPTION
The bug only happens when a judge is viewing a full event.