### PR TITLE
#2066 Add Cisco CX to company drop-down when creating mentor/judge accounts

### DIFF
--- a/app/controllers/registration/top_companies_controller.rb
+++ b/app/controllers/registration/top_companies_controller.rb
@@ -13,6 +13,7 @@ module Registration
         Microsoft
         Accenture
         Bank\ of\ America
+        Cisco\ Customer\ Experience\ (CX)
       }
 
       render json: {


### PR DESCRIPTION
Addresses #2066. This will need to pushed out as a hotfix once approved.