### PR TITLE
#2053 Implement thank you page for finished judges

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -50,6 +50,10 @@
   cursor: pointer;
 }
 
+.display--block {
+  display: block;
+}
+
 .font-size--small {
   font-size: 0.8rem;
 }

--- a/app/technovation/season_toggles/judging_round_toggles.rb
+++ b/app/technovation/season_toggles/judging_round_toggles.rb
@@ -107,6 +107,10 @@ class SeasonToggles
           )
         end
       end
+
+      def judging_finished?
+        judging_round == "finished"
+      end
     end
   end
 end

--- a/app/views/judge/dashboards/onboarded/_certificates.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_certificates.en.html.erb
@@ -1,22 +1,26 @@
 <% if DisplayCertificates.for(current_judge) %>
-  <div id="judge-certificate" class="grid panel">
-    <div class="grid__col-12 grid__col--bleed-y">
-      <h2>Thank you!</h2>
-
-      <p>Thank you for being a judge this season!</p>
-
-      <p>
-        We appreciate your thoughtful feedback and the time you spent
-        supporting teams around the world.
-      </p>
-
-      <span class="margin--t-xlarge text-align--center">
-        <%= link_to 'View your certificate',
-          @certificate_file_url,
-          class: "button",
-          target: :_blank %>
+  <div id="judge-certificate" class="panel panel--left">
+    <div class="flags">
+      <span class="flag flag-registration">
+        Season close
       </span>
     </div>
+
+    <h1>Thank You</h1>
+
+    <p>Thank you for being a judge this season!</p>
+
+    <p>
+      We appreciate your thoughtful feedback and the time you spent
+      supporting teams around the world.
+    </p>
+
+    <span class="display--block margin--t-xlarge text-align--center">
+      <%= link_to 'View your certificate',
+        @certificate_file_url,
+        class: "button",
+        target: :_blank %>
+    </span>
   </div>
 <% elsif SeasonToggles.display_scores? %>
   <%= render 'dashboards/no_certificates' %>

--- a/app/views/judge/dashboards/onboarded/_events.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_events.en.html.erb
@@ -1,5 +1,27 @@
 <div class="panel panel--left">
-  <% if SeasonToggles.between_rounds? %>
+  <% if SeasonToggles.judging_finished? %>
+    <div class="flags">
+      <span class="flag flag-registration">
+        Season close
+      </span>
+    </div>
+
+    <h1>Thank You</h1>
+
+    <p>
+      Thank you for your help scoring and giving valuable feedback to
+      Technovation teams.
+    </p>
+
+    <p>
+      Your judging certificate will be available
+      <%= ImportantDates.certificates_available.strftime("%B %e") %>.
+    </p>
+
+    <p>
+      Thank you again for helping girls lead the change. See you next season!
+    </p>
+  <% elsif SeasonToggles.between_rounds? %>
     <%= render 'judge/dashboards/onboarded/between_rounds' %>
   <% elsif SeasonToggles.quarterfinals_or_earlier? %>
     <div class="flags">

--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -72,7 +72,9 @@
         <%= render 'judge/dashboards/onboarded/certificates' %>
       <% end %>
 
-      <%= render 'judge/dashboards/onboarded/events' %>
+      <% if !SeasonToggles.display_scores? %>
+        <%= render 'judge/dashboards/onboarded/events' %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Addresses #2053.

Added a thank you page that appears when the judge rounds are set to finished, but scores and certificates are not yet available. Once scores and certificates are available, this disappears as we will either display the certificates to the user or a "no certificates available" panel.