### PR TITLE
#2057 add basic certificates datagrid

### DIFF
--- a/app/controllers/admin/certificates_controller.rb
+++ b/app/controllers/admin/certificates_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class CertificatesController < AdminController
+    include DatagridController
+
+    use_datagrid with: CertificatesGrid
+
+    private
+    def grid_params
+      grid = params[:certificates_grid] ||= {}
+      grid.merge(
+        column_names: detect_extra_columns(grid),
+      )
+    end
+  end
+end

--- a/app/data_grids/certificates_grid.rb
+++ b/app/data_grids/certificates_grid.rb
@@ -1,0 +1,69 @@
+class CertificatesGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Certificate
+      .includes(:account, :team)
+      .references(:accounts, :teams)
+  end
+
+  column :season
+
+  column :type do
+    cert_type.humanize.titleize
+  end
+
+  column :email do
+    account.email
+  end
+
+  column :team do
+    team.present? ? team.name : ""
+  end
+
+  column :view, html: true do |certificate|
+    link_to(
+      web_icon('file-pdf-o', size: 16, remote: true),
+      certificate.file_url,
+      {
+        class: "view-details",
+        "v-tooltip" => "'Open certificate'",
+        data: { turbolinks: false },
+        target: :_blank,
+      }
+    )
+  end
+
+  filter :email,
+    filter_group: "searches" do |value|
+      where("LOWER(accounts.email) = LOWER(?)", value)
+    end
+
+  filter :team_name,
+    filter_group: "searches" do |value|
+      where("LOWER(teams.name) = LOWER(?)", value)
+    end
+
+  filter :type,
+    :enum,
+    header: "Certificate type",
+    select: CERTIFICATE_TYPES.map { |t|
+      [t.humanize.titleize, t]
+    },
+    filter_group: "selections" do |value|
+      public_send(value)
+    end
+
+  filter :season,
+    :enum,
+    select: (2015..Season.current.year).to_a.reverse,
+    filter_group: "selections",
+    html: {
+      class: "and-or-field",
+    },
+    multiple: true do |value, scope, grid|
+      scope.by_season(value)
+    end
+end

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -37,6 +37,10 @@
       admin_score_exports_path,
       class: al(admin_score_exports_path) %>
 
+    <%= link_to "Certificates",
+    admin_certificates_path,
+    class: al(admin_certificates_path) %>
+
     <%= link_to "Judges",
       admin_judges_path,
       class: al(admin_judges_path) %>

--- a/app/views/admin/certificates/index.html.erb
+++ b/app/views/admin/certificates/index.html.erb
@@ -1,0 +1,7 @@
+<% provide :title, "Admin Data • Certificates" %>
+
+<%= render 'datagrid/datagrid',
+  grid: @certificates_grid,
+  form_url: admin_certificates_path,
+  model_name: "certificate",
+  scope: :admin %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,8 @@ Rails.application.routes.draw do
     resources :export_downloads, only: :update
 
     resource :season_schedule_settings, only: [:edit, :update]
+
+    resources :certificates, only: :index
   end
 
   namespace :public do


### PR DESCRIPTION
Adds a basic datagrid for certificates. You can search for user email or team name, and you can filter by certificate type and season.

I thought I'd add the ability to delete certificates in this PR, but let's keep it simple. I'll make a new ticket for that.