### PR TITLE
#2059 add rake tasks for directly creating certificates

### DIFF
--- a/app/jobs/certificate_job.rb
+++ b/app/jobs/certificate_job.rb
@@ -4,8 +4,8 @@ class CertificateJob < ActiveJob::Base
   queue_as :default
 
   before_enqueue do |job|
-    account_id = job.arguments.second
-    owner = Account.find(account_id)
+    recipient = CertificateRecipient.from_state(job.arguments.first)
+    owner = recipient.account
 
     Job.create!(
       job_id: job.job_id,

--- a/app/models/certificate_recipient.rb
+++ b/app/models/certificate_recipient.rb
@@ -40,6 +40,14 @@ class CertificateRecipient
     mobile_app_name
   end
 
+  def certificates
+    @account.certificates.by_season(@season).public_send(@certificate_type).for_team(@team)
+  end
+
+  def certificate_issued?
+    certificates.any?
+  end
+
   def ==(o)
     o.class == self.class && o.state == self.state
   end

--- a/app/models/certificate_recipient.rb
+++ b/app/models/certificate_recipient.rb
@@ -60,4 +60,13 @@ class CertificateRecipient
       @season
     ]
   end
+
+  def self.from_state(state)
+    certificate_type, account_id, team_id, season = state
+    account = Account.find(account_id)
+    team = Team.find(team_id)
+
+    new(certificate_type, account, team: team, season: season)
+  end
+
 end

--- a/app/models/certificate_recipient.rb
+++ b/app/models/certificate_recipient.rb
@@ -54,17 +54,23 @@ class CertificateRecipient
 
   def state
     return [
-      @certificate_type,
+      @certificate_type.to_s,
       @account.id,
-      @team.id,
+      @team.nil? ? nil : @team.id,
       @season
     ]
   end
 
   def self.from_state(state)
     certificate_type, account_id, team_id, season = state
+
+    certificate_type = certificate_type.to_sym
     account = Account.find(account_id)
-    team = Team.find(team_id)
+    if team_id
+      team = Team.find(team_id)
+    else
+      team = nil
+    end
 
     new(certificate_type, account, team: team, season: season)
   end

--- a/lib/fill_pdfs.rb
+++ b/lib/fill_pdfs.rb
@@ -30,19 +30,23 @@ module FillPdfs
     season = options.fetch(:season) { Season.current.year }
 
     DetermineCertificates.new(account).needed.each do |recipient|
-      certificate_type = recipient.certificate_type
-
-      generator_klass_name = "fill_pdfs/#{certificate_type}"
-      generator_klass = generator_klass_name.camelize.safe_constantize
-
-      generator = if !!generator_klass
-                    generator_klass.new(recipient, certificate_type)
-                  else
-                    GenericPDFFiller.new(recipient, certificate_type)
-                  end
-
-      generator.generate_certificate
+      fill(recipient)
     end
+  end
+
+  def self.fill(recipient)
+    certificate_type = recipient.certificate_type
+
+    generator_klass_name = "fill_pdfs/#{certificate_type}"
+    generator_klass = generator_klass_name.camelize.safe_constantize
+
+    generator = if !!generator_klass
+                  generator_klass.new(recipient, certificate_type)
+                else
+                  GenericPDFFiller.new(recipient, certificate_type)
+                end
+
+    generator.generate_certificate
   end
 
   attr_reader :recipient, :account, :team, :type, :season

--- a/lib/tasks/award_certificates.rake
+++ b/lib/tasks/award_certificates.rake
@@ -20,15 +20,7 @@ def job_for(account)
   puts "\t#{certificates.needed.count} certificate(s) needed"
 
   certificates.needed.each do |recipient|
-    type = recipient.certificate_type.to_s
-    account_id = recipient.account.id
-    team_id = if recipient.team
-                recipient.team.id
-              else
-                nil
-              end
-
-    CertificateJob.perform_later(type, account_id, team_id)
+    CertificateJob.perform_later(recipient.state)
   end
 end
 

--- a/lib/tasks/award_certificates.rake
+++ b/lib/tasks/award_certificates.rake
@@ -11,6 +11,27 @@ def award_to(account)
   FillPdfs.(account)
 end
 
+def job_for(account)
+  certificates = DetermineCertificates.new(account)
+
+  puts "Awarding to Account ID #{account.id}: #{account.full_name} <#{account.email}>..."
+  puts "\tEligible for #{certificates.eligible_types.count}: " +
+    certificates.eligible_types.map { |t| t.humanize.titleize }.join(", ")
+  puts "\t#{certificates.needed.count} certificate(s) needed"
+
+  certificates.needed.each do |recipient|
+    type = recipient.certificate_type.to_s
+    account_id = recipient.account.id
+    team_id = if recipient.team
+                recipient.team.id
+              else
+                nil
+              end
+
+    CertificateJob.perform_later(type, account_id, team_id)
+  end
+end
+
 namespace :certificates do
   desc "Award certificates to one current account by id"
   task :award_direct, [:account_id] => :environment do |t, args|
@@ -39,14 +60,28 @@ namespace :certificates do
   end
 
   desc "Create certificate job for one current account by id"
-  task :award_job, [:account_id] => :environment do
+  task :award_job, [:account_id] => :environment do |t, args|
+    account = Account.current.find(args[:account_id])
+    job_for(account)
   end
 
   desc "Create certificate jobs for a batch of current accounts"
   task :award_batch_jobs, [:starting_id, :batch_size] => :environment do |t, args|
+    accounts = Account.current
+      .where("id > ?", args[:starting_id])
+      .first(args[:batch_size])
+
+    accounts.each do |account|
+      job_for(account)
+    end
   end
 
   desc "Create certificate jobs for all current accounts"
   task :award_all_jobs => :environment do
+    accounts = Account.current.order(id: :asc)
+
+    accounts.each do |account|
+      job_for(account)
+    end
   end
 end

--- a/lib/tasks/award_certificates.rake
+++ b/lib/tasks/award_certificates.rake
@@ -1,0 +1,52 @@
+require "fill_pdfs"
+
+def award_to(account)
+  certificates = DetermineCertificates.new(account)
+
+  puts "Awarding to Account ID #{account.id}: #{account.full_name} <#{account.email}>..."
+  puts "\tEligible for #{certificates.eligible_types.count}: " +
+    certificates.eligible_types.map { |t| t.humanize.titleize }.join(", ")
+  puts "\t#{certificates.needed.count} certificate(s) needed"
+
+  FillPdfs.(account)
+end
+
+namespace :certificates do
+  desc "Award certificates to one current account by id"
+  task :award_direct, [:account_id] => :environment do |t, args|
+    account = Account.current.find(args[:account_id])
+    award_to(account)
+  end
+
+  desc "Award certificates to a batch of current accounts"
+  task :award_batch_direct, [:starting_id, :batch_size] => :environment do |t, args|
+    accounts = Account.current
+      .where("id > ?", args[:starting_id])
+      .first(args[:batch_size])
+
+    accounts.each do |account|
+      award_to(account)
+    end
+  end
+
+  desc "Award certificates to all current accounts"
+  task :award_all_direct => :environment do
+    accounts = Account.current.order(id: :asc)
+
+    accounts.each do |account|
+      award_to(account)
+    end
+  end
+
+  desc "Create certificate job for one current account by id"
+  task :award_job, [:account_id] => :environment do
+  end
+
+  desc "Create certificate jobs for a batch of current accounts"
+  task :award_batch_jobs, [:starting_id, :batch_size] => :environment do |t, args|
+  end
+
+  desc "Create certificate jobs for all current accounts"
+  task :award_all_jobs => :environment do
+  end
+end

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CertificateJob do
     team = mentor.current_teams.last
 
     expect {
-      CertificateJob.perform_later(mentor.account_id, team.id)
+      CertificateJob.perform_later("mentor_appreciation", mentor.account_id, team.id)
     }.to change {
       mentor.current_appreciation_certificates.count
     }.from(0).to(1)
@@ -17,7 +17,7 @@ RSpec.describe CertificateJob do
     job_id = nil
 
     expect {
-      job_id = CertificateJob.perform_later(mentor.account_id).job_id
+      job_id = CertificateJob.perform_later("mentor_appreciation", mentor.account_id).job_id
     }.to change {
       Job.count
     }.from(0).to(1)
@@ -28,7 +28,7 @@ RSpec.describe CertificateJob do
   it "adds the certificale file url to the DB job payload" do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)
 
-    job_id = CertificateJob.perform_later(mentor.account_id).job_id
+    job_id = CertificateJob.perform_later("mentor_appreciation", mentor.account_id).job_id
     job = Job.find_by(job_id: job_id)
 
     expect(job.payload).to eq({

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe CertificateJob do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)
     team = mentor.current_teams.last
 
+    cr = CertificateRecipient.new(:mentor_appreciation, mentor.account, team: team)
+
     expect {
-      CertificateJob.perform_later("mentor_appreciation", mentor.account_id, team.id)
+      CertificateJob.perform_later(cr.state)
     }.to change {
       mentor.current_appreciation_certificates.count
     }.from(0).to(1)
@@ -16,8 +18,10 @@ RSpec.describe CertificateJob do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)
     job_id = nil
 
+    cr = CertificateRecipient.new(:mentor_appreciation, mentor.account)
+
     expect {
-      job_id = CertificateJob.perform_later("mentor_appreciation", mentor.account_id).job_id
+      job_id = CertificateJob.perform_later(cr.state).job_id
     }.to change {
       Job.count
     }.from(0).to(1)
@@ -28,7 +32,9 @@ RSpec.describe CertificateJob do
   it "adds the certificale file url to the DB job payload" do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)
 
-    job_id = CertificateJob.perform_later("mentor_appreciation", mentor.account_id).job_id
+    cr = CertificateRecipient.new(:mentor_appreciation, mentor.account)
+
+    job_id = CertificateJob.perform_later(cr.state).job_id
     job = Job.find_by(job_id: job_id)
 
     expect(job.payload).to eq({

--- a/spec/models/certificate_recipient_spec.rb
+++ b/spec/models/certificate_recipient_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe CertificateRecipient do
+  it "considers same state equal" do
+    account = FactoryBot.create(:mentor).account
+    team = FactoryBot.create(:team)
+
+    a = CertificateRecipient.new(:mentor_appreciation, account, team: team, season: 2018)
+    b = CertificateRecipient.new(:mentor_appreciation, account, team: team, season: 2018)
+
+    expect(a).to eq(b)
+    expect(a).not_to eql(b)
+  end
+
+  it "creates from state" do
+    account = FactoryBot.create(:mentor).account
+    team = FactoryBot.create(:team)
+
+    a = CertificateRecipient.new(:mentor_appreciation, account, team: team, season: 2018)
+    b = CertificateRecipient.from_state(a.state)
+
+    expect(a).to eq(b)
+  end
+end


### PR DESCRIPTION
The rough plan is to add the following tasks:

* `certificates:award_direct` to call FillPdfs on one current account without a Sidekiq job
* `certificates:award_batch_direct` to call FillPdfs on a batch of current accounts without Sidekiq jobs
* `certificates:award_all_direct` to call FillPdfs on all current accounts without Sidekiq jobs
* `certificates:award_job` to call FillPdfs on one current account through a Sidekiq job
* `certificates:award_batch_jobs` to call FillPdfs on a batch of current accounts through Sidekiq jobs
* `certificates:award_all_jobs` to call FillPdfs on all current accounts through Sidekiq jobs