### PR TITLE
#2057 fix: show all cert types in DB as filter options

### DIFF
--- a/app/data_grids/certificates_grid.rb
+++ b/app/data_grids/certificates_grid.rb
@@ -52,9 +52,9 @@ class CertificatesGrid
   filter :type,
     :enum,
     header: "Certificate type",
-    select: CERTIFICATE_TYPES.map { |t|
-      [t.humanize.titleize, t]
-    },
+    select: Certificate.select(:cert_type).distinct.map { |o|
+      [o.cert_type.humanize.titleize, o.cert_type]
+    }.sort,
     filter_group: "selections" do |value|
       public_send(value)
     end


### PR DESCRIPTION
This may be more helpful, and maybe more flexible as certificates change.