### PR TITLE
#2076 Rework drop lowest scores rake task

### DIFF
--- a/app/models/judge_profile.rb
+++ b/app/models/judge_profile.rb
@@ -82,7 +82,7 @@ class JudgeProfile < ActiveRecord::Base
   has_many :current_complete_scores, -> { current.complete },
    class_name: "SubmissionScore"
 
-  has_many :completed_scores, -> { complete },
+  has_many :completed_scores, -> { complete_with_dropped },
    class_name: "SubmissionScore"
 
   has_many :current_completed_scores, -> { current.complete },

--- a/app/models/judge_profile.rb
+++ b/app/models/judge_profile.rb
@@ -85,7 +85,7 @@ class JudgeProfile < ActiveRecord::Base
   has_many :completed_scores, -> { complete_with_dropped },
    class_name: "SubmissionScore"
 
-  has_many :current_completed_scores, -> { current.complete },
+  has_many :current_completed_scores, -> { current.complete_with_dropped },
    class_name: "SubmissionScore"
 
   has_many :current_quarterfinals_complete_scores,

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -144,6 +144,13 @@ class SubmissionScore < ActiveRecord::Base
   scope :complete, -> { where("submission_scores.completed_at IS NOT NULL") }
   scope :incomplete, -> { where("submission_scores.completed_at IS NULL") }
 
+  scope :complete_with_dropped, -> {
+    with_deleted.where(
+      "submission_scores.completed_at IS NOT NULL " +
+      "AND (submission_scores.deleted_at IS NULL OR submission_scores.dropped_at IS NOT NULL)"
+    )
+  }
+
   scope :completed_too_fast, -> { where(completed_too_fast: true) }
   scope :completed_too_fast_repeat_offense, -> {
     where(completed_too_fast_repeat_offense: true)
@@ -279,6 +286,10 @@ class SubmissionScore < ActiveRecord::Base
 
   def complete!
     update(completed_at: Time.current)
+  end
+
+  def drop_score!
+    update(dropped_at: Time.current)
   end
 
   def approved?

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -290,6 +290,7 @@ class SubmissionScore < ActiveRecord::Base
 
   def drop_score!
     update(dropped_at: Time.current)
+    self.destroy
   end
 
   def approved?

--- a/db/migrate/20190403154655_add_dropped_status_to_submission_scores.rb
+++ b/db/migrate/20190403154655_add_dropped_status_to_submission_scores.rb
@@ -1,0 +1,5 @@
+class AddDroppedStatusToSubmissionScores < ActiveRecord::Migration[5.1]
+  def change
+    add_column :submission_scores, :dropped_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1413,7 +1413,8 @@ CREATE TABLE public.submission_scores (
     completed_too_fast boolean DEFAULT false,
     completed_too_fast_repeat_offense boolean DEFAULT false,
     seems_too_low boolean DEFAULT false,
-    approved_at timestamp without time zone
+    approved_at timestamp without time zone,
+    dropped_at timestamp without time zone
 );
 
 
@@ -3162,6 +3163,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190207223128'),
 ('20190213212436'),
 ('20190228185145'),
-('20190328190221');
+('20190328190221'),
+('20190403154655');
 
 

--- a/lib/drop_lowest_scores.rb
+++ b/lib/drop_lowest_scores.rb
@@ -29,8 +29,6 @@ module DropLowestScores
 
       submission.lowest_score_dropped!
       minimum_score.drop_score!
-      minimum_score.save
-      minimum_score.destroy
 
       logger.info "Updated SF Average: #{submission.reload.semifinals_average_score}"
     end

--- a/lib/drop_lowest_scores.rb
+++ b/lib/drop_lowest_scores.rb
@@ -13,6 +13,9 @@ module DropLowestScores
     if submission.lowest_score_dropped?
       logger.info "SKIP already dropped score for Submission##{submission.id}"
       return false
+    elsif !submission.semifinals_complete_submission_scores.any?
+      logger.info "SKIP no semifinals scores available for Submission##{submission.id}"
+      return false
     else
       minimum_score = submission.semifinals_complete_submission_scores.min_by(&:total)
 
@@ -25,6 +28,8 @@ module DropLowestScores
       logger.info minimum_score.total
 
       submission.lowest_score_dropped!
+      minimum_score.drop_score!
+      minimum_score.save
       minimum_score.destroy
 
       logger.info "Updated SF Average: #{submission.reload.semifinals_average_score}"

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -93,7 +93,7 @@ namespace :teams do
     puts "Data exported to #{filename}"
   end
 
-  desc "List all current season technical checlists"
+  desc "List all current season technical checklists"
   task technical_checklist_dump: :environment do
     puts "Exporting data..."
 

--- a/spec/lib/drop_lowest_scores_integration_spec.rb
+++ b/spec/lib/drop_lowest_scores_integration_spec.rb
@@ -20,4 +20,20 @@ RSpec.describe DropLowestScores do
       submission.semifinals_complete_submission_scores.count
     }
   end
+
+  it "ignores submissions with no complete scores" do
+    SeasonToggles.set_judging_round(:sf)
+
+    submission = FactoryBot.create(:submission, :complete)
+
+    expect(submission.scores.length).to be(0)
+
+    expect {
+      DropLowestScores.(submission)
+    }.not_to change {
+      submission.semifinals_complete_submission_scores.count
+    }
+
+    expect(DropLowestScores.(submission)).to be false
+  end
 end

--- a/spec/lib/drop_lowest_scores_spec.rb
+++ b/spec/lib/drop_lowest_scores_spec.rb
@@ -4,7 +4,14 @@ require "./app/null_objects/null_profile"
 
 RSpec.describe DropLowestScores do
   it "deletes the lowest score " do
-    lowest_score = double(:Score, total: 45, destroy: true, judge_profile: NullProfile.new)
+    lowest_score = double(
+      :Score,
+      total: 45,
+      destroy: true,
+      save: true,
+      :drop_score! => true,
+      judge_profile: NullProfile.new
+    )
 
     scores = [
       double(:Score, total: 100),

--- a/spec/lib/drop_lowest_scores_spec.rb
+++ b/spec/lib/drop_lowest_scores_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe DropLowestScores do
     lowest_score = double(
       :Score,
       total: 45,
-      destroy: true,
-      save: true,
       :drop_score! => true,
       judge_profile: NullProfile.new
     )
@@ -30,7 +28,7 @@ RSpec.describe DropLowestScores do
 
     allow(submission).to receive(:reload).and_return(submission)
 
-    expect(lowest_score).to receive(:destroy)
+    expect(lowest_score).to receive(:drop_score!)
     DropLowestScores.(submission)
   end
 


### PR DESCRIPTION
`JudgeProfile.complete_scores` now takes dropped scores into account when calculating the total. I wasn't sure if I would need to address `JudgeProfile.current_completed_scores` during this work. I am also a little unsure if we have enough coverage around this functionality, but I don't know where I should add it if we don't. So if that is necessary, a little guidance would be appreciated. :)

Addresses #2076.