### PR TITLE
#2050 add task for setting semifinalists

### DIFF
--- a/lib/set_semifinalists.rb
+++ b/lib/set_semifinalists.rb
@@ -1,0 +1,98 @@
+class SetSemifinalists
+  private
+  attr_reader :filename
+
+  public
+  attr_reader :logger
+
+  def initialize(filename)
+    @filename = filename
+    @logger = Rails.env.test? ? Logger.new("tmp/judging_tasks.log") : Logger.new($stdout)
+  end
+
+  def self.read(filename)
+    new(filename)
+  end
+
+  def dry_run
+    perform
+  end
+
+  def perform!
+    perform(dry_run: false)
+  end
+
+  private
+  def perform(opts = {})
+    dry_run = opts.fetch(:dry_run) { true }
+    fail_fast = !dry_run
+
+    submission_ids_seen = []
+
+    CSV.foreach(@filename, headers:true) do |row|
+      begin
+        submission_ids_seen << check_row(row)
+      rescue => err
+        raise if fail_fast
+        @logger.error err.message
+      end
+    end
+
+    begin
+      check_database(submission_ids_seen)
+    rescue => err
+      raise if fail_fast
+      @logger.error err.message
+    end
+
+    if !dry_run
+      TeamSubmission.current.where(id: submission_ids_seen).find_each do |submission|
+        if submission.semifinalist?
+          @logger.info "NOT UPDATED: Team id=#{submission.team.id} #{submission.team.name} is already a semifinalist."
+        else
+          submission.update_column(:contest_rank, :semifinalist)
+          @logger.info "UPDATED: Team id=#{submission.team.id} #{submission.team.name} is now a semifinalist."
+        end
+      end
+    end
+  end
+
+  def check_row(row)
+    unless row.headers.include?('team_id') && row.headers.include?('team_submission_id')
+      raise "CSV FORMAT PROBLEM: Please ensure the csv contains a header row specifying both team_id and team_submission_id columns."
+    end
+
+    team_id = row['team_id']
+    team_submission_id = row['team_submission_id']
+
+    unless team_id && team_submission_id
+      raise "DATA PROBLEM: Please ensure line #{$.} specifies a team_id and team_submission_id."
+    end
+
+    begin
+      team = Team.find(team_id)
+      submission = TeamSubmission.find(team_submission_id)
+    rescue => err
+      raise "DATA PROBLEM: On line #{$.}, team id=#{team_id} or submission id=#{team_submission_id} were not found\n" +
+        "\t#{err}"
+    end
+
+    unless team.submission == submission
+      raise "DATA PROBLEM: On line #{$.}, team and submission do not match.\n" +
+        "\tTeam id=#{team_id} #{team.name} has submission id=#{team.submission.id} #{team.submission.app_name}, not submission id=#{submission.id} #{submission.app_name}"
+    end
+
+    submission.id
+  end
+
+  def check_database(ids_seen)
+    other_semifinalists = TeamSubmission.current.semifinalist.where.not(id: ids_seen)
+    if other_semifinalists.exists?
+      other_semifinalists.each do |sub|
+        @logger.error "Team id=#{sub.team.id} #{sub.team.name} not in csv, but marked as semifinalist in the database."
+      end
+      raise "DATA PROBLEM: Please ensure all semifinalists are included in csv, or set current semifinalists in the database back to quarterfinalists."
+    end
+  end
+
+end

--- a/lib/tasks/judging.rake
+++ b/lib/tasks/judging.rake
@@ -1,0 +1,71 @@
+namespace :judging do
+  desc "Validate CSV for setting semifinalists"
+  task :check_semifinalists, [:filename] => :environment do |t, args|
+    set_semifinalists(args[:filename], dry_run: true)
+  end
+
+  desc "Set semifinalists from CSV"
+  task :set_semifinalists, [:filename] => :environment do |t, args|
+    logger.info "### DRY RUN: true"
+    set_semifinalists(args[:filename], dry_run: true) # let's make sure the file gets checked
+    logger.info "### DRY RUN: false"
+    set_semifinalists(args[:filename], dry_run: false)
+  end
+end
+
+def logger
+  Rails.env.test? ? Logger.new("tmp/judging_tasks.log") : Logger.new($stdout)
+end
+
+def set_semifinalists(filename, opts = {})
+  dry_run = opts.fetch(:dry_run) { true }
+
+  submission_ids_seen = []
+
+  CSV.foreach(filename, headers:true) do |row|
+    unless row.headers.include?('team_id') && row.headers.include?('team_submission_id')
+      raise "CSV FORMAT PROBLEM: Please ensure the csv contains a header row specifying both team_id and team_submission_id columns."
+    end
+
+    team_id = row['team_id']
+    team_submission_id = row['team_submission_id']
+
+    unless team_id && team_submission_id
+      raise "DATA PROBLEM: Please ensure line #{$.} specifies a team_id and team_submission_id."
+    end
+
+    begin
+      team = Team.find(team_id)
+      submission = TeamSubmission.find(team_submission_id)
+    rescue => err
+      raise "DATA PROBLEM: On line #{$.}, team id=#{team_id} or submission id=#{team_submission_id} were not found\n" +
+        "\t#{err}"
+    end
+
+    unless team.submission == submission
+      raise "DATA PROBLEM: On line #{$.}, team and submission do not match.\n" +
+        "\tTeam id=#{team_id} #{team.name} has submission id=#{team.submission.id} #{team.submission.app_name}, not submission id=#{submission.id} #{submission.app_name}"
+    end
+
+    submission_ids_seen << submission.id
+  end
+
+  other_semifinalists = TeamSubmission.current.semifinalist.where.not(id: submission_ids_seen)
+  if other_semifinalists.exists?
+    other_semifinalists.each do |sub|
+      logger.info "Team id=#{sub.team.id} #{sub.team.name} not in csv, but marked as semifinalist in the database."
+    end
+    raise "DATA PROBLEM: Please ensure all semifinalists are included in csv, or set current semifinalists in the database back to quarterfinalists."
+  end
+
+  if !dry_run
+    TeamSubmission.current.where(id: submission_ids_seen).find_each do |submission|
+      if submission.semifinalist?
+        logger.info "NOT UPDATED: Team id=#{submission.team.id} #{submission.team.name} is already a semifinalist."
+      else
+        submission.update_column(:contest_rank, :semifinalist)
+        logger.info "UPDATED: Team id=#{submission.team.id} #{submission.team.name} is now a semifinalist."
+      end
+    end
+  end
+end

--- a/lib/tasks/judging.rake
+++ b/lib/tasks/judging.rake
@@ -1,71 +1,20 @@
+require './lib/set_semifinalists'
+
 namespace :judging do
   desc "Validate CSV for setting semifinalists"
   task :check_semifinalists, [:filename] => :environment do |t, args|
-    set_semifinalists(args[:filename], dry_run: true)
+    SetSemifinalists.read(args[:filename]).dry_run
   end
 
   desc "Set semifinalists from CSV"
   task :set_semifinalists, [:filename] => :environment do |t, args|
-    logger.info "### DRY RUN: true"
-    set_semifinalists(args[:filename], dry_run: true) # let's make sure the file gets checked
-    logger.info "### DRY RUN: false"
-    set_semifinalists(args[:filename], dry_run: false)
+    ssf = SetSemifinalists.read(args[:filename])
+
+    ssf.logger.info "### DRY RUN: true"
+    ssf.dry_run
+
+    ssf.logger.info "### DRY RUN: false"
+    ssf.perform!
   end
 end
 
-def logger
-  Rails.env.test? ? Logger.new("tmp/judging_tasks.log") : Logger.new($stdout)
-end
-
-def set_semifinalists(filename, opts = {})
-  dry_run = opts.fetch(:dry_run) { true }
-
-  submission_ids_seen = []
-
-  CSV.foreach(filename, headers:true) do |row|
-    unless row.headers.include?('team_id') && row.headers.include?('team_submission_id')
-      raise "CSV FORMAT PROBLEM: Please ensure the csv contains a header row specifying both team_id and team_submission_id columns."
-    end
-
-    team_id = row['team_id']
-    team_submission_id = row['team_submission_id']
-
-    unless team_id && team_submission_id
-      raise "DATA PROBLEM: Please ensure line #{$.} specifies a team_id and team_submission_id."
-    end
-
-    begin
-      team = Team.find(team_id)
-      submission = TeamSubmission.find(team_submission_id)
-    rescue => err
-      raise "DATA PROBLEM: On line #{$.}, team id=#{team_id} or submission id=#{team_submission_id} were not found\n" +
-        "\t#{err}"
-    end
-
-    unless team.submission == submission
-      raise "DATA PROBLEM: On line #{$.}, team and submission do not match.\n" +
-        "\tTeam id=#{team_id} #{team.name} has submission id=#{team.submission.id} #{team.submission.app_name}, not submission id=#{submission.id} #{submission.app_name}"
-    end
-
-    submission_ids_seen << submission.id
-  end
-
-  other_semifinalists = TeamSubmission.current.semifinalist.where.not(id: submission_ids_seen)
-  if other_semifinalists.exists?
-    other_semifinalists.each do |sub|
-      logger.info "Team id=#{sub.team.id} #{sub.team.name} not in csv, but marked as semifinalist in the database."
-    end
-    raise "DATA PROBLEM: Please ensure all semifinalists are included in csv, or set current semifinalists in the database back to quarterfinalists."
-  end
-
-  if !dry_run
-    TeamSubmission.current.where(id: submission_ids_seen).find_each do |submission|
-      if submission.semifinalist?
-        logger.info "NOT UPDATED: Team id=#{submission.team.id} #{submission.team.name} is already a semifinalist."
-      else
-        submission.update_column(:contest_rank, :semifinalist)
-        logger.info "UPDATED: Team id=#{submission.team.id} #{submission.team.name} is now a semifinalist."
-      end
-    end
-  end
-end

--- a/spec/tasks/judging.rb
+++ b/spec/tasks/judging.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+RSpec.describe "Tasks:" do
+  describe "rails judging:check_semifinalists[path/to/file.csv]" do
+    it "raises without expected headers" do
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{not what it wants}
+        csv << %w{1 2 3 4}
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/CSV FORMAT PROBLEM/)
+    end
+
+    it "raises without expected values" do
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [1, nil]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*specifies a team_id and team_submission_id/)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [nil, 1]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*specifies a team_id and team_submission_id/)
+    end
+
+    it "raises if either model can't be found" do
+      team = FactoryBot.create(:team, :submitted)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [0, team.submission.id]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*were not found.*Team with/m)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [team.id, 0]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*were not found.*TeamSubmission with/m)
+    end
+
+    it "raises unless team and submission match" do
+      team = FactoryBot.create(:team, :submitted)
+      other_submission = FactoryBot.create(:submission)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [team.id, other_submission.id]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*team and submission do not match/)
+    end
+
+    it "raises if other semifinalists exist in database" do
+      team = FactoryBot.create(:team, :submitted)
+      other = FactoryBot.create(:submission, :semifinalist)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [team.id, team.submission.id]
+      end
+
+      expect {
+        Rake::Task['judging:check_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to raise_error(/DATA PROBLEM.*all semifinalists are included/)
+    end
+  end
+
+  describe "rails judging:set_semifinalists[path/to/file.csv]" do
+    it "sets specified team/submission to semifinalist" do
+      team = FactoryBot.create(:team, :submitted)
+      other = FactoryBot.create(:team, :submitted)
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [team.id, team.submission.id]
+      end
+
+      expect {
+        Rake::Task['judging:set_semifinalists'].execute(filename: "./tmp/test.csv")
+      }.to change {
+        TeamSubmission.current.semifinalist.count
+      }.from(0).to(1)
+
+      expect(team.reload.submission).to be_semifinalist
+    end
+
+    it "sets no semifinalists on error" do
+      team = FactoryBot.create(:team, :submitted)
+      other = FactoryBot.create(:submission, :semifinalist).team
+
+      CSV.open("./tmp/test.csv", "wb") do |csv|
+        csv << %w{team_id team_submission_id}
+        csv << [team.id, team.submission.id]
+      end
+
+      expect {
+        begin
+          Rake::Task['judging:set_semifinalists'].execute(filename: "./tmp/test.csv")
+        rescue
+          # nothing
+        end
+      }.not_to change {
+        TeamSubmission.current.semifinalist.count
+      }
+
+      expect(team.reload.submission).not_to be_semifinalist
+    end
+  end
+end


### PR DESCRIPTION
New rake tasks:
* `rake judging:check_semifinalists[path/to/file.csv]`
* `rake judging:set_semifinalists[path/to/file.csv]`

Both expect a csv file with a header row, and require the following two columns:
* `team_id`: id of quarterfinalist team that will be moved to semifinals
* `team_submission_id`: the id of their submission

`check_semifinalists` will only check the file for validity, while `set_semifinalists` will first check the file for validity, and then run again making the actual changes in the database.

The tasks assume the csv includes **all semifinalists**, so if semifinalists are found in the database that aren't included in the csv, the task will fail.

