### PR TITLE
Fix a bug where search wasn't firing properly in AttendeeSearch for RPEs

### DIFF
--- a/app/javascript/ra/events/AttendeeSearch.vue
+++ b/app/javascript/ra/events/AttendeeSearch.vue
@@ -135,6 +135,10 @@
       ], () => {
         this.fetchRemoteItems();
       });
+
+      this.debouncedFetchRemoteItems = debounce(() => {
+        this.fetchRemoteItems({ expandSearch: 1 });
+      }, 300);
     },
 
     computed: {
@@ -160,14 +164,9 @@
 
     watch: {
       query (val) {
-        this.selectableItems = Array.from(this.items || [])
-                                    .filter(item => item.matchesQuery(val))
-
-        if (val.length >= 3 && !this.selectableItems.length)
-          debounce(
-            this.fetchRemoteItems.bind(this, { expandSearch: 1 }),
-            300
-          )();
+        if (val.length >= 3) {
+          this.debouncedFetchRemoteItems();
+        }
       },
 
       searching (current) {


### PR DESCRIPTION
Mike, I think this shores up a bit of the weirdness around adding judges to RPEs. I am a little bit apprehensive about this being a good solution though. Basically, the code queries the database for `UserInvitation` records with an email address containing the query string. So the problem is, if someone typoed with an extra "g" on the end of a ".org" email address and added them to an event, they can never add the proper ".org" email without this code in place.

This solution essentially just does a check if the result set contains an exact query match, and if not, it adds that `UserInvitation` to the list.

This solves the issue, but it doesn't really address everything that can go wrong here. Say an RA invites "alan@fakeemailplace.orgg". They realize they have a typo so they remove "alan@fakeemailplace.orgg" from the event and add "alan@fakeemailplace.org". In this case, the "alan@fakeemailplace.orgg" invite is still in the database, and now so is "alan@fakeemailplace.org". I think it might be a good idea to invalidate the invites in the case that they came from this UI somehow, but I am not sure what the proper approach to that would be or whether or not it should even fall within the scope of this fix. Thoughts?