### PR TITLE
#2088 fix judge invites through events app bug

### DIFF
--- a/app/javascript/ra/events/Attendee.js
+++ b/app/javascript/ra/events/Attendee.js
@@ -1,7 +1,8 @@
 import escapeRegExp from "escape-string-regexp";
 
 export default function Attendee (json) {
-  this.id = parseInt(json.id);
+  this.persisted = json['persisted?'];
+  this.id = json.id;
   this.scope = json.scope;
   this.name = json.name;
   this.links = json.links;

--- a/app/javascript/ra/events/Event.js
+++ b/app/javascript/ra/events/Event.js
@@ -120,12 +120,12 @@ export default function (event) {
 
   this.findTeam = (id) => {
     return Array.from(this.selectedTeams || [])
-      .find(team => team.id === parseInt(id))
+      .find(team => team.id === id)
   }
 
   this.findJudge = (id) => {
     return Array.from(this.selectedJudges || [])
-      .find(judge => judge.id === parseInt(id))
+      .find(judge => judge.id === id)
   }
 
   this.fetchTeams = (opts) => {

--- a/app/javascript/ra/events/EventJudgeList.vue
+++ b/app/javascript/ra/events/EventJudgeList.vue
@@ -264,10 +264,12 @@
         var form = new FormData();
 
         Array.from(this.event.selectedJudges || []).forEach((judge, idx) => {
-          form.append(
-            `event_assignment[invites][${idx}][]id`,
-            judge.id
-          )
+          if (judge.persisted) {
+            form.append(
+              `event_assignment[invites][${idx}][]id`,
+              judge.id
+            )
+          }
 
           form.append(
             `event_assignment[invites][${idx}][]scope`,

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -83,4 +83,8 @@ class Attendee
       record.email
     end
   end
+
+  def persisted?
+    record.persisted?
+  end
 end

--- a/app/serializers/attendees_serializer.rb
+++ b/app/serializers/attendees_serializer.rb
@@ -11,5 +11,6 @@ class AttendeesSerializer
     :assignments,
     :division,
     :submission,
-    :email
+    :email,
+    :persisted?
 end

--- a/spec/javascript/event.spec.js
+++ b/spec/javascript/event.spec.js
@@ -8,14 +8,14 @@ test('resultReadyForList ignores double entry', () => {
   event.resultReadyForList(teamResp, event.selectedTeams)
   event.resultReadyForList(teamResp, event.selectedTeams)
 
-  expect(event.selectedTeams.map((team) => team.id)).toEqual([1])
+  expect(event.selectedTeams.map((team) => team.id)).toEqual(["1"])
 })
 
 test('resultReadyForList appends assignments', () => {
   let event = new Event({ id: 1 })
 
-  const teamResp = { id: "1", assignments: { judge_ids: [1, 2] } }
-  const judgeResp = { id: "2", assignments: { team_ids: [1] } }
+  const teamResp = { id: "1", assignments: { judge_ids: ["1", "2"] } }
+  const judgeResp = { id: "2", assignments: { team_ids: ["1"] } }
 
   event.resultReadyForList(teamResp, event.selectedTeams)
   event.resultReadyForList(judgeResp, event.selectedJudges)
@@ -23,8 +23,8 @@ test('resultReadyForList appends assignments', () => {
   const team = event.selectedTeams[0]
   const judge = event.selectedJudges[0]
 
-  expect(team.assignedJudges.map((judge) => judge.id)).toEqual([2])
-  expect(judge.assignedTeams.map((team) => team.id)).toEqual([1])
+  expect(team.assignedJudges.map((judge) => judge.id)).toEqual(["2"])
+  expect(judge.assignedTeams.map((team) => team.id)).toEqual(["1"])
 })
 
 test('addTeam adds new teams', () => {
@@ -36,7 +36,7 @@ test('addTeam adds new teams', () => {
   const team2 = new Attendee({ id: "2" })
   event.addTeam(team2)
 
-  expect(event.selectedTeams.map((team) => team.id)).toEqual([1, 2])
+  expect(event.selectedTeams.map((team) => team.id)).toEqual(["1", "2"])
 })
 
 test('addTeam ignores already added teams', () => {
@@ -46,7 +46,7 @@ test('addTeam ignores already added teams', () => {
   event.addTeam(team)
   event.addTeam(team)
 
-  expect(event.selectedTeams.map((team) => team.id)).toEqual([1])
+  expect(event.selectedTeams.map((team) => team.id)).toEqual(["1"])
 })
 
 test('removeTeam removes specified team', () => {
@@ -59,7 +59,7 @@ test('removeTeam removes specified team', () => {
   event.addTeam(keep)
 
   event.removeTeam(remove)
-  expect(event.selectedTeams.map((team) => team.id)).toEqual([2])
+  expect(event.selectedTeams.map((team) => team.id)).toEqual(["2"])
 })
 
 test('addTeam/removeTeam notifies teams of the action', () => {


### PR DESCRIPTION
The bug happened when an admin or RA would edit their event and attempt to add a judge that wasn't on the platform yet. Typing their email to search for them eventually gives you the option to invite them through the search UI. Sometimes when you select that option the correct judge is invited, sometimes a totally random user got invited instead.

What was happening was that the `possible_event_attendees.json` endpoint was serializing `UserInvitations` that hadn't been persisted to the database, so they came across the wire with ids like 71bd5946839c4e5f5ea6a88c22d00a03. `Attendee.js` on the client-side was trying to `parseInt` that id and in this case would end up with `id=71`. From there on, the Vue app would look like it had the right invitation, but when saving the changes, the controller on the back-end would look for `UserInvitation` with id = 71, which could be someone totally different. 

In the cases where the feature worked, it was because either the non-persisted object's id didn't parse, or didn't parse to an id that existed in the database, so the controller would decide to create a new one instead.

This fix passes the `persisted?` status of the attendee across to the client-side, and then doesn't send back the id when saving the attendees in the non-persisted case. I considered not even giving non-persisted attendees an id, but it seems like Vue code relies on id's, and care was taken to generate a unique hex for the non-persisted case. Simply removing the `parseInt` may also have been enough to fix this issue, but I'm not 100% certain that a secure random hex will never overlap with database IDs, so this fix is more explicit in checking `persisted?`. 