### PR TITLE
Convert CERTIFICATE_TYPES constant over to hashes

### DIFF
--- a/app/constants/certificate_types.rb
+++ b/app/constants/certificate_types.rb
@@ -1,30 +1,30 @@
-MENTOR_CERTIFICATE_TYPES = %w{
-  mentor_appreciation
+MENTOR_CERTIFICATE_TYPES = {
+  mentor_appreciation: 1
 }
 
-STUDENT_CERTIFICATE_TYPES = %w{
-  participation
-  completion
-  semifinalist
+STUDENT_CERTIFICATE_TYPES = {
+  participation: 3,
+  completion: 0,
+  semifinalist: 4
 }
 
-JUDGE_CERTIFICATE_TYPES = %w{
-  certified_judge
-  head_judge
-  judge_advisor
+JUDGE_CERTIFICATE_TYPES = {
+  certified_judge: 6,
+  head_judge: 7,
+  judge_advisor: 8
 }
 
-OFF_PLATFORM_CERTIFICATE_TYPES = %w{
-  rpe_winner
+OFF_PLATFORM_CERTIFICATE_TYPES = {
+  rpe_winner: 2
 }
 
-PAST_CERTIFICATE_TYPES = %w{
-  general_judge
+PAST_CERTIFICATE_TYPES = {
+  general_judge: 5
 }
 
-CERTIFICATE_TYPES =  
-  MENTOR_CERTIFICATE_TYPES +
-  STUDENT_CERTIFICATE_TYPES +
-  JUDGE_CERTIFICATE_TYPES +
-  OFF_PLATFORM_CERTIFICATE_TYPES +
-  PAST_CERTIFICATE_TYPES
+CERTIFICATE_TYPES = MENTOR_CERTIFICATE_TYPES.merge(
+  **STUDENT_CERTIFICATE_TYPES,
+  **JUDGE_CERTIFICATE_TYPES,
+  **OFF_PLATFORM_CERTIFICATE_TYPES,
+  **PAST_CERTIFICATE_TYPES
+)

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -9,15 +9,15 @@ class Certificate < ApplicationRecord
   mount_uploader :file, FileProcessor
 
   scope :judge_types, -> {
-    where(cert_type: JUDGE_CERTIFICATE_TYPES)
+    where(cert_type: JUDGE_CERTIFICATE_TYPES.keys)
   }
 
   scope :student_types, -> {
-    where(cert_type: STUDENT_CERTIFICATE_TYPES)
+    where(cert_type: STUDENT_CERTIFICATE_TYPES.keys)
   }
 
   scope :mentor_types, -> {
-    where(cert_type: MENTOR_CERTIFICATE_TYPES)
+    where(cert_type: MENTOR_CERTIFICATE_TYPES.keys)
   }
 
   scope :for_team, -> (team) {

--- a/app/technovation/determine_certificates.rb
+++ b/app/technovation/determine_certificates.rb
@@ -18,7 +18,7 @@ class DetermineCertificates
   def needed
     needed = []
 
-    eligible_types.each do |certificate_type|
+    eligible_types.select do |certificate_type|
       needed += needed_recipients(certificate_type)
     end
 

--- a/app/technovation/determine_certificates.rb
+++ b/app/technovation/determine_certificates.rb
@@ -10,9 +10,11 @@ class DetermineCertificates
   end
 
   def eligible_types
-    CERTIFICATE_TYPES.select do |certificate_type|
+    types = CERTIFICATE_TYPES.select do |certificate_type|
       gets_certificate?(certificate_type)
     end
+
+    types.keys.map { |type| type.to_s }
   end
 
   def needed
@@ -31,9 +33,11 @@ class DetermineCertificates
   end
 
   def eligible_certificate_types
-    CERTIFICATE_TYPES.select do |certificate_type|
+    types = CERTIFICATE_TYPES.select do |certificate_type|
       gets_certificate?(certificate_type, @account)
     end
+
+    types.keys.map { |type| type.to_s }
   end
 
   def gets_certificate?(certificate_type)

--- a/app/technovation/determine_certificates.rb
+++ b/app/technovation/determine_certificates.rb
@@ -10,11 +10,11 @@ class DetermineCertificates
   end
 
   def eligible_types
-    types = CERTIFICATE_TYPES.select do |certificate_type|
+    types = CERTIFICATE_TYPES.keys.select do |certificate_type|
       gets_certificate?(certificate_type)
     end
 
-    types.keys.map { |type| type.to_s }
+    types.map(&:to_s)
   end
 
   def needed
@@ -30,14 +30,6 @@ class DetermineCertificates
   private
   def season
     Season.current.year
-  end
-
-  def eligible_certificate_types
-    types = CERTIFICATE_TYPES.select do |certificate_type|
-      gets_certificate?(certificate_type, @account)
-    end
-
-    types.keys.map { |type| type.to_s }
   end
 
   def gets_certificate?(certificate_type)

--- a/app/views/admin/participants/_certificates.en.html.erb
+++ b/app/views/admin/participants/_certificates.en.html.erb
@@ -38,8 +38,8 @@
         <h6 class="reset">Student certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(STUDENT_CERTIFICATE_TYPES.transform_keys { |t|
-                t.to_s.humanize.titleize
+              options_for_select(STUDENT_CERTIFICATE_TYPES.keys.map { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,
@@ -66,8 +66,8 @@
         <h6 class="reset">Mentor certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(MENTOR_CERTIFICATE_TYPES.transform_keys { |t|
-                t.to_s.humanize.titleize
+              options_for_select(MENTOR_CERTIFICATE_TYPES.keys.map { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,
@@ -94,8 +94,8 @@
         <h6 class="reset">Judge certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(JUDGE_CERTIFICATE_TYPES.transform_keys { |t|
-                t.to_s.humanize.titleize
+              options_for_select(JUDGE_CERTIFICATE_TYPES.keys.map { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,

--- a/app/views/admin/participants/_certificates.en.html.erb
+++ b/app/views/admin/participants/_certificates.en.html.erb
@@ -32,14 +32,14 @@
 
   <div class="grid">
     <% if account.student_profile.present? %>
-      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %> 
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
         <%= hidden_field_tag :account_id, account.id %>
 
         <h6 class="reset">Student certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(STUDENT_CERTIFICATE_TYPES.map { |t|
-                [t.humanize.titleize, t]
+              options_for_select(STUDENT_CERTIFICATE_TYPES.select { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,
@@ -55,19 +55,19 @@
         <p>
           <%= submit_tag 'Award', class: "button" %>
         </p>
-      <% end %>  
+      <% end %>
       <div class="grid__col-1"></div>
     <% end %>
 
     <% if account.mentor_profile.present? %>
-      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %> 
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
         <%= hidden_field_tag :account_id, account.id %>
 
         <h6 class="reset">Mentor certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(MENTOR_CERTIFICATE_TYPES.map { |t|
-                [t.humanize.titleize, t]
+              options_for_select(MENTOR_CERTIFICATE_TYPES.select { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,
@@ -83,19 +83,19 @@
         <p>
           <%= submit_tag 'Award', class: "button" %>
         </p>
-      <% end %>  
+      <% end %>
       <div class="grid__col-1"></div>
     <% end %>
 
     <% if account.judge_profile.present? %>
-      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %> 
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
         <%= hidden_field_tag :account_id, account.id %>
 
         <h6 class="reset">Judge certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(JUDGE_CERTIFICATE_TYPES.map { |t|
-                [t.humanize.titleize, t]
+              options_for_select(JUDGE_CERTIFICATE_TYPES.select { |t|
+                [t.to_s.humanize.titleize, t]
               }),
               prompt: "Select type",
               required: true,
@@ -104,7 +104,7 @@
         <p>
           <%= submit_tag 'Award', class: "button" %>
         </p>
-      <% end %>  
+      <% end %>
       <div class="grid__col-1"></div>
     <% end %>
   </div>

--- a/app/views/admin/participants/_certificates.en.html.erb
+++ b/app/views/admin/participants/_certificates.en.html.erb
@@ -38,8 +38,8 @@
         <h6 class="reset">Student certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(STUDENT_CERTIFICATE_TYPES.select { |t|
-                [t.to_s.humanize.titleize, t]
+              options_for_select(STUDENT_CERTIFICATE_TYPES.transform_keys { |t|
+                t.to_s.humanize.titleize
               }),
               prompt: "Select type",
               required: true,
@@ -66,8 +66,8 @@
         <h6 class="reset">Mentor certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(MENTOR_CERTIFICATE_TYPES.select { |t|
-                [t.to_s.humanize.titleize, t]
+              options_for_select(MENTOR_CERTIFICATE_TYPES.transform_keys { |t|
+                t.to_s.humanize.titleize
               }),
               prompt: "Select type",
               required: true,
@@ -94,8 +94,8 @@
         <h6 class="reset">Judge certificate</h6>
         <p>
           <%= select_tag :certificate_type,
-              options_for_select(JUDGE_CERTIFICATE_TYPES.select { |t|
-                [t.to_s.humanize.titleize, t]
+              options_for_select(JUDGE_CERTIFICATE_TYPES.transform_keys { |t|
+                t.to_s.humanize.titleize
               }),
               prompt: "Select type",
               required: true,


### PR DESCRIPTION
After this gets merged in, we need to remove `Certificates` with IDs greater than 240 from QA as they contain incorrect indexes.