### PR TITLE
serialize attendee assignment ids as strings

### DIFF
--- a/app/serializers/attendees_serializer.rb
+++ b/app/serializers/attendees_serializer.rb
@@ -8,9 +8,15 @@ class AttendeesSerializer
     :status_explained,
     :selected,
     :links,
-    :assignments,
     :division,
     :submission,
     :email,
     :persisted?
+
+  attribute :assignments do |obj|
+    # ids are strings on the client side
+    obj.assignments.map { |k, v|
+      [k, v.map(&:to_s)]
+    }.to_h
+  end
 end


### PR DESCRIPTION
This is an alternative solution for the bug found and fixed in #2043. 

It looks to me like FastJsonapi has a whole system for serializing relations that we're bypassing here to just send across assignment ids, but that's maybe a separate issue. 

FastJsonapi sends `id` as a string by default, but it doesn't know the `assignments` hash values are ids, so they go across as numbers. After #2089 though, ids on the client-side are left as strings, because un-persisted `UserInvitations` have a hex string as an id so they can't reliably be parsed as numbers. 

One option is to use `==` instead of `===` where necessary so e.g. "1" == 1 will evaluate as true, but it makes me uneasy to start playing fast and loose with ids.