### PR TITLE
Allow editing of pitch presentations all the way through quarterfinals

### DIFF
--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -45,7 +45,7 @@ module TeamSubmissionController
   end
 
   def edit
-    unless SeasonToggles.team_submissions_editable?
+    unless SeasonToggles.team_submissions_editable? or piece_name == 'pitch_presentation'
       redirect_to send("#{current_scope}_dashboard_path") and return
     end
 
@@ -111,10 +111,11 @@ module TeamSubmissionController
       back: request.fullpath
     )
 
-    SeasonToggles.team_submissions(
-      open:   -> { render piece_or_full_edit },
-      closed: -> { notify_on_dashboard }
-    )
+    if SeasonToggles.team_submissions_editable? or piece_name == 'pitch_presentation'
+      render piece_or_full_edit
+    else
+      notify_on_dashboard
+    end
   end
 
   def update

--- a/app/controllers/concerns/team_submission_section_controller.rb
+++ b/app/controllers/concerns/team_submission_section_controller.rb
@@ -6,6 +6,10 @@ module TeamSubmissionSectionController
   end
 
   def show
+    unless SeasonToggles.team_submissions_editable? or section_name == 'pitch_presentation'
+      redirect_to send("#{current_scope}_dashboard_path") and return
+    end
+
     @team_submission = current_team.submission
     @team = current_team
 

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -90,6 +90,39 @@
 
       <div slot="submission">
         <%= render 'slots/student/submissions' %>
+
+        <% if SeasonToggles.submissions_disabled? and
+                SeasonToggles.quarterfinals_or_earlier? and
+                  current_team.live_event? %>
+          <div class="progress">
+            <div class="progress__section">
+              <h1>
+                <%= link_to "Regional events",
+                  [
+                    current_scope,
+                    current_submission,
+                    :section,
+                    section: :pitch_presentation,
+                  ] %>
+              </h1>
+
+              <ol class="list--reset">
+                <li>
+                  <small>
+                    only if attending a live, regional event:
+                  </small>
+
+                  <%= link_to submission_progress_web_icon(
+                    current_submission,
+                    :pitch_presentation,
+                    "Presentation slides"
+                  ),
+                  [current_scope, current_submission, piece: :pitch_presentation] %>
+                </li>
+              </ol>
+            </div>
+          </div>
+        <% end %>
       </div>
 
       <div slot="events">

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -1,168 +1,170 @@
 <% embedded ||= false %>
 
 <div class="progress">
-  <div class="progress__section">
-    <h1>
-      <%= link_to "Start",
-        [current_scope, submission, :section, section: :start] %>
-    </h1>
+  <% if SeasonToggles.team_submissions_editable? %>
+    <div class="progress__section">
+      <h1>
+        <%= link_to "Start",
+          [current_scope, submission, :section, section: :start] %>
+      </h1>
 
-    <ol class="list--reset">
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :honor_code,
-          "Honor code"
-        ),
-        [
-          current_scope,
-          :honor_code,
-          team_submission_id: submission.id,
-        ] %>
-      </li>
+      <ol class="list--reset">
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :honor_code,
+            "Honor code"
+          ),
+          [
+            current_scope,
+            :honor_code,
+            team_submission_id: submission.id,
+          ] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :team_photo,
-          "Team photo"
-        ),
-        [current_scope, current_team] %>
-      </li>
-    </ol>
-  </div>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :team_photo,
+            "Team photo"
+          ),
+          [current_scope, current_team] %>
+        </li>
+      </ol>
+    </div>
 
-  <div class="progress__section">
-    <h1>
-      <%= link_to "Ideation",
-        [current_scope, submission, :section, section: :ideation] %>
-    </h1>
+    <div class="progress__section">
+      <h1>
+        <%= link_to "Ideation",
+          [current_scope, submission, :section, section: :ideation] %>
+      </h1>
 
-    <ol class="list--reset">
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :app_name,
-          "Your app's name"
-        ),
-        [current_scope, submission, piece: :app_name] %>
-      </li>
+      <ol class="list--reset">
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :app_name,
+            "Your app's name"
+          ),
+          [current_scope, submission, piece: :app_name] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :app_description,
-          "A description of your app"
-        ),
-        [current_scope, submission, piece: :app_description] %>
-      </li>
-    </ol>
-  </div>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :app_description,
+            "A description of your app"
+          ),
+          [current_scope, submission, piece: :app_description] %>
+        </li>
+      </ol>
+    </div>
 
-  <div class="progress__section">
-    <h1>
-      <%= link_to "Pitch",
-        [current_scope, submission, :section, section: :pitch] %>
-    </h1>
+    <div class="progress__section">
+      <h1>
+        <%= link_to "Pitch",
+          [current_scope, submission, :section, section: :pitch] %>
+      </h1>
 
-    <ol class="list--reset">
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :demo_video,
-          "Demo video"
-        ),
-        [current_scope, submission, piece: :demo_video_link] %>
-      </li>
+      <ol class="list--reset">
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :demo_video,
+            "Demo video"
+          ),
+          [current_scope, submission, piece: :demo_video_link] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :pitch_video,
-          "Pitch video"
-        ),
-        [current_scope, submission, piece: :pitch_video_link] %>
-      </li>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :pitch_video,
+            "Pitch video"
+          ),
+          [current_scope, submission, piece: :pitch_video_link] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :screenshots,
-          "2 or more screenshots"
-        ),
-        [current_scope, submission, piece: :screenshots],
-        data: { turbolinks: false } %>
-      </li>
-    </ol>
-  </div>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :screenshots,
+            "2 or more screenshots"
+          ),
+          [current_scope, submission, piece: :screenshots],
+          data: { turbolinks: false } %>
+        </li>
+      </ol>
+    </div>
 
-  <div class="progress__section">
-    <h1>
-      <%= link_to "Code",
-        [current_scope, submission, :section, section: :code] %>
-    </h1>
+    <div class="progress__section">
+      <h1>
+        <%= link_to "Code",
+          [current_scope, submission, :section, section: :code] %>
+      </h1>
 
-    <ol class="list--reset">
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :development_platform,
-          "Development platform"
-        ),
-        [current_scope, submission, piece: :development_platform] %>
-      </li>
+      <ol class="list--reset">
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :development_platform,
+            "Development platform"
+          ),
+          [current_scope, submission, piece: :development_platform] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :source_code_url,
-          "Upload your source code"
-        ),
-        [current_scope, submission, piece: :source_code_url] %>
-      </li>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :source_code_url,
+            "Upload your source code"
+          ),
+          [current_scope, submission, piece: :source_code_url] %>
+        </li>
 
-      <li>
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :code_checklist,
-          submission.code_checklist_points > 0 ?
-            "Code checklist* (#{submission.code_checklist_points}/10)" :
-              "Code checklist*"
-        ),
-        [current_scope, submission, piece: :code_checklist] %>
+        <li>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :code_checklist,
+            submission.code_checklist_points > 0 ?
+              "Code checklist* (#{submission.code_checklist_points}/10)" :
+                "Code checklist*"
+          ),
+          [current_scope, submission, piece: :code_checklist] %>
 
-        <% unless embedded %>
+          <% unless embedded %>
+            <small>
+              * The checklist does not have to be complete;<br />
+              &nbsp;&nbsp;
+              However, you may not change it after the deadline.
+            </small>
+          <% end %>
+        </li>
+      </ol>
+    </div>
+
+    <div class="progress__section">
+      <h1>
+        <%= link_to "Business",
+          [current_scope, submission, :section, section: :business] %>
+      </h1>
+
+      <ol class="list--reset">
+        <li>
           <small>
-            * The checklist does not have to be complete;<br />
-            &nbsp;&nbsp;
-            However, you may not change it after the deadline.
+            senior division teams only:
           </small>
-        <% end %>
-      </li>
-    </ol>
-  </div>
 
-  <div class="progress__section">
-    <h1>
-      <%= link_to "Business",
-        [current_scope, submission, :section, section: :business] %>
-    </h1>
-
-    <ol class="list--reset">
-      <li>
-        <small>
-          senior division teams only:
-        </small>
-
-        <%= link_to submission_progress_web_icon(
-          submission,
-          :business_plan,
-          "Your business plan"
-        ),
-        [current_scope, submission, piece: :business_plan] %>
-      </li>
-    </ol>
-  </div>
+          <%= link_to submission_progress_web_icon(
+            submission,
+            :business_plan,
+            "Your business plan"
+          ),
+          [current_scope, submission, piece: :business_plan] %>
+        </li>
+      </ol>
+    </div>
+  <% end %>
 
   <div class="progress__section">
     <h1>

--- a/app/views/team_submissions/sections/pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/sections/pitch_presentation.en.html.erb
@@ -1,11 +1,13 @@
 <% provide :title, "Submission: Regional events" %>
 
-<% provide :back_link_txt, "Business" %>
-<% provide :back_link, send(
-  "#{current_scope}_team_submission_section_path",
-  @team_submission,
-  section: :business
-) %>
+<% if SeasonToggles.team_submissions_editable? %>
+  <% provide :back_link_txt, "Business" %>
+  <% provide :back_link, send(
+    "#{current_scope}_team_submission_section_path",
+    @team_submission,
+    section: :business
+  ) %>
+<% end %>
 
 <div
   id="<%= dom_id(@team_submission) %>_pitch_presentation"


### PR DESCRIPTION
It's not beautiful, but I think it works:

![Screen Shot 2019-05-01 at 4 01 58 PM](https://user-images.githubusercontent.com/55319/57039387-80fcfb00-6c2a-11e9-9f66-d2f34db5d6d0.png)
![Screen Shot 2019-05-01 at 4 02 02 PM](https://user-images.githubusercontent.com/55319/57039388-822e2800-6c2a-11e9-9dd3-149690c503c1.png)
