### PR TITLE
#2204 #2198 update timeline and mentor orientation urls

### DIFF
--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -36,16 +36,7 @@ class RegistrationMailer < ApplicationMailer
 
     @first_name = account.first_name
 
-    @orientation_url =
-      "https://infograph.venngage.com/publish/02844b99-420b-4016-8c13-1426fc29fbe7"
-
-    @timeline_url =
-      "https://infograph.venngage.com/publish/e02d29e0-28a3-4be2-b41f-3d57c475a1fe"
-
     @root_url = mentor_dashboard_url(mailer_token: account.mailer_token)
-
-    @ebook_url =
-      "https://iridescentlearning.atavist.com/technovation-mentor-training"
 
     @slack_url =
       "https://join.slack.com/t/technovationmentors/shared_invite/" +
@@ -70,8 +61,6 @@ class RegistrationMailer < ApplicationMailer
     @root_url = root_url(mailer_token: student.mailer_token)
     @dashboard_url = student_dashboard_url(mailer_token: student.mailer_token)
     @safety_url = "http://iridescentlearning.org/internet-safety/"
-    @timeline_url =
-      "https://infograph.venngage.com/publish/e02d29e0-28a3-4be2-b41f-3d57c475a1fe"
     @faq_url = "https://iridescentsupport.zendesk.com/hc/en-us/categories/115000091348-Technovation"
 
     I18n.with_locale(student.locale) do

--- a/app/views/registration_mailer/welcome_mentor.en.html.erb
+++ b/app/views/registration_mailer/welcome_mentor.en.html.erb
@@ -43,13 +43,15 @@
             </li>
 
             <li>
-              <%= link_to "Read the mentor orientation", @orientation_url, itemprop: "url" %>
+              <%= link_to "Read the mentor orientation",
+                "https://infograph.venngage.com/pl/6bzOhyG16fc",
+                itemprop: "url" %>
               (5 minutes)
             </li>
 
             <li>
               <%= link_to "Review the important dates and timeline",
-               @timeline_url,
+              "https://infograph.venngage.com/ps/bAAeKGLlsk/2019-technovation-important-dates-and-milestones",
                itemprop: "url" %>
               (2 minutes)
             </li>

--- a/app/views/registration_mailer/welcome_student.en.html.erb
+++ b/app/views/registration_mailer/welcome_student.en.html.erb
@@ -52,7 +52,9 @@
 
       <tr>
         <td class="content-block">
-          <%= link_to "Key Dates", @timeline_url %><br />
+          <%= link_to "Key Dates",
+            "https://infograph.venngage.com/ps/bAAeKGLlsk/2019-technovation-important-dates-and-milestones" %>
+          <br />
           <strong>
             Write these dates on your calendar! All deadlines are firm.
           </strong>


### PR DESCRIPTION
It was decided putting urls directly in templates made for easier review and/or updating by the program team.