### PR TITLE
#2206 hide switch to judge link 

### DIFF
--- a/app/views/mentor/dashboards/_header.en.html.erb
+++ b/app/views/mentor/dashboards/_header.en.html.erb
@@ -6,11 +6,13 @@
   <template slot="survey-links"><%= render 'program_survey' %></template>
 <% end %>
 
-<template slot="judge-switch-link">
-  <%= link_to "Switch to Judge mode",
-    judge_dashboard_path,
-    data: { turbolinks: false } %>
-</template>
+<% if ENV.fetch("ENABLE_SWITCH_TO_JUDGE", false) %>
+  <template slot="judge-switch-link">
+    <%= link_to "Switch to Judge mode",
+      judge_dashboard_path,
+      data: { turbolinks: false } %>
+  </template>
+<% end %>
 
 <% if current_mentor.is_an_ambassador? %>
   <template slot="ra-switch-link">

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Mentors switch to judging mode" do
+  
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(true)
+  end
+
   scenario "mentors with a judge profile can switch to judge mode" do
     mentor = FactoryBot.create(:mentor, :onboarded, :has_judge_profile)
 


### PR DESCRIPTION
`ENABLE_SWITCH_TO_JUDGE` now controls whether the "Switch to judge mode" link is shown to logged in mentors.