### PR TITLE
#2162 fix: send in scope, not env key

### DIFF
--- a/app/technovation/profile_updating.rb
+++ b/app/technovation/profile_updating.rb
@@ -95,7 +95,7 @@ class ProfileUpdating
         UpdateProfileOnEmailListJob.perform_later(
           id,
           email_before_last_save,
-          "#{scope.sub(/^\w+_regional/, "regional").upcase}_LIST_ID"
+          scope.sub(/^\w+_regional/, "regional").upcase
         )
       end
     end

--- a/spec/controllers/admin/participants_controller_spec.rb
+++ b/spec/controllers/admin/participants_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Admin::ParticipantsController do
         .with(
           profile.account_id,
           "old@oldtime.com",
-          "#{scope.upcase}_LIST_ID",
+          scope.upcase,
         )
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Admin::ParticipantsController do
         .with(
           profile.account_id,
           profile.account.email,
-          "#{scope.upcase}_LIST_ID",
+          scope.upcase,
         )
     end
 
@@ -96,7 +96,7 @@ RSpec.describe Admin::ParticipantsController do
         .with(
           profile.account_id,
           profile.account.email,
-          "#{scope.upcase}_LIST_ID",
+          scope.upcase,
         )
     end
 
@@ -116,7 +116,7 @@ RSpec.describe Admin::ParticipantsController do
         .with(
           profile.account_id,
           profile.account.email,
-          "#{scope.upcase}_LIST_ID",
+          scope.upcase,
         )
     end
   end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -28,7 +28,7 @@ require "rails_helper"
         .with(
           profile.account_id,
           profile.account.email,
-          "#{scope.upcase}_LIST_ID"
+          scope.upcase
         )
     end
 
@@ -43,7 +43,7 @@ require "rails_helper"
       }
 
       expect(UpdateProfileOnEmailListJob).to have_received(:perform_later)
-        .with(profile.account_id, profile.account.email, "#{scope.upcase}_LIST_ID")
+        .with(profile.account_id, profile.account.email, scope.upcase)
     end
 
     it "updates #{scope} newsletters with changes to last name" do
@@ -57,7 +57,7 @@ require "rails_helper"
       }
 
       expect(UpdateProfileOnEmailListJob).to have_received(:perform_later)
-        .with(profile.account_id, profile.account.email, "#{scope.upcase}_LIST_ID")
+        .with(profile.account_id, profile.account.email, scope.upcase)
     end
 
     it "errors out when #{scope} country is blank" do


### PR DESCRIPTION
Emails weren't updating in Mailchimp, error was `WARN: KeyError: key not found: "STUDENT_LIST_ID_LIST_ID"`