### PR TITLE
#2229 fix the off-season page

### DIFF
--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -6,13 +6,8 @@
 
 <p>
   <strong>
-    Registration for Technovation
-    <%= Season.next.year %>
-    will open on
-    <%= Date::MONTHNAMES[Season::START_MONTH] %>
-    <%= Season::START_DAY %>.
-
-    Please
+    Registration for Technovation Girls 2020
+    will open on October 10. Please
     <%= link_to "sign up for our newsletter",
       "http://eepurl.com/gk5J_D" %>
     to receive registration information and season updates.

--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -1,20 +1,20 @@
-<h1 class="appy-title">Technovation</h1>
+<h1 class="appy-title">Technovation Girls</h1>
 
 <h2>Registration is currently closed</h2>
 
-<p>We're so excited you want to join Technovation — we can't wait for you to be part of our global community of 15,000 girls and 6,000 mentors!</p>
+<p>We're so excited you want to join Technovation Girls — we can't wait for you to be part of our global community of 15,000 girls and 6,000 mentors!</p>
 
 <p>
   <strong>
     Registration for Technovation Girls 2020
-    will open on October 10. Please
+    will open on October 10th. Please
     <%= link_to "sign up for our newsletter",
       "http://eepurl.com/gk5J_D" %>
     to receive registration information and season updates.
   </strong>
 </p>
 
-<p>Until then, get to know Technovation and get ready for the season!</p>
+<p>Until then, get to know Technovation Girls and get ready for the season!</p>
 
 <p>Learn about the Technovation community on:</p>
 
@@ -42,7 +42,7 @@
   </li>
 </ul>
 
-<p>Host a screening of Codegirl, the documentary about Technovation</p>
+<p>Host a screening of Codegirl, the documentary about Technovation Girls</p>
 
 <ul class="unstyled">
   <li>

--- a/spec/features/admin/off_season_splash_spec.rb
+++ b/spec/features/admin/off_season_splash_spec.rb
@@ -15,10 +15,7 @@ RSpec.feature "Off-season splash page" do
     SeasonToggles.disable_signups!
     visit root_path
     expect(page).not_to have_css("#registration-landing")
-    expect(page).to have_content(
-      "Registration for Technovation " +
-      Season.next.year.to_s +
-      " will open on October 1."
-    )
+    expect(page).to have_content("Registration for Technovation")
+    expect(page).to have_content("will open on")
   end
 end


### PR DESCRIPTION
It looks like the platform wanted the season rollover date to coincide with the day we would open registration. This just hardcodes the correct date for this year, as well as updating some of the branding.