### PR TITLE
#2256 demo video clearout

### DIFF
--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -42,7 +42,6 @@ module Admin
         :app_name,
         :app_description,
         :pitch_video_link,
-        :demo_video_link,
         :business_plan,
         :development_platform,
         :app_inventor_app_name,

--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -125,8 +125,6 @@ module TeamSubmissionController
       handle_screenshots_update(@team_submission)
     elsif team_submission_params[:pitch_video_link]
       handle_video_link_review(@team_submission, :pitch_video_link)
-    elsif team_submission_params[:demo_video_link]
-      handle_video_link_review(@team_submission, :demo_video_link)
     elsif @team_submission.update(team_submission_params)
       if request.xhr? && team_submission_params[:pitch_presentation]
         piece_name = "pitch_presentation"
@@ -245,7 +243,6 @@ module TeamSubmissionController
         :pitch_presentation,
         :app_description,
         :app_name,
-        :demo_video_link,
         :pitch_video_link,
         :development_platform_other,
         :development_platform,

--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -127,7 +127,6 @@ module Judge
         :ideation_comment_word_count,
 
         :app_functional,
-        :demo_video,
         :technical_comment,
         :technical_comment_word_count,
 

--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -31,8 +31,6 @@ module StudentHelper
                 :complete unless submission.app_description.blank?
               when :pitch_video
                 :complete unless submission.pitch_video_link.blank?
-              when :demo_video
-                :complete unless submission.demo_video_link.blank?
               when :screenshots
                 :complete if submission.screenshots.many?
               when :development_platform

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -168,12 +168,12 @@ class Questions
 
       Question.new(
         section: 'technical',
-        field: :demo_video,
+        field: :demo,
         idx: 2,
         text: "The app is easy to use and the " +
               "features are well thought out.",
         worth: 5,
-        score: submission_score.demo_video,
+        score: submission_score.demo,
       ),
 
       Question.new(

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -81,9 +81,6 @@ class Questions
           }
         },
 
-        demo_video_id: submission.video_id(:demo),
-        demo_video_url: judge_embed_code_path(submission, piece: :demo),
-
         pitch_video_id: submission.video_id(:pitch),
         pitch_video_url: judge_embed_code_path(submission, piece: :pitch),
 

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -341,7 +341,7 @@ class SubmissionScore < ActiveRecord::Base
 
   def technical_total
     app_functional +
-      demo_video +
+      demo +
         total_technical_checklist
   end
 

--- a/app/models/submission_section.rb
+++ b/app/models/submission_section.rb
@@ -11,7 +11,7 @@ class SubmissionSection
   SECTION_GROUPS = {
     0 => %w{honor_code team_photo},
     1 => %w{app_name app_description},
-    2 => %w{demo_video_link pitch_video_link screenshots},
+    2 => %w{pitch_video_link screenshots},
     3 => %w{development_platform source_code source_code_url code_checklist},
     4 => %w{business_plan},
     5 => %w{pitch_presentation},

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -233,7 +233,6 @@ class TeamSubmission < ActiveRecord::Base
   %i{
     app_name
     app_description
-    demo_video_link
     pitch_video_link
     development_platform
     source_code_url

--- a/app/views/regional_ambassador/printable_scores/show.en.html.erb
+++ b/app/views/regional_ambassador/printable_scores/show.en.html.erb
@@ -121,7 +121,7 @@
 
             <tr>
               <td>The app is easy to use and the features are well thought out.</td>
-              <td><%= score.demo_video %></td>
+              <td><%= score.demo %></td>
               <td></td>
             </tr>
 

--- a/app/views/regional_ambassador/scores/detail/_technical.en.html.erb
+++ b/app/views/regional_ambassador/scores/detail/_technical.en.html.erb
@@ -12,7 +12,7 @@
     The demo video demonstrates the functionality of the app well.
   </dt>
   <dd>
-    <%= JudgingRubricScores::Explain.(score.demo_video) %>
+    <%= JudgingRubricScores::Explain.(score.demo) %>
   </dd>
 
   <dt>

--- a/app/views/student/scores_2017/_technical.html.erb
+++ b/app/views/student/scores_2017/_technical.html.erb
@@ -12,7 +12,7 @@
     The demo video demonstrates the functionality of the app well.
   </dt>
   <dd>
-    <%= JudgingRubricScores::Explain.(@score.demo_video) %>
+    <%= JudgingRubricScores::Explain.(@score.demo) %>
   </dd>
 
   <dt>

--- a/db/migrate/20191120151220_remove_demo_video_link_from_team_submissions.rb
+++ b/db/migrate/20191120151220_remove_demo_video_link_from_team_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveDemoVideoLinkFromTeamSubmissions < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :team_submissions, :demo_video_link, :string
+  end
+end

--- a/db/migrate/20191120151819_rename_demo_video_column_on_submission_scores.rb
+++ b/db/migrate/20191120151819_rename_demo_video_column_on_submission_scores.rb
@@ -1,0 +1,5 @@
+class RenameDemoVideoColumnOnSubmissionScores < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :submission_scores, :demo_video, :demo
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1366,7 +1366,7 @@ CREATE TABLE public.submission_scores (
     evidence_of_problem integer DEFAULT 0,
     problem_addressed integer DEFAULT 0,
     app_functional integer DEFAULT 0,
-    demo_video integer DEFAULT 0,
+    demo integer DEFAULT 0,
     business_plan_short_term integer DEFAULT 0,
     business_plan_long_term integer DEFAULT 0,
     market_research integer DEFAULT 0,
@@ -3155,6 +3155,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190506212403'),
 ('20191008152233'),
 ('20191014194309'),
-('20191120151220');
+('20191120151220'),
+('20191120151819');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -1492,7 +1478,6 @@ CREATE TABLE public.team_submissions (
     source_code character varying,
     app_description text,
     app_name character varying,
-    demo_video_link character varying,
     pitch_video_link character varying,
     development_platform_other character varying,
     development_platform integer,
@@ -3169,6 +3154,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190403154655'),
 ('20190506212403'),
 ('20191008152233'),
-('20191014194309');
+('20191014194309'),
+('20191120151220');
 
 

--- a/spec/models/submission_score_spec.rb
+++ b/spec/models/submission_score_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe SubmissionScore do
       problem_addressed: 4,
       app_functional: 2,
 
-      demo_video: 0,
+      demo: 0,
       business_plan_short_term: 5,
       business_plan_long_term: 5,
       market_research: 3,


### PR DESCRIPTION
This removes any additional mentions of `demo_video_link` not yet taken care of, and changes the `demo_video` field on submission scores to be called `demo`, to reduce the potential for confusion later.