### PR TITLE
#2330 add uid_value formatting to survey links

### DIFF
--- a/app/technovation/season_toggles/survey_links.rb
+++ b/app/technovation/season_toggles/survey_links.rb
@@ -62,6 +62,7 @@ class SeasonToggles
       def format_parsed_url(parsed_url, account)
         unless parsed_url.blank?
           formatted_url = parsed_url.dup
+          formatted_url.sub!("[uid_value]", account.id.to_s)
           formatted_url.sub!("[email_value]", account.email)
           formatted_url.sub!("[country_value]", FriendlyCountry.(account))
           formatted_url.sub!("[state_value]", FriendlySubregion.(account))

--- a/spec/technovation/season_toggles_spec.rb
+++ b/spec/technovation/season_toggles_spec.rb
@@ -169,6 +169,21 @@ RSpec.describe SeasonToggles do
       end
     end
 
+    describe ".survey_link" do
+      it "formats url with user id" do
+        SeasonToggles.public_send("#{scope}_survey_link=", {
+          text: "Hello World",
+          long_desc: "Longer description for modal content",
+          url: "https://example.com?uid=[uid_value]",
+        })
+
+        account = FactoryBot.create(:student).account
+
+        expect(SeasonToggles.survey_link(scope, "url", format_url: true, account: account))
+          .to eq("https://example.com?uid=#{account.id}")
+      end
+    end
+
     describe ".survey_link_available?" do
       it "returns true if the text and url are present" do
         SeasonToggles.public_send("#{scope}_survey_link=", {


### PR DESCRIPTION
With this PR for #2330 and #2329, if a custom variable for `uid` is set up in a Surveymonkey survey we have a better point of connection between the surveys and the platform.