### PR TITLE
#2260 removing checklist from admin/RA ui

### DIFF
--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -23,10 +23,6 @@ class SubmissionsGrid
     screenshots.count
   end
 
-  column :code_checklist do
-    total_technical_checklist
-  end
-
   column :development_platform_text
   column :app_inventor_app_name
   column :app_inventor_gmail

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -49,17 +49,6 @@
             <td><%= @score.total_for_question(question) %></td>
           </tr>
         <% end %>
-
-        <% if section.to_sym === :technical %>
-          <tr>
-            <td>
-              The team automatically earned
-              <%= pluralize(@score.total_technical_checklist, "points") %>
-              from their code checklist
-            </td>
-            <td><%= @score.total_technical_checklist %></td>
-          </tr>
-        <% end %>
       </table>
 
       <%= simple_format @score.comment_for_section(section) %>

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -166,10 +166,6 @@
           No screenshots uploaded
         <% end %>
       </p>
-
-      <p>
-        <%= "#{@team_submission.team_name} has earned #{@team_submission.code_checklist_points}/10 for their code checklist." %>
-     </p>
     </div>
   </div>
 </div>

--- a/app/views/regional_ambassador/printable_scores/show.en.html.erb
+++ b/app/views/regional_ambassador/printable_scores/show.en.html.erb
@@ -124,16 +124,6 @@
               <td><%= score.demo %></td>
               <td></td>
             </tr>
-
-            <tr>
-              <td>
-                The team automatically earned
-                <%= pluralize(score.total_technical_checklist, "points") %>
-                from their code checklist
-              </td>
-              <td><%= score.total_technical_checklist %></td>
-              <td><%= score.total_technical_checklist %></td>
-            </tr>
           </table>
 
           <h3>Pitch</h3>

--- a/app/views/regional_ambassador/score_details/show.en.html.erb
+++ b/app/views/regional_ambassador/score_details/show.en.html.erb
@@ -27,13 +27,6 @@
     <% end %>
   </dl>
 
-  <p>
-    <%= @submission.team_name %>
-    earned
-    <%= pluralize @submission.code_checklist_points, 'point' %>
-    for their code checklist.
-  </p>
-
   <% if current_account.is_admin? or SeasonToggles.display_scores? %>
 
     <%= render 'regional_ambassador/score_details/scores_table',

--- a/app/views/regional_ambassador/scores/_detail_summary.en.html.erb
+++ b/app/views/regional_ambassador/scores/_detail_summary.en.html.erb
@@ -1,16 +1,5 @@
 <h3>Summary</h3>
 
-<p>
-  <em>
-    <%= team.name %>
-    earned
-    <strong>
-      <%= pluralize(score.total_technical_checklist, 'point') %>
-    </strong>
-    from their technical checklist.
-  </em>
-</p>
-
 <table class="ra-participants-list">
   <thead>
     <tr>

--- a/app/views/regional_ambassador/scores/detail/_technical.en.html.erb
+++ b/app/views/regional_ambassador/scores/detail/_technical.en.html.erb
@@ -15,16 +15,6 @@
     <%= JudgingRubricScores::Explain.(score.demo) %>
   </dd>
 
-  <dt>
-    Technical Checklist
-  </dt>
-  <dd>
-    <%= score.team_submission_team_name %>
-    earned
-    <%= pluralize(score.total_technical_checklist, 'point') %>
-    from their technical checklist.
-  </dd>
-
   <dt>Comment:</dt>
   <dd><%= simple_format score.technical_comment %></dd>
 </dl>

--- a/app/views/regional_ambassador/team_submissions/show.html.erb
+++ b/app/views/regional_ambassador/team_submissions/show.html.erb
@@ -156,13 +156,6 @@
           <% end %>
         </dd>
       </dt>
-
-      <p>
-        <%= @team_submission.team_name %>
-        has earned
-        <%= @team_submission.code_checklist_points %>/10
-        for their code checklist.
-      </p>
     </div>
   </div>
 </div>

--- a/spec/features/admin/view_scores_spec.rb
+++ b/spec/features/admin/view_scores_spec.rb
@@ -6,10 +6,6 @@ RSpec.feature "Admins view scores" do
       :submission,
       :junior,
       :complete,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(
@@ -25,7 +21,7 @@ RSpec.feature "Admins view scores" do
     visit admin_scores_path
     find("a.view-details").click
 
-    expect(page).to have_content("earned 2 points")
+    expect(page).to have_content("View score")
   end
 
   scenario "view SF scores" do
@@ -34,10 +30,6 @@ RSpec.feature "Admins view scores" do
       :junior,
       :complete,
       :semifinalist,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(
@@ -54,6 +46,6 @@ RSpec.feature "Admins view scores" do
     visit admin_scores_path
     find("a.view-details").click
 
-    expect(page).to have_content("earned 2 points")
+    expect(page).to have_content("View score")
   end
 end

--- a/spec/features/mentor/view_scores_spec.rb
+++ b/spec/features/mentor/view_scores_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Mentors view scores" do
     sign_in(mentor)
     click_link("View details")
 
-    expect(page.status_code).to be(200)
+    expect(page).to have_title("Review Score")
   end
 
   scenario "view SF scores" do
@@ -46,6 +46,6 @@ RSpec.feature "Mentors view scores" do
     sign_in(mentor)
     click_link("View details")
 
-    expect(page.status_code).to be(200)
+    expect(page).to have_title("Review Score")
   end
 end

--- a/spec/features/mentor/view_scores_spec.rb
+++ b/spec/features/mentor/view_scores_spec.rb
@@ -13,10 +13,6 @@ RSpec.feature "Mentors view scores" do
       :submission,
       :complete,
       team: team,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -24,7 +20,7 @@ RSpec.feature "Mentors view scores" do
     sign_in(mentor)
     click_link("View details")
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 
   scenario "view SF scores" do
@@ -38,10 +34,6 @@ RSpec.feature "Mentors view scores" do
       :complete,
       :semifinalist,
       team: team,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(
@@ -54,6 +46,6 @@ RSpec.feature "Mentors view scores" do
     sign_in(mentor)
     click_link("View details")
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 end

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page.status_code).to be(200)
+      expect(page).to have_content("View score")
     end
 
     scenario "can view SF scores" do
@@ -53,7 +53,7 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page.status_code).to be(200)
+      expect(page).to have_content("View score")
     end
 
     scenario "can see SF columns and data" do
@@ -106,7 +106,7 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page.status_code).to be(200)
+      expect(page).to have_content("View score")
     end
 
     scenario "can not view virtual QF scores" do

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -22,10 +22,6 @@ RSpec.feature "Regional Ambassador views scores" do
       submission = FactoryBot.create(
         :submission,
         :complete,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -35,7 +31,7 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page).to have_content("earned 2 points")
+      expect(page.status_code).to be(200)
     end
 
     scenario "can view SF scores" do
@@ -43,10 +39,6 @@ RSpec.feature "Regional Ambassador views scores" do
         :submission,
         :complete,
         :semifinalist,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       FactoryBot.create(
@@ -61,7 +53,7 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page).to have_content("earned 2 points")
+      expect(page.status_code).to be(200)
     end
 
     scenario "can see SF columns and data" do
@@ -69,10 +61,6 @@ RSpec.feature "Regional Ambassador views scores" do
         :submission,
         :complete,
         :semifinalist,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -105,10 +93,6 @@ RSpec.feature "Regional Ambassador views scores" do
       submission = FactoryBot.create(
         :submission,
         :complete,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -122,17 +106,13 @@ RSpec.feature "Regional Ambassador views scores" do
         find('a.view-details').click
       end
 
-      expect(page).to have_content("earned 2 points")
+      expect(page.status_code).to be(200)
     end
 
     scenario "can not view virtual QF scores" do
       submission = FactoryBot.create(
         :submission,
         :complete,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -147,10 +127,6 @@ RSpec.feature "Regional Ambassador views scores" do
         :submission,
         :complete,
         :semifinalist,
-        technical_checklist_attributes: {
-          used_camera: true,
-          used_camera_explanation: "We did it...",
-        }
       )
 
       rpe = FactoryBot.create(:rpe)

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page.status_code).to be(200)
+    expect(page).to have_content("Scores Explained")
   end
 
   it "view SF scores" do
@@ -61,54 +61,6 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page.status_code).to be(200)
-  end
-
-  it "view QF scores" do
-    submission = FactoryBot.create(
-      :submission,
-      :complete,
-    )
-
-    FactoryBot.create(:submission_score, :complete, team_submission: submission)
-
-    sign_in(submission.team.students.sample)
-    click_button "Scores & Feedback"
-    click_link "View your scores and certificate"
-
-    expect(page).to have_selector('.ui-accordion-content', visible: false)
-    accordions = page.all(:css, '.ui-accordion-content', visible: false)
-    accordions.each do |el|
-      execute_script("arguments[0].style.display = 'block'", el)
-    end
-
-    expect(page.status_code).to be(200)
-  end
-
-  it "view SF scores" do
-    submission = FactoryBot.create(
-      :submission,
-      :complete,
-      :semifinalist,
-    )
-
-    FactoryBot.create(
-      :score,
-      :complete,
-      round: :semifinals,
-      team_submission: submission
-    )
-
-    sign_in(submission.team.students.sample)
-    click_button "Scores & Feedback"
-    click_link "View your scores and certificate"
-
-    expect(page).to have_selector('.ui-accordion-content', visible: false)
-    accordions = page.all(:css, '.ui-accordion-content', visible: false)
-    accordions.each do |el|
-      execute_script("arguments[0].style.display = 'block'", el)
-    end
-
-    expect(page.status_code).to be(200)
+    expect(page).to have_content("Scores Explained")
   end
 end

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe "Students view scores", :js do
     submission = FactoryBot.create(
       :submission,
       :complete,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -38,7 +34,7 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 
   it "view SF scores" do
@@ -46,10 +42,6 @@ RSpec.describe "Students view scores", :js do
       :submission,
       :complete,
       :semifinalist,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(
@@ -69,17 +61,13 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 
   it "view QF scores" do
     submission = FactoryBot.create(
       :submission,
       :complete,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(:submission_score, :complete, team_submission: submission)
@@ -94,7 +82,7 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 
   it "view SF scores" do
@@ -102,10 +90,6 @@ RSpec.describe "Students view scores", :js do
       :submission,
       :complete,
       :semifinalist,
-      technical_checklist_attributes: {
-        used_camera: true,
-        used_camera_explanation: "We did it...",
-      }
     )
 
     FactoryBot.create(
@@ -125,6 +109,6 @@ RSpec.describe "Students view scores", :js do
       execute_script("arguments[0].style.display = 'block'", el)
     end
 
-    expect(page).to have_content("earned 2 points")
+    expect(page.status_code).to be(200)
   end
 end


### PR DESCRIPTION
Information about technical checklist scores is peppered throughout the admin and RA screens. This PR is trying to remove all visible traces from the admin/RA UI, while #2261 can handle a final clearout of anything behind-the-scenes that's no longer needed.