### PR TITLE
#2366 Make RPE date range configurable

### DIFF
--- a/app/javascript/ra/events/EventForm.vue
+++ b/app/javascript/ra/events/EventForm.vue
@@ -174,8 +174,8 @@
           altInput: true,
           altFormat: "l, F J",
           dateFormat: "Y-m-d",
-          minDate: "2019-04-27",
-          maxDate: "2019-06-02",
+          minDate: this.minDate(),
+          maxDate: this.maxDate(),
         },
 
         timeOpts: {
@@ -461,6 +461,18 @@
           0
         );
         return newTime;
+      },
+
+      minDate() {
+        return process.env.DATES_REGIONAL_PITCH_EVENTS_BEGINS_YEAR + '-' +
+          process.env.DATES_REGIONAL_PITCH_EVENTS_BEGINS_MONTH + '-' +
+          process.env.DATES_REGIONAL_PITCH_EVENTS_BEGINS_DAY
+      },
+
+      maxDate() {
+        return process.env.DATES_REGIONAL_PITCH_EVENTS_ENDS_YEAR + '-' +
+          process.env.DATES_REGIONAL_PITCH_EVENTS_ENDS_MONTH + '-' +
+          process.env.DATES_REGIONAL_PITCH_EVENTS_ENDS_DAY
       },
     },
 


### PR DESCRIPTION
This will make the RPE date range dynamic via new configuration settings:
```
DATES_REGIONAL_PITCH_EVENTS_BEGINS_YEAR
DATES_REGIONAL_PITCH_EVENTS_BEGINS_MONTH
DATES_REGIONAL_PITCH_EVENTS_BEGINS_DAY

DATES_REGIONAL_PITCH_EVENTS_ENDS_YEAR
DATES_REGIONAL_PITCH_EVENTS_ENDS_MONTH
DATES_REGIONAL_PITCH_EVENTS_ENDS_DAY
```