### PR TITLE
Validate student email address is different than parent/guardian's email address

### DIFF
--- a/app/controllers/concerns/profile_controller.rb
+++ b/app/controllers/concerns/profile_controller.rb
@@ -41,6 +41,8 @@ module ProfileController
       else
         render "passwords/edit"
       end
+    elsif profile.errors["account.email"].any?
+      render 'email_addresses/edit'
     elsif profile.errors["account.city"].any? or
             profile.errors["account.state_province"].any? or
               profile.errors["account.country"].any?

--- a/app/controllers/concerns/profile_controller.rb
+++ b/app/controllers/concerns/profile_controller.rb
@@ -34,6 +34,8 @@ module ProfileController
             success: t('controllers.accounts.update.success')
         }
       end
+    elsif profile.errors["parent_guardian_email"].any?
+      render "student/parental_consent_notices/new"
     elsif profile.errors["account.password"].any? or
       profile.errors["account.existing_password"].any?
       if profile.account.email_changed?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -16,6 +16,8 @@ class Account < ActiveRecord::Base
 
   acts_as_paranoid
 
+  include ActiveModel::Validations
+
   include Seasoned
 
   include Regioned
@@ -548,6 +550,8 @@ class Account < ActiveRecord::Base
       email.gsub(".", "")
     ])
   }
+
+  validates_with StudentEmailValidator
 
   def self.find_with_token(token)
     find_by(auth_token: token) || ::NullAuth.new

--- a/app/validators/student_email_validator.rb
+++ b/app/validators/student_email_validator.rb
@@ -1,0 +1,7 @@
+class StudentEmailValidator < ActiveModel::Validator
+  def validate(record)
+    if record.student_profile.present? && (record.email == record.student_profile.parent_guardian_email)
+      record.errors.add(:email, :matches_parent_guardian_email)
+    end
+  end
+end

--- a/app/views/student/parental_consent_notices/new.html.erb
+++ b/app/views/student/parental_consent_notices/new.html.erb
@@ -4,6 +4,6 @@
   <div class="panel grid__col-sm-8">
     <h3><%= t("views.student.parental_consent_notices.new.title") %></h3>
 
-    <%= render 'form' %>
+    <%= render "student/parental_consent_notices/form" %>
   </div>
 </div>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -21,6 +21,8 @@ en:
       models:
         account:
           attributes:
+            email:
+              matches_parent_guardian_email: "cannot be the same as parent/guardian email address"
             existing_password:
               blank: "is required to change your email address or password"
               invalid: "is incorrect"

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,6 +2,36 @@ require "rails_helper"
 require "./lib/fill_pdfs"
 
 RSpec.describe Account do
+  context "validations" do
+    describe "student email address validations" do
+      let!(:student_account) { FactoryBot.build_stubbed(:account, email: student_email_address) }
+      let!(:student_profile) { FactoryBot.build_stubbed(:student_profile,
+        account: student_account,
+        parent_guardian_email: parent_guardian_email_address
+      ) }
+
+      context "when the student's email address matches the parent/guardian's email address" do
+        let(:student_email_address) { "rose@example.com" }
+        let(:parent_guardian_email_address) { "rose@example.com" }
+
+        it "is not valid and adds an error to the email attribute" do
+          expect(student_account).not_to be_valid
+          expect(student_account.errors[:email]).to include "cannot be the same as parent/guardian email address"
+        end
+      end
+
+      context "when the student's email address is different than the parent/guardian's email address" do
+        let(:student_email_address) { "crocus@example.com" }
+        let(:parent_guardian_email_address) { "iris@example.com" }
+
+        it "is valid and does not add an error to the email attribute" do
+          expect(student_account).to be_valid
+          expect(student_account.errors[:email]).to be_blank
+        end
+      end
+    end
+  end
+
   it "formats the country as a short code before validating" do
     account = Account.new(country: "United States")
     account.valid?

--- a/spec/requests/student/profile_requests_spec.rb
+++ b/spec/requests/student/profile_requests_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe "Student Profile Requests", type: :request do
+  let(:student_account) { FactoryBot.create(:account, email: student_email_address) }
+  let(:student_email_address) { "harry@example.com"  }
+  let(:student_profile) {
+    FactoryBot.create(:student_profile, :geocoded,
+      account: student_account,
+      parent_guardian_email: parent_guardian_email_address)
+  }
+  let(:parent_guardian_email_address) { "lily@example.com" }
+
+  before do
+    sign_in(student_profile)
+  end
+
+  describe "updating a student profile" do
+    before do
+      patch student_profile_path, params: params, headers: headers
+    end
+
+    let(:headers) { { "ACCEPT" => "text/html" } }
+    let(:params) do
+      { student_profile: {
+        account_attributes: { id: student_account.id }
+      } }
+    end
+
+    context "when the :setting_location param is present, and country and latitude are both blank" do
+      let(:params) do
+        {
+          setting_location: { bing: "bong" },
+          student_profile: {
+            account_attributes: { id: student_account.id,
+                                  country: "",
+                                  latitude: "" }
+          }
+        }
+      end
+
+      it "renders the location_details/show template" do
+        expect(response).to render_template("location_details/show")
+      end
+    end
+
+    context "when updating is successful" do
+      before do
+        allow(ProfileUpdating).to receive(:execute).and_return(true)
+
+        patch student_profile_path, params: params, headers: headers
+      end
+
+      context "when it's an HTML request" do
+        let(:headers) { { "ACCEPT" => "text/html" } }
+
+        it "redirects to the student profile page" do
+          expect(response).to redirect_to("/student/profile")
+        end
+      end
+
+      context "when it's a JSON request" do
+        let(:headers) { {  "ACCEPT" => "application/json" } }
+
+        it "returns a success message in JSON format" do
+          expect(response.body).to include("You updated your account!")
+          expect(response.content_type).to eq("application/json")
+        end
+      end
+    end
+
+    context "when a student is trying to change their email address without providing their existing password" do
+      let(:params) do
+        {
+          student_profile: {
+            account_attributes: { id: student_account.id,
+                                  email: "harry2.0@example.com" }
+          }
+        }
+      end
+
+      it "renders the edit email address template" do
+        expect(response).to render_template("email_addresses/edit")
+      end
+    end
+
+    context "when a student is trying to set a new password without providing their existing password" do
+      let(:params) do
+        {
+          student_profile: {
+            account_attributes: { id: student_account.id,
+                                  password: "mugglesftw" }
+          }
+        }
+      end
+
+      it "renders the edit password template" do
+        expect(response).to render_template("passwords/edit")
+      end
+    end
+
+    context "when a student is changing their email address to be the same as their parent's email address" do
+      let(:params) do
+        {
+          student_profile: {
+            account_attributes: { id: student_account.id,
+                                  email: parent_guardian_email_address,
+                                  existing_password: "secret1234" }
+          }
+        }
+      end
+
+      it "renders the edit email address template" do
+        expect(response).to render_template("email_addresses/edit")
+      end
+    end
+
+    context "when there is any other validation error" do
+      let(:params) do
+        {
+          student_profile: {
+            account_attributes: { id: student_account.id,
+                                  first_name: "",
+                                  last_name: "" }
+          }
+        }
+      end
+
+      it "renders the edit profile template" do
+        expect(response).to render_template("edit")
+      end
+    end
+  end
+end

--- a/spec/requests/student/profile_requests_spec.rb
+++ b/spec/requests/student/profile_requests_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe "Student Profile Requests", type: :request do
       end
     end
 
+    context "when a student already has an email address that's the same as their parent's email address, and they try to update their profile" do
+      it "renders the parental consent form" do
+        student_account.update_column(:email, parent_guardian_email_address)
+
+        patch student_profile_path, params: params, headers: headers
+
+        expect(response).to render_template("student/parental_consent_notices/new")
+      end
+    end
+
     context "when a student is trying to change their email address without providing their existing password" do
       let(:params) do
         {


### PR DESCRIPTION
I added a custom validator to ensure that the student's email address is different than the parent/guardian's email address.

Repro steps are in the issue #2347


