### PR TITLE
#2378 make rpe_officiality_finalized config independent of user timezone

### DIFF
--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -24,7 +24,7 @@ module ImportantDates
     year = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_YEAR"))
     month = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_MONTH"))
     day = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_DAY"))
-    Time.find_zone(Rails.configuration.time_zone).local(year, month, day, 0, 0, 0)
+    Time.find_zone(Rails.configuration.time_zone).local(year, month, day, 0, 1)
   end
 
   def self.submission_deadline

--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -24,7 +24,7 @@ module ImportantDates
     year = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_YEAR"))
     month = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_MONTH"))
     day = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_DAY"))
-    Time.zone.local(year, month, day)
+    Time.find_zone(Rails.configuration.time_zone).local(year, month, day, 0, 0, 0)
   end
 
   def self.submission_deadline

--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -24,7 +24,7 @@ module ImportantDates
     year = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_YEAR"))
     month = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_MONTH"))
     day = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_DAY"))
-    Time.find_zone(Rails.configuration.time_zone).local(year, month, day, 0, 1)
+    Time.find_zone(Rails.configuration.time_zone).local(year, month, day, 23, 59)
   end
 
   def self.submission_deadline

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -105,7 +105,7 @@ class RegionalPitchEvent < ActiveRecord::Base
   end
 
   def officiality
-    if Time.zone.today > ImportantDates.rpe_officiality_finalized
+    if Time.zone.now >= ImportantDates.rpe_officiality_finalized
       official? ? :official : :unofficial
     else
       :pending

--- a/spec/helpers/important_dates_spec.rb
+++ b/spec/helpers/important_dates_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe ImportantDates do
   describe ".rpe_officiality_finalized" do
-    it "is 12:01 am of the configured date" do
-      expect(ImportantDates.rpe_officiality_finalized.hour).to eq(0)
-      expect(ImportantDates.rpe_officiality_finalized.min).to eq(1)
+    it "is 11:59 pm of the configured date" do
+      expect(ImportantDates.rpe_officiality_finalized.hour).to eq(23)
+      expect(ImportantDates.rpe_officiality_finalized.min).to eq(59)
     end
 
     it "is the application configured time zone regardless of user time zone" do

--- a/spec/helpers/important_dates_spec.rb
+++ b/spec/helpers/important_dates_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe ImportantDates do
+  describe ".rpe_officiality_finalized" do
+    it "is 12:01 am of the configured date" do
+      expect(ImportantDates.rpe_officiality_finalized.hour).to eq(0)
+      expect(ImportantDates.rpe_officiality_finalized.min).to eq(1)
+    end
+
+    it "is the application configured time zone regardless of user time zone" do
+      [
+        'Alaska',
+        'London',
+        'Tokyo',
+      ].each do |zone|
+        Time.use_zone(zone) do
+          expect(ImportantDates.rpe_officiality_finalized.time_zone.name).to eq(Rails.configuration.time_zone)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/regional_pitch_event_spec.rb
+++ b/spec/models/regional_pitch_event_spec.rb
@@ -2,38 +2,46 @@ require "rails_helper"
 
 RSpec.describe RegionalPitchEvent do
   describe ".officiality" do
-    let(:finalization_date) { ImportantDates.rpe_officiality_finalized }
+    let(:finalization_point) { ImportantDates.rpe_officiality_finalized }
     let(:official_rpe) { FactoryBot.create(:rpe, unofficial: false) }
     let(:unofficial_rpe) { FactoryBot.create(:rpe, unofficial: true) }
 
-    it "is pending before finalization date" do
+    it "is pending before finalization point" do
       [
-        finalization_date - 1.day,
-        finalization_date - 1.minute,
-      ].each do |date|
-        Timecop.freeze(date) do
+        finalization_point - 1.day,
+        finalization_point - 1.minute,
+      ].each do |point|
+        Timecop.freeze(point) do
           expect(official_rpe.officiality).to be :pending
           expect(unofficial_rpe.officiality).to be :pending
         end
       end
     end
 
-    it "is appropriate status on or after finalization date" do
+    it "is appropriate status on or after finalization point" do
       [
-        finalization_date,
-        finalization_date + 1.day,
-      ].each do |date|
-        Timecop.freeze(date) do
+        finalization_point,
+        finalization_point + 1.minute,
+        finalization_point + 1.day,
+      ].each do |point|
+        Timecop.freeze(point) do
           expect(official_rpe.officiality).to be :official
           expect(unofficial_rpe.officiality).to be :unofficial
         end
       end
     end
 
-    it "is independent of timezone" do
-      Timecop.freeze(finalization_date) do
-        west = Time.use_zone('Alaska') { official_rpe.officiality }
-        east = Time.use_zone('Tokyo') { official_rpe.officiality }
+    it "is independent of user time zone" do
+      Timecop.freeze(finalization_point) do
+        west_zone = Time.find_zone('International Date Line West')
+        app_zone = Time.zone
+        east_zone = Time.find_zone('Samoa')
+
+        expect(west_zone).to be < app_zone
+        expect(app_zone).to be < east_zone
+
+        west = Time.use_zone('International Date Line West') { official_rpe.officiality }
+        east = Time.use_zone('Samoa') { official_rpe.officiality }
 
         expect(west).to eq(east)
       end


### PR DESCRIPTION
Despite only specifying a date in configuration (year/month/day) what we're really talking about is a specific time in a specific timezone when we want RPE statuses to go from being pending to finalized. This change reflects that a little bit better: the config is now assumed to be expressing midnight of the date configured, in the application's default timezone which is Pacific time.

Now the comparison against an RA's local time can happen much more transparently, and all RA's will be able to see their statuses simultaneously rather than on a rolling basis throughout the configured day, which I think was the intention.