### PR TITLE
#2391 default events to unofficial and show event timestamps

### DIFF
--- a/app/data_grids/events_grid.rb
+++ b/app/data_grids/events_grid.rb
@@ -49,6 +49,14 @@ class EventsGrid
     link_to "view", admin_event_path(event)
   end
 
+  column :created_at do
+    created_at.strftime("%Y-%m-%d %H:%M %Z")
+  end
+
+  column :updated_at, header: "Last updated at" do
+    updated_at.strftime("%Y-%m-%d %H:%M %Z")
+  end
+
   filter :ambassador_name do |value|
     names = value.split(" ")
     first_name = names.first

--- a/app/views/admin/regional_pitch_events/show.en.html.erb
+++ b/app/views/admin/regional_pitch_events/show.en.html.erb
@@ -95,6 +95,25 @@
           </dl>
         </div>
       </div>
+
+      <hr />
+
+      <div class="grid grid--bleed">
+        <div class="grid__col-auto">
+          <dl>
+            <dt>Created at</dt>
+
+            <dd>
+              <%= @event.created_at.strftime("%Y-%m-%d %H:%M %Z") %>
+            </dd>
+
+            <dt>Updated at</dt>
+
+            <dd>
+              <%= @event.updated_at.strftime("%Y-%m-%d %H:%M %Z") %>
+            </dd>
+        </div>
+      </div>
     </div>
 
     <p>

--- a/db/migrate/20200303221521_change_regional_pitch_event_unofficial_default.rb
+++ b/db/migrate/20200303221521_change_regional_pitch_event_unofficial_default.rb
@@ -1,0 +1,5 @@
+class ChangeRegionalPitchEventUnofficialDefault < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :regional_pitch_events, :unofficial, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1044,7 +1044,7 @@ CREATE TABLE public.regional_pitch_events (
     venue_address character varying,
     event_link character varying,
     name character varying,
-    unofficial boolean DEFAULT false,
+    unofficial boolean DEFAULT true,
     seasons text[] DEFAULT '{}'::text[],
     teams_count integer DEFAULT 0,
     capacity integer
@@ -3058,6 +3058,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191120151220'),
 ('20191120151819'),
 ('20191220170611'),
-('20200115211026');
+('20200115211026'),
+('20200303221521');
 
 


### PR DESCRIPTION
This should help out the program team, because now events will be defaulted to "unofficial" until they go through and promote certain events to be official. After that point, RAs aren't supposed to create more events, but if they do, they will be unofficial by default with no action from the program team, which is appropriate for the program policy.

@shaunxp20 one thing that bugged me while doing this one... can you think of a good place to pull out the timestamp formatting? Should that live in a helper somewhere?