### PR TITLE
#2423 prevent judges switching to mentors when the reverse is turned off

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -746,6 +746,16 @@ class Account < ActiveRecord::Base
     end
   end
 
+  def can_switch_to_mentor?
+    if is_an_ambassador?
+      true
+    elsif is_a_judge?
+      !!ENV.fetch("ENABLE_SWITCH_TO_JUDGE", false)
+    else
+      false
+    end
+  end
+
   def email_confirmed!
     update(email_confirmed_at: Time.current)
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -740,7 +740,7 @@ class Account < ActiveRecord::Base
     if is_an_ambassador?
       !!ENV.fetch("ENABLE_RA_SWITCH_TO_JUDGE", false) && is_a_judge?
     elsif is_a_mentor?
-      !!ENV.fetch("ENABLE_SWITCH_TO_JUDGE", false)
+      !!ENV.fetch("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", false)
     else
       false
     end
@@ -750,7 +750,7 @@ class Account < ActiveRecord::Base
     if is_an_ambassador?
       true
     elsif is_a_judge?
-      !!ENV.fetch("ENABLE_SWITCH_TO_JUDGE", false)
+      !!ENV.fetch("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", false)
     else
       false
     end

--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -4,9 +4,11 @@
       <h1 class="page-heading">
         Judge Dashboard
 
-        <small>
-          <%= link_to "Switch to Mentor mode", mentor_dashboard_path %>
-        </small>
+        <% if current_judge.can_switch_to_mentor? %>
+          <small>
+            <%= link_to "Switch to Mentor mode", mentor_dashboard_path %>
+          </small>
+        <% end %>
 
         <% if current_judge.is_an_ambassador? %>
           <small>

--- a/spec/features/judge/switch_to_mentor_spec.rb
+++ b/spec/features/judge/switch_to_mentor_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Judges switch to mentor mode" do
+
+  context "config ON" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(true)
+    end
+
+    scenario "judges can switch to mentor profile" do
+      judge = FactoryBot.create(:judge, :onboarded)
+
+      sign_in(judge)
+
+      expect(judge.is_a_mentor?).to be_falsey
+
+      click_link "Switch to Mentor mode"
+      expect(current_path).to eq(mentor_dashboard_path)
+      expect(judge.reload.is_a_mentor?).to be_truthy
+
+      click_link "Switch to Judge mode"
+      expect(current_path).to eq(judge_dashboard_path)
+    end
+  end
+
+  context "config OFF" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+    end
+
+    scenario "judges do not see mentor mode link" do
+      judge = FactoryBot.create(:judge, :onboarded)
+
+      sign_in(judge)
+
+      expect(current_path).to eq(judge_dashboard_path)
+      expect(page).not_to have_link("Switch to Mentor mode")
+    end
+  end
+end
+    

--- a/spec/features/judge/switch_to_mentor_spec.rb
+++ b/spec/features/judge/switch_to_mentor_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Judges switch to mentor mode" do
   context "config ON" do
     before do
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(true)
+      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(true)
     end
 
     scenario "judges can switch to mentor profile" do
@@ -27,7 +27,7 @@ RSpec.feature "Judges switch to mentor mode" do
   context "config OFF" do
     before do
       allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+      allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(false)
     end
 
     scenario "judges do not see mentor mode link" do

--- a/spec/features/mentor/switch_to_judging_spec.rb
+++ b/spec/features/mentor/switch_to_judging_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Mentors switch to judging mode" do
   
   before do
     allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(true)
+    allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(true)
   end
 
   scenario "mentors with a judge profile can switch to judge mode" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -772,7 +772,7 @@ RSpec.describe Account do
     describe "when config is off" do
       before do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(false)
         allow(ENV).to receive(:fetch).with("ENABLE_RA_SWITCH_TO_JUDGE", any_args).and_return(false)
       end
 
@@ -786,7 +786,7 @@ RSpec.describe Account do
     describe "when mentor config is on" do
       before do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(1)
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(1)
         allow(ENV).to receive(:fetch).with("ENABLE_RA_SWITCH_TO_JUDGE", any_args).and_return(false)
       end
 
@@ -800,7 +800,7 @@ RSpec.describe Account do
     describe "when RA config is on" do
       before do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(false)
         allow(ENV).to receive(:fetch).with("ENABLE_RA_SWITCH_TO_JUDGE", any_args).and_return(1)
       end
 
@@ -817,7 +817,7 @@ RSpec.describe Account do
     describe "when config is off" do
       before do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(false)
       end
 
       it "allows RAs" do
@@ -830,7 +830,7 @@ RSpec.describe Account do
     describe "when mentor config is on" do
       before do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(1)
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", any_args).and_return(1)
       end
 
       it "allows judges and RAs" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -812,4 +812,32 @@ RSpec.describe Account do
       end
     end
   end
+
+  describe "#can_switch_to_mentor?" do
+    describe "when config is off" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(false)
+      end
+
+      it "allows RAs" do
+        expect(FactoryBot.create(:student).can_switch_to_mentor?).to be false
+        expect(FactoryBot.create(:judge).can_switch_to_mentor?).to be false
+        expect(FactoryBot.create(:regional_ambassador).can_switch_to_mentor?).to be true
+      end
+    end
+
+    describe "when mentor config is on" do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with("ENABLE_SWITCH_TO_JUDGE", any_args).and_return(1)
+      end
+
+      it "allows judges and RAs" do
+        expect(FactoryBot.create(:student).can_switch_to_mentor?).to be false
+        expect(FactoryBot.create(:judge).can_switch_to_mentor?).to be true
+        expect(FactoryBot.create(:regional_ambassador).can_switch_to_mentor?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
This prevents users who sign up as judges from clicking a dashboard button to switch to mentor mode and getting stuck there if there reverse judge to mentor mode button is turned off in config.

The config was `ENABLE_SWITCH_TO_JUDGE`, but is renamed by this PR to `ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR`.

RAs are an exception here, in that RAs can always switch between mentor mode and RA mode, so they don't face the same dead end problem.