### PR TITLE
circleci suddenly cares that this config is duplicated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -54,7 +54,6 @@ jobs:
           COOKIES_SIGNUP_WIZARD_MODE: signup_wizard_mode_SEPT_2018
           COOKIES_SESSION_TOKEN: session_token_JUNE_2018
           COOKIES_SIGNUP_EMAIL: n-a
-          MAILGUN_PRIVATE_KEY: n-a
           MENTOR_TRAINING_URL: https://google.com
           DATES_NEW_SEASON_START_MONTH: 10
           DATES_NEW_SEASON_START_DAY: 1


### PR DESCRIPTION
Builds are breaking all of a sudden with

```
# found duplicate key MAILGUN_PRIVATE_KEY
#  in 'string', line 57, column 11:
#               MAILGUN_PRIVATE_KEY: n-a
#               ^
```