### PR TITLE
#2411 don't show RAs the suspension status or controls on judge

### DIFF
--- a/app/views/admin/participants/_judge_debugging.html.erb
+++ b/app/views/admin/participants/_judge_debugging.html.erb
@@ -69,37 +69,39 @@
   </dl>
 </div>
 
-<h4 class="reset">Judge suspension</h4>
+<% if current_account.is_admin? %>
+  <h4 class="reset">Judge suspension</h4>
 
-<div class="panel">
-  <p class="hint">
-    Suspending a judge does not mean that their scores will be deleted, but
-    they will not be able to create new ones. Please note any changes you make
-    here in the appropriate tracking sheet.
-  </p>
+  <div class="panel">
+    <p class="hint">
+      Suspending a judge does not mean that their scores will be deleted, but
+      they will not be able to create new ones. Please note any changes you make
+      here in the appropriate tracking sheet.
+    </p>
 
-  <% if profile.suspended? %>
-    <%= link_to(
-      "Enable this judge",
-      admin_judge_unsuspend_path(profile),
-      class: "button danger",
-      data: {
-        method: :patch,
-        confirm: "You are about to ENABLE this suspended judge"
-      }
-    ) %>
-  <% else %>
-    <%= link_to(
-      "Suspend this judge",
-      admin_judge_suspend_path(profile),
-      class: "button danger",
-      data: {
-        method: :patch,
-        confirm: "You are about to SUSPEND this judge"
-      }
-    ) %>
-  <% end %>
-</div>
+    <% if profile.suspended? %>
+      <%= link_to(
+        "Enable this judge",
+        admin_judge_unsuspend_path(profile),
+        class: "button danger",
+        data: {
+          method: :patch,
+          confirm: "You are about to ENABLE this suspended judge"
+        }
+      ) %>
+    <% else %>
+      <%= link_to(
+        "Suspend this judge",
+        admin_judge_suspend_path(profile),
+        class: "button danger",
+        data: {
+          method: :patch,
+          confirm: "You are about to SUSPEND this judge"
+        }
+      ) %>
+    <% end %>
+  </div>
+<% end %>
 
 <% unless profile.mentor_profile.present? %>
   <h4 class="reset">Environment information</h4>

--- a/spec/views/admin/participants/judge_debugging_spec.rb
+++ b/spec/views/admin/participants/judge_debugging_spec.rb
@@ -13,8 +13,13 @@ RSpec.describe "admin/participants/judge_debugging", type: :view do
     )
   }
 
+  let(:current_profiles_account) {
+    FactoryBot.build_stubbed(:account)
+  }
   let(:current_profile) {
-    FactoryBot.create(:judge).judge_profile
+    FactoryBot.build_stubbed(:judge,
+      account: current_profiles_account
+    ).judge_profile
   }
 
   context "as an admin" do

--- a/spec/views/admin/participants/judge_debugging_spec.rb
+++ b/spec/views/admin/participants/judge_debugging_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "admin/participants/judge_debugging", type: :view do
+  before do
+    render partial: "admin/participants/judge_debugging",
+      locals: { current_account: current_account, profile: current_profile }
+  end
+
+  let(:current_account) {
+    instance_double(
+      Account,
+      is_admin?: current_account_admin
+    )
+  }
+
+  let(:current_profile) {
+    FactoryBot.create(:judge).judge_profile
+  }
+
+  context "as an admin" do
+    let(:current_account_admin) { true }
+    
+    it "shows judge suspended status" do
+      expect(rendered).to have_text("Suspended?")
+    end
+
+    it "shows judge suspension section" do
+      expect(rendered).to have_text("Judge suspension")
+      expect(rendered).to have_link("Suspend this judge")
+    end
+  end
+
+  context "as an RA" do
+    let(:current_account_admin) { false }
+
+    it "does not show judge suspended status" do
+      expect(rendered).not_to have_text("Suspended?")
+    end
+
+    it "does not show judge suspension section" do
+      expect(rendered).not_to have_text("Judge suspension")
+      expect(rendered).not_to have_link("Suspend this judge")
+    end
+  end
+end


### PR DESCRIPTION
I realized just as I was writing up QA that RAs could see (but not actually use) the judge suspension controls, so this fixes that.