### PR TITLE
#2413 Update puma and nokogiri to address security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (3.18.1.330)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     normalize-rails (4.1.1)
     paranoia (2.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,7 +298,7 @@ GEM
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
     public_suffix (4.0.3)
-    puma (3.12.2)
+    puma (3.12.4)
     rack (2.1.1)
     rack-protection (2.0.8.1)
       rack


### PR DESCRIPTION
Bump puma and nokogiri versions to address security alerts. 

#2413 