### PR TITLE
#2433 Add deleted score info to judge profile admin page

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -6,6 +6,10 @@
   background-color: rgba(200, 200, 200, 0.4);
 }
 
+.background-color--subtle-red {
+  background-color: #fed7d7;
+}
+
 .background-color--white {
   background-color: white;
 }
@@ -84,6 +88,10 @@
 
 .height--100-percent {
   height: 100%;
+}
+
+.width--100-percent {
+  width: 100%;
 }
 
 .hover--opacity-75:not(.opacity--100) {

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -111,7 +111,7 @@ module Admin
 
     def submission_score(account)
       if account.judge_profile.present?
-        account.judge_profile.submission_scores.current.complete
+        account.judge_profile.submission_scores.current.with_deleted.complete
       else
         SubmissionScore.none
       end

--- a/app/views/admin/participants/_judge_scores.html.erb
+++ b/app/views/admin/participants/_judge_scores.html.erb
@@ -1,23 +1,25 @@
 <% if scores.any? %>
-  <table>
+  <table class="width--100-percent">
     <th>
       <tr>
         <td>Team Name</td>
         <td>Submission Name</td>
         <td>Score</td>
-        <td>Details </td>
+        <td>Deleted</td>
+        <td>Details</td>
       </tr>
     </th>
     <tbody>
       <% scores.each do |score| %>
-        <tr>
+        <tr class="<%= score.deleted? ? "background-color--subtle-red" : "" %>">
           <td><%= score.team_name %></td>
           <td>
             <%= link_to score.team_submission_app_name,
                         admin_team_submission_path(score.team_submission_id),
                         class: "cta-link" %>
           </td>
-          <td> <%= score.total %> / <%= score.total_possible %> </td>
+          <td><%= score.total %> / <%= score.total_possible %></td>
+          <td class="deleted-info"><%= score.deleted? ? "yes" : "no" %></td>
           <td>
             <%= link_to 'View',
                         admin_score_path(score),

--- a/spec/views/admin/participants/judge_scores_spec.rb
+++ b/spec/views/admin/participants/judge_scores_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "admin/participants/judge_scores", type: :view do
+  before do
+    render partial: "admin/participants/judge_scores", locals: { scores: scores }
+  end
+
+  context "when a judge has scored a submission" do
+    let(:scores) { [score_submission] }
+    let(:score_submission) { instance_double(SubmissionScore,
+      team_submission_id: 1,
+      team_name: "Amazing Team",
+      team_submission_app_name: "Amazing App",
+      total: 99,
+      total_possible: 100,
+      deleted?: score_submission_deleted) }
+    let(:score_submission_deleted) { false }
+
+    it "displays score summary information" do
+      expect(rendered).to have_content("Score")
+      expect(rendered).to have_content("99 / 100")
+    end
+
+    it "displays the team name" do
+      expect(rendered).to have_content("Team Name")
+      expect(rendered).to have_content("Amazing Team")
+    end
+
+    it "displays the team's submission name" do
+      expect(rendered).to have_content("Submission Name")
+      expect(rendered).to have_content("Amazing App")
+    end
+
+    it "displays displays a link to view score details" do
+      expect(rendered).to have_content("Details")
+      expect(rendered).to have_link("View")
+    end
+
+    describe "deleted information" do
+      context "when the score is marked as deleted" do
+        let(:score_submission_deleted) { true }
+
+        it "indicates that the score has been deleted" do
+          expect(rendered).to have_content("Deleted")
+          expect(rendered).to have_css(".deleted-info", text: "yes")
+        end
+
+        it "displays the the deleted information with a subtle red background color" do
+          expect(rendered).to have_css(".background-color--subtle-red")
+        end
+      end
+
+      context "when the score is not marked as deleted" do
+        let(:score_submission_deleted) { false }
+
+        it "indicates that the score has not been deleted" do
+          expect(rendered).to have_content("Deleted")
+          expect(rendered).to have_css(".deleted-info", text: "no")
+        end
+
+        it "displays the the deleted information without a special background color" do
+          expect(rendered).not_to have_css(".background-color--subtle-red")
+        end
+      end
+    end
+  end
+
+  context "when a judge has not scored any submissions" do
+    let(:scores) { [] }
+
+    it "displays a 'no scores' message" do
+      expect(rendered).to have_content("No scores")
+    end
+  end
+end


### PR DESCRIPTION
This will allow admins to view deleted scores on a judge's profile page.

#2433

