### PR TITLE
#2382 Don't allow admins to approve deleted scores

### DIFF
--- a/app/views/admin/scores/_score_controls.html.erb
+++ b/app/views/admin/scores/_score_controls.html.erb
@@ -1,6 +1,13 @@
 <% if current_account.admin? %>
   <div class="admin-actions-buttons">
-    <% if score.pending_approval? %>
+  <% if score.deleted? %>
+    <%= button_to "Restore this score",
+      admin_score_restore_path(score),
+      method: :patch,
+      class: "button",
+      data: { confirm: "You are about to RESTORE this score" }
+    %>
+    <% elsif score.pending_approval? %>
       <%= button_to "Approve this score",
         admin_score_approvals_path(id: score.id),
         method: :post,
@@ -10,13 +17,6 @@
           positive: "true",
         }
       %>
-  <% elsif score.deleted? %>
-    <%= button_to "Restore this score",
-      admin_score_restore_path(score),
-      method: :patch,
-      class: "button",
-      data: { confirm: "You are about to RESTORE this score" }
-    %>
   <% end %>
 
   <% if !score.deleted? %>

--- a/spec/views/admin/scores/score_controls_spec.rb
+++ b/spec/views/admin/scores/score_controls_spec.rb
@@ -19,35 +19,71 @@ RSpec.describe "admin/scores/score_controls", type: :view do
   context "as an admin" do
     let(:current_account_admin) { true }
 
-    context "when the score is deleted" do
-      let(:score_submission_deleted) { true }
+    context "when a score is pending approval and not deleted" do
+      let(:score_submission_pending_approval) { true }
+      let(:score_submission_deleted) { false }
 
-      it "renders a button to restore the score" do
-        expect(rendered).to have_button("Restore this score")
+      it "renders a button to approve the score" do
+        expect(rendered).to have_button("Approve this score")
+      end
+
+      it "renders a button to delete the score" do
+        expect(rendered).to have_button("Delete this score")
+      end
+
+      it "does not render a button to restore the score" do
+        expect(rendered).not_to have_button("Restore this score")
       end
     end
 
-    context "when the score is not deleted" do
+    context "when a score is offcial/approved and is not deleted" do
+      let(:score_submission_pending_approval) { false }
       let(:score_submission_deleted) { false }
 
       it "renders a button to delete the score" do
         expect(rendered).to have_button("Delete this score")
       end
-    end
-
-    context "when the score is pending approval" do
-      let(:score_submission_pending_approval) { true }
-
-      it "renders a button to approve the score" do
-        expect(rendered).to have_button("Approve this score")
-      end
-    end
-
-    context "when the score is not pending approval" do
-      let(:score_submission_pending_approval) { false }
 
       it "does not render a button to approve the score" do
         expect(rendered).not_to have_button("Approve this score")
+      end
+
+      it "does not render a button to restore the score" do
+        expect(rendered).not_to have_button("Restore this score")
+      end
+    end
+
+    context "when a score is pending approval and deleted" do
+      let(:score_submission_pending_approval) { true }
+      let(:score_submission_deleted) { true }
+
+      it "renders a button to restore the score" do
+        expect(rendered).to have_button("Restore this score")
+      end
+
+      it "does not render a button to approve the score" do
+        expect(rendered).not_to have_button("Approve this score")
+      end
+
+      it "does not render a button to delete the score" do
+        expect(rendered).not_to have_button("Delete this score")
+      end
+    end
+
+    context "when a score is official/approved and deleted" do
+      let(:score_submission_pending_approval) { false }
+      let(:score_submission_deleted) { true }
+
+      it "renders a button to restore the score" do
+        expect(rendered).to have_button("Restore this score")
+      end
+
+      it "does not render a button to approve the score" do
+        expect(rendered).not_to have_button("Approve this score")
+      end
+
+      it "does not render a button to delete the score" do
+        expect(rendered).not_to have_button("Delete this score")
       end
     end
   end


### PR DESCRIPTION
While writing up the QA instructions for #2382, I realized that if there's a deleted score that is pending approval, an admin can view and approve this score. For these cases, this PR will make it so that the flow will be to first restore the score, and then (if desired) approve it.

#2382


