### PR TITLE
#2425 Add mentor expertise to participants page

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -25,6 +25,14 @@ class AccountsGrid
     end
   end
 
+  column :mentor_expertise do
+    if mentor_profile.present?
+      mentor_profile.expertise_names.join(",")
+    else
+      "-"
+    end
+  end
+
   column :judge_industry do
     if judge_profile.present?
       judge_profile.industry_text


### PR DESCRIPTION
This will make "Mentor expertise" a selectable column for admins and RAs to optionally view on the participants page. It will also be on the CSV report.

#2425


