### PR TITLE
#2432 Add deleted scores to admin score details page

### DIFF
--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -90,6 +90,10 @@
   height: 100%;
 }
 
+.width--70-percent {
+  width: 70%;
+}
+
 .width--100-percent {
   width: 100%;
 }

--- a/app/controllers/admin/score_details_controller.rb
+++ b/app/controllers/admin/score_details_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ScoreDetailsController < AdminController
     def show
-      @submission = TeamSubmission.includes(:team, :submission_scores)
+      @submission = TeamSubmission.includes(:team, :scores_including_deleted)
         .find(params.fetch(:id))
 
       render 'regional_ambassador/score_details/show'

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -126,6 +126,10 @@ class TeamSubmission < ActiveRecord::Base
     -> { current },
     class_name: "SubmissionScore"
 
+  has_many :scores_including_deleted,
+    -> { with_deleted },
+    class_name: "SubmissionScore"
+
   has_many :complete_submission_scores,
     -> { current.complete },
     class_name: "SubmissionScore"

--- a/app/views/regional_ambassador/score_details/_scores_table.en.html.erb
+++ b/app/views/regional_ambassador/score_details/_scores_table.en.html.erb
@@ -1,21 +1,18 @@
-<%
-  status = String(status)
-  round = String(round)
-%>
-
-<h5><%= status.titlecase %> <%= round.titlecase %> scores</h5>
-
-<% if scores.public_send(round).public_send(status).any? %>
-  <table>
+<% if scores.present? %>
+  <table class="width--70-percent">
     <tbody>
-      <% scores.public_send(round).public_send(status).each do |score| %>
-        <tr>
-          <td style="width: 100px;"><%= score.total %> / <%= score.total_possible %></td>
-          <td style="width: 200px;">
+      <% scores.each do |score| %>
+        <tr class="<%= (current_account.admin? && score.deleted?) ? "background-color--subtle-red" : "" %>">
+          <td><%= score.total %> / <%= score.total_possible %></td>
+          <td>
             <%= link_to score.judge_name,
               [current_scope, :participant, id: score.judge_profile.account_id] %>
           </td>
-          <td style="width: 100px;"><%= score.official? ? "official" : "unofficial" %></td>
+          <td class="official-info"><%= score.official? ? "official" : "unofficial" %></td>
+
+          <% if current_account.admin? %>
+            <td class="deleted-info"><%= score.deleted? ? "deleted" : "" %></td>
+          <% end %>
 
           <td>
             <%= link_to 'View score',
@@ -27,5 +24,5 @@
     </tbody>
   </table>
 <% else %>
-  — No <%= status %> <%= round %> scores —
+  — No scores —
 <% end %>

--- a/app/views/regional_ambassador/score_details/show.en.html.erb
+++ b/app/views/regional_ambassador/score_details/show.en.html.erb
@@ -27,33 +27,35 @@
     <% end %>
   </dl>
 
+  <% scores = current_account.admin? ? @submission.scores_including_deleted : @submission.scores %>
+
   <% if current_account.is_admin? or SeasonToggles.display_scores? %>
 
+    <h5>Complete Semifinals scores</h5>
     <%= render 'regional_ambassador/score_details/scores_table',
-      scores: @submission.scores,
-      round: :semifinals,
-      status: :complete
-    %>
+      scores: scores.semifinals.complete,
+      current_account: current_account,
+      current_scope: current_scope %>
 
+    <h5>Incomplete Semifinals scores</h5>
     <%= render 'regional_ambassador/score_details/scores_table',
-      scores: @submission.scores,
-      round: :semifinals,
-      status: :incomplete
-    %>
+      scores: scores.semifinals.incomplete,
+      current_account: current_account,
+      current_scope: current_scope %>
 
   <% end %>
 
+  <h5>Complete Quarterfinal scores</h5>
   <%= render 'regional_ambassador/score_details/scores_table',
-    scores: @submission.scores,
-    round: :quarterfinals,
-    status: :complete
-  %>
+    scores: scores.quarterfinals.complete,
+    current_account: current_account,
+    current_scope: current_scope %>
 
+  <h5>Incomplete Quarterfinal scores</h5>
   <%= render 'regional_ambassador/score_details/scores_table',
-    scores: @submission.scores,
-    round: :quarterfinals,
-    status: :incomplete
-  %>
+    scores: scores.quarterfinals.incomplete,
+    current_account: current_account,
+    current_scope: current_scope %>
 
   <p>
     <%= link_to 'Back to scores',

--- a/app/views/regional_ambassador/score_details/show.en.html.erb
+++ b/app/views/regional_ambassador/score_details/show.en.html.erb
@@ -32,30 +32,30 @@
   <% if current_account.is_admin? or SeasonToggles.display_scores? %>
 
     <h5>Complete Semifinals scores</h5>
-    <%= render 'regional_ambassador/score_details/scores_table',
-      scores: scores.semifinals.complete,
-      current_account: current_account,
-      current_scope: current_scope %>
+    <div id="complete-semifinal-scores">
+      <%= render 'regional_ambassador/score_details/scores_table',
+        scores: scores.semifinals.complete %>
+    </div>
 
     <h5>Incomplete Semifinals scores</h5>
-    <%= render 'regional_ambassador/score_details/scores_table',
-      scores: scores.semifinals.incomplete,
-      current_account: current_account,
-      current_scope: current_scope %>
+    <div id="incomplete-semifinal-scores">
+      <%= render 'regional_ambassador/score_details/scores_table',
+        scores: scores.semifinals.incomplete %>
+    </div>
 
   <% end %>
 
   <h5>Complete Quarterfinal scores</h5>
-  <%= render 'regional_ambassador/score_details/scores_table',
-    scores: scores.quarterfinals.complete,
-    current_account: current_account,
-    current_scope: current_scope %>
+  <div id="complete-quarterfinal-scores">
+    <%= render 'regional_ambassador/score_details/scores_table',
+      scores: scores.quarterfinals.complete %>
+  </div>
 
   <h5>Incomplete Quarterfinal scores</h5>
-  <%= render 'regional_ambassador/score_details/scores_table',
-    scores: scores.quarterfinals.incomplete,
-    current_account: current_account,
-    current_scope: current_scope %>
+  <div id="incomplete-quarterfinal-scores">
+    <%= render 'regional_ambassador/score_details/scores_table',
+      scores: scores.quarterfinals.incomplete %>
+  </div>
 
   <p>
     <%= link_to 'Back to scores',

--- a/spec/factories/submission_scores.rb
+++ b/spec/factories/submission_scores.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       completed_at { nil }
     end
 
+    trait :approved do
+      approved_at { Time.current }
+    end
+
     trait :senior do
       association(:team_submission, factory: [:team_submission, :complete, :senior])
     end

--- a/spec/system/regional_ambassador/view_score_details_spec.rb
+++ b/spec/system/regional_ambassador/view_score_details_spec.rb
@@ -1,0 +1,253 @@
+require "rails_helper"
+
+RSpec.describe "viewing score details page" do
+  let!(:regional_ambassador) { FactoryBot.create(:regional_ambassador, :approved, :chicago) }
+  let!(:team) { FactoryBot.create(:team, :chicago, name: 'Ravenclaw') }
+  let!(:team_submission) { FactoryBot.create(:team_submission,
+    :complete,
+    :semifinalist,
+    :chicago,
+    team: team) }
+  let!(:complete_quarterfinal_score) { FactoryBot.create(:score,
+    :complete,
+    :quarterfinals,
+    :minimum_auto_approved_total,
+    :approved,
+    :chicago,
+    team_submission: team_submission) }
+  let!(:incomplete_quarterfinal_score) { FactoryBot.create(:score,
+    :incomplete,
+    :quarterfinals,
+    :minimum_auto_approved_total,
+    :approved,
+    :chicago,
+    team_submission: team_submission) }
+  let!(:complete_semifinal_score) { FactoryBot.create(:score,
+    :complete,
+    :semifinals,
+    :minimum_auto_approved_total,
+    :approved,
+    :chicago,
+    team_submission: team_submission) }
+  let!(:incomplete_semifinal_score) { FactoryBot.create(:score,
+    :incomplete,
+    :semifinals,
+    :minimum_auto_approved_total,
+    :approved,
+    :chicago,
+    team_submission: team_submission) }
+
+  context "when the 'display_scores' setting is turned off" do
+    before do
+      SeasonToggles.display_scores_off!
+    end
+
+    context "when the team has attended an RPE" do
+      let!(:live_regional_pitch_event) { FactoryBot.create(:regional_pitch_event, :chicago, name: "Windy City Event", ambassador: regional_ambassador) }
+
+      before do
+        live_regional_pitch_event.teams << team
+      end
+
+      context "when the regional ambassador views the main scores page" do
+        before do
+          sign_in(regional_ambassador)
+
+          click_link "Scores"
+        end
+
+        it "displays the team who attended the RPE" do
+          expect(page).to have_content("Ravenclaw")
+          expect(page).to have_css("#team_submission_#{team_submission.id}")
+        end
+      end
+
+      context "when the RA views the score details page for the team who attended the RPE" do
+        before do
+          sign_in(regional_ambassador)
+
+          click_link "Scores"
+          within "#team_submission_#{team_submission.id}" do
+            find("a.view-details").click
+          end
+        end
+
+        it "displays the team's name" do
+          within "h1" do
+            expect(page).to have_content("Ravenclaw")
+          end
+        end
+
+        it "displays the team's rank" do
+          expect(page).to have_content("semifinalist")
+        end
+
+        it "displays the name of the RPE" do
+          expect(page).to have_content("Windy City Event")
+        end
+
+        it "displays complete quarterfinal scores" do
+          within "#complete-quarterfinal-scores" do
+            expect(page).to have_content("20 / 60")
+            expect(page).to have_content("View score")
+          end
+        end
+
+        it "displays incomplete quarterfinal scores" do
+          within "#incomplete-quarterfinal-scores" do
+            expect(page).to have_content("20 / 60")
+            expect(page).to have_content("View score")
+          end
+        end
+
+        it "does not display complete semifinal scores" do
+          expect(page).not_to have_css("#complete-semifinal-scores")
+        end
+
+        it "does not display incomplete semifinal scores" do
+          expect(page).not_to have_css("#incomplete-semifinal-scores")
+        end
+      end
+
+      context "when a score has been deleted" do
+        before do
+          complete_quarterfinal_score.destroy
+        end
+
+        context "when the RA views the score details page for the team who attended the RPE" do
+          before do
+            sign_in(regional_ambassador)
+
+            click_link "Scores"
+            within "#team_submission_#{team_submission.id}" do
+              find("a.view-details").click
+            end
+          end
+
+          it "does not display the deleted score" do
+            within "#complete-quarterfinal-scores" do
+              expect(page).not_to have_content("20 / 60")
+              expect(page).not_to have_content("View score")
+
+              expect(page).to have_content("No scores")
+            end
+          end
+        end
+      end
+    end
+
+    context "when the team has not attended an RPE" do
+      context "when the regional ambassador views the main scores page" do
+        before do
+          sign_in(regional_ambassador)
+
+          click_link "Scores"
+        end
+
+        it "does not display the team" do
+          expect(page).not_to have_content("Ravenclaw")
+          expect(page).not_to have_css("#team_submission_#{team_submission.id}")
+        end
+      end
+    end
+
+  end
+
+  context "when the 'display_scores' setting is turned on" do
+    before do
+      SeasonToggles.display_scores_on!
+    end
+
+    context "when the regional ambassador views the main scores page" do
+      before do
+        sign_in(regional_ambassador)
+
+        click_link "Scores"
+      end
+
+      it "displays the team (regardless if they attended an RPE or not)" do
+        expect(page).to have_content("Ravenclaw")
+        expect(page).to have_css("#team_submission_#{team_submission.id}")
+      end
+    end
+
+    context "when the RA views the score details page for the team" do
+      before do
+        sign_in(regional_ambassador)
+
+        click_link "Scores"
+        within "#team_submission_#{team_submission.id}" do
+          find("a.view-details").click
+        end
+      end
+
+      it "displays the team's name" do
+        within "h1" do
+          expect(page).to have_content("Ravenclaw")
+        end
+      end
+
+      it "displays the team's rank" do
+        expect(page).to have_content("semifinalist")
+      end
+
+      it "displays the name of the RPE" do
+        expect(page).to have_content("Online Judging")
+      end
+
+      it "displays complete quarterfinal scores" do
+        within "#complete-quarterfinal-scores" do
+          expect(page).to have_content("20 / 60")
+          expect(page).to have_content("View score")
+        end
+      end
+
+      it "displays incomplete quarterfinal scores" do
+        within "#incomplete-quarterfinal-scores" do
+          expect(page).to have_content("20 / 60")
+          expect(page).to have_content("View score")
+        end
+      end
+
+      it "displays complete semifinal scores" do
+        within "#complete-semifinal-scores" do
+          expect(page).to have_content("20 / 60")
+          expect(page).to have_content("View score")
+        end
+      end
+
+      it "displays incomplete semifinal scores" do
+        within "#incomplete-semifinal-scores" do
+          expect(page).to have_content("20 / 60")
+          expect(page).to have_content("View score")
+        end
+      end
+    end
+
+    context "when a score has been deleted" do
+      before do
+        complete_quarterfinal_score.destroy
+      end
+
+      context "when the RA views the score details page for that team" do
+        before do
+          sign_in(regional_ambassador)
+
+          click_link "Scores"
+          within "#team_submission_#{team_submission.id}" do
+            find("a.view-details").click
+          end
+        end
+
+        it "does not display the deleted score" do
+          within "#complete-quarterfinal-scores" do
+            expect(page).not_to have_content("20 / 60")
+            expect(page).not_to have_content("View score")
+
+            expect(page).to have_content("No scores")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/views/admin/regional_ambassador/score_details/scores_table_spec.rb
+++ b/spec/views/admin/regional_ambassador/score_details/scores_table_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe "regional_ambassador/score_details/scores_table", type: :view do
+  before do
+    render partial: "regional_ambassador/score_details/scores_table",
+      locals: { scores: scores, current_account: current_account, current_scope: current_scope }
+  end
+
+  let(:scores) { [score_submission] }
+  let(:score_submission) { instance_double(SubmissionScore,
+    id: 1,
+    team_submission_id: 22,
+    team_name: "Dream Team",
+    team_submission_app_name: "Dreamy App",
+    judge_name: "Judge Dredd",
+    judge_profile: double("judge_profile", account_id: 333),
+    total: 75,
+    total_possible: 80,
+    official?: score_submission_offical,
+    deleted?: score_submission_deleted) }
+  let(:score_submission_offical) { false }
+  let(:score_submission_deleted) { false }
+
+  let(:current_account) { instance_double(Account,
+    admin?: current_account_admin) }
+  let(:current_account_admin) { false }
+
+  let(:current_scope) { "regional_ambassador" }
+
+  context "as a non-admin" do
+    let(:current_account_admin) { false }
+    let(:current_scope) { "regional_ambassador" }
+
+    it "displays the score for the submisison and grand total score" do
+      expect(rendered).to have_content("75 / 80")
+    end
+
+    it "displays a link to the judge who scored the submission" do
+      expect(rendered).to have_link("Judge Dredd")
+    end
+
+    context "when a score is offical" do
+      let(:score_submission_offical) { true }
+
+      it "displays 'offical'" do
+        within ".official-info" do
+          expect(rendered).to have_content("official")
+        end
+      end
+    end
+
+    context "when a score is unoffical" do
+      let(:score_submission_offical) { false }
+
+      it "displays 'unofficial'" do
+        within ".official-info" do
+          expect(rendered).to have_content("unofficial")
+        end
+      end
+    end
+
+    it "displays a link to view the score details" do
+      expect(rendered).to have_link("View score")
+    end
+
+    it "does not display deleted scores" do
+      expect(rendered).not_to have_css(".deleted-info")
+    end
+  end
+
+  context "as an admin" do
+    let(:current_account_admin) { true }
+    let(:current_scope) { "admin" }
+
+    context "when a score is marked as deleted" do
+      let(:score_submission_deleted) { true }
+
+      it "displays 'deleted'" do
+        within ".deleted-info" do
+          expect(rendered).to have_content("deleted")
+        end
+      end
+
+      it "displays the row in a subtle red color" do
+        within "tr" do
+          expect(rendered).to have_css(".background-color--subtle-red")
+        end
+      end
+    end
+
+    context "when a score is not marked as deleted" do
+      let(:score_submission_deleted) { false }
+
+      it "does not display 'deleted'" do
+        within ".deleted-info" do
+          expect(rendered).not_to have_content("deleted")
+        end
+      end
+
+      it "does not displays the row in a subtle red color" do
+        within "tr" do
+          expect(rendered).not_to have_css(".background-color--subtle-red")
+        end
+      end
+    end
+  end
+
+  context "when there are no scores to display" do
+    let(:scores) { [] }
+
+    it "displays a no scores message" do
+      expect(rendered).to have_content("No scores")
+    end
+  end
+end


### PR DESCRIPTION
This will allow admins to see deleted scores on the score details page.

#2432


