### PR TITLE
Conditionally show judge's certificate page

### DIFF
--- a/app/guards/display_certificates.rb
+++ b/app/guards/display_certificates.rb
@@ -1,9 +1,0 @@
-require "./app/constants/badge_levels"
-
-module DisplayCertificates
-  def self.for(judge)
-    SeasonToggles.display_scores? &&
-      (judge.current_complete_scores.count >= NUMBER_OF_SCORES_FOR_CERTIFIED_JUDGE ||
-        judge.current_judge_certificates.any?)
-  end
-end

--- a/app/views/judge/dashboards/onboarded/_certificates.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_certificates.en.html.erb
@@ -1,27 +1,29 @@
-<% if DisplayCertificates.for(current_judge) %>
-  <div id="judge-certificate" class="panel panel--left">
-    <div class="flags">
-      <span class="flag flag-registration">
-        Season close
+<% if SeasonToggles.display_scores? %>
+  <% if current_judge.judge_certificates.present? && !current_judge.suspended? %>
+    <div id="judge-certificate" class="panel panel--left">
+      <div class="flags">
+        <span class="flag flag-registration">
+          Season close
+        </span>
+      </div>
+
+      <h1>Thank You</h1>
+
+      <p>Thank you for being a judge this season!</p>
+
+      <p>
+        We appreciate your thoughtful feedback and the time you spent
+        supporting teams around the world.
+      </p>
+
+      <span class="display--block margin--t-xlarge text-align--center">
+        <%= link_to 'View your certificate',
+          @certificate_file_url,
+          class: "button",
+          target: :_blank %>
       </span>
     </div>
-
-    <h1>Thank You</h1>
-
-    <p>Thank you for being a judge this season!</p>
-
-    <p>
-      We appreciate your thoughtful feedback and the time you spent
-      supporting teams around the world.
-    </p>
-
-    <span class="display--block margin--t-xlarge text-align--center">
-      <%= link_to 'View your certificate',
-        @certificate_file_url,
-        class: "button",
-        target: :_blank %>
-    </span>
-  </div>
-<% elsif SeasonToggles.display_scores? %>
-  <%= render 'dashboards/no_certificates' %>
+  <% else %>
+    <%= render 'dashboards/no_certificates' %>
+  <% end %>
 <% end %>

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -72,6 +72,38 @@ RSpec.feature "Judge certificates" do
     )
   end
 
+  scenario "judge who is suspended - it doesn't display the certificate's page" do
+    SeasonToggles.set_judging_round(:sf)
+
+    judge = FactoryBot.create(:judge, :onboarded, number_of_scores: 10)
+
+    SeasonToggles.set_judging_round(:off)
+    SeasonToggles.display_scores_on!
+
+    FillPdfs.(judge.account)
+    judge.suspend!
+
+    sign_in(judge)
+    expect(page).not_to have_css("#judge-certificate")
+    expect(page).not_to have_link("View your certificate")
+  end
+
+  scenario "judge who doesn't have a certificate - it doesn't display the certficate's page" do
+    SeasonToggles.set_judging_round(:sf)
+
+    judge = FactoryBot.create(:judge, :onboarded, number_of_scores: 10)
+
+    SeasonToggles.set_judging_round(:off)
+    SeasonToggles.display_scores_on!
+
+    FillPdfs.(judge.account)
+    judge.account.judge_certificates.destroy_all
+
+    sign_in(judge)
+    expect(page).not_to have_css("#judge-certificate")
+    expect(page).not_to have_link("View your certificate")
+  end
+
   Array(1..4).each do |n|
     scenario "judge with #{n} completed current scores" do
       SeasonToggles.set_judging_round(:sf)


### PR DESCRIPTION
I updated the logic so that in order for a judge to see the certificate's page:
 * SeasonToggles.display_scores has to be turned on (true)
 * a certificate has to exist for the judge
 * the judge can't be suspended (this will handle the edge case where certificates are generated, and then the judge is suspended)

#2458