### PR TITLE
#2494 add team and submission id columns to scores page for admins only

### DIFF
--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -123,6 +123,14 @@ class ScoredSubmissionsGrid
     end
   end
 
+  column :team_id, header: 'Team ID', if: ->(g) { g.admin } do |submission|
+    submission.team.id
+  end
+
+  column :submission_id, header: 'Submission ID', if: ->(g) { g.admin } do |submission|
+    submission.id
+  end
+
   filter :round,
   :enum,
   select: -> { [

--- a/spec/features/admin/view_scores_spec.rb
+++ b/spec/features/admin/view_scores_spec.rb
@@ -48,4 +48,32 @@ RSpec.feature "Admins view scores" do
 
     expect(page).to have_content("View score")
   end
+
+  scenario "Admin has admin-only extra columns" do
+    submission = FactoryBot.create(
+      :submission,
+      :junior,
+      :complete,
+    )
+
+    FactoryBot.create(
+      :submission_score,
+      :complete,
+      team_submission: submission
+    )
+
+    SeasonToggles.judging_round = :qf
+    admin = FactoryBot.create(:admin)
+    sign_in(admin)
+
+    visit admin_scores_path
+
+    expect(page).to have_select(
+      "More columns",
+      with_options: [
+        "Team ID",
+        "Submission ID"
+      ]
+    )
+  end
 end

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -152,4 +152,30 @@ RSpec.feature "Regional Ambassador views scores" do
       expect(page).not_to have_content("Semifinals average")
     end
   end
+
+  scenario "RA lacks admin-only extra columns" do
+    submission = FactoryBot.create(
+      :submission,
+      :junior,
+      :complete,
+    )
+
+    FactoryBot.create(
+      :submission_score,
+      :complete,
+      team_submission: submission
+    )
+
+    SeasonToggles.judging_round = :qf
+
+    visit regional_ambassador_scores_path
+
+    expect(page).not_to have_select(
+      "More columns",
+      with_options: [
+        "Team ID",
+        "Submission ID"
+      ]
+    )
+  end
 end


### PR DESCRIPTION
This adds some ID columns that the program team can use in their export to make it easier for us to consume their spreadsheet afterwards for setting semifinalists.