### PR TITLE
#2406 Update email address error messages

### DIFF
--- a/app/views/profiles/_email.en.html.erb
+++ b/app/views/profiles/_email.en.html.erb
@@ -19,27 +19,14 @@
   to confirm your new email address and restore full access to this site.
 </p>
 
-<%= form_with model: current_profile, local: true do |f| %>
-  <%= f.fields_for :account, include_id: false do |a| %>
-    <%= a.label :existing_password, "Current password" %>
-    <%= a.password_field :existing_password,
+<%= simple_form_for current_profile, local: true do |f| %>
+  <%= f.simple_fields_for :account, include_id: false do |a| %>
+    <%= a.input :existing_password,
+      label: "Current password",
       id: "existing_password_field_email",
       placeholder: "Enter your password first" %>
 
-    <% unless a.object.errors[:existing_password].empty? %>
-      <div class="field_with_errors">
-        <span class="error"><%= a.object.errors[:existing_password][0] %></span>
-      </div>
-    <% end %>
-
-    <%= a.label :email %>
-    <%= a.email_field :email %>
-
-    <% unless a.object.errors[:email].empty? %>
-      <div class="field_with_errors">
-        <span class="error"><%= a.object.errors[:email].to_sentence %></span>
-      </div>
-    <% end %>
+    <%= a.input :email %>
   <% end %>
 
   <p>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -40,9 +40,9 @@ en:
         student_profile:
           attributes:
             parent_guardian_email:
-              found_in_student_accounts: "cannot match another student's email"
+              found_in_student_accounts: "cannot match your (or any other student's) email"
               invalid: "does not appear to be an email address"
-              matches_student_email: "cannot be the same as your email"
+              matches_student_email: "cannot match your (or any other student's) email"
 
         team_member_invite:
           attributes:

--- a/spec/models/student_profile_spec.rb
+++ b/spec/models/student_profile_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe StudentProfile do
 
     expect(profile).not_to be_valid
     expect(profile.errors[:parent_guardian_email]).to include(
-      "cannot match another student's email"
+      "cannot match your (or any other student's) email"
     )
   end
 


### PR DESCRIPTION
This will convert the "Change your email" form to use Simple Form, which will ultimately eliminate the triple error messages! :grin:

Just FYI: this was part of the culprit (responsible for two of the three error messages):
`config/initializers/action_view.rb`.

#2406