### PR TITLE
#2491 Add integration test for CSV export notifications

### DIFF
--- a/spec/features/admin/export_a_csv_spec.rb
+++ b/spec/features/admin/export_a_csv_spec.rb
@@ -8,14 +8,11 @@ RSpec.feature "Admin exporting a CSV", js: true do
     before {
       sign_in(admin)
       visit admin_participants_path
+      click_link "Export current results to CSV"
+      click_button "Export now"
     }
 
     scenario "sees a confirmation dialog" do
-      expect(page).to have_content("1 account found")
-
-      click_link "Export current results to CSV"
-      click_button "Export now"
-
       within("#queued-jobs") do
         expect(page).to have_content("Your file is ready!")
         expect(page).to have_link("Download")
@@ -24,8 +21,6 @@ RSpec.feature "Admin exporting a CSV", js: true do
     end
 
     scenario "clears the confirmation dialog" do
-      click_link "Export current results to CSV"
-      click_button "Export now"
       within("#queued-jobs") do
         click_link "I no longer need this file"
       end

--- a/spec/features/admin/export_a_csv_spec.rb
+++ b/spec/features/admin/export_a_csv_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Admin exporting a CSV", js: true do
+  context "from the Participants page" do
+    let(:admin) { FactoryBot.create(:admin) }
+    let!(:student) { FactoryBot.create(:student, :onboarded) }
+
+    before {
+      sign_in(admin)
+      visit admin_participants_path
+    }
+
+    scenario "sees a confirmation dialog" do
+      expect(page).to have_content("1 account found")
+
+      click_link "Export current results to CSV"
+      click_button "Export now"
+
+      within("#queued-jobs") do
+        expect(page).to have_content("Your file is ready!")
+        expect(page).to have_link("Download")
+        expect(page).to have_link("I no longer need this file")
+      end
+    end
+
+    scenario "clears the confirmation dialog" do
+      click_link "Export current results to CSV"
+      click_button "Export now"
+      within("#queued-jobs") do
+        click_link "I no longer need this file"
+      end
+
+      expect(page).not_to have_css("#queued-jobs")
+    end
+  end
+end


### PR DESCRIPTION
Adding an integration test for the export notification pop up you get when you export a CSV. Just covers two basic scenarios on a single page of the admin, but that at least provides some check that this is working.