### PR TITLE
#2462 fix: use select instead of filter

### DIFF
--- a/app/controllers/admin/semifinalist_snippet_controller.rb
+++ b/app/controllers/admin/semifinalist_snippet_controller.rb
@@ -6,13 +6,13 @@ module Admin
       senior_submissions = TeamSubmission
         .current
         .semifinalist
-        .filter { |sub| sub.senior_division? }
+        .select { |sub| sub.senior_division? }
       @senior_section = Section.new("senior", senior_submissions)
 
       junior_submissions = TeamSubmission
         .current
         .semifinalist
-        .filter { |sub| sub.junior_division? }
+        .select { |sub| sub.junior_division? }
       @junior_section = Section.new("junior", junior_submissions)
 
       respond_to :html, :text


### PR DESCRIPTION
Apparently ruby 2.6 introduces `#filter` as an alias for `#select`, but our Heroku environments are on 2.5.1. This should get the previous PR working in staging, and I wrote up #2529 as a bug report for the differing versions.