### PR TITLE
#2517 Add link to student dashboard to view submission

### DIFF
--- a/app/guards/student_submission_link_guard.rb
+++ b/app/guards/student_submission_link_guard.rb
@@ -1,0 +1,21 @@
+class StudentSubmissionLinkGuard
+  attr_accessor :team, :student, :season_toggles
+
+  def initialize(team:, student:, season_toggles: SeasonToggles)
+    @team           = team
+    @student        = student
+    @season_toggles = season_toggles
+  end
+
+  def display_link_to_new?
+    season_toggles.team_submissions_editable? && student.is_on_team? && team.submission.blank?
+  end
+
+  def display_link_to_in_progress?
+    student.is_on_team? && team.submission.present?
+  end
+
+  def display_link_to_published?
+    !season_toggles.team_submissions_editable? && student.is_on_team? && team.submission.complete?
+  end
+end

--- a/app/views/student/dashboards/_view_submission_link.html.erb
+++ b/app/views/student/dashboards/_view_submission_link.html.erb
@@ -1,0 +1,9 @@
+<% if StudentSubmissionLinkGuard.new(team: current_team, student: current_student).
+  display_link_to_published? %>
+
+  <div class="margin--t-xlarge">
+    <%= link_to t("views.application.dashboards.buttons.team_submission_html"),
+      student_published_team_submission_path(current_team.submission),
+      class: "button" %>
+  </div>
+<% end %>

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -89,7 +89,10 @@
       </div>
 
       <div slot="submission">
-        <%= render 'slots/student/submissions' %>
+        <%= render "slots/student/submissions" %>
+        <%= render "student/dashboards/view_submission_link",
+          current_team: current_team,
+          current_student: current_student %>
 
         <% if SeasonToggles.submissions_disabled? and
                 SeasonToggles.quarterfinals_or_earlier? and

--- a/app/views/student/navigation/_global_nav.html.erb
+++ b/app/views/student/navigation/_global_nav.html.erb
@@ -24,22 +24,22 @@
     class: al(new_student_team_search_path) %>
 <% end %>
 
-<% if !SeasonToggles.team_submissions_editable? &&
-        current_student.is_on_team? &&
-          current_team.submission.complete? %>
+<% submission_link_guard = StudentSubmissionLinkGuard.new(
+  team: current_team, student: current_student) %>
+
+<% if submission_link_guard.display_link_to_published? %>
 
   <%= link_to t("views.application.dashboards.menu.team_submission"),
     student_published_team_submission_path(current_team.submission),
     class: al(student_published_team_submission_path(current_team.submission)) %>
 
-<% elsif current_student.is_on_team? and current_team.submission.present? %>
+<% elsif submission_link_guard.display_link_to_in_progress? %>
 
   <%= link_to t("views.application.dashboards.menu.team_submission"),
     student_team_submission_path(current_team.submission),
     class: al(student_team_submission_path(current_team.submission)) %>
 
-<% elsif current_student.is_on_team? and
-  SeasonToggles.team_submissions_editable? %>
+<% elsif submission_link_guard.display_link_to_new? %>
 
   <%= link_to t("views.application.dashboards.menu.team_submission"),
     new_student_team_submission_path,

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -17,6 +17,8 @@ en:
           my_requests: "My requests"
           my_teams: "My teams"
           team_submission: "My team's submission"
+        buttons:
+          team_submission_html: "View my team's submission"
         show:
           no_more_invites: "You cannot receive any more invitations while you are on a team."
           no_more_requests: "You cannot send any more requests while you are on a team."

--- a/spec/guards/student_submission_link_guard_spec.rb
+++ b/spec/guards/student_submission_link_guard_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe StudentSubmissionLinkGuard do
+  let(:submission_link_guard) { StudentSubmissionLinkGuard.new(team: team, student: student, season_toggles: season_toggles) }
+  let(:team) { instance_double(Team, submission: submission) }
+  let(:submission) { instance_double(TeamSubmission, complete?: submission_complete) }
+  let(:student) { instance_double(StudentProfile, is_on_team?: student_on_a_team) }
+  let(:season_toggles) { class_double(SeasonToggles, team_submissions_editable?: submissions_editable) }
+  let(:student_on_a_team) { false }
+  let(:submission_complete) { false }
+  let(:submissions_editable) { false }
+
+  describe "#display_link_to_new?" do
+    context "when submissions are editable" do
+      let(:submissions_editable) { true }
+
+      context "when the student is on a team" do
+        let(:student_on_a_team) { true }
+
+        context "when the team doesn't have a submission" do
+          let(:submission) { nil }
+
+          it "returns true" do
+            expect(submission_link_guard.display_link_to_new?).to eq(true)
+          end
+        end
+
+        context "when the team has a submission" do
+          let(:submission) { instance_double(TeamSubmission) }
+
+          it "returns false" do
+            expect(submission_link_guard.display_link_to_new?).to eq(false)
+          end
+        end
+      end
+
+      context "when the student isn't on a team" do
+        let(:student_on_a_team) { false }
+
+        it "returns false" do
+          expect(submission_link_guard.display_link_to_new?).to eq(false)
+        end
+      end
+    end
+
+    context "when submissions are not editable" do
+      let(:submissions_editable) { false }
+
+      it "returns false" do
+        expect(submission_link_guard.display_link_to_new?).to eq(false)
+      end
+    end
+  end
+
+  describe "#display_link_to_in_progress?" do
+    context "when the student is on a team" do
+      let(:student_on_a_team) { true }
+
+      context "when the team has a submission, and it isn't complete" do
+        let(:submission_complete) { false }
+
+        it "returns true" do
+          expect(submission_link_guard.display_link_to_in_progress?).to eq(true)
+        end
+      end
+
+      context "when the team doesn't have a submission" do
+        let(:submission) { nil }
+
+        it "returns false" do
+          expect(submission_link_guard.display_link_to_in_progress?).to eq(false)
+        end
+      end
+    end
+
+    context "when the student isn't on a team" do
+      let(:student_on_a_team) { false }
+
+      it "returns false" do
+        expect(submission_link_guard.display_link_to_in_progress?).to eq(false)
+      end
+    end
+  end
+
+  describe "#display_link_to_published?" do
+    context "when submissions are not editable" do
+      let(:submissions_editable) { false }
+
+      context "when the student is on a team" do
+        let(:student_on_a_team) { true }
+
+        context "when the team's submission is complete" do
+          let(:submission_complete) { true }
+
+          it "returns true" do
+            expect(submission_link_guard.display_link_to_published?).to eq(true)
+          end
+        end
+
+        context "when the team's submission is not complete" do
+          let(:submission_complete) { false }
+
+          it "returns false" do
+            expect(submission_link_guard.display_link_to_published?).to eq(false)
+          end
+        end
+      end
+
+      context "when the sudent is not on a team" do
+        let(:student_on_a_team) { true }
+
+        it "returns false" do
+          expect(submission_link_guard.display_link_to_published?).to eq(false)
+        end
+      end
+
+    end
+
+    context "when submissions are editable" do
+      let(:submissions_editable) { true }
+
+      it "returns false" do
+        expect(submission_link_guard.display_link_to_published?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/views/admin/student/dashboards/view_submission_link_spec.rb
+++ b/spec/views/admin/student/dashboards/view_submission_link_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "student/dashboards/view_submission_link", type: :view do
+  before do
+    allow(StudentSubmissionLinkGuard).to receive(:new).with(team: team, student: student).and_return(submission_link_guard)
+
+    render partial: "student/dashboards/view_submission_link",
+      locals: { current_team: team, current_student: student }
+  end
+
+  let(:submission_link_guard) { instance_double(StudentSubmissionLinkGuard, display_link_to_published?: display_link_to_published) }
+  let(:display_link_to_published) { false }
+  let(:team) { instance_double(Team, submission: instance_double(TeamSubmission)) }
+  let(:student) { instance_double(StudentProfile) }
+
+  context "when #display_link_to_published? returns true" do
+    let(:display_link_to_published) { true }
+
+    it "renders a link to view the team's published submission" do
+      expect(rendered).to have_link("View my team's submission")
+      expect(rendered).to include("/published_team_submissions")
+    end
+  end
+
+  context "when #display_link_to_published? returns false" do
+    let(:display_link_to_published) { false }
+
+    it "does not render a link to view the team's published submission" do
+      expect(rendered).not_to have_link("View my team's submission")
+      expect(rendered).not_to include("/published_team_submissions")
+    end
+  end
+end


### PR DESCRIPTION
This will add a new link to the student's dashboard to view their completed submission, when editing submissions is turned off.

Refs: #2517


