### PR TITLE
Address actionview security vulnerability

### DIFF
--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -22,6 +22,30 @@ ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
   html.html_safe
 end
 
+ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP.merge!(
+  {
+    "`" => "\\`",
+    "$" => "\\$"
+  }
+)
+
+module ActionView::Helpers::JavaScriptHelper
+  alias :old_ej :escape_javascript
+  alias :old_j :j
+
+  def escape_javascript(javascript)
+    javascript = javascript.to_s
+    if javascript.empty?
+      result = ""
+    else
+      result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
+    end
+    javascript.html_safe? ? result.html_safe : result
+  end
+
+  alias :j :escape_javascript
+end
+
 module TechnovationApp
   module FormErrorProc
     NullType = Struct.new(:value)


### PR DESCRIPTION
This is to address the actionview security vulnerability:
https://github.com/Iridescent-CM/technovation-app/network/alert/Gemfile.lock/actionview/open

I tried upgrading actionview to `5.2.4.2`, but ran into this issue:
```
Bundler could not find compatible versions for gem "actionview":
  In Gemfile:
    actionview (>= 5.2.4.2)

    country_state_select (~> 3.0) was resolved to 3.0.5, which depends on
      rails was resolved to 5.1.7, which depends on
        actionview (= 5.1.7)
```

Which feels out of scope for this ticket to me, so instead, I applied the workaround patch provided in the link above.

#2460


