### PR TITLE
fix reset_for_season task to properly include rails environment

### DIFF
--- a/lib/tasks/reset_for_season.rake
+++ b/lib/tasks/reset_for_season.rake
@@ -1,5 +1,5 @@
 desc "Reset data for the new season on season start date every year"
-task :reset_for_season, :environment do
+task reset_for_season: :environment do
 
   if Date.today.month == Season::START_MONTH and
       Date.today.day == Season::START_DAY


### PR DESCRIPTION
I found this rake task while working on #2523, and I think we may want to use it depending on the outcome of #2551. It has a small syntax error though, so this PR is fixing that.