### PR TITLE
specify node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
     }
   },
+  "engines": {
+    "node": "10.x"
+  },
   "dependencies": {
     "@rails/webpacker": "^3.6.0",
     "airbrake-js": "^1.1.0",


### PR DESCRIPTION
We weren't telling Heroku what version of node we wanted, and it switched from 10.x to 12.x which broke the canvas build. This tells it to use 10.x which I'm hoping will fix deployments, although I'm not sure how much longer that version will be supported. See https://devcenter.heroku.com/articles/nodejs-support