### PR TITLE
#2553 Redirect to Scores and Certificates Page

### DIFF
--- a/app/javascript/mentor/DashboardMenu.vue
+++ b/app/javascript/mentor/DashboardMenu.vue
@@ -49,7 +49,7 @@
       :disabled-tooltip="tooltips.AVAILABLE_LATER"
       :condition-to-enable="scoresAndCertificatesEnabled"
       :condition-to-complete="false"
-    >Scores & Feedback</tab-link>
+    >Scores & Certificates</tab-link>
   </ul>
 </template>
 

--- a/app/javascript/mentor/routes/index.js
+++ b/app/javascript/mentor/routes/index.js
@@ -35,15 +35,21 @@ const loadOrRedirect = (to, from, next) => {
   }
 }
 
-const getRootComponent = () => {
-  if (anyCurrentTeams()) {
+export const getRootComponent = () => {
+  if (canDisplayScores()) {
+    return Scores
+  } else if (anyCurrentTeams()) {
     return Submission
   } else {
     return TeamBuilding
   }
 }
 
-const getRootRoute = () => {
+export const getRootRoute = () => {
+  if (canDisplayScores()) {
+    return { name: 'scores' }
+  }
+
   if (anyCurrentTeams()) {
     return { name: 'submission' }
   }
@@ -61,6 +67,10 @@ const anyCurrentTeams = () => {
 
 const isOnboarded = () => {
   return store.getters['authenticated/isOnboarded']
+}
+
+const canDisplayScores = () => {
+  return store.getters['authenticated/canDisplayScores']
 }
 
 export const routes = [

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -76,4 +76,8 @@ export default {
   consentWaiverSignedAtEpoch (state) {
     return digStateAttributes(state, 'consentWaiver', 'signedAtEpoch')
   },
+
+  canDisplayScores (state) {
+    return state.settings.canDisplayScores
+  },
 }

--- a/app/javascript/mentor/store/mutations.js
+++ b/app/javascript/mentor/store/mutations.js
@@ -7,7 +7,8 @@ export default {
       'currentAccount',
       'currentMentor',
       'consentWaiver',
-      'backgroundCheck'
+      'backgroundCheck',
+      'settings',
     ].forEach(key => {
       if (dataset[key])
         Vue.set(state, key, JSON.parse(dataset[key]))

--- a/app/javascript/mentor/store/state.js
+++ b/app/javascript/mentor/store/state.js
@@ -9,5 +9,7 @@ export default {
 
   backgroundCheck: {},
 
+  settings: {},
+
   submission: {},
 }

--- a/app/javascript/student/DashboardMenu.vue
+++ b/app/javascript/student/DashboardMenu.vue
@@ -50,7 +50,7 @@
       :disabled-tooltip="tooltips.AVAILABLE_LATER"
       :condition-to-enable="scoresAndCertificatesEnabled"
       :condition-to-complete="false"
-    >Scores & Feedback</tab-link>
+    >Scores & Certificates</tab-link>
   </ul>
 </template>
 

--- a/app/javascript/student/routes/index.js
+++ b/app/javascript/student/routes/index.js
@@ -36,7 +36,9 @@ const loadOrRedirect = (to, from, next) => {
 }
 
 export const getRootComponent = () => {
-  if (isOnTeam() && hasParentalConsent()) {
+  if (canDisplayScores()) {
+    return Scores
+  } else if (isOnTeam() && hasParentalConsent()) {
     return Submission
   } else {
     return TeamBuilding
@@ -44,7 +46,9 @@ export const getRootComponent = () => {
 }
 
 export const getRootRoute = () => {
-  if (isOnTeam() && hasParentalConsent()) {
+  if (canDisplayScores()) {
+    return { name: 'scores' }
+  } else if (isOnTeam() && hasParentalConsent()) {
     return { name: 'submission' }
   } else {
     return { name: 'parental-consent' }
@@ -57,6 +61,10 @@ const isOnTeam = () => {
 
 const hasParentalConsent = () => {
   return store.getters['authenticated/hasParentalConsent']
+}
+
+const canDisplayScores = () => {
+  return store.getters['authenticated/canDisplayScores']
 }
 
 export const routes = [

--- a/app/javascript/student/store/getters.js
+++ b/app/javascript/student/store/getters.js
@@ -74,4 +74,8 @@ export default {
   submissionComplete (state) {
     return digStateAttributes(state, 'currentSubmission', 'isComplete')
   },
+
+  canDisplayScores (state) {
+    return state.settings.canDisplayScores
+  },
 }

--- a/app/javascript/student/store/mutations.js
+++ b/app/javascript/student/store/mutations.js
@@ -8,6 +8,7 @@ export default {
       'currentTeam',
       'currentSubmission',
       'parentalConsent',
+      'settings',
     ].forEach(key => {
       if (dataset[key])
         Vue.set(state, key, JSON.parse(dataset[key]))

--- a/app/javascript/student/store/state.js
+++ b/app/javascript/student/store/state.js
@@ -7,5 +7,7 @@ export default {
 
   parentalConsent: {},
 
+  settings: {},
+
   submission: {},
 }

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -9,6 +9,7 @@
       current_teams: TeamSerializer.new(current_mentor.current_teams).serialized_json,
       consent_waiver: ConsentSerializer.new(current_mentor.consent_waiver).serialized_json,
       background_check: BackgroundCheckSerializer.new(current_mentor.background_check).serialized_json,
+      settings: { canDisplayScores: SeasonToggles.display_scores? }.to_json
     } %>
   <app
     :profile-icons="{

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -12,6 +12,7 @@
         current_team: TeamSerializer.new(current_team).serialized_json,
         current_submission: SubmissionSerializer.new(current_submission).serialized_json,
         parental_consent: ConsentSerializer.new(current_student.parental_consent).serialized_json,
+        settings: { canDisplayScores: SeasonToggles.display_scores? }.to_json
       } %>
     <app
       :profile-icons="{

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -101,4 +101,18 @@ describe("mentor/store/getters.js", () => {
       expect(getters.isOnboarded(state)).toBeTruthy()
     })
   })
+
+  describe("canDisplayScores", () => {
+    it("returns true when the display_scores setting is enabled", () => {
+      const state = { settings: { canDisplayScores: true } }
+
+      expect(getters.canDisplayScores(state)).toBe(true)
+    })
+
+    it("returns false when the display_scores setting is disabled", () => {
+      const state = { settings: { canDisplayScores: false } }
+
+      expect(getters.canDisplayScores(state)).toBe(false)
+    })
+  })
 })

--- a/spec/javascript/student/routes/index.spec.js
+++ b/spec/javascript/student/routes/index.spec.js
@@ -3,6 +3,22 @@ import store from 'student/store'
 
 describe("student/routes/index.js", () => {
   describe("#getRootRoute()", () => {
+    it("returns 'scores' if the display_scores setting is enabled", () => {
+      store.commit("authenticated/htmlDataset", {
+        settings: '{"canDisplayScores": true}',
+      })
+
+      expect(getRootRoute()).toEqual({ name: "scores" })
+    })
+
+    it("does not returns 'scores' if the display_scores setting is disabled", () => {
+      store.commit("authenticated/htmlDataset", {
+        settings: '{"canDisplayScores": false}',
+      })
+
+      expect(getRootRoute()).not.toEqual({ name: "scores" })
+    })
+
     it("returns parental consent if the student is not on a team or has no permission", () => {
       store.commit('authenticated/htmlDataset', {
         currentTeam:'{"data":{"id":"0","attributes":{}}}',
@@ -23,6 +39,22 @@ describe("student/routes/index.js", () => {
   })
 
   describe("#getRootComponent()", () => {
+    it("returns 'scores' if the display_scores setting is enabled", () => {
+      store.commit("authenticated/htmlDataset", {
+        settings: '{"canDisplayScores": true}',
+      })
+
+      expect(getRootRoute()).toEqual({ name: "scores" })
+    })
+
+    it("does not returns 'scores' if the display_scores setting is disabled", () => {
+      store.commit("authenticated/htmlDataset", {
+        settings: '{"canDisplayScores": false}',
+      })
+
+      expect(getRootRoute()).not.toEqual({ name: "scores" })
+    })
+
     it("returns TeamBuilding if the student is not on a team or has no permission", () => {
       store.commit('authenticated/htmlDataset', {
         currentTeam:'{"data":{"id":"0","attributes":{}}}',

--- a/spec/javascript/student/store/getters.spec.js
+++ b/spec/javascript/student/store/getters.spec.js
@@ -70,4 +70,18 @@ describe("student/store/getters.js", () => {
       expect(getters.isOnTeam(state)).toBeTruthy()
     })
   })
+
+  describe("canDisplayScores", () => {
+    it("returns true when the display_scores setting is enabled", () => {
+      const state = { settings: { canDisplayScores: true } }
+
+      expect(getters.canDisplayScores(state)).toBe(true)
+    })
+
+    it("returns false when the display_scores setting is disabled", () => {
+      const state = { settings: { canDisplayScores: false } }
+
+      expect(getters.canDisplayScores(state)).toBe(false)
+    })
+  })
 })

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Students view scores", :js do
     submission = FactoryBot.create(:submission, :incomplete)
 
     sign_in(submission.team.students.sample)
-    click_button "Scores & Feedback"
+    click_button "Scores & Certificates"
 
     expect(page).to have_content("Thank you for your participation")
     expect(page).to have_content(
@@ -25,7 +25,7 @@ RSpec.describe "Students view scores", :js do
     FactoryBot.create(:submission_score, :complete, team_submission: submission)
 
     sign_in(submission.team.students.sample)
-    click_button "Scores & Feedback"
+    click_button "Scores & Certificates"
     click_link "View your scores and certificate"
 
     expect(page).to have_selector('.ui-accordion-content', visible: false)
@@ -52,7 +52,7 @@ RSpec.describe "Students view scores", :js do
     )
 
     sign_in(submission.team.students.sample)
-    click_button "Scores & Feedback"
+    click_button "Scores & Certificates"
     click_link "View your scores and certificate"
 
     expect(page).to have_selector('.ui-accordion-content', visible: false)


### PR DESCRIPTION
When `display_scores?` is enabled, this will load/redirect students and mentors to the "Scores & Certificates" (formerly the "Scores & Feedback") page.

This was a really tricky one for me to figure out everything that was going on. I left some comments to try to help clarify the approach I took.
