### PR TITLE
#2550 rollover test fixes

### DIFF
--- a/spec/circleci/env_spec.rb
+++ b/spec/circleci/env_spec.rb
@@ -38,6 +38,7 @@ if !!defined?(Dotenv)
     OPEN_PAGE_ON_FAILURE
     OPEN_SCREENSHOT_ON_FAILURE
     RSPEC_FAIL_FAST
+    DO_NOT_FILL_CERTIFICATES
   }
 
   RSpec.describe "Circle CI config" do

--- a/spec/controllers/team_memberships_controller_spec.rb
+++ b/spec/controllers/team_memberships_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Team Memberships Controllers" do
         )
         younger_student = FactoryBot.create(
           :student,
-          date_of_birth: 14.years.ago
+          date_of_birth: 13.years.ago
         )
 
         TeamRosterManaging.add(team, [younger_student, older_student])
@@ -43,7 +43,7 @@ RSpec.describe "Team Memberships Controllers" do
           )
           younger_student = FactoryBot.create(
             :student,
-            date_of_birth: 14.years.ago
+            date_of_birth: 13.years.ago
           )
 
           TeamRosterManaging.add(team, [younger_student, older_student])

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       city { "Chicago" }
       state_province { "IL" }
       country { "US" }
-      date_of_birth { Date.today - 14.years }
+      date_of_birth { Date.today - 12.years }
       sequence(:email) { |n| "factory-student-#{n}@example.com" }
       password { "secret1234" }
       not_onboarded { false }
@@ -162,7 +162,7 @@ FactoryBot.define do
     end
 
     trait :junior do |s|
-      date_of_birth { Date.today - 14.years }
+      date_of_birth { Date.today - 12.years }
     end
 
     trait :on_team do

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.feature "Judge certificates" do
+  before {
+    allow(Season).to receive(:current).and_return(Season.new(2020))
+  }
+
   scenario "no link available when viewing scores is turned off" do
     SeasonToggles.display_scores_off!
 

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.feature "Judge certificates" do
+  let(:season_with_templates) { Season.new(2020) }
+
   before {
-    allow(Season).to receive(:current).and_return(Season.new(2020))
+    allow(Season).to receive(:current).and_return(season_with_templates)
   }
 
   scenario "no link available when viewing scores is turned off" do

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.feature "Judge certificates" do
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year: 2020) }
 
   before do
     allow(Season).to receive(:current).and_return(season_with_templates)

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -4,9 +4,9 @@ require "fill_pdfs"
 RSpec.feature "Judge certificates" do
   let(:season_with_templates) { Season.new(2020) }
 
-  before {
+  before do
     allow(Season).to receive(:current).and_return(season_with_templates)
-  }
+  end
 
   scenario "no link available when viewing scores is turned off" do
     SeasonToggles.display_scores_off!

--- a/spec/features/mentor/certificates_spec.rb
+++ b/spec/features/mentor/certificates_spec.rb
@@ -3,7 +3,7 @@ require "fill_pdfs"
 
 RSpec.feature "Mentor certificates" do
   before  { SeasonToggles.display_scores_on! }
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year:2020) }
   before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   scenario "no certificates for no teams" do

--- a/spec/features/mentor/certificates_spec.rb
+++ b/spec/features/mentor/certificates_spec.rb
@@ -3,6 +3,7 @@ require "fill_pdfs"
 
 RSpec.feature "Mentor certificates" do
   before  { SeasonToggles.display_scores_on! }
+  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
 
   scenario "no certificates for no teams" do
     mentor = FactoryBot.create(:mentor, :onboarded)

--- a/spec/features/mentor/certificates_spec.rb
+++ b/spec/features/mentor/certificates_spec.rb
@@ -3,7 +3,8 @@ require "fill_pdfs"
 
 RSpec.feature "Mentor certificates" do
   before  { SeasonToggles.display_scores_on! }
-  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
+  let(:season_with_templates) { Season.new(2020) }
+  before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   scenario "no certificates for no teams" do
     mentor = FactoryBot.create(:mentor, :onboarded)

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "Mentors find a team" do
-  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
-  let(:current_season) { Season.new(today.year) }
+  let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(day_before_qfs.year) }
 
   before do
     allow(Season).to receive(:current).and_return(current_season)
-    Timecop.freeze(today)
+    Timecop.freeze(day_before_qfs)
 
     mentor = FactoryBot.create(:mentor, :onboarded, :geocoded) # City is Chicago
     sign_in(mentor)

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -1,15 +1,20 @@
 require "rails_helper"
 
 RSpec.feature "Mentors find a team" do
-  let!(:find_mentor) {
-    FactoryBot.create(:mentor, :onboarded, :geocoded, first_name: "Findme")
-  } # City is Chicago
+  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(today.year) }
 
   before do
-    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+    allow(Season).to receive(:current).and_return(current_season)
+    Timecop.freeze(today)
+
     mentor = FactoryBot.create(:mentor, :onboarded, :geocoded) # City is Chicago
     sign_in(mentor)
   end
+
+  let!(:find_mentor) {
+    FactoryBot.create(:mentor, :onboarded, :geocoded, first_name: "Findme")
+  } # City is Chicago
 
   after do
     Timecop.return
@@ -25,7 +30,7 @@ RSpec.feature "Mentors find a team" do
     )
 
     past.account.update(
-      seasons: [Season.current.year - 1]
+      seasons: [current_season.year - 1]
     )
 
     click_link "Connect with mentors"

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -12,9 +12,9 @@ RSpec.feature "Mentors find a team" do
     sign_in(mentor)
   end
 
-  let!(:find_mentor) {
-    FactoryBot.create(:mentor, :onboarded, :geocoded, first_name: "Findme")
-  } # City is Chicago
+  let!(:find_mentor) do
+    FactoryBot.create(:mentor, :onboarded, :geocoded, first_name: "Findme") # City is Chicago
+  end
 
   after do
     Timecop.return

--- a/spec/features/mentor/find_a_team_spec.rb
+++ b/spec/features/mentor/find_a_team_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Mentors find a team" do
-  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
-  let(:current_season) { Season.new(today.year) }
+  let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(day_before_qfs.year) }
 
   before { allow(Season).to receive(:current).and_return(current_season) }
   before { SeasonToggles.team_building_enabled! }
@@ -116,7 +116,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   scenario "request to join a team" do
-    Timecop.freeze(today) do
+    Timecop.freeze(day_before_qfs) do
       within('#find-team') { click_link "Find a team" }
 
       click_link "Ask to join"
@@ -134,7 +134,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   scenario "request to join the same team again, even if you deleted an earlier request" do
-    Timecop.freeze(today) do
+    Timecop.freeze(day_before_qfs) do
       join_request = JoinRequest.create!({
         requestor: mentor,
         team: available_team,

--- a/spec/features/mentor/find_a_team_spec.rb
+++ b/spec/features/mentor/find_a_team_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "Mentors find a team" do
+  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(today.year) }
+
+  before { allow(Season).to receive(:current).and_return(current_season) }
   before { SeasonToggles.team_building_enabled! }
 
   let!(:available_team) { FactoryBot.create(:team, :geocoded) }
@@ -112,7 +116,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   scenario "request to join a team" do
-    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+    Timecop.freeze(today) do
       within('#find-team') { click_link "Find a team" }
 
       click_link "Ask to join"
@@ -130,7 +134,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   scenario "request to join the same team again, even if you deleted an earlier request" do
-    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+    Timecop.freeze(today) do
       join_request = JoinRequest.create!({
         requestor: mentor,
         team: available_team,

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -3,6 +3,7 @@ require "fill_pdfs"
 
 RSpec.feature "Student certificates" do
   before { SeasonToggles.display_scores_on! }
+  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
 
   context "virtual semifinalist students" do
     let(:student) { FactoryBot.create(:student, :virtual, :semifinalist) }

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -3,7 +3,7 @@ require "fill_pdfs"
 
 RSpec.feature "Student certificates" do
   before { SeasonToggles.display_scores_on! }
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year: 2020) }
   before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   context "virtual semifinalist students" do

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -3,7 +3,8 @@ require "fill_pdfs"
 
 RSpec.feature "Student certificates" do
   before { SeasonToggles.display_scores_on! }
-  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
+  let(:season_with_templates) { Season.new(2020) }
+  before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   context "virtual semifinalist students" do
     let(:student) { FactoryBot.create(:student, :virtual, :semifinalist) }

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "Students find a team" do
+  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(today.year) }
+
+  before { allow(Season).to receive(:current).and_return(current_season) }
   before { SeasonToggles.team_building_enabled! }
 
   let!(:available_team) { FactoryBot.create(:team, :geocoded) }
@@ -29,7 +33,7 @@ RSpec.feature "Students find a team" do
   end
 
   scenario "request to join a team" do
-    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+    Timecop.freeze(today) do
       within (".navigation") { click_link "Find a team" }
       click_link "Ask to join"
       click_button "Ask to join #{available_team.name}"
@@ -43,7 +47,7 @@ RSpec.feature "Students find a team" do
   end
 
   scenario "onboarded student sees pending requests" do
-    Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day) do
+    Timecop.freeze(today) do
       sign_out
 
       onboarded = FactoryBot.create(:student, :geocoded)

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Students find a team" do
-  let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
-  let(:current_season) { Season.new(today.year) }
+  let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(day_before_qfs.year) }
 
   before { allow(Season).to receive(:current).and_return(current_season) }
   before { SeasonToggles.team_building_enabled! }
@@ -33,7 +33,7 @@ RSpec.feature "Students find a team" do
   end
 
   scenario "request to join a team" do
-    Timecop.freeze(today) do
+    Timecop.freeze(day_before_qfs) do
       within (".navigation") { click_link "Find a team" }
       click_link "Ask to join"
       click_button "Ask to join #{available_team.name}"
@@ -47,7 +47,7 @@ RSpec.feature "Students find a team" do
   end
 
   scenario "onboarded student sees pending requests" do
-    Timecop.freeze(today) do
+    Timecop.freeze(day_before_qfs) do
       sign_out
 
       onboarded = FactoryBot.create(:student, :geocoded)

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CertificateJob do
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year: 2020) }
   before do
     allow(Season).to receive(:current).and_return(season_with_templates)
   end

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe CertificateJob do
+  before {
+    allow(Season).to receive(:current).and_return(Season.new(2020))
+  }
+
   it "fills and attaches PDFs" do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)
     team = mentor.current_teams.last

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe CertificateJob do
   let(:season_with_templates) { Season.new(2020) }
-  before {
+  before do
     allow(Season).to receive(:current).and_return(season_with_templates)
-  }
+  end
 
   it "fills and attaches PDFs" do
     mentor = FactoryBot.create(:mentor, :onboarded, :on_team, :complete_submission)

--- a/spec/jobs/certificate_job_spec.rb
+++ b/spec/jobs/certificate_job_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 RSpec.describe CertificateJob do
+  let(:season_with_templates) { Season.new(2020) }
   before {
-    allow(Season).to receive(:current).and_return(Season.new(2020))
+    allow(Season).to receive(:current).and_return(season_with_templates)
   }
 
   it "fills and attaches PDFs" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -3,9 +3,9 @@ require "./lib/fill_pdfs"
 
 RSpec.describe Account do
   let(:season_with_templates) { Season.new(2020) }
-  before {
+  before do
     allow(Season).to receive(:current).and_return(season_with_templates)
-  }
+  end
 
   context "validations" do
     describe "student email address validations" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 require "./lib/fill_pdfs"
 
 RSpec.describe Account do
+  before {
+    allow(Season).to receive(:current).and_return(Season.new(2020))
+  }
+
   context "validations" do
     describe "student email address validations" do
       let!(:student_account) { FactoryBot.build_stubbed(:account, email: student_email_address) }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 require "./lib/fill_pdfs"
 
 RSpec.describe Account do
+  let(:season_with_templates) { Season.new(2020) }
   before {
-    allow(Season).to receive(:current).and_return(Season.new(2020))
+    allow(Season).to receive(:current).and_return(season_with_templates)
   }
 
   context "validations" do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "./lib/fill_pdfs"
 
 RSpec.describe Account do
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year: 2020) }
   before do
     allow(Season).to receive(:current).and_return(season_with_templates)
   end

--- a/spec/models/division_spec.rb
+++ b/spec/models/division_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Division do
         student = FactoryBot.create(
           :student,
           :on_team,
-          date_of_birth: 14.years.ago
+          date_of_birth: 13.years.ago
         )
         expect(Division.for(student.team)).to eq(Division.junior)
       end
@@ -28,7 +28,7 @@ RSpec.describe Division do
       Timecop.freeze(Division.cutoff_date - 1.day) do
         team = FactoryBot.create(:team)
         older_student = FactoryBot.create(:student, date_of_birth: 15.years.ago)
-        younger_student = FactoryBot.create(:student, date_of_birth: 14.years.ago)
+        younger_student = FactoryBot.create(:student, date_of_birth: 13.years.ago)
 
         TeamRosterManaging.add(team, [older_student, younger_student])
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Team do
     team.reload
 
     old_student = FactoryBot.create(:student, date_of_birth: 15.years.ago)
-    young_student = FactoryBot.create(:student, date_of_birth: 14.years.ago)
+    young_student = FactoryBot.create(:student, date_of_birth: 13.years.ago)
 
     TeamRosterManaging.add(team, [old_student, young_student])
     expect(team.reload).to be_senior

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe "Students request to join a team",
   end
 
   context "a valid student requestor" do
-    let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
-    let(:current_season) { Season.new(today.year) }
+    let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+    let(:current_season) { Season.new(day_before_qfs.year) }
 
     before { allow(Season).to receive(:current).and_return(current_season) }
 
@@ -49,7 +49,7 @@ RSpec.describe "Students request to join a team",
       # Default Chicago
 
     before do
-      Timecop.freeze(today)
+      Timecop.freeze(day_before_qfs)
       ActionMailer::Base.deliveries.clear
       sign_in(student)
       visit new_student_join_request_path(team_id: team.id)

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe "Students request to join a team",
   end
 
   context "a valid student requestor" do
+    let(:today) { ImportantDates.quarterfinals_judging_begins - 1.day }
+    let(:current_season) { Season.new(today.year) }
+
+    before { allow(Season).to receive(:current).and_return(current_season) }
+
     let!(:team) { FactoryBot.create(:team, :with_mentor) }
       # Default is in Chicago
 
@@ -44,7 +49,7 @@ RSpec.describe "Students request to join a team",
       # Default Chicago
 
     before do
-      Timecop.freeze(ImportantDates.quarterfinals_judging_begins - 1.day)
+      Timecop.freeze(today)
       ActionMailer::Base.deliveries.clear
       sign_in(student)
       visit new_student_join_request_path(team_id: team.id)

--- a/spec/technovation/determine_certificates_spec.rb
+++ b/spec/technovation/determine_certificates_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.describe DetermineCertificates do
-  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
+  let(:season_with_templates) { Season.new(2020) }
+  before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   context "for student" do
     it "awards participation" do

--- a/spec/technovation/determine_certificates_spec.rb
+++ b/spec/technovation/determine_certificates_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.describe DetermineCertificates do
-  let(:season_with_templates) { Season.new(2020) }
+  let(:season_with_templates) { instance_double(Season, year: 2020) }
   before { allow(Season).to receive(:current).and_return(season_with_templates) }
 
   context "for student" do

--- a/spec/technovation/determine_certificates_spec.rb
+++ b/spec/technovation/determine_certificates_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "fill_pdfs"
 
 RSpec.describe DetermineCertificates do
+  before { allow(Season).to receive(:current).and_return(Season.new(2020)) }
+
   context "for student" do
     it "awards participation" do
       student = FactoryBot.create(:student, :half_complete_submission)


### PR DESCRIPTION
I think this will fix some tests that previously relied on config in the .env matching the actual date, i.e the `DATES_*_YEAR` config needed to agree with `Season.year.current` or tests would fail.

It also fixes some tests that started to break when I set the season rollover date to be June 1. Doing so somehow changed the division calculations so that students intended to be in the junior division were being calculated as senior.