### PR TITLE
#2488 Add feature specs for admins viewing suspicious scores

### DIFF
--- a/spec/factories/submission_scores.rb
+++ b/spec/factories/submission_scores.rb
@@ -30,6 +30,36 @@ FactoryBot.define do
       approved_at { Time.current }
     end
 
+    trait :score_too_low do
+      after :create do |score|
+        score.update_columns(seems_too_low: true,
+                             completed_too_fast: false,
+                             completed_too_fast_repeat_offense: false,
+                             approved_at: nil,
+                             completed_at: Time.now)
+      end
+    end
+
+    trait :score_completed_too_fast_by_repeat_offender do
+      after :create do |score|
+        score.update_columns(seems_too_low: false,
+                             completed_too_fast: true,
+                             completed_too_fast_repeat_offense: true,
+                             approved_at: nil,
+                             completed_at: Time.now)
+      end
+    end
+
+    trait :score_too_low_and_completed_too_fast_by_repeat_offender do
+      after :create do |score|
+        score.update_columns(seems_too_low: true,
+                             completed_too_fast: true,
+                             completed_too_fast_repeat_offense: true,
+                             approved_at: nil,
+                             completed_at: Time.now)
+      end
+    end
+
     trait :senior do
       association(:team_submission, factory: [:team_submission, :complete, :senior])
     end

--- a/spec/features/admin/view_suspicious_scores_spec.rb
+++ b/spec/features/admin/view_suspicious_scores_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.feature "Admins viewing suspicious scores", js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  scenario "scores that are too low are displayed on the Scores page" do
+    FactoryBot.create(:score, :score_too_low)
+
+    sign_in(admin)
+    click_link "Scores"
+
+    within ".suspicious-scores" do
+      expect(page).to have_content("SEEMS TOO LOW")
+    end
+  end
+
+  scenario "scores that are completed too fast by repeat offenders are displayed on the Scores page" do
+    FactoryBot.create(:score, :score_completed_too_fast_by_repeat_offender)
+
+    sign_in(admin)
+    click_link "Scores"
+
+    within ".suspicious-scores" do
+      expect(page).to have_content("COMPLETED TOO FAST")
+    end
+  end
+
+  scenario "scores that are too low and completed too fast by repeat offenders are displayed on the Scores page" do
+    FactoryBot.create(:score, :score_too_low, :score_too_low_and_completed_too_fast_by_repeat_offender)
+
+    sign_in(admin)
+    click_link "Scores"
+
+    within ".suspicious-scores" do
+      expect(page).to have_content("SEEMS TOO LOW AND COMPLETED TOO FAST")
+    end
+  end
+
+  scenario "no suspicious scores" do
+    sign_in(admin)
+    click_link "Scores"
+
+    within ".suspicious-scores" do
+      expect(page).to have_content("There are no suspicious scores at this time.")
+    end
+  end
+end


### PR DESCRIPTION
I added feature specs for admins viewing suspicious scores flagged as:
 * Too low
 * Too fast by a repeat offender
 * Too low and too fast by a repeat offender

And for the case when there are no suspicious scores.

Refs: #2488


