### PR TITLE
#2492 Add feature specs for Regional Pitch Events

### DIFF
--- a/spec/system/chapter_ambassador/regional_pitch_event_judges_spec.rb
+++ b/spec/system/chapter_ambassador/regional_pitch_event_judges_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "Regional Pitch Event Judges", :js do
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :approved) }
+
+  context "when MANAGE_EVENTS is enabled" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("MANAGE_EVENTS", any_args).and_return(true)
+    end
+
+    it "successfully adds a judge an event" do
+      FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+      FactoryBot.create(:judge, first_name: "Judge B12")
+      expect(RegionalPitchEvent.count).to be_present
+      expect(Team.count).to be_present
+
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      find("img[alt='edit judges']").click
+      expect(page).to have_content("ADD JUDGES")
+
+      click_button "Add judges"
+      find("img[src*='check-circle-o.svg']").click
+      click_button "Done"
+      click_button "Save changes"
+
+      expect(page).to have_content "You saved your selected attendees"
+
+      within("table.attendee-list") do
+        expect(page).to have_content "Judge B12"
+      end
+    end
+
+    it "successfully removes a judge from an event" do
+      event = FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+      judge = FactoryBot.create(:judge, first_name: "Judge P.")
+      expect(RegionalPitchEvent.count).to be_present
+      expect(Team.count).to be_present
+      event.judges = [judge]
+
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      find("img[alt='edit judges']").click
+
+      within("table.attendee-list") do
+        expect(page).to have_content "Judge P."
+      end
+
+      find("table.attendee-list td:first-child").hover
+      find(".attendee-list__actions img[src*='remove.svg']").click
+      click_button "Yes, remove this judge"
+
+      expect(page).to have_content "You removed Judge P."
+    end
+  end
+
+  context "when MANAGE_EVENTS is disabled" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("MANAGE_EVENTS", any_args).and_return(false)
+    end
+
+    it "does not display the 'Edit Judges' icon/link" do
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      expect(page).not_to have_css("img[alt='edit judges']")
+    end
+  end
+end

--- a/spec/system/chapter_ambassador/regional_pitch_event_teams_spec.rb
+++ b/spec/system/chapter_ambassador/regional_pitch_event_teams_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Regional Pitch Event Teams", :js do
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :approved)}
+
+  context "when MANAGE_EVENTS is enabled" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("MANAGE_EVENTS", any_args).and_return(true)
+    end
+
+    it "sucessfully adds a team to an event" do
+      FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+      FactoryBot.create(:team, :senior, :live_event_eligible, name: "A1 Team")
+      expect(RegionalPitchEvent.count).to be_present
+      expect(Team.count).to be_present
+
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      find("img[alt='edit teams']").click
+      expect(page).to have_content("ADD TEAMS")
+
+      click_button "Add teams"
+      find("img[src*='check-circle-o.svg']").click
+      click_button "Done"
+      click_button "Save selected teams"
+
+      within("table.attendee-list") do
+        expect(page).to have_content "A1 Team"
+      end
+    end
+
+    it "prevents adding a team that would go over the event's capacity" do
+      event = FactoryBot.create(:regional_pitch_event, capacity: 1, ambassador: chapter_ambassador)
+      team_squares = FactoryBot.create(:team, :senior, :live_event_eligible, name: "Team Squares")
+      event.teams << team_squares
+      FactoryBot.create(:team, :senior, :live_event_eligible, name: "Team Triangles")
+      expect(RegionalPitchEvent.count).to be_present
+      expect(Team.count).to be_present
+
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      find("img[alt='edit teams']").click
+      expect(page).to have_content("ADD TEAMS")
+
+      click_button "Add teams"
+      all("img[src*='check-circle-o.svg']").each { |img| img.click }
+      click_button "Done"
+
+      within("table.attendee-list") do
+        expect(page).to have_content "Team Squares"
+        expect(page).not_to have_content "Team Triangles"
+      end
+    end
+
+    it "successfully removes a team from an event" do
+      team  = FactoryBot.create(:team, :senior, :live_event_eligible, name: "Team LMNO")
+      event = FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+      expect(RegionalPitchEvent.count).to be_present
+      expect(Team.count).to be_present
+      event.teams = [team]
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      find("img[alt='edit teams']").click
+
+      within("table.attendee-list") do
+        expect(page).to have_content "Team LMNO"
+      end
+
+      find("table.attendee-list td:first-child").hover
+      find(".attendee-list__actions img[src*='remove.svg']").click
+      click_button "Yes, remove this team"
+
+      expect(page).to have_content "You removed Team LMNO"
+    end
+  end
+
+  context "when MANAGE_EVENTS is disabled" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("MANAGE_EVENTS", any_args).and_return(false)
+    end
+
+    it "does not display the 'Edit Teams' icon/link" do
+      sign_in(chapter_ambassador)
+
+      click_link "Events"
+      expect(page).not_to have_css("img[alt='edit teams']")
+    end
+  end
+end

--- a/spec/system/chapter_ambassador/regional_pitch_events_spec.rb
+++ b/spec/system/chapter_ambassador/regional_pitch_events_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "Regional Pitch Events", :js do
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :approved) }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+  end
+
+  it "successfully creates a new event" do
+    sign_in(chapter_ambassador)
+
+    click_link "Events"
+    click_button "Add an event"
+
+    find("#new-event .grid div:nth-child(5) label").click
+    all(".dayContainer .flatpickr-day:not(.disabled)").first.click
+    expect(find_field("Date").value).to be_present
+
+    find("#new-event .grid div:nth-child(6) label:nth-child(1)").click
+    find(".numInputWrapper:nth-child(1)").hover
+    find(".arrowDown").click
+    expect(find_field("From").value).to be_present
+
+    find("#new-event .grid div:nth-child(6) label:nth-child(2)").click
+    find(".numInputWrapper:nth-child(1)").hover
+    find(".arrowUp").click
+    expect(find_field("To").value).to be_present
+
+    fill_in "Event name", with: "Super Event"
+    fill_in "City", with: "New City"
+    fill_in "Venue address", with: "123 45th St"
+    choose "Senior division"
+
+    click_button "Create this event"
+
+    within ".vue-events-table" do
+      expect(page).to have_content "Super Event"
+    end
+  end
+
+  it "successfully updates an event" do
+    FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+    expect(RegionalPitchEvent.count).to be_present
+
+    sign_in(chapter_ambassador)
+
+    click_link "Events"
+    find("img[alt='edit']").click
+    fill_in "Event name", with: "Main Event"
+    click_button "Save changes"
+
+    within ".vue-events-table" do
+      expect(page).to have_content "Main Event"
+    end
+  end
+
+  it "sucessfully deletes an event" do
+    FactoryBot.create(:regional_pitch_event, ambassador: chapter_ambassador)
+    expect(RegionalPitchEvent.count).to be_present
+
+    sign_in(chapter_ambassador)
+
+    click_link "Events"
+    find("img[alt='remove']").click
+    click_button "Yes, delete this event"
+
+    expect(page).to have_content "Regional pitch event was successfully deleted"
+  end
+end


### PR DESCRIPTION
This will add feature specs for these scenarios:

RPEs:
 * creating/viewing an event
 * editing an event
 * deleting an event

Teams:
 * a team can be added to an event
 * a team can be removed from an event
 * a team cannot be added if it goes over the event capacity

Judges:
 * a judge can be added to an event
 * a judge can be removed from an event
