### PR TITLE
#2565 Rename Regional Ambassador to Chapter Ambassador

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Seeded users:
   * username: judge@judge.com
   * password: judge@judge.com
 
-* Regional Ambassador
+* Chapter Ambassador
   * username: ra@ra.com
   * password: ra@ra.com
 

--- a/app/controllers/admin/regional_ambassador_status_controller.rb
+++ b/app/controllers/admin/regional_ambassador_status_controller.rb
@@ -4,7 +4,7 @@ module Admin
       @regional_ambassador_profile = RegionalAmbassadorProfile.find(params[:id])
       @regional_ambassador_profile.update(regional_ambassador_status_params)
       redirect_to admin_participant_path(@regional_ambassador_profile.account),
-        success: "You set this RA to #{@regional_ambassador_profile.status}"
+        success: "You set this Chapter Ambassador to #{@regional_ambassador_profile.status}"
     end
 
     private

--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -447,7 +447,7 @@ class AccountsGrid
       ['Students', 'student'],
       ['Mentors', 'mentor'],
       ['Judges', 'judge'],
-      ['Regional Ambassadors', 'regional_ambassador'],
+      ['Chapter Ambassadors', 'regional_ambassador'],
     ],
     filter_group: "more-specific",
     html: {

--- a/app/javascript/admin/content-settings/components/Notices.vue
+++ b/app/javascript/admin/content-settings/components/Notices.vue
@@ -35,7 +35,7 @@
     </p>
 
     <p>
-      <label for="season_toggles_regional_ambassador_dashboard_text">Regional ambassadors</label>
+      <label for="season_toggles_regional_ambassador_dashboard_text">Chapter ambassadors</label>
       <input
         id="season_toggles_regional_ambassador_dashboard_text"
         type="text"

--- a/app/javascript/admin/content-settings/components/Registration.vue
+++ b/app/javascript/admin/content-settings/components/Registration.vue
@@ -47,7 +47,7 @@ export default {
         student: 'Students',
         mentor: 'Mentors',
         judge: 'Judges',
-        regional_ambassador: 'Regional Ambassadors',
+        regional_ambassador: 'Chapter Ambassadors',
       },
     }
   },

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -43,7 +43,7 @@
 
         <div ref="signupFieldAmbassadors" class="review-label">
           <p>
-            Regional Ambassadors
+            Chapter Ambassadors
             <strong
               :class="{
                 on: formData.regional_ambassador_signup,
@@ -204,7 +204,7 @@ export default {
         student_dashboard_text: 'Students',
         mentor_dashboard_text: 'Mentors',
         judge_dashboard_text: 'Judges',
-        regional_ambassador_dashboard_text: 'Regional Ambassadors',
+        regional_ambassador_dashboard_text: 'Chapter Ambassadors',
       },
       surveysFields: {
         student_survey_link: 'Students',

--- a/app/javascript/admin/dashboard/index.js
+++ b/app/javascript/admin/dashboard/index.js
@@ -43,7 +43,7 @@ document.addEventListener('turbolinks:load', () => {
   }
 
   /**
-   * Regional Ambassador Dashboards
+   * Chapter Ambassador Dashboards
    */
   const studentsSectionElement = document.getElementById('ra-admin-students-section')
 

--- a/app/javascript/components/DashboardHeader.vue
+++ b/app/javascript/components/DashboardHeader.vue
@@ -12,7 +12,7 @@
           {{ regionalProgramName }}
 
           <small>
-            <drop-down label="Meet your Regional Ambassador">
+            <drop-down label="Meet your Chapter Ambassador">
               <slot name="ra-intro" />
             </drop-down>
           </small>

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -23,7 +23,7 @@ class TeamMailer < ApplicationMailer
 
     I18n.with_locale(@member.locale) do
       mail to: @member.email,
-        subject: "Your RA has removed #{@team.name} " +
+        subject: "Your Chapter Ambassador has removed #{@team.name} " +
                  "from the regional pitch event: #{@event.name}"
     end
   end
@@ -39,7 +39,7 @@ class TeamMailer < ApplicationMailer
 
     I18n.with_locale(@member.locale) do
       mail to: @member.email,
-        subject: "Your RA has added #{@team.name} to the regional pitch event: #{@event.name}"
+        subject: "Your Chapter Ambassador has added #{@team.name} to the regional pitch event: #{@event.name}"
     end
   end
 

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -46,7 +46,7 @@ module SignIn
 
     (last_profile_used && "#{last_profile_used}_dashboard_path") or
       "#{signin.scope_name.sub(/^\w+_regional/, "regional")}_dashboard_path"
-    # TODO --- root out this pending regional ambassador stuff into something
+    # TODO --- root out this pending chapter ambassador stuff into something
     # sensible
   end
 end

--- a/app/views/ambassador_mailer/_email_declined.en.html.erb
+++ b/app/views/ambassador_mailer/_email_declined.en.html.erb
@@ -1,6 +1,6 @@
 <p>
   We're sorry, but it looks like you don’t fully meet the requirements
-  to become a Regional Ambassador.
+  to become a Chapter Ambassador.
 </p>
 
 <p>
@@ -40,7 +40,7 @@
 </p>
 
 <p>
-  <%= link_to "Email a Regional Ambassador in your area",
+  <%= link_to "Email a Chapter Ambassador in your area",
     "http://www.technovationchallenge.org/chapters/" %>
 </p>
 
@@ -48,7 +48,7 @@
   Review the
   <%= link_to "Chapters webpage",
     "http://www.technovationchallenge.org/chapters/" %>
-  to see if there is a Regional Ambassador in your area already.
+  to see if there is a Chapter Ambassador in your area already.
   Reach out to see how you might support their efforts.
 </p>
 
@@ -56,7 +56,7 @@
   If you have any questions, please reply to this email or email the
   Technovation Team at
   <%= mail_to ENV.fetch("ADMIN_EMAIL"), nil,
-    subject: "RA Follow-up Request" %>
+    subject: "Chapter Ambassador Follow-up Request" %>
   and someone will be in touch shortly.
 </p>
 

--- a/app/views/ambassador_mailer/approved.en.html.erb
+++ b/app/views/ambassador_mailer/approved.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          Your application has been approved, and you are now and Official Regional Ambassador for the <%= @season_year %> Technovation season!
+          Your application has been approved, and you are now an official Chapter Ambassador for the <%= @season_year %> Technovation season!
         </td>
       </tr>
       <tr>
@@ -24,7 +24,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          As an official Regional Ambassador (RA), you will have access to user data for students, mentors, and judges within your "region" ("country" for RAs outside of the US and "state" for those within the US) by logging into your account on <%= link_to @root_url, @root_url %>. We will be adding more features to support your events and outreach as the season progresses.
+          As an official Chapter Ambassador, you will have access to user data for students, mentors, and judges within your "region" ("country" for Chapter Ambassadors outside of the US and "state" for those within the US) by logging into your account on <%= link_to @root_url, @root_url %>. We will be adding more features to support your events and outreach as the season progresses.
         </td>
       </tr>
       <tr>

--- a/app/views/application/_welcome_message.html.erb
+++ b/app/views/application/_welcome_message.html.erb
@@ -13,7 +13,7 @@
       <%= Season.current.year %>
       Technovation season.
       Through this website, you will be able to sign up as a student, as a mentor,
-      as a judge, or you can apply to become a regional ambassador.
+      as a judge, or you can apply to become a chapter ambassador.
     </p>
 
     <p>

--- a/app/views/event_mailer/invite.en.html.erb
+++ b/app/views/event_mailer/invite.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          A Regional Ambassador has just added you to the event:
+          A Chapter Ambassador has just added you to the event:
           <strong><%= @event.name %></strong>
         </td>
       </tr>

--- a/app/views/event_mailer/notify_removed.en.html.erb
+++ b/app/views/event_mailer/notify_removed.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          A Regional Ambassador has just removed you from the event:
+          A Chapter Ambassador has just removed you from the event:
           <strong><%= @event.name %></strong>
         </td>
       </tr>

--- a/app/views/judge/dashboards/onboarded/_events.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_events.en.html.erb
@@ -44,7 +44,7 @@
 
       <p>
         If you want to change events or leave an event,
-        please contact your Regional Ambassador.
+        please contact your Chapter Ambassador.
       </p>
 
       <% current_judge.events.each do |event| %>
@@ -73,7 +73,7 @@
           </div>
 
           <div class="grid__col-auto grid__col--bleed-x">
-            <h6>Regional Ambassador</h6>
+            <h6>Chapter Ambassador</h6>
 
             <dl>
               <dt>Name</dt>
@@ -111,7 +111,7 @@
 
       <p class="scent--strong">
         You may be expecting an invitation to a live event from a
-        Regional Ambassador. In that case, just wait for the email.
+        Chapter Ambassador. In that case, just wait for the email.
         <strong>
           Most judges are online and will not attend a live event.
         </strong>

--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -12,7 +12,7 @@
 
         <% if current_judge.is_an_ambassador? %>
           <small>
-            <%= link_to "Switch to RA mode",
+            <%= link_to "Switch to Chapter Ambassador mode",
               regional_ambassador_dashboard_path,
               data: { turbolinks: false } %>
           </small>

--- a/app/views/judge_mailer/invite_to_event.en.html.erb
+++ b/app/views/judge_mailer/invite_to_event.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          Your Regional Ambassador has just added you to the event:
+          Your Chapter Ambassador has just added you to the event:
           <strong><%= @event.name %></strong>
         </td>
       </tr>

--- a/app/views/judge_mailer/notify_removed_from_event.en.html.erb
+++ b/app/views/judge_mailer/notify_removed_from_event.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          Your Regional Ambassador has just removed you from the event:
+          Your Chapter Ambassador has just removed you from the event:
           <strong><%= @event.name %></strong>
         </td>
       </tr>

--- a/app/views/mentor/dashboards/_header.en.html.erb
+++ b/app/views/mentor/dashboards/_header.en.html.erb
@@ -16,7 +16,7 @@
 
 <% if current_mentor.is_an_ambassador? %>
   <template slot="ra-switch-link">
-    <%= link_to "Switch to RA mode",
+    <%= link_to "Switch to Chapter Ambassador mode",
       regional_ambassador_dashboard_path,
       data: { turbolinks: false } %>
   </template>

--- a/app/views/mentor/profiles/_location.en.html.erb
+++ b/app/views/mentor/profiles/_location.en.html.erb
@@ -14,7 +14,7 @@
     </dl>
 
     <p class="hint">
-      Regional Ambassadors cannot edit their own location.
+      Chapter Ambassadors cannot edit their own location.
       <br />
       Contact <%= mail_to ENV.fetch("HELP_EMAIL") %> if you need to make a change.
     </p>

--- a/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
+++ b/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
@@ -77,7 +77,7 @@
 
               <p>
                 If this is a mistake or you want to change the event
-                please contact your regional ambassador.
+                please contact your chapter ambassador.
               </p>
 
               <p>

--- a/app/views/message_mailer/send_message.en.html.erb
+++ b/app/views/message_mailer/send_message.en.html.erb
@@ -11,7 +11,7 @@
       <% if @regarding_url %>
         <tr>
           <td class="content-block">
-            This is a message from your Regional Ambassador regarding<br />
+            This is a message from your Chapter Ambassador regarding<br />
             <strong><%= @regarding_name %></strong>.
           </td>
         </tr>

--- a/app/views/regional_ambassador/activities/index.en.html.erb
+++ b/app/views/regional_ambassador/activities/index.en.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Activity" %>
+<% provide :title, "Chapter Ambassador Data • Activity" %>
 
 <%= render 'datagrid/datagrid',
   grid: @activities_grid,

--- a/app/views/regional_ambassador/dashboards/_info_sidebar.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/_info_sidebar.en.html.erb
@@ -7,12 +7,12 @@
       target: "_blank" %>
   </li>
   <li>
-    <%= link_to "RA Resource Page",
+    <%= link_to "Chapter Ambassador Resource Page",
       "http://technovationchallenge.org/ra-resources/",
       target: "_blank" %>
   </li>
   <li>
-    <%= link_to "RA Handbook",
+    <%= link_to "Chapter Ambassador Handbook",
       "https://technovation.atavist.com/regional-ambassador-handbook-2019-2020",
       target: "_blank" %>
   </li>

--- a/app/views/regional_ambassador/dashboards/_menu.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/_menu.en.html.erb
@@ -55,7 +55,7 @@
       class="tabs__menu-button"
       data-tab-id="resources"
     >
-      RA resources
+      Chapter Ambassador resources
     </button>
   </li>
 </ul>

--- a/app/views/regional_ambassador/dashboards/show_declined.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/show_declined.en.html.erb
@@ -2,7 +2,7 @@
   <div class="grid__col-auto">
     <div class="panel">
       <p>
-        Your Regional Ambassador profile is declined.
+        Your Chapter Ambassador profile is declined.
         Speak with Ophelie for help.
       </p>
     </div>

--- a/app/views/regional_ambassador/dashboards/show_pending.en.html.erb
+++ b/app/views/regional_ambassador/dashboards/show_pending.en.html.erb
@@ -2,7 +2,7 @@
   <div class="grid__col-auto">
     <div class="panel">
       <p>
-        Your Regional Ambassador profile is pending.
+        Your Chapter Ambassador profile is pending.
         Speak with Ophelie for help.
       </p>
     </div>

--- a/app/views/regional_ambassador/judges/index.en.html.erb
+++ b/app/views/regional_ambassador/judges/index.en.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Judges" %>
+<% provide :title, "Chapter Ambassador Data • Judges" %>
 
 <%= render 'datagrid/datagrid',
   grid: @judges_grid,

--- a/app/views/regional_ambassador/messages/_new.en.html.erb
+++ b/app/views/regional_ambassador/messages/_new.en.html.erb
@@ -21,7 +21,7 @@
 
     <% if message.regarding %>
       <p>
-        This is a message from your Regional Ambassador regarding<br />
+        This is a message from your Chapter Ambassador regarding<br />
         <strong><%= message.regarding_name %></strong>.
       </p>
 

--- a/app/views/regional_ambassador/messages/show.en.html.erb
+++ b/app/views/regional_ambassador/messages/show.en.html.erb
@@ -16,7 +16,7 @@
 
     <% if @message.regarding %>
       <p>
-        This is a message from your Regional Ambassador regarding<br />
+        This is a message from your Chapter Ambassador regarding<br />
         <strong><%= @message.regarding_name %></strong>.
       </p>
 

--- a/app/views/regional_ambassador/participants/_sub_menu.en.html.erb
+++ b/app/views/regional_ambassador/participants/_sub_menu.en.html.erb
@@ -25,7 +25,7 @@
     data: { turbolinks: false },
     class: al(["scope=judge", "accounts_grid[scope_names][]=judge"]) %>
 
-  <%= link_to 'Regional Ambassadors',
+  <%= link_to 'Chapter Ambassadors',
     regional_ambassador_participants_path(
       accounts_grid: { scope_names: [:regional_ambassador] }
     ),

--- a/app/views/regional_ambassador/participants/index.en.html.erb
+++ b/app/views/regional_ambassador/participants/index.en.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Participants" %>
+<% provide :title, "Chapter Ambassador Data • Participants" %>
 
 <%= render 'datagrid/datagrid',
   grid: @accounts_grid,

--- a/app/views/regional_ambassador/profiles/_location.en.html.erb
+++ b/app/views/regional_ambassador/profiles/_location.en.html.erb
@@ -12,7 +12,7 @@
   <p><%= current_ambassador.address_details %></p>
 
   <p class="hint">
-    Regional Ambassadors cannot edit their own location.
+    Chapter Ambassadors cannot edit their own location.
     <br />
     Contact <%= mail_to ENV.fetch("HELP_EMAIL") %> if you need to make a change.
   </p>

--- a/app/views/regional_ambassador/regional_pitch_events/index.html.erb
+++ b/app/views/regional_ambassador/regional_pitch_events/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Events" %>
+<% provide :title, "Chapter Ambassador Data • Events" %>
 
 <div class="panel panel--left">
   <h1>Regional Pitch Events</h1>

--- a/app/views/regional_ambassador/signups/new.html.erb
+++ b/app/views/regional_ambassador/signups/new.html.erb
@@ -1,9 +1,9 @@
-<% provide(:title, "Regional Ambassador Signup") %>
+<% provide(:title, "Chapter Ambassador Signup") %>
 
 <div class="grid grid--justify-space-around">
   <div class="grid__col-sm-8 panel">
     <h1>
-      Confirm your Regional Ambassador details
+      Confirm your Chapter Ambassador details
     </h1>
 
     <%= simple_form_for(

--- a/app/views/regional_ambassador/team_submissions/index.html.erb
+++ b/app/views/regional_ambassador/team_submissions/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Team Submissions" %>
+<% provide :title, "Chapter Ambassador Data • Team Submissions" %>
 
 <%= render 'datagrid/datagrid',
   grid: @submissions_grid,

--- a/app/views/regional_ambassador/teams/index.en.html.erb
+++ b/app/views/regional_ambassador/teams/index.en.html.erb
@@ -1,4 +1,4 @@
-<% provide :title, "RA Data • Teams" %>
+<% provide :title, "Chapter Ambassador Data • Teams" %>
 
 <%= render 'datagrid/datagrid',
   grid: @teams_grid,

--- a/app/views/regional_pitch_events/_event.en.html.erb
+++ b/app/views/regional_pitch_events/_event.en.html.erb
@@ -63,7 +63,7 @@
         For more information, please check out the
         <%= link_to 'Technovation FAQ',
           'https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events'
-        %> or contact your regional ambassador.
+        %> or contact your chapter ambassador.
       </p>
 
       <dl>

--- a/app/views/student/dashboards/completion_steps/_regional_pitch_events.html.erb
+++ b/app/views/student/dashboards/completion_steps/_regional_pitch_events.html.erb
@@ -24,7 +24,7 @@
     You are attending
     <strong><%= current_team.event_name %></strong>.
     If this is a mistake or you want to attend a
-    different event please contact your regional ambassador.
+    different event please contact your chapter ambassador.
   </p>
 
   <%= render 'regional_pitch_events/dashboard_disclaimer' %>

--- a/app/views/student/dashboards/completion_steps/_scores_and_certificates.html.erb
+++ b/app/views/student/dashboards/completion_steps/_scores_and_certificates.html.erb
@@ -13,7 +13,7 @@
 <% elsif current_team.submission.complete? %>
   <p>
     Congratulations on completing your submission! Your certificate is ready.
-    To see your scores from your live event, ask your Regional Ambassador for a copy.
+    To see your scores from your live event, ask your Chapter Ambassador for a copy.
   </p>
 
   <div class="step-actions">

--- a/app/views/team_mailer/notify_added_event.en.html.erb
+++ b/app/views/team_mailer/notify_added_event.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          Your Regional Ambassador has just added
+          Your Chapter Ambassador has just added
           <strong><%= @team.name %></strong>
           to the event:
           <strong><%= @event.name %></strong>

--- a/app/views/team_mailer/notify_removed_event.en.html.erb
+++ b/app/views/team_mailer/notify_removed_event.en.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <tr>
         <td class="content-block">
-          Your Regional Ambassador has just removed
+          Your Chapter Ambassador has just removed
           <strong><%= @team.name %></strong>
           from the event:
           <strong><%= @event.name %></strong>

--- a/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
@@ -65,7 +65,7 @@
     </p>
 
     <p>
-      In the spring, Regional Ambassadors will invite teams
+      In the spring, Chapter Ambassadors will invite teams
       to pitch at a live event.
     </p>
 
@@ -74,7 +74,7 @@
       pitch presentation slides here.
     </p>
 
-    <p>Contact your Regional Ambassador for the due date.</p>
+    <p>Contact your Chapter Ambassador for the due date.</p>
 
     <p class="scent">
       (Pitching at a live Regional Pitch Event is not required.)

--- a/app/views/team_submissions/sections/pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/sections/pitch_presentation.en.html.erb
@@ -66,7 +66,7 @@
     </p>
 
     <p>
-      In the spring, Regional Ambassadors will invite teams
+      In the spring, Chapter Ambassadors will invite teams
       to pitch at a live event.
     </p>
 
@@ -75,7 +75,7 @@
       pitch presentation slides here.
     </p>
 
-    <p>Contact your Regional Ambassador for the due date.</p>
+    <p>Contact your Chapter Ambassador for the due date.</p>
 
     <p class="scent">
       (Pitching at a live Regional Pitch Event is not required.)

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -42,8 +42,8 @@ en:
       dashboards:
         show:
           approved_message: "Welcome! Your account has been reviewed by our staff and approved. Stay tuned, new RA features will be announced soon."
-          pending_message: "Thank you for registering as a Regional Ambassador. Technovation staff will review your account shortly to ensure that your information is correct. Once you are confirmed, you will have access to student data in your region."
-          declined_message: "Thank you for expressing interest in becoming a Regional Ambassador. Unfortunately, your request has been declined at this time."
+          pending_message: "Thank you for registering as a Chapter Ambassador. Technovation staff will review your account shortly to ensure that your information is correct. Once you are confirmed, you will have access to student data in your region."
+          declined_message: "Thank you for expressing interest in becoming a Chapter Ambassador. Unfortunately, your request has been declined at this time."
 
     student:
       dashboards:

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -7,11 +7,11 @@ en:
 
   ambassador_mailer:
     approved:
-      message: "Hey there, good news! Your Regional Ambassador account has been approved!"
+      message: "Hey there, good news! Your Chapter Ambassador account has been approved!"
       next_steps: "For now, there isn't anything for you to do. We are rolling out new RA features soon, and you will get an email when we have updates."
-      subject: "Regional Ambassador Approved Request Follow-up"
+      subject: "Chapter Ambassador Approved Request Follow-up"
     declined:
-      subject: "Regional Ambassador Request Follow-up"
+      subject: "Chapter Ambassador Request Follow-up"
 
   files_mailer:
     export_ready:

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -46,7 +46,7 @@ en:
       bio: "Bio"
 
     regional_ambassador_profile:
-      ambassador_since_year: "In which year did you become a regional ambassador?"
+      ambassador_since_year: "In which year did you become a chapter ambassador?"
       ambassador_since_year_option_new: "I'm new!"
       bio:
         signup_label: "Tell us about yourself"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -41,9 +41,9 @@ en:
       or: "or"
       survey: "Take our survey"
       privacy_policy: "Privacy Policy"
-      ra_mode: "RA mode"
+      ra_mode: "Chapter Ambassador mode"
       resources: "Resources"
-      regional_ambassador_dashboard: "Regional Ambassador"
+      regional_ambassador_dashboard: "Chapter Ambassador"
       review: "review"
       review_now: "Review now"
       save: "Save"
@@ -255,7 +255,7 @@ en:
           disabled:
             judge: "Judge registration will open in March %{year}"
             mentor: "Mentor registration for %{year} is closed."
-            regional_ambassador: "Regional Ambassador registration for %{year} is closed."
+            regional_ambassador: "Chapter Ambassador registration for %{year} is closed."
             student: "Student registration for %{year} is closed."
           judge: "Use your expertise to rate Technovation apps and provide feedback to teams."
           mentor: "Guide teams as they identify a problem in their community and help them build a real smartphone app to address it."
@@ -264,7 +264,7 @@ en:
         scopes:
           judge: "Judge"
           mentor: "Mentor"
-          regional_ambassador: "Regional Ambassador"
+          regional_ambassador: "Chapter Ambassador"
           student: "Student"
         section_headers:
           account_details: "Account details"
@@ -274,12 +274,12 @@ en:
         signup_link:
           judge: "I am a Judge"
           mentor: "I am a Mentor"
-          regional_ambassador: "Confirm your Regional Ambassador account"
+          regional_ambassador: "Confirm your Chapter Ambassador account"
           student: "I am a Student"
         title:
           judge: "Sign up as a"
           mentor: "Sign up as a"
-          regional_ambassador: "Confirm your Regional Ambassador account"
+          regional_ambassador: "Confirm your Chapter Ambassador account"
           student: "Sign up as a"
 
     student:

--- a/lib/tasks/ras.rake
+++ b/lib/tasks/ras.rake
@@ -1,5 +1,5 @@
 namespace :ras do
-  desc "List all current season regional ambassador assignments"
+  desc "List all current season chapter ambassador assignments"
   task ra_data_dump: :environment do
     puts "Exporting data..."
 

--- a/spec/features/admin/content_and_settings_spec.rb
+++ b/spec/features/admin/content_and_settings_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
       fill_in "Students", with: ""
       fill_in "Mentors", with: ""
       fill_in "Judges", with: ""
-      fill_in "Regional ambassadors", with: ""
+      fill_in "Chapter ambassadors", with: ""
 
       click_button "Review"
       click_button "Save these settings"
@@ -70,7 +70,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
       fill_in "Students", with: "Student notice"
       fill_in "Mentors", with: "Mentor notice"
       fill_in "Judges", with: "Judge notice"
-      fill_in "Regional ambassadors", with: "Regional ambassador notice"
+      fill_in "Chapter ambassadors", with: "Chapter ambassador notice"
 
       click_button "Review"
       click_button "Save these settings"
@@ -78,7 +78,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
       expect(SeasonToggles.dashboard_text(:student)).to eq("Student notice")
       expect(SeasonToggles.dashboard_text(:mentor)).to eq("Mentor notice")
       expect(SeasonToggles.dashboard_text(:judge)).to eq("Judge notice")
-      expect(SeasonToggles.dashboard_text(:regional_ambassador)).to eq("Regional ambassador notice")
+      expect(SeasonToggles.dashboard_text(:regional_ambassador)).to eq("Chapter ambassador notice")
     end
   end
 
@@ -232,7 +232,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
         expect(page).to have_unchecked_field("Students", disabled: true)
         expect(page).to have_unchecked_field("Mentors", disabled: true)
         expect(page).to have_unchecked_field("Judges", disabled: true)
-        expect(page).to have_unchecked_field("Regional Ambassadors", disabled: true)
+        expect(page).to have_unchecked_field("Chapter Ambassadors", disabled: true)
 
         click_button "Teams & Submissions"
         expect(page).to have_unchecked_field("Forming teams allowed", disabled: true)
@@ -293,7 +293,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
         expect(page).to have_field("Students", disabled: false)
         expect(page).to have_field("Mentors", disabled: false)
         expect(page).to have_field("Judges", disabled: false)
-        expect(page).to have_field("Regional Ambassadors", disabled: false)
+        expect(page).to have_field("Chapter Ambassadors", disabled: false)
 
         click_button "Teams & Submissions"
         expect(page).to have_field("Forming teams allowed", disabled: false)
@@ -313,7 +313,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
     uncheck "Students"
     uncheck "Mentors"
     uncheck "Judges"
-    uncheck "Regional Ambassadors"
+    uncheck "Chapter Ambassadors"
 
     click_button "Teams & Submissions"
     uncheck "Forming teams allowed"
@@ -331,7 +331,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
     check "Students"
     check "Mentors"
     check "Judges"
-    check "Regional Ambassadors"
+    check "Chapter Ambassadors"
 
     click_button "Teams & Submissions"
     check "Forming teams allowed"

--- a/spec/features/mentor/submission_spec.rb
+++ b/spec/features/mentor/submission_spec.rb
@@ -169,7 +169,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_content(
-      "In the spring, Regional Ambassadors will invite teams " +
+      "In the spring, Chapter Ambassadors will invite teams " +
       "to pitch at a live event."
     )
 
@@ -179,7 +179,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_content(
-      "Contact your Regional Ambassador for the due date."
+      "Contact your Chapter Ambassador for the due date."
     )
 
     expect(page).to have_content(

--- a/spec/features/regional_ambassador/approved_spec.rb
+++ b/spec/features/regional_ambassador/approved_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Approved regional ambassadors" do
+RSpec.feature "Approved chapter ambassadors" do
   scenario "updating their dashboard blurb" do
     ambassador = FactoryBot.create(:regional_ambassador, :approved)
 

--- a/spec/features/regional_ambassador/switch_to_judge_spec.rb
+++ b/spec/features/regional_ambassador/switch_to_judge_spec.rb
@@ -28,7 +28,7 @@ feature "RAs switch to judge mode from RA dashboard", :js do
       expect(page).to have_text("Judge Dashboard")
       expect(current_path).to eq(judge_dashboard_path)
 
-      click_link "Switch to RA mode"
+      click_link "Switch to Chapter Ambassador mode"
       expect(page).to have_text("Technovation Ambassador")
       expect(current_path).to eq(regional_ambassador_dashboard_path)
     end
@@ -36,7 +36,7 @@ feature "RAs switch to judge mode from RA dashboard", :js do
     scenario "a judge without an RA profile cannot switch to RA mode" do
       judge = FactoryBot.create(:judge, :onboarded)
       sign_in(judge)
-      expect(page).not_to have_link("Switch to RA mode")
+      expect(page).not_to have_link("Switch to Chapter Ambassador mode")
 
       visit regional_ambassador_dashboard_path
       expect(current_path).to eq(judge_dashboard_path)
@@ -109,7 +109,7 @@ feature "RAs switch to judge mode through mentor dashboard", :js do
       expect(regional_ambassador.is_a_judge?).to be_truthy
 
       click_link "Mentor Mode"
-      expect(page).to have_link("Switch to RA mode")
+      expect(page).to have_link("Switch to Chapter Ambassador mode")
       expect(current_path).to eq(mentor_dashboard_path)
 
       click_link "Switch to Judge mode"
@@ -125,7 +125,7 @@ feature "RAs switch to judge mode through mentor dashboard", :js do
       expect(regional_ambassador.is_a_judge?).to be_falsey
 
       click_link "Mentor Mode"
-      expect(page).to have_link("Switch to RA mode")
+      expect(page).to have_link("Switch to Chapter Ambassador mode")
       expect(current_path).to eq(mentor_dashboard_path)
 
       expect(page).not_to have_link("Switch to Judge mode")
@@ -146,7 +146,7 @@ feature "RAs switch to judge mode through mentor dashboard", :js do
       expect(regional_ambassador.is_a_judge?).to be_truthy
 
       click_link "Mentor Mode"
-      expect(page).to have_link("Switch to RA mode")
+      expect(page).to have_link("Switch to Chapter Ambassador mode")
       expect(current_path).to eq(mentor_dashboard_path)
 
       expect(page).not_to have_link("Switch to Judge mode")
@@ -160,7 +160,7 @@ feature "RAs switch to judge mode through mentor dashboard", :js do
       expect(regional_ambassador.is_a_judge?).to be_falsey
 
       click_link "Mentor Mode"
-      expect(page).to have_link("Switch to RA mode")
+      expect(page).to have_link("Switch to Chapter Ambassador mode")
       expect(current_path).to eq(mentor_dashboard_path)
 
       expect(page).not_to have_link("Switch to Judge mode")

--- a/spec/features/regional_ambassador/switch_to_mentor_spec.rb
+++ b/spec/features/regional_ambassador/switch_to_mentor_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "RAs switch to mentor mode", :js do
 
     sign_in(ra)
     click_link "Mentor Mode"
-    expect(page).to have_link("Switch to RA mode")
+    expect(page).to have_link("Switch to Chapter Ambassador mode")
 
     expect(current_path).to eq(mentor_dashboard_path)
   end
@@ -18,7 +18,7 @@ RSpec.feature "RAs switch to mentor mode", :js do
 
     sign_in(ra)
     click_link "Mentor Mode"
-    expect(page).to have_link("Switch to RA mode")
+    expect(page).to have_link("Switch to Chapter Ambassador mode")
 
     expect(current_path).to eq(mentor_dashboard_path)
   end
@@ -28,7 +28,7 @@ RSpec.feature "RAs switch to mentor mode", :js do
 
     sign_in(ra)
     click_link "Mentor Mode"
-    click_link "RA mode"
+    click_link "Chapter Ambassador mode"
 
     expect(current_path).to eq(regional_ambassador_dashboard_path)
   end
@@ -36,7 +36,7 @@ RSpec.feature "RAs switch to mentor mode", :js do
   scenario "a mentor without an RA profile cannot switch to RA mode" do
     mentor = FactoryBot.create(:mentor, :onboarded)
     sign_in(mentor)
-    expect(page).not_to have_link("RA mode")
+    expect(page).not_to have_link("Chapter Ambassador mode")
 
     visit regional_ambassador_dashboard_path
     expect(current_path).to eq(mentor_dashboard_path)

--- a/spec/features/regional_ambassador/view_scores_spec.rb
+++ b/spec/features/regional_ambassador/view_scores_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Regional Ambassador views scores" do
+RSpec.feature "Chapter Ambassador views scores" do
   before do
     ra = FactoryBot.create(:regional_ambassador, :approved)
     sign_in(ra)

--- a/spec/features/student/submission_spec.rb
+++ b/spec/features/student/submission_spec.rb
@@ -156,7 +156,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_content(
-      "In the spring, Regional Ambassadors will invite teams " +
+      "In the spring, Chapter Ambassadors will invite teams " +
       "to pitch at a live event."
     )
 
@@ -166,7 +166,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_content(
-      "Contact your Regional Ambassador for the due date."
+      "Contact your Chapter Ambassador for the due date."
     )
 
     expect(page).to have_content(

--- a/spec/javascript/admin/content-settings/components/Registration.spec.js
+++ b/spec/javascript/admin/content-settings/components/Registration.spec.js
@@ -34,7 +34,7 @@ describe('Admin Content & Settings - Registration component', () => {
           student: 'Students',
           mentor: 'Mentors',
           judge: 'Judges',
-          regional_ambassador: 'Regional Ambassadors',
+          regional_ambassador: 'Chapter Ambassadors',
         },
       })
     })

--- a/spec/javascript/admin/content-settings/components/Review.spec.js
+++ b/spec/javascript/admin/content-settings/components/Review.spec.js
@@ -31,7 +31,7 @@ describe('Admin Content & Settings - Review component', () => {
         student_dashboard_text: 'Students',
         mentor_dashboard_text: 'Mentors',
         judge_dashboard_text: 'Judges',
-        regional_ambassador_dashboard_text: 'Regional Ambassadors',
+        regional_ambassador_dashboard_text: 'Chapter Ambassadors',
       },
       surveysFields: {
         student_survey_link: 'Students',
@@ -218,9 +218,9 @@ describe('Admin Content & Settings - Review component', () => {
           await wrapper.vm.$nextTick()
 
           const notice = wrapper
-            .find({ ref: 'noticeFieldHintRegionalAmbassadors' })
+            .find({ ref: 'noticeFieldHintChapterAmbassadors' })
           const input = wrapper
-            .find({ ref: 'noticeFieldLabelRegionalAmbassadors' })
+            .find({ ref: 'noticeFieldLabelChapterAmbassadors' })
 
           expect(notice.exists()).toBe(true)
           expect(input.exists()).toBe(false)
@@ -233,9 +233,9 @@ describe('Admin Content & Settings - Review component', () => {
           await wrapper.vm.$nextTick()
 
           const notice = wrapper
-            .find({ ref: 'noticeFieldHintRegionalAmbassadors' })
+            .find({ ref: 'noticeFieldHintChapterAmbassadors' })
           const input = wrapper
-            .find({ ref: 'noticeFieldLabelRegionalAmbassadors' })
+            .find({ ref: 'noticeFieldLabelChapterAmbassadors' })
 
           expect(notice.exists()).toBe(false)
           expect(input.text()).toBe('Hello world, this is a test.')

--- a/spec/system/regional_ambassador/view_score_details_spec.rb
+++ b/spec/system/regional_ambassador/view_score_details_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "viewing score details page" do
         live_regional_pitch_event.teams << team
       end
 
-      context "when the regional ambassador views the main scores page" do
+      context "when the chapter ambassador views the main scores page" do
         before do
           sign_in(regional_ambassador)
 
@@ -137,7 +137,7 @@ RSpec.describe "viewing score details page" do
     end
 
     context "when the team has not attended an RPE" do
-      context "when the regional ambassador views the main scores page" do
+      context "when the chapter ambassador views the main scores page" do
         before do
           sign_in(regional_ambassador)
 
@@ -158,7 +158,7 @@ RSpec.describe "viewing score details page" do
       SeasonToggles.display_scores_on!
     end
 
-    context "when the regional ambassador views the main scores page" do
+    context "when the chapter ambassador views the main scores page" do
       before do
         sign_in(regional_ambassador)
 


### PR DESCRIPTION
These are the front-end changes for renaming Regional Ambassador to Chapter Ambassador. The term "RA" was also changed to Chapter Ambassador.

I think this one's good to go, I kept finding stragglers, but I think I got them all; I figured there's another opportunity to catch them in #2566 too.

#2565


