### PR TITLE
#2621 Update puma library to version 3.12.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby "2.6.4"
 
 gem 'rails', '~> 5.2.0'
 
-gem 'puma', '~> 3.12.2'
+gem 'puma', '~> 3.12.6'
 gem 'pg', '~> 0.21'
 gem 'casting', '~> 0.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
     public_suffix (4.0.3)
-    puma (3.12.4)
+    puma (3.12.6)
     rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
@@ -536,7 +536,7 @@ DEPENDENCIES
   pp_sql (~> 0.2)
   premailer-rails (~> 1.10)
   public_activity (~> 1.6)
-  puma (~> 3.12.2)
+  puma (~> 3.12.6)
   rack-rewrite (~> 1.5)
   rack-timeout (~> 0.5)
   rails (~> 5.2.0)


### PR DESCRIPTION
Update Puma to version 3.12.6 to remove this security vulnerability:
https://github.com/advisories/GHSA-x7jg-6pwg-fx5h

#2621