### PR TITLE
#2615 Remove judge and chapter ambassador signup options from Content & Settings section

### DIFF
--- a/app/javascript/admin/content-settings/components/Registration.vue
+++ b/app/javascript/admin/content-settings/components/Registration.vue
@@ -46,8 +46,6 @@ export default {
       checkboxes: {
         student: 'Students',
         mentor: 'Mentors',
-        judge: 'Judges',
-        chapter_ambassador: 'Chapter Ambassadors',
       },
     }
   },

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -26,34 +26,6 @@
             </strong>
           </p>
         </div>
-
-        <div ref="signupFieldJudges" class="review-label">
-          <p>
-            Judges
-            <strong
-              :class="{
-                on: formData.judge_signup,
-                off: !formData.judge_signup
-              }"
-            >
-              {{ formData.judge_signup ? 'yes' : 'no' }}
-            </strong>
-          </p>
-        </div>
-
-        <div ref="signupFieldAmbassadors" class="review-label">
-          <p>
-            Chapter Ambassadors
-            <strong
-              :class="{
-                on: formData.chapter_ambassador_signup,
-                off: !formData.chapter_ambassador_signup
-              }"
-            >
-              {{ formData.chapter_ambassador_signup ? 'yes' : 'no' }}
-            </strong>
-          </p>
-        </div>
       </div>
 
       <div class="review-panel">

--- a/app/views/admin/season_schedule_settings/edit.html.erb
+++ b/app/views/admin/season_schedule_settings/edit.html.erb
@@ -16,8 +16,6 @@
       :saved-form-data="{
         student_signup: <%= SeasonToggles.signup_enabled?('student') %>,
         mentor_signup: <%= SeasonToggles.signup_enabled?('mentor') %>,
-        judge_signup: <%= SeasonToggles.signup_enabled?('judge') %>,
-        chapter_ambassador_signup: <%= SeasonToggles.signup_enabled?('chapter_ambassador') %>,
         student_dashboard_text: '<%= escape_single_quotes(SeasonToggles.dashboard_text('student')) %>',
         mentor_dashboard_text: '<%= escape_single_quotes(SeasonToggles.dashboard_text('mentor')) %>',
         judge_dashboard_text: '<%= escape_single_quotes(SeasonToggles.dashboard_text('judge')) %>',

--- a/spec/features/admin/content_and_settings_spec.rb
+++ b/spec/features/admin/content_and_settings_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
 
       expect(SeasonToggles.student_signup?).to be false
       expect(SeasonToggles.mentor_signup?).to be false
-      expect(SeasonToggles.judge_signup?).to be false
-      expect(SeasonToggles.chapter_ambassador_signup?).to be false
 
       expect(SeasonToggles.team_building_enabled?).to be false
       expect(SeasonToggles.team_submissions_editable?).to be false
@@ -36,8 +34,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
 
       expect(SeasonToggles.student_signup?).to be true
       expect(SeasonToggles.mentor_signup?).to be true
-      expect(SeasonToggles.judge_signup?).to be true
-      expect(SeasonToggles.chapter_ambassador_signup?).to be true
 
       expect(SeasonToggles.team_building_enabled?).to be true
       expect(SeasonToggles.team_submissions_editable?).to be true
@@ -193,8 +189,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
 
         expect(SeasonToggles.student_signup?).to be false
         expect(SeasonToggles.mentor_signup?).to be false
-        expect(SeasonToggles.judge_signup?).to be false
-        expect(SeasonToggles.chapter_ambassador_signup?).to be false
         expect(SeasonToggles.team_building_enabled?).to be false
         expect(SeasonToggles.team_submissions_editable?).to be false
         expect(SeasonToggles.select_regional_pitch_event?).to be false
@@ -210,7 +204,7 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
         expect(page).to have_content("Enabling judging has affected other season features.")
 
         click_button "Registration"
-        expect(page).to have_content("When judging is enabled", count: 4)
+        expect(page).to have_content("When judging is enabled", count: 2)
 
         click_button "Teams & Submissions"
         expect(page).to have_content("When judging is enabled", count: 2)
@@ -231,8 +225,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
         click_button "Registration"
         expect(page).to have_unchecked_field("Students", disabled: true)
         expect(page).to have_unchecked_field("Mentors", disabled: true)
-        expect(page).to have_unchecked_field("Judges", disabled: true)
-        expect(page).to have_unchecked_field("Chapter Ambassadors", disabled: true)
 
         click_button "Teams & Submissions"
         expect(page).to have_unchecked_field("Forming teams allowed", disabled: true)
@@ -258,8 +250,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
 
         expect(SeasonToggles.student_signup?).to be true
         expect(SeasonToggles.mentor_signup?).to be true
-        expect(SeasonToggles.judge_signup?).to be true
-        expect(SeasonToggles.chapter_ambassador_signup?).to be true
         expect(SeasonToggles.team_building_enabled?).to be true
         expect(SeasonToggles.team_submissions_editable?).to be true
         expect(SeasonToggles.select_regional_pitch_event?).to be true
@@ -292,8 +282,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
         click_button "Registration"
         expect(page).to have_field("Students", disabled: false)
         expect(page).to have_field("Mentors", disabled: false)
-        expect(page).to have_field("Judges", disabled: false)
-        expect(page).to have_field("Chapter Ambassadors", disabled: false)
 
         click_button "Teams & Submissions"
         expect(page).to have_field("Forming teams allowed", disabled: false)
@@ -312,8 +300,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
     click_button "Registration"
     uncheck "Students"
     uncheck "Mentors"
-    uncheck "Judges"
-    uncheck "Chapter Ambassadors"
 
     click_button "Teams & Submissions"
     uncheck "Forming teams allowed"
@@ -330,8 +316,6 @@ RSpec.feature "Season controls exposed through Content & Settings tab", js: true
     click_button "Registration"
     check "Students"
     check "Mentors"
-    check "Judges"
-    check "Chapter Ambassadors"
 
     click_button "Teams & Submissions"
     check "Forming teams allowed"

--- a/spec/javascript/admin/content-settings/components/Registration.spec.js
+++ b/spec/javascript/admin/content-settings/components/Registration.spec.js
@@ -33,8 +33,6 @@ describe('Admin Content & Settings - Registration component', () => {
         checkboxes: {
           student: 'Students',
           mentor: 'Mentors',
-          judge: 'Judges',
-          chapter_ambassador: 'Chapter Ambassadors',
         },
       })
     })
@@ -132,7 +130,7 @@ describe('Admin Content & Settings - Registration component', () => {
       const notices = wrapper.findAll('.notice')
 
       expect(wrapper.vm.judgingEnabled).toBe(true)
-      expect(notices.length).toEqual(4)
+      expect(notices.length).toEqual(2)
       notices.wrappers.forEach((notice) => {
         const props = notice.find(Icon).props()
 


### PR DESCRIPTION
This will remove the Judge and Chapter Ambassador registration options from the admin area.

I created #2632 to remove the outstanding/non-admin code.