### PR TITLE
Make release stop pushing all branches

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -22,7 +22,7 @@ task :release do
 
   releasing.run_command("git checkout qa")
   releasing.run_command("git push --tags")
-  releasing.run_command("git push #{releasing.stable_branch} master production")
+  releasing.run_command("git push origin #{releasing.stable_branch} master production")
 
   # prevent Rake from running the `updating_version_part` ARG as another task
   exit

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -22,7 +22,7 @@ task :release do
 
   releasing.run_command("git checkout qa")
   releasing.run_command("git push --tags")
-  releasing.run_command("git push --all")
+  releasing.run_command("git push #{releasing.stable_branch} master production")
 
   # prevent Rake from running the `updating_version_part` ARG as another task
   exit


### PR DESCRIPTION
@shaunxp20 does this look right? I think this would just push the right branches and we could take the branch clean up step out of the deployment process.