### PR TITLE
#2606 Update conditions to #prepare_student_for_current_season

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -6,7 +6,10 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
 
     update_season_data_with_resets(record)
 
-    prepare_student_for_current_season(record) if is_student?(record)
+    if is_student?(record) && !is_mentor?(record)
+      prepare_student_for_current_season(record)
+    end
+
     prepare_mentor_for_current_season(record)  if is_mentor?(record)
     prepare_judge_for_current_season(record)   if is_judge?(record)
 
@@ -62,7 +65,7 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
         !profile.parent_guardian_email.blank?
       ParentMailer.consent_notice(profile.id).deliver_later
     end
-    
+
     profile.save # fire commit hooks, if needed
   end
 

--- a/spec/jobs/register_to_current_season_job_spec.rb
+++ b/spec/jobs/register_to_current_season_job_spec.rb
@@ -162,4 +162,34 @@ RSpec.describe RegisterToCurrentSeasonJob do
       student.season_registered_at
     }
   end
+
+  context "students who are now mentors" do
+    let(:account) { FactoryBot.create(:account) }
+    let!(:student) { FactoryBot.create(:student, account: account) }
+    let!(:mentor) { FactoryBot.create(:mentor, account: account) }
+    let(:welcome_student_email) { double("welcome student email") }
+    let(:parental_consent_notice_email) { double("parental consent notice email") }
+
+    before do
+      allow(RegistrationMailer).to receive(:welcome_student)
+        .with(account)
+        .and_return(welcome_student_email)
+
+      allow(ParentMailer).to receive(:consent_notice)
+        .with(student.id)
+        .and_return(parental_consent_notice_email)
+    end
+
+    it "does not send a student welcome email" do
+      expect(welcome_student_email).not_to receive(:deliver_later)
+
+      RegisterToCurrentSeasonJob.perform_now(account)
+    end
+
+    it "does not send a parental consent notice email" do
+      expect(parental_consent_notice_email).not_to receive(:deliver_later)
+
+      RegisterToCurrentSeasonJob.perform_now(account)
+    end
+  end
 end


### PR DESCRIPTION
This is more of a band-aid fix, basically if an account has both a student profile and a mentor profile, we'll just treat them as a mentor, and not run `#prepare_student_for_current_season`, which includes the two emails we don't want to send out.

#2606


