### PR TITLE
#2620 add back the legacy 'name or email' field for first iteration of this

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -405,6 +405,19 @@ class AccountsGrid
         .where("mentor_profiles.school_company_name IN (?) OR judge_profiles.company_name IN (?)", value, value)
     end
 
+  filter :name_email,
+    header: "Name or Email",
+    filter_group: "more-specific" do |value|
+      names = value.strip.downcase.split(' ').map { |n|
+        I18n.transliterate(n).gsub("'", "''")
+      }
+      fuzzy_search({
+        first_name: names.first,
+        last_name: names.last || names.first,
+        email: names.first,
+      }, false) # false enables OR search
+    end
+
   filter :first_name,
     filter_group: "more-specific" do |value|
       basic_search({


### PR DESCRIPTION
This adds back the original "Name or email" search field, so now the change is only additive. People who prefer the old-style search have it, and the more specific exact-match search fields can go to production for some feedback on real data. 