### PR TITLE
#2616 Add help text to judging options in admin

### DIFF
--- a/app/javascript/admin/content-settings/components/Judging.vue
+++ b/app/javascript/admin/content-settings/components/Judging.vue
@@ -9,6 +9,7 @@
         v-model="$store.state.judging_round"
       >
       <label for="season_toggles_judging_round_off">Off</label>
+      <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Before judging: Judges cannot judge'" />
     </p>
     <p class="inline-radio">
       <input
@@ -18,6 +19,7 @@
         v-model="$store.state.judging_round"
       >
       <label for="season_toggles_judging_round_qf">Quarterfinals</label>
+      <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges can now judge either virtually or their assigned submissions'" />
     </p>
     <p class="inline-radio">
       <input
@@ -27,6 +29,7 @@
         v-model="$store.state.judging_round"
       >
       <label for="season_toggles_judging_round_between">Between rounds</label>
+      <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges now see the &quot;between rounds&quot; screen'" />
     </p>
     <p class="inline-radio">
       <input
@@ -36,6 +39,7 @@
         v-model="$store.state.judging_round"
       >
       <label for="season_toggles_judging_round_sf">Semifinals</label>
+      <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges can now judge semifinals submissions'" />
     </p>
     <p class="inline-radio">
       <input
@@ -45,7 +49,13 @@
         v-model="$store.state.judging_round"
       >
       <label for="season_toggles_judging_round_finished">Finished</label>
+      <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'After judging: judges cannot judge'" />
     </p>
+
+    <p class="margin--t-large">
+      <a href="https://docs.google.com/document/d/1bFN0yf2M0RrpdxBaq4tudNfhcvGetifY3v1gnHvkV20/" class="small">View judging document</a>
+    </p>
+
     <div v-if="judgingEnabled" class="notice info hint">
       <icon name="exclamation-circle" :size="16" color="00529B" />
       Enabling judging has affected other season features.
@@ -54,8 +64,10 @@
 </template>
 
 <script>
+import { VTooltip } from 'v-tooltip'
 import { mapGetters } from 'vuex'
 
+import 'components/tooltip.scss'
 import Icon from 'components/Icon'
 
 export default {

--- a/app/javascript/components/tooltip.scss
+++ b/app/javascript/components/tooltip.scss
@@ -4,9 +4,9 @@
   font-size: 0.9rem;
 
   .tooltip-inner {
-    background: black;
+    background: #333;
     color: white;
-    border-radius: 16px;
+    border-radius: 4px;
     padding: 5px 10px 4px;
   }
 
@@ -16,7 +16,7 @@
     border-style: solid;
     position: absolute;
     margin: 5px;
-    border-color: black;
+    border-color: #333;
     z-index: 1;
   }
 


### PR DESCRIPTION
This will add help text via tooltips to the judging options in the Content & Settings area in the admin.

#2616
