### PR TITLE
Test and fix for bug #2663

### DIFF
--- a/app/controllers/student/team_searches_controller.rb
+++ b/app/controllers/student/team_searches_controller.rb
@@ -29,6 +29,8 @@ module Student
 
         h[:country] = current_account.country
         h[:location] = current_account.address_details
+
+        h[:scope] = current_scope
       end
     end
   end

--- a/spec/requests/student/team_searches_spec.rb
+++ b/spec/requests/student/team_searches_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Student::TeamSearchesController do
+  let(:student_account) { FactoryBot.create(:account) }
+  let(:student_profile) do
+    FactoryBot.create(
+      :student_profile,
+      :geocoded,
+      account: student_account
+    )
+  end
+
+  describe "GET #new" do
+    before do
+      sign_in student_profile
+    end
+
+    context "when a team is accepting student join requests" do
+      let!(:team) do
+        FactoryBot.create(
+          :team,
+          accepting_student_requests: true
+        )
+      end
+
+      it "includes them in search results" do
+        get new_student_team_search_path(nearby: :anywhere)
+        expect(response.body).to include(team.name)
+      end
+    end
+
+    context "when a team is not accepting student join requests" do
+      let!(:team) do
+        FactoryBot.create(
+          :team,
+          accepting_student_requests: false
+        )
+      end
+
+      it "excludes them from search results" do
+        get new_student_team_search_path(nearby: :anywhere)
+        expect(response.body).not_to include(team.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Students could find teams that had chosen not to be searchable. This fixes that, with a test to cover the functionality.