### PR TITLE
#2660 Add ability for users to cancel their team join requests

### DIFF
--- a/app/controllers/mentor/join_requests_controller.rb
+++ b/app/controllers/mentor/join_requests_controller.rb
@@ -77,7 +77,7 @@ module Mentor
     end
 
     def destroy
-      join_request = JoinRequest.find_by(review_token: params.fetch(:id))
+      join_request = current_mentor.join_requests.find_by(review_token: params.fetch(:id))
       join_request.deleted!
 
       redirect_to mentor_dashboard_path(anchor: "/find-team"),

--- a/app/controllers/mentor/join_requests_controller.rb
+++ b/app/controllers/mentor/join_requests_controller.rb
@@ -76,6 +76,17 @@ module Mentor
       end
     end
 
+    def destroy
+      join_request = JoinRequest.find_by(review_token: params.fetch(:id))
+      join_request.deleted!
+
+      redirect_to mentor_dashboard_path(anchor: "/find-team"),
+        success: t(
+          "controllers.mentor.join_requests.destroy.success",
+          name: join_request.team_name
+        )
+    end
+
     private
     def reviewer_is_requestor?(join_request)
       current_mentor.authenticated? and current_mentor == join_request.requestor

--- a/app/controllers/student/join_requests_controller.rb
+++ b/app/controllers/student/join_requests_controller.rb
@@ -39,7 +39,11 @@ module Student
         redirect_to student_team_path(team),
           alert: t("views.team_member_invites.show.invites_disabled_by_judging")
       elsif
-        current_student.join_requests.find_or_create_by!(team: team)
+        if join_request = current_student.join_requests.find_by(team: team)
+          join_request.pending!
+        else
+          join_request = current_student.join_requests.create!(team: team)
+        end
 
         redirect_to student_dashboard_path,
           success: t(

--- a/app/controllers/student/join_requests_controller.rb
+++ b/app/controllers/student/join_requests_controller.rb
@@ -74,6 +74,17 @@ module Student
       end
     end
 
+    def destroy
+      join_request = JoinRequest.find_by(review_token: params.fetch(:id))
+      join_request.deleted!
+
+      redirect_to student_dashboard_path(anchor: "/find-team"),
+        success: t(
+          "controllers.student.join_requests.destroy.success",
+          name: join_request.team_name
+        )
+    end
+
     private
     def join_request_params
       params.require(:join_request).permit(:status)

--- a/app/controllers/student/join_requests_controller.rb
+++ b/app/controllers/student/join_requests_controller.rb
@@ -79,7 +79,7 @@ module Student
     end
 
     def destroy
-      join_request = JoinRequest.find_by(review_token: params.fetch(:id))
+      join_request = current_student.join_requests.find_by(review_token: params.fetch(:id))
       join_request.deleted!
 
       redirect_to student_dashboard_path(anchor: "/find-team"),

--- a/app/views/completion_steps/_join_requests.en.html.erb
+++ b/app/views/completion_steps/_join_requests.en.html.erb
@@ -29,7 +29,21 @@
               <%= join_request.team_name %><br />
               Division:
               <%= join_request.team_division_name.humanize %><br />
-              <%= join_request.team_primary_location %>
+              <%= join_request.team_primary_location %><br />
+              <%= link_to "Cancel my request to join this team",
+                [
+                  current_scope,
+                  :join_request,
+                  {
+                    id: join_request.review_token
+                  }
+                ],
+                data: {
+                  method: :delete,
+                  confirm: t("controllers.student.join_requests.destroy.confirm")
+                },
+                class: "danger small"
+              %>
             </p>
           </div>
         </div>

--- a/app/views/join_requests/show_deleted.en.html.erb
+++ b/app/views/join_requests/show_deleted.en.html.erb
@@ -14,6 +14,13 @@
         they sent will be marked as deleted. That could be why
         you can no longer see this request.
       </p>
+
+      <p class="margin--t-xlarge">
+        <%= link_to "Manage my team",
+          [current_scope, @join_request.team],
+          class: "button"
+        %>
+      </p>
     </div>
   </div>
 </div>

--- a/app/views/slots/student/available/_join_team.en.html.erb
+++ b/app/views/slots/student/available/_join_team.en.html.erb
@@ -26,7 +26,21 @@
               <%= join_request.team_name %><br />
               Division:
               <%= join_request.team_division_name.humanize %><br />
-              <%= join_request.team_primary_location %>
+              <%= join_request.team_primary_location %><br />
+              <%= link_to "Cancel my request to join this team",
+                [
+                  current_scope,
+                  :join_request,
+                  {
+                    id: join_request.review_token
+                  }
+                ],
+                data: {
+                  method: :delete,
+                  confirm: t("controllers.student.join_requests.destroy.confirm")
+                },
+                class: "danger small"
+              %>
             </p>
           </div>
         </div>

--- a/app/views/slots/student/available/_join_team.en.html.erb
+++ b/app/views/slots/student/available/_join_team.en.html.erb
@@ -5,54 +5,56 @@
 
 <h3 class="margin--t-large">Ask to join a team</h3>
 
-<% if current_student.pending_join_requests.any? %>
-  <p>You have asked to join a team!</p>
+<div id="join-requests">
+  <% if current_student.join_requests.pending.any? %>
+    <p>You have asked to join a team!</p>
 
-  <% current_student.pending_join_requests.each do |join_request| %>
-    <%= content_tag :div,
-      class: "join_request",
-      id: dom_id(join_request) do %>
-      <div class="grid grid--bleed">
-        <div class="grid__col-4">
-          <div class="grid__cell">
-            <%= image_tag join_request.team_team_photo_url,
-              class: 'thumbnail-md grid__cell-img' %>
+    <% current_student.join_requests.pending.each do |join_request| %>
+      <%= content_tag :div,
+        class: "join_request",
+        id: dom_id(join_request) do %>
+        <div class="grid grid--bleed">
+          <div class="grid__col-4">
+            <div class="grid__cell">
+              <%= image_tag join_request.team_team_photo_url,
+                class: 'thumbnail-md grid__cell-img' %>
+            </div>
+          </div>
+
+          <div class="grid__col-8">
+            <div class="grid__cell">
+              <p>
+                <%= join_request.team_name %><br />
+                Division:
+                <%= join_request.team_division_name.humanize %><br />
+                <%= join_request.team_primary_location %><br />
+                <%= link_to "Cancel my request to join this team",
+                  [
+                    current_scope,
+                    :join_request,
+                    {
+                      id: join_request.review_token
+                    }
+                  ],
+                  data: {
+                    method: :delete,
+                    confirm: t("controllers.student.join_requests.destroy.confirm")
+                  },
+                  class: "danger small"
+                %>
+              </p>
+            </div>
           </div>
         </div>
-
-        <div class="grid__col-8">
-          <div class="grid__cell">
-            <p>
-              <%= join_request.team_name %><br />
-              Division:
-              <%= join_request.team_division_name.humanize %><br />
-              <%= join_request.team_primary_location %><br />
-              <%= link_to "Cancel my request to join this team",
-                [
-                  current_scope,
-                  :join_request,
-                  {
-                    id: join_request.review_token
-                  }
-                ],
-                data: {
-                  method: :delete,
-                  confirm: t("controllers.student.join_requests.destroy.confirm")
-                },
-                class: "danger small"
-              %>
-            </p>
-          </div>
-        </div>
-      </div>
+      <% end %>
     <% end %>
-  <% end %>
-<% else %>
-  <p>Use our team search to find a team and ask to join them!</p>
+  <% else %>
+    <p>Use our team search to find a team and ask to join them!</p>
 
-  <%= link_to(
-    t("views.profile_requirements.create_join_team.links.join.text"),
-    [:new, current_scope, :team_search],
-    class: "button"
-  ) %>
-<% end %>
+    <%= link_to(
+      t("views.profile_requirements.create_join_team.links.join.text"),
+      [:new, current_scope, :team_search],
+      class: "button"
+    ) %>
+  <% end %>
+</div>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -131,6 +131,9 @@ en:
           success: "You have requested to join %{name}"
         update:
           success: "%{name} was %{status}"
+        destroy:
+          confirm: "Are you sure you want to cancel this request?"
+          success: "You have cancelled your request to join %{name}"
 
       mentors:
         show:

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -77,6 +77,9 @@ en:
           success: "You have requested to be a mentor for %{name}"
         update:
           success: "%{name} was %{status}"
+        destroy:
+          confirm: "Are you sure you want to cancel this request?"
+          success: "You have cancelled your request to join %{name}"
 
     parental_consents:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
 
     resources :team_member_invites, except: [:edit, :index]
     resources :mentor_invites, only: [:create, :destroy]
-    resources :join_requests, only: [:new, :show, :create, :update]
+    resources :join_requests, only: [:new, :show, :create, :update, :destroy]
 
     resources :team_searches, except: [:index, :destroy]
     resources :mentor_searches, except: [:index, :destroy]

--- a/spec/features/mentor/find_a_team_spec.rb
+++ b/spec/features/mentor/find_a_team_spec.rb
@@ -114,42 +114,4 @@ RSpec.feature "Mentors find a team" do
       text: senior_team.name
     )
   end
-
-  scenario "request to join a team" do
-    Timecop.freeze(day_before_qfs) do
-      within('#find-team') { click_link "Find a team" }
-
-      click_link "View more details"
-      click_button "Ask to be a mentor for #{available_team.name}"
-
-      join_request = JoinRequest.last
-
-      expect(current_path).to eq(mentor_join_request_path(join_request))
-      expect(page).to have_content(join_request.team_name)
-      expect(page).to have_content(
-        "You have requested to be a mentor for #{available_team.name}"
-      )
-      expect(page).to have_content("You have requested to join this team")
-    end
-  end
-
-  scenario "request to join the same team again, even if you deleted an earlier request" do
-    Timecop.freeze(day_before_qfs) do
-      join_request = JoinRequest.create!({
-        requestor: mentor,
-        team: available_team,
-      })
-
-      join_request.deleted!
-
-      within('#find-team') { click_link "Find a team" }
-
-      click_link "View more details"
-      click_button "Ask to be a mentor for #{available_team.name}"
-
-      expect(current_path).to eq(mentor_join_request_path(join_request))
-      expect(page).to have_content("You have requested to join this team")
-      expect(page).to have_content(join_request.team_name)
-    end
-  end
 end

--- a/spec/features/mentor/join_a_team_spec.rb
+++ b/spec/features/mentor/join_a_team_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.feature "Mentors join a team" do
+  let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(day_before_qfs.year) }
+
+  before { allow(Season).to receive(:current).and_return(current_season) }
+  before { SeasonToggles.team_building_enabled! }
+
+  let!(:available_team) { FactoryBot.create(:team, :geocoded) }
+    # Default is in Chicago
+
+  let(:mentor) { FactoryBot.create(:mentor, :onboarded, :geocoded) } # City is Chicago
+
+  before { sign_in(mentor) }
+
+  scenario "request to join a team" do
+    Timecop.freeze(day_before_qfs) do
+      within('#find-team') { click_link "Find a team" }
+
+      click_link "View more details"
+      click_button "Ask to be a mentor for #{available_team.name}"
+
+      join_request = JoinRequest.last
+
+      expect(current_path).to eq(mentor_join_request_path(join_request))
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content(
+        "You have requested to be a mentor for #{available_team.name}"
+      )
+      expect(page).to have_content("You have requested to join this team")
+    end
+  end
+
+  scenario "request to join the same team again, even if you deleted an earlier request" do
+    Timecop.freeze(day_before_qfs) do
+      join_request = JoinRequest.create!({
+        requestor: mentor,
+        team: available_team,
+      })
+
+      join_request.deleted!
+
+      within('#find-team') { click_link "Find a team" }
+
+      click_link "View more details"
+      click_button "Ask to be a mentor for #{available_team.name}"
+
+      expect(current_path).to eq(mentor_join_request_path(join_request))
+      expect(page).to have_content("You have requested to join this team")
+      expect(page).to have_content(join_request.team_name)
+    end
+  end
+
+  scenario "cancel a request to join a team", js: true do
+    Timecop.freeze(day_before_qfs) do
+      join_request = JoinRequest.create!({
+        requestor: mentor,
+        team: available_team,
+      })
+
+      visit mentor_dashboard_path
+
+      within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
+      click_button "Yes, do it"
+
+      expect(page).to have_content("You have cancelled your request")
+      within("#find-team") { expect(page).not_to have_content(available_team.name) }
+    end
+  end
+end

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -31,39 +31,4 @@ RSpec.feature "Students find a team" do
     expect(page).to have_css(".search-result-head", text: team.name)
     expect(page).not_to have_css(".search-result-head", text: faraway_team.name)
   end
-
-  scenario "request to join a team" do
-    Timecop.freeze(day_before_qfs) do
-      within (".navigation") { click_link "Find a team" }
-      click_link "View more details"
-      click_button "Ask to join #{available_team.name}"
-
-      join_request = JoinRequest.last
-
-      expect(current_path).to eq(student_dashboard_path)
-      expect(page).to have_content(join_request.team_name)
-      expect(page).to have_content("You have asked to join")
-    end
-  end
-
-  scenario "onboarded student sees pending requests" do
-    Timecop.freeze(day_before_qfs) do
-      sign_out
-
-      onboarded = FactoryBot.create(:student, :geocoded)
-
-      sign_in(onboarded)
-
-      within(".navigation") { click_link "Find a team" }
-
-      click_link "View more details"
-      click_button "Ask to join #{available_team.name}"
-
-      join_request = JoinRequest.last
-
-      expect(current_path).to eq(student_dashboard_path)
-      expect(page).to have_content(join_request.team_name)
-      expect(page).to have_content("You have asked to join")
-    end
-  end
 end

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.feature "Students find a team" do
+  let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
+  let(:current_season) { Season.new(day_before_qfs.year) }
+
+  before { allow(Season).to receive(:current).and_return(current_season) }
+  before { SeasonToggles.team_building_enabled! }
+
+  let!(:available_team) { FactoryBot.create(:team, :geocoded) }
+  # Default is in Chicago
+  let(:student) { FactoryBot.create(:student, :geocoded) }
+  # City is Chicago
+
+  before do
+    sign_in(student)
+  end
+
+  scenario "request to join a team" do
+    Timecop.freeze(day_before_qfs) do
+      within (".navigation") { click_link "Find a team" }
+      click_link "View more details"
+      click_button "Ask to join #{available_team.name}"
+
+      join_request = JoinRequest.last
+
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content("You have asked to join")
+    end
+  end
+
+  scenario "onboarded student sees pending requests" do
+    Timecop.freeze(day_before_qfs) do
+      within(".navigation") { click_link "Find a team" }
+
+      click_link "View more details"
+      click_button "Ask to join #{available_team.name}"
+
+      join_request = JoinRequest.last
+
+      visit student_dashboard_path(anchor: "/find-team")
+
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content("You have asked to join")
+    end
+  end
+
+  scenario "cancel a join request", js: true do
+    Timecop.freeze(day_before_qfs) do
+      within(".navigation") { click_link "Find a team" }
+      click_link "View more details"
+      click_button "Ask to join #{available_team.name}"
+
+      join_request = JoinRequest.last
+
+      visit student_dashboard_path(anchor: "/find-team")
+
+      within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
+      click_button "Yes, do it"
+
+      expect(page).to have_content("You have cancelled your request")
+      within("#join-requests") { expect(page).not_to have_content(available_team.name) }
+    end
+  end
+end


### PR DESCRIPTION
For students and mentors to be able to cancel join requests.

Right now, the implementation is that the join requests gets `deleted!`, which sets a `deleted_at` timestamp. The system also uses that in certain contexts, and I'm not explicitly capturing that the user cancelled vs. one of the other contexts, because the ticket didn't require that.