### PR TITLE
#2675 Rework gender identity filter 

### DIFF
--- a/app/models/search_filter.rb
+++ b/app/models/search_filter.rb
@@ -7,10 +7,6 @@ class SearchFilter < Struct.new(:filter_options)
     from_search_filter(:expertise_ids)
   end
 
-  def gender_identities
-    from_search_filter(:gender_identities)
-  end
-
   def nearby
     filter_options.fetch(:nearby) { nil }
   end
@@ -45,6 +41,10 @@ class SearchFilter < Struct.new(:filter_options)
 
   def needs_team
     filter_options.fetch(:needs_team) { "0" } == "1"
+  end
+
+  def female_only
+    filter_options.fetch(:female_only) { "0" } == "1"
   end
 
   def on_team

--- a/app/technovation/search_mentors.rb
+++ b/app/technovation/search_mentors.rb
@@ -16,8 +16,8 @@ module SearchMentors
       mentors = mentors.by_expertise_ids(filter.expertise_ids)
     end
 
-    if filter.gender_identities.any?
-      mentors = mentors.by_gender_identities(filter.gender_identities)
+    if filter.female_only
+      mentors = mentors.by_gender_identities([Account.genders["Female"]])
     end
 
     if filter.needs_team

--- a/app/views/mentor_searches/_filter_options.html.erb
+++ b/app/views/mentor_searches/_filter_options.html.erb
@@ -19,18 +19,7 @@
 
     <h3>Gender Identity</h3>
 
-    <%= collection_check_boxes :search_filter, :gender_identities,
-      @gender_identities, :second, :first do |b| %>
-      <p>
-        <%= b.check_box(
-          id: "gender_#{b.value}",
-          class: "toggle-based-search",
-          checked: gender_identity_params.include?(b.value),
-        ) %>
-
-        <%= b.label text: b.text, for: "gender_#{b.value}" %>
-      </p>
-    <% end %>
+    <%= render 'searches/toggle_gender_identity_preference', account: account, f: f %>
 
     <h3>Expertise</h3>
 

--- a/app/views/searches/_toggle_gender_identity_preference.en.html.erb
+++ b/app/views/searches/_toggle_gender_identity_preference.en.html.erb
@@ -1,0 +1,19 @@
+<p class="reset">
+  <%= f.radio_button :female_only,
+    1,
+    checked: params[:female_only] == "1",
+    id: :female_only_1,
+    class: "toggle-based-search "%>
+
+  <%= f.label :female_only_1, "Female" %>
+</p>
+
+<p class="reset">
+  <%= f.radio_button :female_only,
+    0,
+    checked: params[:female_only] == "0",
+    id: :female_only_0,
+    class: "toggle-based-search "%>
+
+  <%= f.label :female_only_0, "No preference" %>
+</p>

--- a/spec/technovation/search_mentors_spec.rb
+++ b/spec/technovation/search_mentors_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe SearchMentors do
+  let(:searcher) { FactoryBot.create(:account) }
+  let(:search_filter) do
+    SearchFilter.new({
+      nearby: "anywhere",
+      coordinates: searcher.coordinates,
+      female_only: female_only,
+    })
+  end
+  let(:female_only) { "0" }
+  let(:onboarded_mentor) { FactoryBot.create(:mentor, :onboarded) }
+
+  it "returns an onboarded mentor" do
+    expect(SearchMentors.(search_filter)).to include(onboarded_mentor)
+  end
+
+  context "gender identity filter" do
+    let!(:male) { FactoryBot.create(:mentor, :onboarded, gender: "Male") }
+    let!(:female) { FactoryBot.create(:mentor, :onboarded, gender: "Female") }
+    let!(:non_binary) { FactoryBot.create(:mentor, :onboarded, gender: "Non-binary") }
+    let!(:prefer_not_to_say) { FactoryBot.create(:mentor, :onboarded, gender: "Prefer not to say") }
+
+    context "no preference" do
+      let(:female_only) { "0" }
+
+      it "finds all gender identities" do
+        results = SearchMentors.(search_filter)
+        expect(results).to include(male)
+        expect(results).to include(female)
+        expect(results).to include(non_binary)
+        expect(results).to include(prefer_not_to_say)
+      end
+    end
+
+    context "female only" do
+      let(:female_only) { "1" }
+
+      it "finds only female" do
+        results = SearchMentors.(search_filter)
+        expect(results).to include(female)
+        expect(results).not_to include(male)
+        expect(results).not_to include(non_binary)
+        expect(results).not_to include(prefer_not_to_say)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reworking the mentor search gender identity filter to provide "Female" or "No preference" options, and filter searches appropriately.