### PR TITLE
#2740 Fix next onboarding step calculation for mentors

### DIFF
--- a/app/serializers/mentor_profile_serializer.rb
+++ b/app/serializers/mentor_profile_serializer.rb
@@ -12,7 +12,7 @@ class MentorProfileSerializer
 
   attribute(:next_onboarding_step) do |mentor|
     case mentor.onboarding_steps.first
-    when :training_complete?
+    when :training_complete_or_not_required?
       "mentor-training"
     when :consent_signed?
       "consent-waiver"

--- a/spec/serializers/mentor_profile_serializer_spec.rb
+++ b/spec/serializers/mentor_profile_serializer_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe MentorProfileSerializer do
+  context "next onboarding step" do
+    let(:mentor) { FactoryBot.create(:mentor, not_onboarded: true) }
+    let(:next_onboarding_step) do
+      serializer = MentorProfileSerializer.new(mentor.reload)
+      h = serializer.serializable_hash
+      h[:data][:attributes][:nextOnboardingStep]
+    end
+
+    it "sends user to training first" do
+      expect(next_onboarding_step).to eq('mentor-training')
+    end
+
+    it "then to the consent waiver" do
+      mentor.complete_training!
+
+      expect(next_onboarding_step).to eq('consent-waiver')
+    end
+
+    it "then the background check, if required" do
+      mentor.complete_training!
+      FactoryBot.create(:consent_waiver, account: mentor.account)
+
+      expect(next_onboarding_step).to eq('background-check')
+    end
+
+    it "then the bio" do
+      mentor.complete_training!
+      FactoryBot.create(:consent_waiver, account: mentor.account)
+      FactoryBot.create(:background_check, account: mentor.account)
+
+      expect(next_onboarding_step).to eq('bio')
+    end
+  end
+end


### PR DESCRIPTION
The next onboarding step is sent across as part of the serializer, and hadn't been updated to account for a mentor profile change, I think. This should fix the problem, and adds tests for that part of the serializer.