### PR TITLE
user docker credentials in CI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -103,6 +103,9 @@ jobs:
           THUNKABLE_PROMO_IMAGE: n-a
           WKHTMLTOPDF_PATH: /usr/local/bin/wkhtmltopdf
       - image: circleci/postgres:11-alpine-ram
+        auth:
+          username: technovationdocker
+          password: $DOCKERHUB_PASSWORD
 
     steps:
       - checkout

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,9 @@ jobs:
     working_directory: ~/circleci-demo-ruby-rails
     docker:
       - image: circleci/ruby:2.6.4-node-browsers
+        auth:
+          username: technovationdocker
+          password: $DOCKERHUB_PASSWORD
         environment:
           ADMIN_EMAIL: info@technovationchallenge.org
           AIRBRAKE_PROJECT_ID: n-a


### PR DESCRIPTION
Docker Hub is going to begin rate limiting anonymous pulls, which could affect our CircleCI builds. This adds credentials for a Docker Hub account on the free plan, so at least we know what kind of rates we're dealing with.

See https://discuss.circleci.com/t/updated-authenticate-with-docker-to-avoid-impact-of-nov-1st-rate-limits/37567