### PR TITLE
#2732 prevent creation of duplicate mentor expertise

### DIFF
--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -90,6 +90,7 @@ class MentorProfile < ActiveRecord::Base
     dependent: :destroy
 
   has_many :expertises,
+    -> { distinct },
     through: :mentor_profile_expertises
 
   has_many :memberships,

--- a/spec/models/mentor_profile_spec.rb
+++ b/spec/models/mentor_profile_spec.rb
@@ -112,4 +112,14 @@ RSpec.describe MentorProfile do
       ).to eq([intl_mentor])
     end
   end
+
+  describe "expertise" do
+    it "prevent duplicates" do
+      mentor = FactoryBot.create(:mentor)
+      expertise = FactoryBot.create(:expertise)
+      mentor.update(expertise_ids: [expertise.id, expertise.id])
+
+      expect(mentor.expertises.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
I believe this PR both prevents the further creation of duplicate mentor expertise, and where we already have them it hides that duplication without interfering with the mentor's profile.
