### PR TITLE
Update support email address

### DIFF
--- a/app/javascript/judge/scores/TeamInfo.vue
+++ b/app/javascript/judge/scores/TeamInfo.vue
@@ -26,7 +26,7 @@
 
           <p>
             Complete as much of the score as you can and
-            <a :href="mailToHelp">email us</a>.
+            <a :href="emailSupport">email us</a>.
             If the team is able to fix the issue,
             we will email you back and you will be able
             to update the score.
@@ -58,12 +58,10 @@ export default {
       'deadline',
     ]),
 
-    mailToHelp () {
-      return 'mailto:help@technovationchallenge.org?subject=' +
-             'Errors while judging submission ' +
-             '"' + this.submission.name + '"' +
-             ' by ' +
-             this.team.name
+    emailSupport() {
+      const subject = `Errors while judging submission "${this.submission.name}" by ${this.team.name}`
+
+      return `mailto:${process.env.HELP_EMAIL}?subject=${subject}`
     },
   },
 

--- a/circle.yml
+++ b/circle.yml
@@ -84,7 +84,7 @@ jobs:
           GOOGLE_MAPS_API_KEY: n-a
           GOOGLE_PLACES_API_KEY: n-a
           GOOGLE_TIMEZONE_API_KEY: n-a
-          HELP_EMAIL: help@technovationchallenge.org
+          HELP_EMAIL: support@technovation.org
           HOST_DOMAIN: localhost:31337
           JUDGE_SLACK_SIGNUP_URL: n-a
           JUDGE_TRAINING_URL: n-a

--- a/public/404.html
+++ b/public/404.html
@@ -103,9 +103,8 @@
 
       <p class="contact">
         If you really need the content you expected to find here, please contact us at
-        <a href="mailto:help@technovationchallenge.org">help@technovationchallenge.org</a>.
+        <a href="mailto:support@technovation.org">support@technovation.org</a>.
       </p>
-
     </div>
   </div>
 

--- a/public/422.html
+++ b/public/422.html
@@ -101,9 +101,10 @@
       <p>We're experiencing a temporary issue with our site.</p>
       <p><a href="/">Click here</a> to go back to the homepage.</p>
 
-      <p class="contact">If the problem persists, please contact us at <a
-        href="mailto:help@technovationchallenge.org">help@technovationchallenge.org</a>.</p>
-
+      <p class="contact">
+        If the problem persists, please contact us at
+        <a href="mailto:support@technovation.org">support@technovation.org</a>.
+      </p>
     </div>
   </div>
 

--- a/public/500.html
+++ b/public/500.html
@@ -102,8 +102,10 @@
       <p>Our technical team has been notified and will try to correct it as soon as possible.</p>
       <p>You can try to <a href="/">go back to the homepage</a>.</p>
 
-      <p class="contact">If the problem persists, please contact us at <a
-        href="mailto:help@technovationchallenge.org">help@technovationchallenge.org</a>.</p>
+      <p class="contact">
+        If the problem persists, please contact us at
+        <a href="mailto:support@technovation.org">support@technovation.org</a>.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
Updating a couple of lingering references of `help@technovationchallenge.org` to be `support@technovation.org`.

Refs: #2785


