### PR TITLE
Display judge recusal info on a judge's profile page in admin

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -9,7 +9,8 @@ module Admin
     def show
       @account = Account.find(params.fetch(:id))
       @teams = Team.current
-      @scores = submission_score(@account)
+      @scores = submission_score
+      @recused_scores = recused_scores
       @season_flag = SeasonFlag.new(@account)
       @certificates = @account.current_certificates
       @needed_certificates = DetermineCertificates.new(@account).needed
@@ -122,9 +123,17 @@ module Admin
       end
     end
 
-    def submission_score(account)
-      if account.judge_profile.present?
-        account.judge_profile.submission_scores.current.with_deleted.complete
+    def submission_score
+      if @account.judge_profile.present?
+        @account.judge_profile.submission_scores.current.with_deleted.complete
+      else
+        SubmissionScore.none
+      end
+    end
+
+    def recused_scores
+      if @account.judge_profile.present?
+        @account.judge_profile.submission_scores.recused
       else
         SubmissionScore.none
       end

--- a/app/views/admin/participants/_judge_recused_scores.html.erb
+++ b/app/views/admin/participants/_judge_recused_scores.html.erb
@@ -1,0 +1,30 @@
+<% if recused_scores.any? %>
+  <table class="width--100-percent">
+    <th>
+      <tr>
+        <td>Team Name</td>
+        <td>Submission Name</td>
+        <td>Reason</td>
+        <td>Round</td>
+      </tr>
+    </th>
+    <tbody>
+      <% recused_scores.each do |score| %>
+        <tr>
+          <td><%= score.team_name %></td>
+          <td>
+            <%= link_to score.team_submission_app_name,
+                        admin_team_submission_path(score.team_submission_id),
+                        class: "cta-link" %>
+          </td>
+          <td><%= content_tag :span, score.judge_recusal_reason.humanize, title: score.judge_recusal_comment %></td>
+          <td><%= score.round.humanize %></itd>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>
+    No recused scores
+  </p>
+<% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -114,6 +114,13 @@
             profile: @account.judge_profile,
             scores: @scores.semifinals %>
         </div>
+
+        <div class="grid__col-12 grid__col--bleed">
+          <h3 class="heading--reset">Recusals:</h3>
+
+          <%= render "admin/participants/judge_recused_scores",
+            recused_scores: @recused_scores %>
+        </div>
       </div>
     <% end %>
 


### PR DESCRIPTION
This is "Admin part 3" from #2556, I added the judge recusal info to a judge's profile page in the admin - this was an easier one to do (of the three admin pieces), and I think it will be helpful when QAing #2875. 😄 

Ticket #2902


