### PR TITLE
Allow projecrPage urls in team share url validator

### DIFF
--- a/app/validators/thunkable_share_url_validator.rb
+++ b/app/validators/thunkable_share_url_validator.rb
@@ -1,6 +1,6 @@
 class ThunkableShareUrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if not value.match(/^https?:\/\/x.thunkable.com\/copy\/\w+$/)
+    if not value.match(/^https?:\/\/x.thunkable.com\/(copy|projectPage)\/\w+$/)
       record.errors.add(attribute, :invalid)
     end
   end

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe TeamSubmission do
     submission.thunkable_project_url = "https://x.thunkable.com/copy/47d800b3aa47590210ad662249e63dd4"
     expect(submission).to be_valid
     expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/copy/47d800b3aa47590210ad662249e63dd4")
+
+    submission.thunkable_project_url = "http://x.thunkable.com/projectPage/abc123"
+    expect(submission).to be_valid
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/abc123")
+
+    submission.thunkable_project_url = "x.thunkable.com/projectPage/abc123"
+    expect(submission).to be_valid
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/abc123")
+
+    submission.thunkable_project_url = "https://x.thunkable.com/projectPage/dd223dzfe50680a0fa2ac515"
+    expect(submission).to be_valid
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/dd223dzfe50680a0fa2ac515")
   end
 
   describe "ACTIVE_DEVELOPMENT_PLATFORMS_ENUM" do


### PR DESCRIPTION
This implements #2905 . Unfortunately, I not manage to run the tests on my machine, the setup seemed pretty involved (especially since I run on windows, I think you do not have a windows setup guide?). 