### PR TITLE
Add mentor/judge accounts to judge email list

### DIFF
--- a/app/jobs/add_profile_type_to_account_on_email_list_job.rb
+++ b/app/jobs/add_profile_type_to_account_on_email_list_job.rb
@@ -1,0 +1,9 @@
+class AddProfileTypeToAccountOnEmailListJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(account_id:, profile_type:)
+    account = Account.find(account_id)
+
+    Mailchimp::MailingList.new.add_profile_type_to_account(profile_type: profile_type, account: account)
+  end
+end

--- a/app/technovation/create_judge_profile.rb
+++ b/app/technovation/create_judge_profile.rb
@@ -1,28 +1,31 @@
 module CreateJudgeProfile
   def self.call(account)
-    if account.can_be_a_judge? and account.is_not_a_judge?
+    if account.can_be_a_judge? && account.is_not_a_judge?
       create_judge_profile(account)
+      AddProfileTypeToAccountOnEmailListJob.perform_later(profile_type: "judge", account_id: account.id)
+
       true
     else
       false
     end
   end
 
-  private
   def self.create_judge_profile(account)
     attrs = if account.chapter_ambassador_profile.present?
-              {
-                company_name: account.chapter_ambassador_profile
-                  .organization_company_name,
-                job_title: account.chapter_ambassador_profile.job_title,
-              }
-            elsif account.mentor_profile.present?
-              {
-                company_name: account.mentor_profile.school_company_name,
-                job_title: account.mentor_profile.job_title,
-              }
-            end
+      {
+        company_name: account.chapter_ambassador_profile
+          .organization_company_name,
+        job_title: account.chapter_ambassador_profile.job_title
+      }
+    elsif account.mentor_profile.present?
+      {
+        company_name: account.mentor_profile.school_company_name,
+        job_title: account.mentor_profile.job_title
+      }
+    end
 
     account.create_judge_profile!(attrs)
   end
+
+  private_class_method :create_judge_profile
 end

--- a/app/technovation/mailchimp.rb
+++ b/app/technovation/mailchimp.rb
@@ -23,6 +23,14 @@ module Mailchimp
       end
     end
 
+    def add_profile_type_to_account(profile_type:, account:)
+      handle("add profile type #{profile_type} to #{account.email} on list: #{list_id}") do
+        list.members(subscriber_hash(account.email)).tags.create(
+          body: {tags: [{name: profile_type, status: "active"}]}
+        )
+      end
+    end
+
     def update(account:, currently_subscribed_as: "")
       if currently_subscribed_as.blank?
         currently_subscribed_as = account.email

--- a/lib/tasks/add_existing_mentor_judge_accounts_to_judge_email_list.rake
+++ b/lib/tasks/add_existing_mentor_judge_accounts_to_judge_email_list.rake
@@ -1,0 +1,14 @@
+desc "Add existing mentor-judge combo accounts to the judge's email list"
+task add_existing_mentor_judge_accounts_to_judge_email_list: :environment do
+  account_ids = Account
+    .joins(:mentor_profile)
+    .joins(:judge_profile)
+    .where("'2021' = ANY(seasons)")
+    .pluck(:id)
+
+  account_ids.each_with_index do |account_id, index|
+    puts "#{(index + 1).to_s.rjust(3)}: Calling AddProfileTypeToAccountOnEmailListJob for account_id: #{account_id}"
+
+    AddProfileTypeToAccountOnEmailListJob.perform_later(profile_type: "judge", account_id: account_id)
+  end
+end

--- a/spec/jobs/add_profile_type_to_account_on_email_list_job_spec.rb
+++ b/spec/jobs/add_profile_type_to_account_on_email_list_job_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe AddProfileTypeToAccountOnEmailListJob do
+  let(:account) { double(Account, id: 1, email: "alina@example.com") }
+  let(:profile_type_to_add) { "student" }
+
+  before do
+    allow(Account).to receive(:find).with(account.id).and_return(account)
+  end
+
+  it "calls the Mailchimp service that will add the profile type to the account" do
+    expect(Mailchimp::MailingList).to receive_message_chain(:new, :add_profile_type_to_account)
+      .with(profile_type: profile_type_to_add, account: account)
+
+    AddProfileTypeToAccountOnEmailListJob.perform_now(
+      profile_type: profile_type_to_add,
+      account_id: account.id
+    )
+  end
+end

--- a/spec/technovation/create_judge_profile_spec.rb
+++ b/spec/technovation/create_judge_profile_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe CreateJudgeProfile do
+  describe ".call" do
+    let(:account) do
+      instance_double(
+        Account,
+        id: 1012,
+        can_be_a_judge?: can_be_a_judge,
+        is_not_a_judge?: is_not_a_judge,
+        chapter_ambassador_profile: chapter_ambassador_profile
+      )
+    end
+
+    let(:can_be_a_judge) { false }
+    let(:is_not_a_judge) { false }
+    let(:chapter_ambassador_profile) do
+      instance_double(
+        ChapterAmbassadorProfile,
+        organization_company_name: "Grisha Inc.",
+        job_title: "Squaller"
+      )
+    end
+
+    before do
+      allow(account).to receive(:create_judge_profile!)
+    end
+
+    context "when an account can be a judge" do
+      let(:can_be_a_judge) { true }
+      let(:is_not_a_judge) { true }
+
+      it "calls AddProfileTypeToAccountOnEmailListJob - adding the profile type 'judge' to the account" do
+        expect(AddProfileTypeToAccountOnEmailListJob).to receive(:perform_later)
+          .with(account_id: account.id, profile_type: "judge")
+
+        CreateJudgeProfile.call(account)
+      end
+    end
+
+    context "when an account cannot be a judge" do
+      let(:can_be_a_judge) { false }
+      let(:is_not_a_judge) { false }
+
+      it "does not call AddProfileTypeToAccountOnEmailListJob" do
+        expect(AddProfileTypeToAccountOnEmailListJob).not_to receive(:perform_later)
+          .with(account_id: account.id, profile_type: "judge")
+
+        CreateJudgeProfile.call(account)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a mentor becomes a judge (via the "Switch to Judge Mode" button), this will add them to the "judge" email list (by tagging them as a judge). The account will only get tagged as a judge when the judge profile is first created (when the button is clicked for the first time), and only if they are currently on the Mailchimp list.

I also added the script to add existing mentor/judge accounts to the judge email list

Tickets: #2912 and #2923