### PR TITLE
added judge_not_deleted scope to incomplete scores on score detail page

### DIFF
--- a/app/views/chapter_ambassador/score_details/show.en.html.erb
+++ b/app/views/chapter_ambassador/score_details/show.en.html.erb
@@ -54,7 +54,7 @@
   <h5>Incomplete Quarterfinal scores</h5>
   <div id="incomplete-quarterfinal-scores">
     <%= render 'chapter_ambassador/score_details/scores_table',
-      scores: scores.quarterfinals.incomplete %>
+      scores: scores.judge_not_deleted.quarterfinals.incomplete %>
   </div>
 
   <% if current_account.is_admin? %>


### PR DESCRIPTION
This accounts for a bug with deleting judges, which still needs to be investigated 

