### PR TITLE
Two-step consent form process

### DIFF
--- a/app/controllers/media_consents_controller.rb
+++ b/app/controllers/media_consents_controller.rb
@@ -16,7 +16,6 @@ class MediaConsentsController < ApplicationController
     elsif @media_consent.signed?
       redirect_to action: :show, token: params.fetch(:token)
     end
-
   end
 
   def update

--- a/app/controllers/media_consents_controller.rb
+++ b/app/controllers/media_consents_controller.rb
@@ -9,12 +9,14 @@ class MediaConsentsController < ApplicationController
 
   def edit
     @media_consent = find_media_consent
+    @parental_consent = find_parental_consent
 
     if @media_consent.blank?
       redirect_to root_path, alert: t("controllers.media_consents.invalid")
     elsif @media_consent.signed?
       redirect_to action: :show, token: params.fetch(:token)
     end
+
   end
 
   def update
@@ -36,9 +38,16 @@ class MediaConsentsController < ApplicationController
   private
 
   def find_media_consent
-    Account.find_by(consent_token: params.fetch(:token))
+    student_profile&.media_consent
+  end
+
+  def find_parental_consent
+    student_profile&.parental_consent
+  end
+
+  def student_profile
+    @student_profile ||= Account.find_by(consent_token: params.fetch(:token))
       &.student_profile
-      &.media_consent
   end
 
   def media_consent_params

--- a/app/controllers/parental_consents_controller.rb
+++ b/app/controllers/parental_consents_controller.rb
@@ -20,6 +20,7 @@ class ParentalConsentsController < ApplicationController
       @parental_consent = student.parental_consent || student.create_parental_consent!
       @parental_consent.student_profile_consent_token = params.fetch(:token)
       @parental_consent.newsletter_opt_in = true
+      @media_consent = student.media_consent
     elsif student.present? && student.consent_signed?
       redirect_to parental_consent_path(student.parental_consent),
         success: t("controllers.parental_consents.create.success")

--- a/app/controllers/parental_consents_controller.rb
+++ b/app/controllers/parental_consents_controller.rb
@@ -20,7 +20,6 @@ class ParentalConsentsController < ApplicationController
       @parental_consent = student.parental_consent || student.create_parental_consent!
       @parental_consent.student_profile_consent_token = params.fetch(:token)
       @parental_consent.newsletter_opt_in = true
-      @media_consent = student.media_consent
     elsif student.present? && student.consent_signed?
       redirect_to parental_consent_path(student.parental_consent),
         success: t("controllers.parental_consents.create.success")
@@ -41,8 +40,7 @@ class ParentalConsentsController < ApplicationController
     @parental_consent = student.parental_consent
 
     if @parental_consent.update(parental_consent_params)
-      redirect_to parental_consent_path(@parental_consent),
-        success: t("controllers.parental_consents.create.success")
+      redirect_to edit_media_consent_path(token: token)
     else
       render :edit
     end

--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -39,15 +39,14 @@ class AccountMailer < ApplicationMailer
     end
   end
 
-  def confirm_next_steps(consent)
-    @name = consent.student_profile_first_name
-
+  def confirm_next_steps(account)
+    @name = account.first_name
     @url = student_dashboard_url(
-      mailer_token: consent.student_profile.mailer_token
+      mailer_token: account.mailer_token
     )
 
-    I18n.with_locale(consent.student_profile_locale) do
-      mail to: consent.student_profile_email
+    I18n.with_locale(account.locale) do
+      mail to: account.email
     end
   end
 

--- a/app/mailers/parent_mailer.rb
+++ b/app/mailers/parent_mailer.rb
@@ -16,28 +16,27 @@ class ParentMailer < ApplicationMailer
     end
   end
 
-  def confirm_consent_finished(consent_id)
-    consent = ParentalConsent.find(consent_id)
-    return unless consent.student_profile.parent_guardian_email
+  def confirm_consent_finished(student_profile)
+    return if student_profile.parent_guardian_email.blank?
 
-    @name = consent.student_profile.parent_guardian_name
-    @student_name = consent.student_profile_full_name
-    @signature = consent.electronic_signature
-    @signed_date = consent.updated_at.strftime("%B %e, %Y")
+    @student_profile = student_profile
+    @parental_consent = student_profile.parental_consent
+    @media_consent = student_profile.media_consent
 
-    I18n.with_locale(consent.student_profile_locale) do
-      mail to: consent.student_profile.parent_guardian_email
+    I18n.with_locale(@student_profile.account.locale) do
+      mail to: @student_profile.parent_guardian_email
     end
   end
 
-  def thank_you(consent_id)
-    profile = ParentalConsent.find(consent_id).student_profile
-    @name = profile.parent_guardian_name
+  def thank_you(student_profile)
+    return if student_profile.parent_guardian_email.blank?
+
+    @student_profile = student_profile
     @technovation_url = "http://technovationchallenge.org/about/"
     @newsletter_url = "https://confirmsubscription.com/h/d/C9D08C6FF3FA972C"
 
-    I18n.with_locale(profile.account.locale) do
-      mail to: profile.parent_guardian_email
+    I18n.with_locale(@student_profile.account.locale) do
+      mail to: @student_profile.parent_guardian_email
     end
   end
 end

--- a/app/models/parental_consent.rb
+++ b/app/models/parental_consent.rb
@@ -58,7 +58,7 @@ class ParentalConsent < ActiveRecord::Base
   alias void? voided?
 
   def after_signed_student_actions
-    AccountMailer.confirm_next_steps(self).deliver_later
+    AccountMailer.confirm_next_steps(student_profile.account).deliver_later
   end
 
   def after_signed_parent_actions
@@ -66,11 +66,11 @@ class ParentalConsent < ActiveRecord::Base
       SubscribeParentToEmailListJob.perform_later(student_profile_id: student_profile.id)
     end
 
-    ParentMailer.confirm_consent_finished(id).deliver_later
+    ParentMailer.confirm_consent_finished(student_profile).deliver_later
 
     if Rails.env.production?
       # TODO: entire test suite requires rewrite due to "wait: 3.days"
-      ParentMailer.thank_you(id).deliver_later(wait: 3.days)
+      ParentMailer.thank_you(student_profile).deliver_later(wait: 3.days)
     end
   end
 

--- a/app/views/media_consents/edit.en.html.erb
+++ b/app/views/media_consents/edit.en.html.erb
@@ -2,6 +2,13 @@
 
 <div class="grid grid--justify-space-around">
   <div class="panel grid__col-sm-8">
+    <%= render partial: "parental_consents/consent_status",
+      locals: {
+        parental_consent: @parental_consent,
+        media_consent: @media_consent
+      }
+    %>
+
     <%= simple_form_for @media_consent do |f| %>
       <%= render "errors", record: @media_consent %>
 

--- a/app/views/parent_mailer/confirm_consent_finished.en.html.erb
+++ b/app/views/parent_mailer/confirm_consent_finished.en.html.erb
@@ -4,19 +4,20 @@
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td class="content-block">
-          Dear <%= @name %>,
+          Dear <%= @student_profile.parent_guardian_name %>,
         </td>
       </tr>
 
       <tr>
         <td class="content-block">
-          Below is a copy of your signed parent/guardian consent form for <%= @student_name %>'s participation in Technovation Girls <%= Season.current.year %>.
+          Below is a copy of your signed parent/guardian consent form for <%= @student_profile.account.full_name %>'s participation in Technovation Girls <%= Season.current.year %>.
         </td>
       </tr>
 
       <tr>
         <td class="content-block">
-          Thanks,<br /> The Technovation Team
+          Thanks,<br>
+          The Technovation Team
         </td>
       </tr>
 
@@ -24,11 +25,11 @@
         <td class="content-block">
           <%= render 'parental_consents/consent' %>
 
-          <p>Student name: <%= @student_name %></p>
+          <p>Student name: <%= @student_profile.account.full_name %></p>
 
           <p>
-            Electronic signature<br />
-            <%= @signature %> signed on <%= @signed_date %>
+            Electronic signature<br>
+            <%= @parental_consent.electronic_signature %> signed on <%= @parental_consent.updated_at.strftime("%B %e, %Y") %>
           </p>
         </td>
       </tr>

--- a/app/views/parent_mailer/thank_you.en.html.erb
+++ b/app/views/parent_mailer/thank_you.en.html.erb
@@ -4,7 +4,7 @@
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td class="content-block">
-          Dear <%= @name %>,
+          Dear <%= @student_profile.parent_guardian_name %>,
         </td>
       </tr>
 

--- a/app/views/parental_consents/_consent_status.en.html.erb
+++ b/app/views/parental_consents/_consent_status.en.html.erb
@@ -1,0 +1,17 @@
+<ul class="unstyled">
+  <li>
+    <%= web_icon(
+      parental_consent.signed? ? "check-circle" : "circle-o",
+      class: "icon--green",
+      text: "Consent to participate in the program",
+    ) %>
+  </li>
+
+  <li>
+    <%= web_icon(
+      media_consent&.signed? ? "check-circle" : "circle-o",
+      class: "icon--green",
+      text: "Media release",
+    ) %>
+  </li>
+</ul>

--- a/app/views/parental_consents/edit.en.html.erb
+++ b/app/views/parental_consents/edit.en.html.erb
@@ -2,6 +2,13 @@
 
 <div class="grid grid--justify-space-around">
   <div class="panel grid__col-sm-8">
+    <%= render partial: "parental_consents/consent_status",
+      locals: {
+        parental_consent: @parental_consent,
+        media_consent: @media_consent
+      }
+    %>
+
     <%= simple_form_for @parental_consent do |f| %>
       <%= render 'errors', record: @parental_consent %>
 

--- a/spec/controllers/media_consents_controller_spec.rb
+++ b/spec/controllers/media_consents_controller_spec.rb
@@ -39,12 +39,17 @@ RSpec.describe MediaConsentsController do
       context "when the media consent form is unsigned" do
         before do
           FactoryBot.create(:media_consent, :unsigned, student_profile: student)
+          FactoryBot.create(:parental_consent, :signed, student_profile: student)
 
           get :edit, params: {token: token}
         end
 
         it "assigns @media_consent" do
           expect(assigns(:media_consent)).to eq(student.media_consent)
+        end
+
+        it "assigns @parental_consent" do
+          expect(assigns(:parental_consent)).to eq(student.parental_consent)
         end
 
         it "renders the edit template" do

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe ParentalConsentsController do
         .with(student_profile_id: student.id)
     end
 
+    it "redirects to the media consent form" do
+      student = FactoryBot.create(:onboarding_student)
+
+      patch :update, params: {
+        id: student.parental_consent.id,
+        parental_consent: FactoryBot.attributes_for(
+          :parental_consent,
+          student_profile_consent_token: student.consent_token
+        )
+      }
+
+      expect(response).to redirect_to(
+        edit_media_consent_path(token: student.consent_token)
+      )
+    end
+
     it "shows the existing parental consent if a repeat visit is made" do
       student = FactoryBot.create(:onboarded_student)
 
@@ -123,9 +139,6 @@ RSpec.describe ParentalConsentsController do
     let(:student) { FactoryBot.create(:onboarding_student) }
 
     before do
-      FactoryBot.create(:media_consent, :unsigned, student_profile: student)
-      FactoryBot.create(:parental_consent, :signed, student_profile: student)
-
       get :edit, params: {token: student.consent_token}
     end
 
@@ -139,15 +152,8 @@ RSpec.describe ParentalConsentsController do
       )
     end
 
-    it "assigns @media_consent" do
-      expect(assigns(:media_consent)).to eq(student.media_consent)
-    end
-
-      get :edit, params: { token: student.consent_token }
-
-      expect(response).to redirect_to(
-        parental_consent_path(student.parental_consent)
-      )
+    it "renders the edit template" do
+      expect(response).to render_template(:edit)
     end
   end
 end

--- a/spec/controllers/parental_consents_controller_spec.rb
+++ b/spec/controllers/parental_consents_controller_spec.rb
@@ -120,18 +120,28 @@ RSpec.describe ParentalConsentsController do
   end
 
   describe "GET #edit" do
-    it "assigns the student to the consent" do
-      student = FactoryBot.create(:onboarding_student)
+    let(:student) { FactoryBot.create(:onboarding_student) }
 
-      get :edit, params: { token: student.consent_token }
+    before do
+      FactoryBot.create(:media_consent, :unsigned, student_profile: student)
+      FactoryBot.create(:parental_consent, :signed, student_profile: student)
 
+      get :edit, params: {token: student.consent_token}
+    end
+
+    it "assigns @parental_consent" do
+      expect(assigns(:parental_consent)).to eq(student.parental_consent)
+    end
+
+    it "assigns @parental_consent.student_profile_consent_token" do
       expect(assigns[:parental_consent].student_profile_consent_token).to eq(
         student.consent_token
       )
     end
 
-    it "shows the existing parental consent if a repeat visit is made" do
-      student = FactoryBot.create(:onboarded_student)
+    it "assigns @media_consent" do
+      expect(assigns(:media_consent)).to eq(student.media_consent)
+    end
 
       get :edit, params: { token: student.consent_token }
 

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
     trait :signed do
       status { :signed }
     end
+
+    trait :unsigned do
+      electronic_signature { nil }
+    end
   end
 
   factory :consent_waiver do

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -133,6 +133,7 @@ FactoryBot.define do
     before(:create) do |s, e|
       if e.not_onboarded
         s.build_parental_consent
+        s.build_media_consent
       else
         s.build_parental_consent(
           FactoryBot.attributes_for(:parental_consent)

--- a/spec/system/student/parental_consent_spec.rb
+++ b/spec/system/student/parental_consent_spec.rb
@@ -46,17 +46,11 @@ RSpec.describe "Parental consent", :js do
     )
   end
 
-  it "handls a valid token, with a valid form" do
+  it "handles a valid token, with a valid form" do
     student = FactoryBot.create(:onboarding_student)
     visit edit_parental_consent_path(token: student.reload.consent_token)
 
-    fill_in "Your name", with: "Parent M. McGee"
-    click_button "I agree"
-
-    expect(current_path).to eq(parental_consent_path(student.parental_consent))
-    expect(page).to have_content(
-      "#{student.full_name} received parental consent from #{student.parental_consent_electronic_signature} on #{student.parental_consent_signed_at.strftime("%-d %B, %Y")}"
-    )
+    expect(page).to have_content("Consent to participate")
   end
 
   it "can be filled out on the dashboard" do

--- a/spec/views/parental_consents/_consent_status.en.html.erb_spec.rb
+++ b/spec/views/parental_consents/_consent_status.en.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "parental_consents/_consent_status.en.html.erb", type: :view do
+  before do
+    render partial: "parental_consents/consent_status",
+      locals: {
+        parental_consent: parental_consent,
+        media_consent: media_consent
+      }
+  end
+
+  let(:parental_consent) { FactoryBot.build(:parental_consent) }
+  let(:media_consent) { FactoryBot.build(:media_consent) }
+
+  context "when the parental consent is signed" do
+    let(:parental_consent) { FactoryBot.build(:parental_consent, :signed) }
+
+    it "renders a circle with a checkmark" do
+      expect(rendered).to include("check-circle")
+    end
+  end
+
+  context "when the parental consent is unsigned" do
+    let(:parental_consent) { FactoryBot.build(:parental_consent, :unsigned) }
+
+    it "renders a circle without a checkmark" do
+      expect(rendered).to include("circle-o")
+      expect(rendered).not_to include("check-circle")
+    end
+  end
+
+  context "when the media consent is signed" do
+    let(:media_consent) { FactoryBot.build(:media_consent, :signed) }
+
+    it "renders a circle with a checkmark" do
+      expect(rendered).to include("check-circle")
+    end
+  end
+
+  context "when the media consent is unsigned" do
+    let(:media_consent) { FactoryBot.build(:media_consent, :unsigned) }
+
+    it "renders a circle without a checkmark" do
+      expect(rendered).to include("circle-o")
+      expect(rendered).not_to include("check-circle")
+    end
+  end
+
+  context "when the media consent doesn't exist" do
+    let(:media_consent) { nil }
+
+    it "renders a circle without a checkmark" do
+      expect(rendered).to include("circle-o")
+      expect(rendered).not_to include("check-circle")
+    end
+  end
+end


### PR DESCRIPTION
This will add a couple pieces of functionality:
- Add the "status bar check boxes" thingie for the parental consent and media consent
- After the parental consent is signed, display the parental consent