### PR TITLE
Updated incorrect paths for ChA profiles in the Recent Activity tab

### DIFF
--- a/app/views/public_activity/account/_join_team.en.html.erb
+++ b/app/views/public_activity/account/_join_team.en.html.erb
@@ -20,7 +20,7 @@
   <% if activity.recipient %>
     <td>
       <%= link_to activity.recipient.name,
-        send("#{current_scope}_participant_path", activity.trackable),
+        send("#{current_scope}_team_path", activity.recipient),
         data: { turbolinks: false } %>
     </td>
   <% else %>

--- a/app/views/public_activity/account/_leave_team.en.html.erb
+++ b/app/views/public_activity/account/_leave_team.en.html.erb
@@ -20,7 +20,7 @@
   <% if activity.recipient %>
     <td>
       <%= link_to activity.recipient.name,
-        send("#{current_scope}_participant_path", activity.trackable),
+        send("#{current_scope}_team_path", activity.recipient),
         data: { turbolinks: false } %>
     </td>
   <% else %>

--- a/app/views/public_activity/team/_update.en.html.erb
+++ b/app/views/public_activity/team/_update.en.html.erb
@@ -9,7 +9,7 @@
 
     <td>
       <%= link_to activity.trackable.name,
-        [current_scope, activity.trackable],
+        send("#{current_scope}_team_path", activity.trackable),
         data: { turbolinks: false } %>
     </td>
   <% else %>
@@ -22,7 +22,7 @@
   <% if activity.recipient %>
     <td>
       <%= link_to activity.recipient.name,
-        [current_scope, activity.trackable],
+        send("#{current_scope}_team_path", activity.trackable),
         data: { turbolinks: false } %>
     </td>
   <% else %>


### PR DESCRIPTION
This was a bug fix based on previous ticket #3052. I missed 2 of the paths which caused an error on production for some of the ChA logins. I also updated 2 other routes, to ensure the dynamic links are going to correct view. 