### PR TITLE
Completed student dashboard tab rebranding with tailwind css

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require chosen-init
 //= require flash-msgs
 //= require tabs
+//= require student-dropdown
 //= require student-tabs
 //= require image-uploaders
 //= require location-details

--- a/app/assets/javascripts/student-dropdown.js
+++ b/app/assets/javascripts/student-dropdown.js
@@ -1,0 +1,9 @@
+$(document).on("turbolinks:load", function() {
+    $('#cha-student-meet').click(function() {
+        $('#cha-student-intro-wrapper').toggle('slow', function() {});
+    });
+
+    $('.tw-dropdown').click(function (){
+        $('.tw-dropdown-menu').toggle();
+    });
+});

--- a/app/javascript/dashboard/components/Curriculum.vue
+++ b/app/javascript/dashboard/components/Curriculum.vue
@@ -1,71 +1,51 @@
 <template>
-  <div :class="mainVerticalTabsClass">
-    <div :class="tabClass">
-      <div :class="gridClass">
-        <div :class="gridTwelveClass">
-          <div id="curriculum" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
-            <div class="sm-header-wrapper ">
-              <p class="font-bold">Curriculum</p>
-            </div>
+  <div class="tabs tabs--vertical tabs--css-only grid">
+    <div class="tabs__content grid__col-12 tabs__content--embedded">
+      <div class="grid">
+        <div class="grid__col-12">
+          <h1>Curriculum</h1>
 
-            <div class="tw-content=-wrapper p-8">
+          <p>Learn how to make your project as strong as possible by following these lessons. Most participants spend around 60 hours working on their ideas.</p>
 
-              <section>
-                <p>Learn how to make your project as strong as possible by following these lessons. Most participants
-                  spend around 60 hours working on their ideas.</p>
+          <p>
+            <a href="https://technovationchallenge.org/curriculum-intro/registered/new/" class="button" target="_blank">
+              Go to Lessons
+            </a>
+          </p>
 
-                <p class="mt-6">
-                  <a href="https://technovationchallenge.org/curriculum-intro/registered/new/" class="tw-green-btn"
-                     target="_blank">
-                    Go to Lessons
-                  </a>
-                </p>
-              </section>
+          <p>Visit these helpful links to prepare your app for judging:</p>
 
-              <section class="mt-12">
-                <p class="font-bold">Visit these helpful links to prepare your app for judging:</p>
+          <ul>
+            <li>
+              <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank">
+                Submission Guidelines (updated each season)
+              </a>
+            </li>
 
-                <ul>
-                  <li>
-                    <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank" class="tw-link">
-                      Submission Guidelines (updated each season)
-                    </a>
-                  </li>
+            <li>
+              <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank">
+                Judging Rubric
+              </a>
+            </li>
 
-                  <li>
-                    <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank" class="tw-link">
-                      Judging Rubric
-                    </a>
-                  </li>
+            <li>
+              <a href="https://technovationchallenge.org/wp-content/uploads/2020/09/Technovation-Girls-2021-Season-Timeline-Key-Dates-Infographic.pdf" target="_blank">
+                Suggested Milestones
+              </a>
+            </li>
 
-                  <li>
-                    <a href="https://technovationchallenge.org/wp-content/uploads/2020/09/Technovation-Girls-2021-Season-Timeline-Key-Dates-Infographic.pdf"
-                       target="_blank" class="tw-link">
-                      Suggested Milestones
-                    </a>
-                  </li>
+            <li>
+              <a href="https://technovationchallenge.org/award-structure/" target="_blank">
+                Awards Page
+              </a>
+            </li>
 
-                  <li>
-                    <a href="https://technovationchallenge.org/award-structure/" target="_blank" class="tw-link">
-                      Awards Page
-                    </a>
-                  </li>
-
-                  <li>
-                    <a href="https://www.technovation.org/app-gallery/" target="_blank" class="tw-link">
-                      Apps from Past Teams
-                    </a>
-                  </li>
-                </ul>
-
-
-
-
-
-              </section>
-
-            </div>
-          </div>
+            <li>
+              <a href="https://www.technovation.org/app-gallery/" target="_blank">
+                Apps from Past Teams
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -75,44 +55,5 @@
 <script>
 export default {
   name: 'curriculum',
-
-  data() {
-    return {
-      isStudentDash: false
-    }
-  },
-
-  beforeMount() {
-    let pathname = window.location.pathname
-    if (pathname === '/student/dashboard') {
-      this.isStudentDash = true
-    }
-  },
-
-  computed: {
-    mainVerticalTabsClass() {
-      if (!this.isStudentDash) {
-        return 'tabs tabs--vertical tabs--css-only grid'
-      }
-    },
-
-    gridClass() {
-      if (!this.isStudentDash) {
-        return 'grid'
-      }
-    },
-
-    gridTwelveClass() {
-      if (!this.isStudentDash) {
-        return 'grid__col-12'
-      }
-    },
-
-    tabClass() {
-      if (!this.isStudentDash) {
-        return 'tabs__content grid__col-12 tabs__content--embedd'
-      }
-    }
-  }
 }
 </script>

--- a/app/javascript/dashboard/components/Curriculum.vue
+++ b/app/javascript/dashboard/components/Curriculum.vue
@@ -1,51 +1,71 @@
 <template>
-  <div class="tabs tabs--vertical tabs--css-only grid">
-    <div class="tabs__content grid__col-12 tabs__content--embedded">
-      <div class="grid">
-        <div class="grid__col-12">
-          <h1>Curriculum</h1>
+  <div :class="mainVerticalTabsClass">
+    <div :class="tabClass">
+      <div :class="gridClass">
+        <div :class="gridTwelveClass">
+          <div id="curriculum" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+            <div class="sm-header-wrapper ">
+              <p class="font-bold">Curriculum</p>
+            </div>
 
-          <p>Learn how to make your project as strong as possible by following these lessons. Most participants spend around 60 hours working on their ideas.</p>
+            <div class="tw-content=-wrapper p-8">
 
-          <p>
-            <a href="https://technovationchallenge.org/curriculum-intro/registered/new/" class="button" target="_blank">
-              Go to Lessons
-            </a>
-          </p>
+              <section>
+                <p>Learn how to make your project as strong as possible by following these lessons. Most participants
+                  spend around 60 hours working on their ideas.</p>
 
-          <p>Visit these helpful links to prepare your app for judging:</p>
+                <p class="mt-6">
+                  <a href="https://technovationchallenge.org/curriculum-intro/registered/new/" class="tw-green-btn"
+                     target="_blank">
+                    Go to Lessons
+                  </a>
+                </p>
+              </section>
 
-          <ul>
-            <li>
-              <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank">
-                Submission Guidelines (updated each season)
-              </a>
-            </li>
+              <section class="mt-12">
+                <p class="font-bold">Visit these helpful links to prepare your app for judging:</p>
 
-            <li>
-              <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank">
-                Judging Rubric
-              </a>
-            </li>
+                <ul>
+                  <li>
+                    <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank" class="tw-link">
+                      Submission Guidelines (updated each season)
+                    </a>
+                  </li>
 
-            <li>
-              <a href="https://technovationchallenge.org/wp-content/uploads/2020/09/Technovation-Girls-2021-Season-Timeline-Key-Dates-Infographic.pdf" target="_blank">
-                Suggested Milestones
-              </a>
-            </li>
+                  <li>
+                    <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank" class="tw-link">
+                      Judging Rubric
+                    </a>
+                  </li>
 
-            <li>
-              <a href="https://technovationchallenge.org/award-structure/" target="_blank">
-                Awards Page
-              </a>
-            </li>
+                  <li>
+                    <a href="https://technovationchallenge.org/wp-content/uploads/2020/09/Technovation-Girls-2021-Season-Timeline-Key-Dates-Infographic.pdf"
+                       target="_blank" class="tw-link">
+                      Suggested Milestones
+                    </a>
+                  </li>
 
-            <li>
-              <a href="https://www.technovation.org/app-gallery/" target="_blank">
-                Apps from Past Teams
-              </a>
-            </li>
-          </ul>
+                  <li>
+                    <a href="https://technovationchallenge.org/award-structure/" target="_blank" class="tw-link">
+                      Awards Page
+                    </a>
+                  </li>
+
+                  <li>
+                    <a href="https://www.technovation.org/app-gallery/" target="_blank" class="tw-link">
+                      Apps from Past Teams
+                    </a>
+                  </li>
+                </ul>
+
+
+
+
+
+              </section>
+
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -55,5 +75,44 @@
 <script>
 export default {
   name: 'curriculum',
+
+  data() {
+    return {
+      isStudentDash: false
+    }
+  },
+
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/student/dashboard') {
+      this.isStudentDash = true
+    }
+  },
+
+  computed: {
+    mainVerticalTabsClass() {
+      if (!this.isStudentDash) {
+        return 'tabs tabs--vertical tabs--css-only grid'
+      }
+    },
+
+    gridClass() {
+      if (!this.isStudentDash) {
+        return 'grid'
+      }
+    },
+
+    gridTwelveClass() {
+      if (!this.isStudentDash) {
+        return 'grid__col-12'
+      }
+    },
+
+    tabClass() {
+      if (!this.isStudentDash) {
+        return 'tabs__content grid__col-12 tabs__content--embedd'
+      }
+    }
+  }
 }
 </script>

--- a/app/javascript/dashboard/components/CurriculumRebrand.vue
+++ b/app/javascript/dashboard/components/CurriculumRebrand.vue
@@ -1,0 +1,56 @@
+<template>
+  <div id="curriculum" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+    <div class="sm-header-wrapper">
+      <p class="font-bold">Curriculum</p>
+    </div>
+    <div class="tw-content=-wrapper p-8">
+      <section>
+        <p>Learn how to make your project as strong as possible by following these lessons. Most participants spend
+          around 60 hours working on their ideas.</p>
+        <p class="mt-6">
+          <a href="https://technovationchallenge.org/curriculum-intro/registered/new/" class="tw-green-btn"
+             target="_blank">
+            Go to Lessons
+          </a>
+        </p>
+      </section>
+      <section class="mt-12">
+        <p class="font-bold">Visit these helpful links to prepare your app for judging:</p>
+        <ul>
+          <li>
+            <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank" class="tw-link">
+              Submission Guidelines (updated each season)
+            </a>
+          </li>
+          <li>
+            <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank" class="tw-link">
+              Judging Rubric
+            </a>
+          </li>
+          <li>
+            <a href="https://technovationchallenge.org/wp-content/uploads/2020/09/Technovation-Girls-2021-Season-Timeline-Key-Dates-Infographic.pdf"
+               target="_blank" class="tw-link">
+              Suggested Milestones
+            </a>
+          </li>
+          <li>
+            <a href="https://technovationchallenge.org/award-structure/" target="_blank" class="tw-link">
+              Awards Page
+            </a>
+          </li>
+          <li>
+            <a href="https://www.technovation.org/app-gallery/" target="_blank" class="tw-link">
+              Apps from Past Teams
+            </a>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'curriculum'
+}
+</script>

--- a/app/javascript/dashboard/components/Events.vue
+++ b/app/javascript/dashboard/components/Events.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tabs tabs--vertical tabs--css-only grid">
-    <div class="tabs__content grid__col-12 tabs__content--embedded">
-      <div class="grid">
-        <div class="grid__col-8">
+  <div :class=mainVerticalTabsClass>
+    <div :class=tabClass>
+      <div :class=gridClass>
+        <div :class=gridEightClass>
           <slot name="events" />
         </div>
       </div>
@@ -13,5 +13,44 @@
 <script>
 export default {
   name: 'events',
+
+  data () {
+    return {
+      isStudentDash: false
+    }
+  },
+
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/student/dashboard') {
+      this.isStudentDash = true
+    }
+  },
+
+  computed: {
+    mainVerticalTabsClass () {
+      if(!this.isStudentDash){
+        return 'tabs tabs--vertical tabs--css-only grid'
+      }
+    },
+
+    gridClass () {
+      if(!this.isStudentDash){
+        return 'grid'
+      }
+    },
+
+    gridEightClass () {
+      if(!this.isStudentDash){
+        return 'grid__col-8'
+      }
+    },
+
+    tabClass () {
+      if(!this.isStudentDash){
+        return 'tabs__content grid__col-12 tabs__content--embedded'
+      }
+    }
+  }
 }
 </script>

--- a/app/javascript/dashboard/components/Events.vue
+++ b/app/javascript/dashboard/components/Events.vue
@@ -1,8 +1,8 @@
 <template>
-  <div :class=mainVerticalTabsClass>
-    <div :class=tabClass>
-      <div :class=gridClass>
-        <div :class=gridEightClass>
+  <div class="tabs tabs--vertical tabs--css-only grid">
+    <div class="tabs__content grid__col-12 tabs__content--embedded">
+      <div class="grid">
+        <div class="grid__col-8">
           <slot name="events" />
         </div>
       </div>
@@ -13,44 +13,5 @@
 <script>
 export default {
   name: 'events',
-
-  data () {
-    return {
-      isStudentDash: false
-    }
-  },
-
-  beforeMount() {
-    let pathname = window.location.pathname
-    if (pathname === '/student/dashboard') {
-      this.isStudentDash = true
-    }
-  },
-
-  computed: {
-    mainVerticalTabsClass () {
-      if(!this.isStudentDash){
-        return 'tabs tabs--vertical tabs--css-only grid'
-      }
-    },
-
-    gridClass () {
-      if(!this.isStudentDash){
-        return 'grid'
-      }
-    },
-
-    gridEightClass () {
-      if(!this.isStudentDash){
-        return 'grid__col-8'
-      }
-    },
-
-    tabClass () {
-      if(!this.isStudentDash){
-        return 'tabs__content grid__col-12 tabs__content--embedded'
-      }
-    }
-  }
 }
 </script>

--- a/app/javascript/dashboard/components/EventsRebrand.vue
+++ b/app/javascript/dashboard/components/EventsRebrand.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <slot name="events" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'events'
+}
+</script>

--- a/app/javascript/dashboard/components/Scores.vue
+++ b/app/javascript/dashboard/components/Scores.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tabs tabs--vertical tabs--css-only grid">
-    <div class="tabs__content grid__col-12 tabs__content--embedded">
-      <div class="grid">
-        <div class="grid__col-12">
+  <div :class="mainVerticalTabsClass">
+    <div :class="tabClass">
+      <div :class="gridClass">
+        <div :class="gridTwelveClass">
           <slot name="scores" />
         </div>
       </div>
@@ -13,5 +13,45 @@
 <script>
 export default {
   name: 'scores',
+
+
+  data () {
+    return {
+      isStudentDash: false
+    }
+  },
+
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/student/dashboard') {
+      this.isStudentDash = true
+    }
+  },
+
+  computed: {
+    mainVerticalTabsClass () {
+      if(!this.isStudentDash){
+        return 'tabs tabs--vertical tabs--css-only grid'
+      }
+    },
+
+    gridClass () {
+      if(!this.isStudentDash){
+        return 'grid'
+      }
+    },
+
+    gridTwelveClass () {
+      if(!this.isStudentDash){
+        return 'grid__col-12'
+      }
+    },
+
+    tabClass () {
+      if(!this.isStudentDash){
+        return 'tabs__content grid__col-12 tabs__content--embedded'
+      }
+    }
+  }
 }
 </script>

--- a/app/javascript/dashboard/components/Scores.vue
+++ b/app/javascript/dashboard/components/Scores.vue
@@ -1,8 +1,8 @@
 <template>
-  <div :class="mainVerticalTabsClass">
-    <div :class="tabClass">
-      <div :class="gridClass">
-        <div :class="gridTwelveClass">
+  <div class="tabs tabs--vertical tabs--css-only grid">
+    <div class="tabs__content grid__col-12 tabs__content--embedded">
+      <div class="grid">
+        <div class="grid__col-12">
           <slot name="scores" />
         </div>
       </div>
@@ -13,45 +13,5 @@
 <script>
 export default {
   name: 'scores',
-
-
-  data () {
-    return {
-      isStudentDash: false
-    }
-  },
-
-  beforeMount() {
-    let pathname = window.location.pathname
-    if (pathname === '/student/dashboard') {
-      this.isStudentDash = true
-    }
-  },
-
-  computed: {
-    mainVerticalTabsClass () {
-      if(!this.isStudentDash){
-        return 'tabs tabs--vertical tabs--css-only grid'
-      }
-    },
-
-    gridClass () {
-      if(!this.isStudentDash){
-        return 'grid'
-      }
-    },
-
-    gridTwelveClass () {
-      if(!this.isStudentDash){
-        return 'grid__col-12'
-      }
-    },
-
-    tabClass () {
-      if(!this.isStudentDash){
-        return 'tabs__content grid__col-12 tabs__content--embedded'
-      }
-    }
-  }
 }
 </script>

--- a/app/javascript/dashboard/components/ScoresRebrand.vue
+++ b/app/javascript/dashboard/components/ScoresRebrand.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+      <slot name="scores" />
+    </div>
+</template>
+
+<script>
+export default {
+  name: 'scores'
+}
+</script>

--- a/app/javascript/dashboard/components/Submission.vue
+++ b/app/javascript/dashboard/components/Submission.vue
@@ -1,8 +1,8 @@
 <template>
-  <div id="your-submission" :class="mainVerticalTabsClass">
-    <div :class="tabClass">
-      <div :class="gridClass">
-        <div :class="gridEightClass-8">
+  <div id="your-submission" class="tabs tabs--vertical tabs--css-only grid">
+    <div class="tabs__content grid__col-12 tabs__content--embedded">
+      <div class="grid">
+        <div class="grid__col-8">
           <slot name="submission" />
         </div>
       </div>
@@ -13,44 +13,5 @@
 <script>
 export default {
   name: 'submission',
-
-  data () {
-    return {
-      isStudentDash: false
-    }
-  },
-
-  beforeMount() {
-    let pathname = window.location.pathname
-    if (pathname === '/student/dashboard') {
-      this.isStudentDash = true
-    }
-  },
-
-  computed: {
-    mainVerticalTabsClass () {
-      if(!this.isStudentDash){
-        return 'tabs tabs--vertical tabs--css-only grid'
-      }
-    },
-
-    gridClass () {
-      if(!this.isStudentDash){
-        return 'grid'
-      }
-    },
-
-    gridEightClass () {
-      if(!this.isStudentDash){
-        return 'grid__col-8'
-      }
-    },
-
-    tabClass () {
-      if(!this.isStudentDash){
-        return 'tabs__content grid__col-12 tabs__content--embedded'
-      }
-    }
-  }
 }
 </script>

--- a/app/javascript/dashboard/components/Submission.vue
+++ b/app/javascript/dashboard/components/Submission.vue
@@ -1,8 +1,8 @@
 <template>
-  <div id="your-submission" class="tabs tabs--vertical tabs--css-only grid">
-    <div class="tabs__content grid__col-12 tabs__content--embedded">
-      <div class="grid">
-        <div class="grid__col-8">
+  <div id="your-submission" :class="mainVerticalTabsClass">
+    <div :class="tabClass">
+      <div :class="gridClass">
+        <div :class="gridEightClass-8">
           <slot name="submission" />
         </div>
       </div>
@@ -13,5 +13,44 @@
 <script>
 export default {
   name: 'submission',
+
+  data () {
+    return {
+      isStudentDash: false
+    }
+  },
+
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/student/dashboard') {
+      this.isStudentDash = true
+    }
+  },
+
+  computed: {
+    mainVerticalTabsClass () {
+      if(!this.isStudentDash){
+        return 'tabs tabs--vertical tabs--css-only grid'
+      }
+    },
+
+    gridClass () {
+      if(!this.isStudentDash){
+        return 'grid'
+      }
+    },
+
+    gridEightClass () {
+      if(!this.isStudentDash){
+        return 'grid__col-8'
+      }
+    },
+
+    tabClass () {
+      if(!this.isStudentDash){
+        return 'tabs__content grid__col-12 tabs__content--embedded'
+      }
+    }
+  }
 }
 </script>

--- a/app/javascript/dashboard/components/SubmissionRebrand.vue
+++ b/app/javascript/dashboard/components/SubmissionRebrand.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <slot name="submission" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'submission'
+}
+</script>

--- a/app/javascript/registration/App.vue
+++ b/app/javascript/registration/App.vue
@@ -73,17 +73,17 @@ export default {
     },
   },
 
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/signup') {
+      this.isSignup = true
+    }
+  },
+
   computed: {
     ...mapState([
       'isReady',
     ]),
-
-    beforeMount() {
-      let pathname = window.location.pathname
-      if (pathname === '/signup') {
-        this.isSignup = true
-      }
-    },
 
     mainContainerGridColumn () {
       if (this.embedded && this.isSignup)
@@ -111,7 +111,7 @@ export default {
         }
       }
     },
-  },
+  }
 }
 </script>
 

--- a/app/javascript/registration/App.vue
+++ b/app/javascript/registration/App.vue
@@ -86,10 +86,12 @@ export default {
     ]),
 
     mainContainerGridColumn () {
-      if (this.embedded && this.isSignup)
+      if (this.embedded)
         return "grid__col-12"
 
-      return "grid__col-9"
+      if(this.isSignup){
+        return "grid__col-9"
+      }
     },
 
     menuGridColumn () {

--- a/app/javascript/registration/App.vue
+++ b/app/javascript/registration/App.vue
@@ -28,6 +28,12 @@ const { mapState } = createNamespacedHelpers('registration')
 export default {
   name: 'app',
 
+  data () {
+    return{
+      isSignup: false
+    }
+  },
+
   directives: {
     'sticky-sidebar': StickySidebar,
   },
@@ -72,8 +78,15 @@ export default {
       'isReady',
     ]),
 
+    beforeMount() {
+      let pathname = window.location.pathname
+      if (pathname === '/signup') {
+        this.isSignup = true
+      }
+    },
+
     mainContainerGridColumn () {
-      if (this.embedded)
+      if (this.embedded && this.isSignup)
         return "grid__col-12"
 
       return "grid__col-9"
@@ -83,16 +96,19 @@ export default {
       if (this.embedded)
         return ''
 
-      return 'grid__col-3 grid__col--bleed'
+      if(this.isSignup)
+        return 'grid__col-3 grid__col--bleed'
     },
 
     wrapperClasses () {
-      return {
-        grid: true,
-        tabs: true,
-        'tabs--vertical': true,
-        'tabs--remove-bg': this.removeWhiteBackground,
-        'tabs--css-only': true,
+      if(this.isSignup){
+        return {
+          grid: true,
+          tabs: true,
+          'tabs--vertical': true,
+          'tabs--remove-bg': this.removeWhiteBackground,
+          'tabs--css-only': true,
+        }
       }
     },
   },

--- a/app/javascript/student/App.vue
+++ b/app/javascript/student/App.vue
@@ -1,32 +1,35 @@
 <template>
   <div>
-    <dashboard-header
-      default-title="Student Dashboard"
-      :resource-links="resourceLinks"
-    >
-      <div slot="chapter-ambassador-intro"><slot name="chapter-ambassador-intro" /></div>
-    </dashboard-header>
+<!--    <dashboard-header-->
+<!--      default-title="Student Dashboard"-->
+<!--      :resource-links="resourceLinks"-->
+<!--    >-->
+<!--      <div slot="chapter-ambassador-intro"><slot name="chapter-ambassador-intro" /></div>-->
+<!--    </dashboard-header>-->
 
-    <div class="tabs tabs--vertical tabs--css-only tabs--content-first grid">
-      <div class="tabs__content background-color--white grid__col-9">
-        <router-view :key="$route.name" :profile-icons="profileIcons">
-          <div slot="change-email"><slot name="change-email" /></div>
-          <div slot="change-password"><slot name="change-password" /></div>
-          <div slot="parental-consent"><slot name="parental-consent" /></div>
-          <div slot="find-team"><slot name="find-team" /></div>
-          <div slot="create-team"><slot name="create-team" /></div>
-          <div slot="find-mentor"><slot name="find-mentor" /></div>
-          <div slot="submission"><slot name="submission" /></div>
-          <div slot="events"><slot name="events" /></div>
-          <div slot="scores"><slot name="scores" /></div>
-        </router-view>
-      </div>
+    <div class="container mx-auto">
+      <div class="p-6 flex flex-col-reverse lg:flex-row justify-between">
+        <div id="student-dash" class="w-full lg:w-4/6">
+          <router-view :key="$route.name" :profile-icons="profileIcons">
+            <div slot="change-email"><slot name="change-email" /></div>
+            <div slot="change-password"><slot name="change-password" /></div>
+            <div slot="parental-consent"><slot name="parental-consent" /></div>
+            <div slot="find-team"><slot name="find-team" /></div>
+            <div slot="create-team"><slot name="create-team" /></div>
+            <div slot="find-mentor"><slot name="find-mentor" /></div>
+            <div slot="submission"><slot name="submission" /></div>
+            <div slot="events"><slot name="events" /></div>
+            <div slot="scores"><slot name="scores" /></div>
+          </router-view>
+        </div>
 
-      <div class="grid__col-3 grid__col--bleed">
-        <dashboard-menu
-          :regional-pitch-events-enabled="regionalPitchEventsEnabled"
-          :scores-and-certificates-enabled="scoresAndCertificatesEnabled"
-        />
+        <div class="tw-blue-lg-container w-full lg:w-1/4">
+          <ContainerHeader header-text="To-do"/>
+          <dashboard-menu-rebrand
+            :regional-pitch-events-enabled="regionalPitchEventsEnabled"
+            :scores-and-certificates-enabled="scoresAndCertificatesEnabled"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -34,14 +37,16 @@
 
 <script>
 import DashboardHeader from './DashboardHeader'
-import DashboardMenu from './DashboardMenu'
+import DashboardMenuRebrand from "./DashboardMenuRebrand";
+import ContainerHeader from "../new_registration/components/ContainerHeader";
 
 export default {
   name: 'app',
 
   components: {
     DashboardHeader,
-    DashboardMenu,
+    DashboardMenuRebrand,
+    ContainerHeader
   },
 
   data () {

--- a/app/javascript/student/App.vue
+++ b/app/javascript/student/App.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-<!--    <dashboard-header-->
-<!--      default-title="Student Dashboard"-->
-<!--      :resource-links="resourceLinks"-->
-<!--    >-->
-<!--      <div slot="chapter-ambassador-intro"><slot name="chapter-ambassador-intro" /></div>-->
-<!--    </dashboard-header>-->
+    <dashboard-header
+      default-title="Student Dashboard"
+      :resource-links="resourceLinks"
+    >
+      <div slot="chapter-ambassador-intro"><slot name="chapter-ambassador-intro" /></div>
+    </dashboard-header>
 
     <div class="container mx-auto">
       <div class="p-6 flex flex-col-reverse lg:flex-row justify-between">

--- a/app/javascript/student/App.vue
+++ b/app/javascript/student/App.vue
@@ -1,12 +1,5 @@
 <template>
   <div>
-    <dashboard-header
-      default-title="Student Dashboard"
-      :resource-links="resourceLinks"
-    >
-      <div slot="chapter-ambassador-intro"><slot name="chapter-ambassador-intro" /></div>
-    </dashboard-header>
-
     <div class="container mx-auto">
       <div class="p-6 flex flex-col-reverse lg:flex-row justify-between">
         <div id="student-dash" class="w-full lg:w-4/6">
@@ -36,7 +29,6 @@
 </template>
 
 <script>
-import DashboardHeader from './DashboardHeader'
 import DashboardMenuRebrand from "./DashboardMenuRebrand";
 import ContainerHeader from "../new_registration/components/ContainerHeader";
 
@@ -44,7 +36,6 @@ export default {
   name: 'app',
 
   components: {
-    DashboardHeader,
     DashboardMenuRebrand,
     ContainerHeader
   },

--- a/app/javascript/student/DashboardMenuRebrand.vue
+++ b/app/javascript/student/DashboardMenuRebrand.vue
@@ -55,7 +55,7 @@
       :condition-to-complete="false"
     >
       <hr class="bg-energetic-blue h-1 w-full">
-      Find a Pitch Event
+      Pitch your project
     </tab-link>
 
     <tab-link

--- a/app/javascript/student/DashboardMenuRebrand.vue
+++ b/app/javascript/student/DashboardMenuRebrand.vue
@@ -1,0 +1,174 @@
+
+<template>
+  <ul class="tabs__menu tabs-menu__parent-menu padding--none">
+    <tab-link
+      :class="registrationTabLinkClasses"
+      :to="{ name: 'basic-profile', meta: { active: registrationPagesActive } }"
+      :condition-to-enable="true"
+      :condition-to-complete="true"
+    >
+      Complete your Profile
+      <div slot="subnav" class="tabs-menu__child-menu" v-if="registrationPagesActive">
+        <registration-menu />
+      </div>
+    </tab-link>
+
+    <tab-link
+      :class="teamTabLinkClasses"
+      :to="{ name: 'parental-consent', meta: { active: teamPagesActive } }"
+      :condition-to-enable="true"
+      :condition-to-complete="hasParentalConsent && isOnTeam"
+    >
+      <hr class="bg-energetic-blue h-1 w-full">
+      Build your Team
+      <div slot="subnav" class="tabs-menu__child-menu" v-if="teamPagesActive">
+        <team-menu />
+      </div>
+    </tab-link>
+
+    <tab-link
+      :class="curriculumTabLinkClasses"
+      :to="{ name: 'curriculum', meta: { active: curriculumPagesActive } }"
+      :condition-to-enable="true"
+      :condition-to-complete="submissionComplete"
+    >
+      <hr class="bg-energetic-blue h-1 w-full">
+      Learn from the Curriculum
+    </tab-link>
+
+    <tab-link
+      :class="submissionTabLinkClasses"
+      :to="{ name: 'submission', meta: { active: submissionPagesActive } }"
+      :disabled-tooltip="submissionDisabledTooltipMessage"
+      :condition-to-enable="hasParentalConsent && isOnTeam"
+      :condition-to-complete="submissionComplete"
+    >
+      <hr class="bg-energetic-blue h-1 w-full">
+      Submit your Project
+    </tab-link>
+
+    <tab-link
+      :class="eventsTabLinkClasses"
+      :to="{ name: 'events', meta: { active: eventsPagesActive } }"
+      :disabled-tooltip="tooltips.UNAVAILABLE_DUE_TO_COVID"
+      :condition-to-enable="regionalPitchEventsEnabled"
+      :condition-to-complete="false"
+    >
+      <hr class="bg-energetic-blue h-1 w-full">
+      Find a Pitch Event
+    </tab-link>
+
+    <tab-link
+      :class="scoresTabLinkClasses"
+      :to="{ name: 'scores', meta: { active: scoresPagesActive } }"
+      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :condition-to-enable="scoresAndCertificatesEnabled"
+      :condition-to-complete="false"
+    >
+      <hr class="bg-energetic-blue h-1 w-full">
+      View Scores & Certificate
+    </tab-link>
+  </ul>
+</template>
+
+<script>
+import { createNamespacedHelpers } from 'vuex'
+import menuMixin from 'mixins/menu'
+import tooltipsMixin from 'mixins/tooltips'
+
+const { mapGetters } = createNamespacedHelpers('authenticated')
+
+import TabLink from 'tabs/components/TabLink'
+
+import RegistrationMenu from 'registration/DashboardMenu'
+import TeamMenu from './menus/Team'
+
+export default {
+  name: 'dashboard-menu',
+
+  mixins: [
+    menuMixin,
+    tooltipsMixin,
+  ],
+
+  components: {
+    TabLink,
+    RegistrationMenu,
+    TeamMenu,
+  },
+
+  computed: {
+    ...mapGetters(['isOnTeam', 'submissionComplete', 'hasParentalConsent']),
+
+    registrationTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.registrationPagesActive,
+      }
+    },
+
+    teamTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.teamPagesActive,
+      }
+    },
+
+    curriculumTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.curriculumPagesActive,
+      }
+    },
+
+    submissionTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.submissionPagesActive,
+      }
+    },
+
+    eventsTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.eventsPagesActive,
+      }
+    },
+
+    scoresTabLinkClasses () {
+      return {
+        'tabs__menu-link--active': this.scoresPagesActive,
+      }
+    },
+
+    scoresPagesActive () {
+      return this.subRouteIsActive('scores')
+    },
+
+    eventsPagesActive () {
+      return this.subRouteIsActive('events')
+    },
+
+    submissionPagesActive () {
+      return this.subRouteIsActive('submission')
+    },
+
+    teamPagesActive () {
+      return this.subRouteIsActive('team')
+    },
+
+    curriculumPagesActive () {
+      return this.subRouteIsActive('curriculum')
+    },
+
+    registrationPagesActive () {
+      return this.subRouteIsActive('registration')
+    },
+
+    submissionDisabledTooltipMessage () {
+      if (!this.isOnTeam && !this.consentSigned)
+        return this.tooltips.student.submissions.MUST_HAVE_PERMISSION_ON_TEAM
+
+      if (!this.consentSigned)
+        return this.tooltips.student.submissions.MUST_HAVE_PERMISSION
+
+      return this.tooltips.student.submissions.MUST_BE_ON_TEAM
+    },
+  },
+}
+</script>

--- a/app/javascript/student/components/TeamBuilding.vue
+++ b/app/javascript/student/components/TeamBuilding.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tabs tabs--vertical tabs--css-only grid">
+  <div :class="mainTabClass">
     <div :class="['tabs__content', mainContainerGridColumn]">
       <router-view :key="$route.name">
         <div slot="parental-consent"><slot name="parental-consent" /></div>
@@ -24,6 +24,12 @@ import TeamMenu from 'student/menus/Team'
 export default {
   name: 'team-building',
 
+  data(){
+    return{
+      isStudentDash: false
+    }
+  },
+
   directives: {
     'sticky-sidebar': StickySidebar,
   },
@@ -43,13 +49,27 @@ export default {
     },
   },
 
+  beforeMount() {
+    let pathname = window.location.pathname
+    if (pathname === '/student/dashboard') {
+      this.isStudentDash = true
+    }
+  },
+
   computed: {
     mainContainerGridColumn () {
-      if (this.embedded)
+      if (this.embedded && !this.isStudentDash)
         return 'grid__col-12 tabs__content--embedded'
 
-      return 'grid__col-9'
+      if(!this.isStudentDash)
+        return 'grid__col-9'
     },
+
+    mainTabClass () {
+      if(this.embedded && !this.isStudentDash){
+        return 'tabs tabs--vertical tabs--css-only grid'
+      }
+    }
   },
 }
 </script>

--- a/app/javascript/student/routes/index.js
+++ b/app/javascript/student/routes/index.js
@@ -3,10 +3,10 @@ import VueRouter from 'vue-router'
 
 import RegistrationApp from 'registration/App'
 import TeamBuilding from 'student/components/TeamBuilding'
-import Submission from 'dashboard/components/Submission'
-import Curriculum from 'dashboard/components/Curriculum'
-import Scores from 'dashboard/components/Scores'
-import Events from 'dashboard/components/Events'
+import Submission from 'dashboard/components/SubmissionRebrand'
+import Curriculum from 'dashboard/components/CurriculumRebrand'
+import Scores from 'dashboard/components/ScoresRebrand'
+import Events from 'dashboard/components/EventsRebrand'
 
 import store from '../store'
 

--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -85,3 +85,7 @@ nav {
 .sub-nav-item-active{
     @apply bg-white text-energetic-blue py-2 px-4 rounded-tr-3xl font-semibold
 }
+
+.tw-flex-basis-33{
+    flex-basis: 33.333333%
+}

--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -1,3 +1,7 @@
+html{
+    @apply bg-white
+}
+
 .social-icon{
     width: 40px;
     height: 40px;

--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -89,3 +89,15 @@ nav {
 .tw-flex-basis-33{
     flex-basis: 33.333333%
 }
+
+#cha-student-intro-wrapper, .tw-dropdown-menu{
+    display: none;
+}
+
+.tw-dropdown-menu a, #student-nav-wrapper a{
+   @apply hover:text-energetic-blue
+}
+
+.tw-dropdown-menu li{
+   @apply py-2
+}

--- a/app/views/application_rebrand/_navigation.html.erb
+++ b/app/views/application_rebrand/_navigation.html.erb
@@ -10,13 +10,40 @@
         <div class="flex items-center space-x-1" id="student-nav-wrapper">
           <a href="">Curriculum</a>
           <a href="">About</a>
-          <% if current_account.authenticated? %>
-            <%= link_to t('views.application.signout'), signout_path %>
-          <% end %>
-          <a href=""><%= current_student.first_name %></a>
-          <%= image_tag current_student.profile_image_url,
-                        class: "rounded-bl-3xl rounded-tr-3xl w-14",
-                        id: "profile-image" %>
+
+          <div class="flex items-center justify-center">
+            <div class="relative inline-block text-left tw-dropdown" id="student-dropdown-wrapper">
+              <span class="flex cursor-pointer hover:text-energetic-blue"><%= current_student.first_name %>
+                <img src="https://icongr.am/fontawesome/caret-down.svg?size=12" alt="">
+              </span>
+
+              <div class="tw-dropdown-menu">
+                <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
+                  <div class="p-4">
+                    <ul class="text-sm">
+                      <li><a href="https://youtu.be/whZjfiB3vgQ">Using Your Dashboard</a></li>
+                      <li><a href="https://iridescentlearning.org/internet-safety/">Safety Information</a></li>
+                      <li><a href="https://www.technovationchallenge.org/curriculum-intro/registered/new/">Curriculum
+                        Lessons</a></li>
+                      <li><a href="https://www.technovationchallenge.org/submission-guidelines/">Submission Guide</a>
+                      </li>
+                      <li><a href="https://www.technovationchallenge.org/judging-rubric/">Judging Rubric</a></li>
+                      <li><a href="">Help Technovation Improve</a></li>
+                      <li>
+                        <% if current_account.authenticated? %>
+                          <%= link_to t('views.application.signout'), signout_path, class: 'text-sm' %>
+                        <% end %>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <%= image_tag current_student.profile_image_url,
+                          class: "rounded-bl-3xl rounded-tr-3xl w-14",
+                          id: "profile-image" %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/application_rebrand/_navigation.html.erb
+++ b/app/views/application_rebrand/_navigation.html.erb
@@ -10,7 +10,16 @@
         <div class="flex items-center space-x-1" id="student-nav-wrapper">
           <a href="">Curriculum</a>
           <a href="">About</a>
-
+          <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>
+            <%= link_to SeasonToggles.survey_link(current_scope, "text"),
+                        SeasonToggles.survey_link(
+                          current_scope, "url",
+                          format_url: true,
+                          account: current_account
+                        ),
+                        target: "_blank"
+            %>
+          <% end %>
           <div class="flex items-center justify-center">
             <div class="relative inline-block text-left tw-dropdown" id="student-dropdown-wrapper">
               <span class="flex cursor-pointer hover:text-energetic-blue"><%= current_student.first_name %>
@@ -27,7 +36,8 @@
                       <li><a href="https://www.technovationchallenge.org/submission-guidelines/">Submission Guide</a></li>
                       <li><a href="https://www.technovationchallenge.org/judging-rubric/">Judging Rubric</a></li>
                       <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>
-                        <%= link_to "Help Technovation Improve! " + SeasonToggles.survey_link(current_scope, "text", account: current_account),
+                        <p>Help Technovation Improve!</p>
+                        <%= link_to SeasonToggles.survey_link(current_scope, "text"),
                                     SeasonToggles.survey_link(
                                       current_scope, "url",
                                       format_url: true,

--- a/app/views/application_rebrand/_navigation.html.erb
+++ b/app/views/application_rebrand/_navigation.html.erb
@@ -20,15 +20,22 @@
               <div class="tw-dropdown-menu">
                 <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
                   <div class="p-4">
-                    <ul class="text-sm">
+                    <ul class="text-sm" id="student-dropdown-list">
                       <li><a href="https://youtu.be/whZjfiB3vgQ">Using Your Dashboard</a></li>
                       <li><a href="https://iridescentlearning.org/internet-safety/">Safety Information</a></li>
-                      <li><a href="https://www.technovationchallenge.org/curriculum-intro/registered/new/">Curriculum
-                        Lessons</a></li>
-                      <li><a href="https://www.technovationchallenge.org/submission-guidelines/">Submission Guide</a>
-                      </li>
+                      <li><a href="https://www.technovationchallenge.org/curriculum-intro/registered/new/">Curriculum Lessons</a></li>
+                      <li><a href="https://www.technovationchallenge.org/submission-guidelines/">Submission Guide</a></li>
                       <li><a href="https://www.technovationchallenge.org/judging-rubric/">Judging Rubric</a></li>
-                      <li><a href="">Help Technovation Improve</a></li>
+                      <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>
+                        <%= link_to "Help Technovation Improve! " + SeasonToggles.survey_link(current_scope, "text", account: current_account),
+                                    SeasonToggles.survey_link(
+                                      current_scope, "url",
+                                      format_url: true,
+                                      account: current_account
+                                    ),
+                                    target: "_blank"
+                        %>
+                      <% end %>
                       <li>
                         <% if current_account.authenticated? %>
                           <%= link_to t('views.application.signout'), signout_path, class: 'text-sm' %>

--- a/app/views/completion_steps/_invitations.en.html.erb
+++ b/app/views/completion_steps/_invitations.en.html.erb
@@ -1,4 +1,4 @@
-<h3 class="margin--t-large">Invites from teams</h3>
+<p class="font-bold mb-6">Invites from teams</p>
 
 <% if hidden ||= false %>
   <%= render 'explanations/feature_not_available', feature: :team_invites %>
@@ -6,35 +6,32 @@
   <% if SeasonToggles.judging_enabled_or_between? %>
     <p><%= t("views.team_member_invites.show.invites_disabled_by_judging") %></p>
   <% elsif invites.any? %>
-    <p>You have been invited!</p>
-
     <% if current_scope == :student and invites.many? %>
       <p class="hint">You can only accept one!</p>
     <% end %>
+    <div id="invite-wrapper" class="flex flex-row flex-wrap justify-between">
+      <% invites.each do |invite| %>
+        <div class="lg:tw-flex-basis-33 mb-8">
+          <%= content_tag :div, id: dom_id(invite), class:'h-full' do %>
+            <div class="w-full md:w-64 h-full justify-center items-center bg-white shadow-lg rounded-lg flex flex-col">
+              <%= image_tag invite.team.team_photo.url, class: "w-full h-auto object-cover rounded-t-lg" %>
+              <div class="w-full p-4 justify-start flex flex-col">
+                <section class="h-4/5">
+                  <p class="font-bold"><%= invite.team_name.titleize %></p>
+                  <p><%= invite.team.state_province %>, <%= invite.team.country %></p>
+                  <p><%= invite.team.division_name.titleize %> Division</p>
+                </section>
 
-    <% invites.each do |invite| %>
-      <%= content_tag :div, id: dom_id(invite) do %>
-        <div class="grid grid--bleed margin--t-large">
-          <div class="grid__col-4">
-            <div class="grid__cell">
-              <%= image_tag invite.team.team_photo.url,
-                class: "thumbnail-md grid__cell-img" %>
+                <%= link_to raw("Open invite &#8227;"),
+                            send("#{current_scope}_team_member_invite_path", invite),
+                            class: 'tw-link mt-8' %>
+
+              </div>
             </div>
-          </div>
-
-          <div class="grid__col-8">
-            <div class="grid__cell">
-              <strong>From team: <%= invite.team_name %></strong>
-
-              <p>
-                <%= link_to "Open this invitation",
-                  send("#{current_scope}_team_member_invite_path", invite) %>
-              </p>
-            </div>
-          </div>
+          <% end %>
         </div>
       <% end %>
-    <% end %>
+    </div>
   <% else %>
     <p>
       You have no pending invitations. When a team invites you to join,

--- a/app/views/completion_steps/_invitations.en.html.erb
+++ b/app/views/completion_steps/_invitations.en.html.erb
@@ -1,4 +1,4 @@
-<p class="font-bold mb-6">Invites from teams</p>
+<h3 class="margin--t-large">Invites from teams</h3>
 
 <% if hidden ||= false %>
   <%= render 'explanations/feature_not_available', feature: :team_invites %>
@@ -6,32 +6,35 @@
   <% if SeasonToggles.judging_enabled_or_between? %>
     <p><%= t("views.team_member_invites.show.invites_disabled_by_judging") %></p>
   <% elsif invites.any? %>
+    <p>You have been invited!</p>
+
     <% if current_scope == :student and invites.many? %>
       <p class="hint">You can only accept one!</p>
     <% end %>
-    <div id="invite-wrapper" class="flex flex-row flex-wrap justify-between">
-      <% invites.each do |invite| %>
-        <div class="lg:tw-flex-basis-33 mb-8">
-          <%= content_tag :div, id: dom_id(invite), class:'h-full' do %>
-            <div class="w-full md:w-64 h-full justify-center items-center bg-white shadow-lg rounded-lg flex flex-col">
-              <%= image_tag invite.team.team_photo.url, class: "w-full h-auto object-cover rounded-t-lg" %>
-              <div class="w-full p-4 justify-start flex flex-col">
-                <section class="h-4/5">
-                  <p class="font-bold"><%= invite.team_name.titleize %></p>
-                  <p><%= invite.team.state_province %>, <%= invite.team.country %></p>
-                  <p><%= invite.team.division_name.titleize %> Division</p>
-                </section>
 
-                <%= link_to raw("Open invite &#8227;"),
-                            send("#{current_scope}_team_member_invite_path", invite),
-                            class: 'tw-link mt-8' %>
-
-              </div>
+    <% invites.each do |invite| %>
+      <%= content_tag :div, id: dom_id(invite) do %>
+        <div class="grid grid--bleed margin--t-large">
+          <div class="grid__col-4">
+            <div class="grid__cell">
+              <%= image_tag invite.team.team_photo.url,
+                            class: "thumbnail-md grid__cell-img" %>
             </div>
-          <% end %>
+          </div>
+
+          <div class="grid__col-8">
+            <div class="grid__cell">
+              <strong>From team: <%= invite.team_name %></strong>
+
+              <p>
+                <%= link_to "Open this invitation",
+                            send("#{current_scope}_team_member_invite_path", invite) %>
+              </p>
+            </div>
+          </div>
         </div>
       <% end %>
-    </div>
+    <% end %>
   <% else %>
     <p>
       You have no pending invitations. When a team invites you to join,

--- a/app/views/completion_steps/rebrand/_invitations.en.html.erb
+++ b/app/views/completion_steps/rebrand/_invitations.en.html.erb
@@ -1,0 +1,41 @@
+<p class="font-bold mb-6">Invites from teams</p>
+
+<% if hidden ||= false %>
+  <%= render 'explanations/feature_not_available', feature: :team_invites %>
+<% else %>
+  <% if SeasonToggles.judging_enabled_or_between? %>
+    <p><%= t("views.team_member_invites.show.invites_disabled_by_judging") %></p>
+  <% elsif invites.any? %>
+    <% if current_scope == :student and invites.many? %>
+      <p class="hint">You can only accept one!</p>
+    <% end %>
+    <div id="invite-wrapper" class="flex flex-row flex-wrap justify-between">
+      <% invites.each do |invite| %>
+        <div class="lg:tw-flex-basis-33 mb-8">
+          <%= content_tag :div, id: dom_id(invite), class:'h-full' do %>
+            <div class="w-full md:w-64 h-full justify-center items-center bg-white shadow-lg rounded-lg flex flex-col">
+              <%= image_tag invite.team.team_photo.url, class: "w-full h-auto object-cover rounded-t-lg" %>
+              <div class="w-full p-4 justify-start flex flex-col">
+                <section class="h-4/5">
+                  <p class="font-bold"><%= invite.team_name.titleize %></p>
+                  <p><%= invite.team.state_province %>, <%= invite.team.country %></p>
+                  <p><%= invite.team.division_name.titleize %> Division</p>
+                </section>
+
+                <%= link_to raw("Open invite &#8227;"),
+                            send("#{current_scope}_team_member_invite_path", invite),
+                            class: 'tw-link mt-8' %>
+
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p>
+      You have no pending invitations. When a team invites you to join,
+      you will see the invitation here.
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/dashboards/rebrand/_chapter_ambassador_intro.en.html.erb
+++ b/app/views/dashboards/rebrand/_chapter_ambassador_intro.en.html.erb
@@ -1,0 +1,27 @@
+<% if chapter_ambassador.provided_intro? %>
+  <div id="cha-student-intro-wrapper">
+    <div class="bg-white p-6 rounded-md flex flex-col lg:flex-row justify-between">
+      <section id="cha-avatar" class="mx-4 mb-4 lg:mb-0">
+        <img class="rounded-bl-3xl rounded-tr-3xl" src="<%= chapter_ambassador.profile_image %>" alt="" style="height: auto; width: 200px;">
+      </section>
+      <section id="cha-profile-summary" class="mx-4 mb-4 lg:mb-0 p-0 lg:px-8">
+        <p class="font-bold text-2xl"><%= chapter_ambassador.full_name %></p>
+        <p class="font-bold"><%= chapter_ambassador.program_name %> Chapter Ambassador</p>
+        <p class="mt-8"><%= chapter_ambassador.intro_summary %></p>
+      </section>
+      <section id=cha-social-links class="mx-4 mb-4 lg:mb-0 w-full lg:w-1/6">
+        <ul>
+          <% chapter_ambassador.regional_links.each do |link| %>
+            <li class="tw-link">
+              <% if link.name == "email" %>
+                <%= mail_to link.value, web_icon("envelope-o", text: link.value) %>
+              <% else %>
+                <%= link_to web_icon(link.icon, text: link.display_text), link.url %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </section>
+    </div>
+  </div>
+<% end %>

--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -1,4 +1,11 @@
 <% feature = TechnovationFeature.new(current_student, :submissions) %>
 
-<h1>Submissions</h1>
-<%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+<div id="join-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Submitting your project</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+  </div>
+</div>

--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -1,6 +1,6 @@
 <% feature = TechnovationFeature.new(current_student, :submissions) %>
 
-<div id="student-submission" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+<div id="your-submission" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
   <div class="sm-header-wrapper ">
     <p class="font-bold">Submitting your project</p>
   </div>

--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -1,6 +1,6 @@
 <% feature = TechnovationFeature.new(current_student, :submissions) %>
 
-<div id="join-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+<div id="student-submission" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
   <div class="sm-header-wrapper ">
     <p class="font-bold">Submitting your project</p>
   </div>

--- a/app/views/slots/student/available/_join_team.en.html.erb
+++ b/app/views/slots/student/available/_join_team.en.html.erb
@@ -1,54 +1,45 @@
-<h1 class="margin--none padding--none">Join a team</h1>
+<section class="mb-8">
+  <%= render "completion_steps/invitations",
+    invites: current_student.team_member_invites.pending %>
+</section>
 
-<%= render "completion_steps/invitations",
-  invites: current_student.team_member_invites.pending %>
+<section>
+  <p class="font-bold">Ask to join a team</p>
 
-<h3 class="margin--t-large">Ask to join a team</h3>
+  <div id="join-requests">
+    <% if current_student.join_requests.pending.any? %>
+      <p>You have asked to join a team!</p>
+      <% current_student.join_requests.pending.each do |join_request| %>
+        <%= content_tag :div,
+          class: "join_request",
+          id: dom_id(join_request) do %>
+          <div class="w-full md:w-64 justify-center items-center bg-white shadow-lg rounded-lg flex flex-col mt-8">
+            <%= image_tag join_request.team_team_photo_url, class: "w-full h-auto object-cover rounded-t-lg" %>
+            <div class="w-full p-4 justify-start flex flex-col">
+              <p class="font-bold"><%= join_request.team_name.titleize %></p>
+              <p><%= join_request.team_primary_location %></p>
+              <p><%= join_request.team_division_name.titleize %> Division</p>
 
-<div id="join-requests">
-  <% if current_student.join_requests.pending.any? %>
-    <p>You have asked to join a team!</p>
-
-    <% current_student.join_requests.pending.each do |join_request| %>
-      <%= content_tag :div,
-        class: "join_request",
-        id: dom_id(join_request) do %>
-        <div class="grid grid--bleed">
-          <div class="grid__col-4">
-            <div class="grid__cell">
-              <%= image_tag join_request.team_team_photo_url,
-                class: 'thumbnail-md grid__cell-img' %>
+              <%= link_to raw("Cancel my request to join this team &#8227;"),
+                          send("#{current_scope}_join_request_path", id: join_request.review_token),
+                          data: {
+                            method: :delete,
+                            confirm: t("controllers.student.join_requests.destroy.confirm")
+                          },
+                          class: "danger small mt-4"
+              %>
             </div>
           </div>
-
-          <div class="grid__col-8">
-            <div class="grid__cell">
-              <p>
-                <%= join_request.team_name %><br />
-                Division:
-                <%= join_request.team_division_name.humanize %><br />
-                <%= join_request.team_primary_location %><br />
-                <%= link_to "Cancel my request to join this team",
-                  send("#{current_scope}_join_request_path", id: join_request.review_token),
-                  data: {
-                    method: :delete,
-                    confirm: t("controllers.student.join_requests.destroy.confirm")
-                  },
-                  class: "danger small"
-                %>
-              </p>
-            </div>
-          </div>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
-  <% else %>
-    <p>Use our team search to find a team and ask to join them!</p>
+    <% else %>
+      <p class="mb-4">Use the team search to find a team and ask to join them!</p>
 
-    <%= link_to(
-      t("views.profile_requirements.create_join_team.links.join.text"),
-      send("new_#{current_scope}_team_search_path"),
-      class: "button"
-    ) %>
-  <% end %>
-</div>
+      <%= link_to(
+        t("views.profile_requirements.create_join_team.links.join.text"),
+        send("new_#{current_scope}_team_search_path"),
+        class: "tw-green-btn"
+      ) %>
+    <% end %>
+  </div>
+</section>

--- a/app/views/slots/student/available/_join_team.en.html.erb
+++ b/app/views/slots/student/available/_join_team.en.html.erb
@@ -1,5 +1,5 @@
 <section class="mb-8">
-  <%= render "completion_steps/invitations",
+  <%= render "completion_steps/rebrand/invitations",
     invites: current_student.team_member_invites.pending %>
 </section>
 

--- a/app/views/slots/student/available/_submissions.en.html.erb
+++ b/app/views/slots/student/available/_submissions.en.html.erb
@@ -6,7 +6,7 @@
     ) %>
   <% else %>
     <%= render(
-      "student/dashboards/completion_steps/start_team_submission"
+      "student/dashboards/completion_steps/rebrand/start_team_submission"
     ) %>
   <% end %>
 <% end %>

--- a/app/views/slots/student/rebrand/_events.en.html.erb
+++ b/app/views/slots/student/rebrand/_events.en.html.erb
@@ -1,0 +1,12 @@
+<div id="events" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Pitch your project</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <% if current_student.onboarded? && SeasonToggles.select_regional_pitch_event? %>
+      <%= render "student/dashboards/completion_steps/regional_pitch_events" %>
+    <% else %>
+      <p>Due to COVID, there are no official pitch events this season.</p>
+    <% end %>  </div>
+</div>

--- a/app/views/slots/student/rebrand/_join_team.en.html.erb
+++ b/app/views/slots/student/rebrand/_join_team.en.html.erb
@@ -1,10 +1,26 @@
-<% if current_student.is_on_team? %>
-  You're on a team!Yay!
-  Your team is called <%= current_team.name %>.
-  You can
-  <%= link_to 'manage your team',
-    student_team_path(current_team) %>
-<% else %>
-  <% feature = TechnovationFeature.new(current_student, :join_team) %>
-  <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
-<% end %>
+<div id="join-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Build a Team</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <% if current_student.is_on_team? %>
+      <p class="text-2xl">You're on a team!</p>
+      <div class="w-full md:w-64 justify-center items-center bg-white shadow-lg rounded-lg flex flex-col mt-8">
+        <%= image_tag current_team.team_photo_url, class: "w-full h-auto object-cover rounded-t-lg" %>
+        <div class="w-full p-4 justify-start flex flex-col">
+          <p class="font-bold"><%= current_team.name.titleize %></p>
+          <p><%= current_team.city %>, <%= current_team.state_province %></p>
+          <p><%= current_team.division_name.titleize %> Division</p>
+
+          <%= link_to raw('Manage Your Team &#8227;'),
+                      student_team_path(current_team) ,
+                      class: 'text-energetic-blue font-bold text-xl mt-4' %>
+        </div>
+      </div>
+    <% else %>
+      <% feature = TechnovationFeature.new(current_student, :join_team) %>
+      <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/slots/student/rebrand/_join_team.en.html.erb
+++ b/app/views/slots/student/rebrand/_join_team.en.html.erb
@@ -1,0 +1,10 @@
+<% if current_student.is_on_team? %>
+  You're on a team!Yay!
+  Your team is called <%= current_team.name %>.
+  You can
+  <%= link_to 'manage your team',
+    student_team_path(current_team) %>
+<% else %>
+  <% feature = TechnovationFeature.new(current_student, :join_team) %>
+  <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+<% end %>

--- a/app/views/slots/student/rebrand/_join_team.en.html.erb
+++ b/app/views/slots/student/rebrand/_join_team.en.html.erb
@@ -1,6 +1,6 @@
 <div id="join-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
   <div class="sm-header-wrapper ">
-    <p class="font-bold">Build a Team</p>
+    <p class="font-bold">Build Your Team</p>
   </div>
 
   <div class="tw-content=-wrapper p-8">

--- a/app/views/slots/student/rebrand/_join_team.en.html.erb
+++ b/app/views/slots/student/rebrand/_join_team.en.html.erb
@@ -3,7 +3,7 @@
     <p class="font-bold">Build Your Team</p>
   </div>
 
-  <div class="tw-content=-wrapper p-8">
+  <div class="tw-content-wrapper p-8">
     <% if current_student.is_on_team? %>
       <p class="text-2xl">You're on a team!</p>
       <div class="w-full md:w-64 justify-center items-center bg-white shadow-lg rounded-lg flex flex-col mt-8">

--- a/app/views/slots/student/rebrand/_scores.en.html.erb
+++ b/app/views/slots/student/rebrand/_scores.en.html.erb
@@ -1,0 +1,25 @@
+<div id="scores-and-certs" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Scores & Certificate</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <% if current_student.onboarded? && SeasonToggles.display_scores? %>
+      <% if current_team.submission.complete? %>
+        <%= render "student/dashboards/completion_steps/scores_and_certificates" %>
+      <% elsif current_student.participated? %>
+        <%= render "student/dashboards/completion_steps/participation_certificate" %>
+      <% else %>
+        <h1 class="content-heading">Thank you for your participation</h1>
+
+        <p>
+          Unfortunately, no scores are available for your team because your
+          submission was incomplete. We hope you will continue working on your
+          app and join us again next season!
+        </p>
+      <% end %>
+    <% else %>
+      <%= render 'explanations/feature_not_available', feature: :scores %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/student/dashboards/completion_steps/rebrand/_create_team.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_create_team.html.erb
@@ -1,0 +1,22 @@
+<% if hidden ||= false %>
+  <%= render 'explanations/feature_not_available', feature: :create_team %>
+<% else %>
+  <p class="font-bold">Create a team</p>
+  <p>
+    Start your own team and then invite team members, or let other students
+    <span>
+     <%= link_to("find you in search",
+           send("new_#{current_scope}_team_search_path"),
+           class: 'tw-link')
+     %>
+      .
+    </span>
+  </p>
+  <div class="step-actions mt-8">
+    <%= link_to(
+      t("views.profile_requirements.create_join_team.links.create.text"),
+      send("new_#{current_scope}_team_path"),
+      class: "tw-green-btn"
+    ) %>
+  </div>
+<% end %>

--- a/app/views/student/dashboards/completion_steps/rebrand/_start_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_start_team_submission.html.erb
@@ -1,0 +1,34 @@
+<% if SeasonToggles.team_submissions_editable? %>
+  <p>
+    You and your teammates can begin submitting your app now!
+    As you work through the curriculum, you can upload it in parts.
+    You can also edit as much as you need to until the deadline!
+  </p>
+
+  <div class="step-actions mt-8">
+    <%= link_to 'Begin your submission',
+      new_student_team_submission_path,
+      class: "tw-green-btn" %>
+  </div>
+<% else %>
+  <h1 class="content-heading">Your Team Submission</h1>
+
+  <p>
+    Submissions are currently locked. Starting a submission
+    is not available at this time.
+  </p>
+
+  <% before_submissions_are_open do %>
+    <h5 class="heading--reset">
+      We are going to open submissions very soon!
+    </h5>
+
+    <p>Watch your email for an update from us!</p>
+  <% end %>
+
+  <p class="scent">
+    Contact
+    <%= mail_to ENV.fetch("HELP_EMAIL") %>
+    if you have questions.
+  </p>
+<% end %>

--- a/app/views/student/dashboards/rebrand/_create_team.html.erb
+++ b/app/views/student/dashboards/rebrand/_create_team.html.erb
@@ -1,0 +1,11 @@
+<% if current_student.is_on_team? %>
+  You're on a team! Test!!
+  Your team is called <%= current_team.name %>.
+  You can
+  <%= link_to 'manage your team',
+              student_team_path(current_team) %>
+<% elsif SeasonToggles.team_building_disabled? %>
+  Technovation Staff has turned off forming teams for everyone right now.
+<% else %>
+  <%= render "completion_steps/create_team" %>
+<% end %>

--- a/app/views/student/dashboards/rebrand/_create_team.html.erb
+++ b/app/views/student/dashboards/rebrand/_create_team.html.erb
@@ -1,4 +1,4 @@
-<div id="create-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+<div id="create-team-wrapper" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
   <div class="sm-header-wrapper ">
     <p class="font-bold">Build your team</p>
   </div>

--- a/app/views/student/dashboards/rebrand/_create_team.html.erb
+++ b/app/views/student/dashboards/rebrand/_create_team.html.erb
@@ -1,11 +1,21 @@
-<% if current_student.is_on_team? %>
-  You're on a team! Test!!
-  Your team is called <%= current_team.name %>.
-  You can
-  <%= link_to 'manage your team',
-              student_team_path(current_team) %>
-<% elsif SeasonToggles.team_building_disabled? %>
-  Technovation Staff has turned off forming teams for everyone right now.
-<% else %>
-  <%= render "completion_steps/create_team" %>
-<% end %>
+<div id="create-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Build your team</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <% if current_student.is_on_team? %>
+      You're on a team!
+      Your team is called <%= current_team.name %>.
+      You can
+      <%= link_to 'manage your team',
+                  student_team_path(current_team),
+                  class: 'tw-link'
+      %>
+    <% elsif SeasonToggles.team_building_disabled? %>
+      Technovation Staff has turned off forming teams for everyone right now.
+    <% else %>
+      <%= render "student/dashboards/completion_steps/rebrand/create_team" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/student/dashboards/rebrand/_find_mentor.html.erb
+++ b/app/views/student/dashboards/rebrand/_find_mentor.html.erb
@@ -1,0 +1,72 @@
+<div id="join-team" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Build a Team</p>
+  </div>
+
+  <div class="tw-content=-wrapper p-8">
+    <section>
+      <% if current_student.team.mentors.any? %>
+        <p class="font-bold">Mentor Status</p>
+        <p>Your team has <%= pluralize(current_student.team.mentors.count, "mentor") %>. You can have more than one.</p>
+      <% else %>
+        <p class="font-bold">Find a Mentor</p>
+        <p>Add one or more mentors to your team. Mentors guide you in completing your submission. You can ask someone you know to sign up as a mentor and join your team, or you can search for a mentor online.</p>
+      <% end %>
+    </section>
+
+    <section class="mt-12">
+      <% if current_team.pending_mentor_invite_ids.any? %>
+        <p>
+          Your team is awaiting a response from
+          <span class="font-bold"><%= pluralize(current_team.pending_mentor_invites.count, "mentor invite") %>.</span>
+        </p>
+      <% else %>
+        <p>Your team has no open invites to a mentor</p>
+      <% end %>
+
+      <% if current_team.pending_mentor_join_request_ids.any? %>
+        <p>
+          You have
+          <span class="font-bold"><%= pluralize(current_team.pending_mentor_join_requests.count, "mentor request") %></span>
+          waiting for you and your team members.
+        </p>
+      <% end %>
+
+      <% if current_team.pending_mentor_invite_ids.any? || current_team.pending_mentor_join_request_ids.any? %>
+        <%= link_to raw("Manage your invites &#8227;"), student_team_path(current_team, anchor: "!mentors"), class: "tw-link" %>
+      <% end %>
+    </section>
+
+
+    <section class="mt-8">
+      <% if current_team.present? %>
+        <%= link_to "Search for mentors", new_student_mentor_search_path, class: "tw-green-btn" %>
+      <% else %>
+        <p>When you are on a team, you will be able to search for mentors.</p>
+      <% end %>
+    </section>
+
+    <section class="mt-12">
+      <% if current_team.present? %>
+        <p class="font-bold">Decide if Mentors (who ask) can join your team</p>
+        <%= form_with model: current_team,
+                      data: { submit_on_change: true },
+                      url:  send("#{current_scope}_team_path", current_team),
+                      method: :patch do |f| %>
+          <p>
+            <%= f.check_box :accepting_mentor_requests,
+                            id: :team_accepting_mentor_requests %>
+
+            <%= f.label :accepting_mentor_requests,
+                        "Make your team appear in search results",
+                        for: :team_accepting_mentor_requests %>
+          </p>
+        <% end %>
+      <% end %>
+    </section>
+  </div>
+</div>
+
+
+
+

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -37,7 +37,7 @@
       <% end %>
 
       <div slot="chapter-ambassador-intro">
-        <%= render 'dashboards/rebrand/chapter_ambassador_intro' %>
+        <%= render 'dashboards/chapter_ambassador_intro' %>
       </div>
 
       <div slot="change-email">

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -62,66 +62,7 @@
       </div>
 
       <div slot="find-mentor">
-        <h2 class="content-heading">Mentor Status</h2>
-
-        <% if current_student.team.mentors.any? %>
-          <p>Your team has <%= pluralize(current_student.team.mentors.count, "mentor") %>. You can have more than one.</p>
-        <% else %>
-          <p>Your team does not have a Mentor. 91% of teams that complete the program have at least one mentor on their team.</p>
-        <% end %>
-
-        <hr class="margin--t-xlarge">
-
-        <h3>Find a Mentor to invite to your team</h3>
-        <% if current_team.present? %>
-          <%= link_to "Search for a Mentor to invite", new_student_mentor_search_path, class: "button" %>
-        <% else %>
-          <p>When you are on a team, you will be able to search for mentors.</p>
-        <% end %>
-
-        <h5 class="margin--t-xlarge">Your Mentor Invitations</h5>
-
-        <% if current_team.pending_mentor_invite_ids.any? %>
-          <p>
-            Your team is awaiting a response from
-            <%= pluralize(current_team.pending_mentor_invites.count, "mentor invite") %>
-          </p>
-
-          <%= link_to "Manage your invites", student_team_path(current_team, anchor: "!mentors"), class: "button" %>
-        <% else %>
-          <p>Your team has no open invites to a mentor</p>
-        <% end %>
-
-        <hr class="margin--t-xlarge">
-        <h2>Decide if Mentors (who ask) can join your team</h2>
-
-        <% if current_team.present? %>
-          <%= form_with model: current_team,
-            data: { submit_on_change: true },
-            url:  send("#{current_scope}_team_path", current_team),
-            method: :patch do |f| %>
-            <p>
-              <%= f.check_box :accepting_mentor_requests,
-                id: :team_accepting_mentor_requests %>
-
-              <%= f.label :accepting_mentor_requests,
-                "Make your team appear in search results",
-                for: :team_accepting_mentor_requests %>
-            </p>
-          <% end %>
-        <% end %>
-
-        <% if current_team.pending_mentor_join_request_ids.any? %>
-          <h5 class="margin--t-xlarge margin--b-none">Respond to Mentor requests to join your team</h5>
-
-          <p>
-            You have
-            <%= pluralize(current_team.pending_mentor_join_requests.count, "mentor request") %>
-            waiting for you and your team members
-          </p>
-
-          <%= link_to "Manage your invites", student_team_path(current_team, anchor: "!mentors"), class: "button" %>
-        <% end %>
+        <%= render 'student/dashboards/rebrand/find_mentor' %>
       </div>
 
       <div slot="submission">

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -37,7 +37,7 @@
       <% end %>
 
       <div slot="chapter-ambassador-intro">
-        <%= render 'dashboards/chapter_ambassador_intro' %>
+        <%= render 'dashboards/rebrand/chapter_ambassador_intro' %>
       </div>
 
       <div slot="change-email">
@@ -49,27 +49,16 @@
       </div>
 
       <div slot="parental-consent">
-        <%= render 'student/profiles/parent' %>
+        <%= render 'student/profiles/rebrand/parent' %>
       </div>
 
       <div slot="find-team">
-        <%= render 'slots/student/join_team' %>
+        <%= render 'slots/student/rebrand/join_team' %>
       </div>
 
       <div id="create-team" slot="create-team">
         <h1 class="margin--none padding--none">Create a team</h1>
-
-        <% if current_student.is_on_team? %>
-          You're on a team!
-          Your team is called <%= current_team.name %>.
-          You can
-          <%= link_to 'manage your team',
-            student_team_path(current_team) %>
-        <% elsif SeasonToggles.team_building_disabled? %>
-          Technovation Staff has turned off forming teams for everyone right now.
-        <% else %>
-          <%= render "completion_steps/create_team" %>
-        <% end %>
+        <%= render 'student/dashboards/rebrand/create_team' %>
       </div>
 
       <div slot="find-mentor">

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -57,7 +57,6 @@
       </div>
 
       <div id="create-team" slot="create-team">
-        <h1 class="margin--none padding--none">Create a team</h1>
         <%= render 'student/dashboards/rebrand/create_team' %>
       </div>
 
@@ -116,11 +115,11 @@
       </div>
 
       <div slot="events">
-        <%= render 'slots/student/events' %>
+        <%= render 'slots/student/rebrand/events' %>
       </div>
 
       <div slot="scores">
-        <%= render 'slots/student/scores' %>
+        <%= render 'slots/student/rebrand/scores' %>
       </div>
     </app>
 

--- a/app/views/student/navigation/rebrand/_tg_global_nav.html.erb
+++ b/app/views/student/navigation/rebrand/_tg_global_nav.html.erb
@@ -2,7 +2,7 @@
   # TODO: Fix hover issue in IE11/Win7
 %>
 
-<nav class="list-reset flex border-b">
+<nav class="list-reset flex">
 
     <%= link_to t("views.application.dashboards.menu.dashboard"),
                 student_dashboard_path,

--- a/app/views/student/navigation/rebrand/_tg_green_header.html.erb
+++ b/app/views/student/navigation/rebrand/_tg_green_header.html.erb
@@ -1,7 +1,14 @@
 <div class="tg-green-stripes rubik h-auto mx-auto pt-16 flex flex-col mb-20">
   <div class="banner-text-wrapper w-full lg:w-3/4 mx-auto pb-16">
-    <div class="text-white text-4xl md:text-7xl font-black">TECHNOVATION GIRLS ####</div>
-    <div class="text-white text-lg md:text-3xl font-bold">Meet your Chapter Ambassador ></div>
+    <div class="text-white text-4xl md:text-6xl font-black mb-8 uppercase">Technovation Girls <%= chapter_ambassador.program_name %> </div>
+    <div class="text-white text-lg md:text-3xl font-bold mb-8">
+      <span id="cha-student-meet" class="cursor-pointer hover:text-energetic-blue">
+          Meet your Chapter Ambassador &#8227;
+      </span>
+    </div>
+    <% if chapter_ambassador.present? %>
+      <%= render 'dashboards/rebrand/chapter_ambassador_intro' %>
+    <% end %>
   </div>
 
   <%= render 'student/navigation/rebrand/tg_sub_nav' %>

--- a/app/views/student/profiles/rebrand/_parent_signed.en.html.erb
+++ b/app/views/student/profiles/rebrand/_parent_signed.en.html.erb
@@ -18,7 +18,7 @@
     new_student_parental_consent_notice_path(
       back: student_profile_path(anchor: "!parent")
     ),
-    class: "button" %>
+    class: "tw-green-btn" %>
 </p>
 
 <p class="hint">Changing this email will send and require a new consent.</p>

--- a/config/locales/dashboards.en.yml
+++ b/config/locales/dashboards.en.yml
@@ -16,7 +16,7 @@ en:
           my_account: "My profile"
           my_requests: "My requests"
           my_teams: "My teams"
-          team_submission: "My team's submission"
+          team_submission: "My Submission"
         buttons:
           team_submission_html: "View my team's submission"
         show:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -312,8 +312,8 @@ en:
         create_a_team: "Create your team"
         find_a_mentor: "Find a mentor"
         join_team: "Find a team"
-        my_profile: "My profile"
-        my_team: "My team"
+        my_profile: "My Profile"
+        my_team: "My Team"
 
 
       parental_consent_notices:

--- a/spec/features/admin/login_as_spec.rb
+++ b/spec/features/admin/login_as_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Admin / chapter ambassador logging in as a user" do
       click_link "Login as #{student.full_name}"
       expect(current_path).to eq(student_dashboard_path)
 
-      click_link "My team"
+      click_link "My Team"
       expect(current_path).to eq(student_team_path(student.team))
 
       click_link "return to Admin mode"

--- a/spec/features/admin/survey_link_toggles_spec.rb
+++ b/spec/features/admin/survey_link_toggles_spec.rb
@@ -1,40 +1,80 @@
 require "rails_helper"
 
 RSpec.feature "Set survey links and link text", :js do
-  %w{student mentor}.each do |scope|
-    context "#{scope} survey link is configured" do
-      let(:user) { FactoryBot.create(scope) }
+  context "student survey link is configured" do
+    # let(:user) { FactoryBot.create(:student) }
+    let(:user) { FactoryBot.create(:student) }
 
-      before do
-        SeasonToggles.set_dashboard_text(scope, "this is a dependency")
-        SeasonToggles.set_survey_link(scope, "link text", "google.com")
+    before do
+      SeasonToggles.set_dashboard_text("student", "this is a dependency")
+      SeasonToggles.set_survey_link("student", "link text", "google.com")
+    end
+
+    scenario "when they have not seen it yet" do
+      allow(SeasonToggles).to receive(:show_survey_link_modal?)
+        .and_return(true)
+
+      sign_in(user)
+
+      expect(current_path).to eq(public_send("student_dashboard_path"))
+      expect(page).to have_link("link text", href: "google.com", count: 1)
+
+      expect(page).to have_css(".swal2-modal")
+      within(".swal2-modal") do
+        expect(page).to have_link("link text", href: "google.com")
       end
+    end
 
-      scenario "when they have not seen it yet" do
-        allow(SeasonToggles).to receive(:show_survey_link_modal?)
-          .and_return(true)
+    scenario "when they have seen it" do
+      allow(SeasonToggles).to receive(:show_survey_link_modal?)
+        .and_return(false)
 
-        sign_in(user)
+      sign_in(user)
 
-        expect(current_path).to eq(public_send("#{scope}_dashboard_path"))
-        expect(page).to have_link("link text", href: "google.com", count: 2)
-        expect(page).to have_css(".swal2-modal")
-        within(".swal2-modal") do
-          expect(page).to have_link("link text", href: "google.com")
-        end
+      expect(current_path).to eq(public_send("student_dashboard_path"))
+
+      find('#student-dropdown-wrapper').click
+      expect(page).to have_link("link text", href: "google.com", count: 1)
+
+      expect(page).not_to have_css(".swal2-modal")
+    end
+  end
+
+  context "mentor survey link is configured" do
+    let(:mentor) { FactoryBot.create(:mentor) }
+
+    before do
+      SeasonToggles.set_dashboard_text("mentor", "this is a dependency")
+      SeasonToggles.set_survey_link("mentor", "link text", "google.com")
+    end
+
+    scenario "when they have not seen it yet" do
+      allow(SeasonToggles).to receive(:show_survey_link_modal?)
+        .and_return(true)
+
+      sign_in(mentor)
+
+      expect(current_path).to eq(public_send("mentor_dashboard_path"))
+      expect(page).to have_link("link text", href: "google.com", count: 2)
+
+      expect(page).to have_css(".swal2-modal")
+      within(".swal2-modal") do
+        expect(page).to have_link("link text", href: "google.com")
       end
+    end
 
-      scenario "when they have seen it" do
-        allow(SeasonToggles).to receive(:show_survey_link_modal?)
-          .and_return(false)
+    scenario "when they have seen it" do
+      allow(SeasonToggles).to receive(:show_survey_link_modal?)
+        .and_return(false)
 
-        sign_in(user)
+      sign_in(mentor)
 
-        expect(current_path).to eq(public_send("#{scope}_dashboard_path"))
-        expect(page).to have_link("link text", href: "google.com", count: 1)
-        expect(page).not_to have_css(".swal2-modal")
-      end
+      expect(current_path).to eq(public_send("mentor_dashboard_path"))
+      expect(page).to have_link("link text", href: "google.com", count: 2)
+
+      expect(page).not_to have_css(".swal2-modal")
     end
   end
 end
+
 

--- a/spec/features/admin/survey_link_toggles_spec.rb
+++ b/spec/features/admin/survey_link_toggles_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Set survey links and link text", :js do
       sign_in(user)
 
       expect(current_path).to eq(public_send("student_dashboard_path"))
-      expect(page).to have_link("link text", href: "google.com", count: 1)
+      expect(page).to have_link("link text", href: "google.com", count: 2)
 
       expect(page).to have_css(".swal2-modal")
       within(".swal2-modal") do

--- a/spec/features/admin/survey_link_toggles_spec.rb
+++ b/spec/features/admin/survey_link_toggles_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.feature "Set survey links and link text", :js do
   context "student survey link is configured" do
-    # let(:user) { FactoryBot.create(:student) }
     let(:user) { FactoryBot.create(:student) }
 
     before do

--- a/spec/features/admin/survey_link_toggles_spec.rb
+++ b/spec/features/admin/survey_link_toggles_spec.rb
@@ -5,8 +5,8 @@ RSpec.feature "Set survey links and link text", :js do
     let(:user) { FactoryBot.create(:student) }
 
     before do
-      SeasonToggles.set_dashboard_text("student", "this is a dependency")
-      SeasonToggles.set_survey_link("student", "link text", "google.com")
+      SeasonToggles.set_dashboard_text(:student, "this is a dependency")
+      SeasonToggles.set_survey_link(:student, "link text", "google.com")
     end
 
     scenario "when they have not seen it yet" do
@@ -33,7 +33,7 @@ RSpec.feature "Set survey links and link text", :js do
       expect(current_path).to eq(public_send("student_dashboard_path"))
 
       find('#student-dropdown-wrapper').click
-      expect(page).to have_link("link text", href: "google.com", count: 1)
+      expect(page).to have_link("link text", href: "google.com", count: 2)
 
       expect(page).not_to have_css(".swal2-modal")
     end
@@ -43,8 +43,8 @@ RSpec.feature "Set survey links and link text", :js do
     let(:mentor) { FactoryBot.create(:mentor) }
 
     before do
-      SeasonToggles.set_dashboard_text("mentor", "this is a dependency")
-      SeasonToggles.set_survey_link("mentor", "link text", "google.com")
+      SeasonToggles.set_dashboard_text(:mentor, "this is a dependency")
+      SeasonToggles.set_survey_link(:mentor, "link text", "google.com")
     end
 
     scenario "when they have not seen it yet" do
@@ -69,7 +69,7 @@ RSpec.feature "Set survey links and link text", :js do
       sign_in(mentor)
 
       expect(current_path).to eq(public_send("mentor_dashboard_path"))
-      expect(page).to have_link("link text", href: "google.com", count: 2)
+      expect(page).to have_link("link text", href: "google.com", count: 1)
 
       expect(page).not_to have_css(".swal2-modal")
     end

--- a/spec/features/mentor/invite_member_to_team_spec.rb
+++ b/spec/features/mentor/invite_member_to_team_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Invite a member to a team" do
     sign_out
     sign_in(invite.invitee)
 
-    click_link "Open this invitation"
+    click_link "Open invite"
     expect(page).to have_content("Chicago, Illinois, United States")
 
     click_button "Accept invitation to #{mentor.team_names.first}"
@@ -87,7 +87,7 @@ RSpec.feature "Invite a member to a team" do
     sign_out
     sign_in(invite.invitee)
 
-    click_link "Open this invitation"
+    click_link "Open invite"
     expect(page).to have_content("Chicago, Illinois, United States")
 
     click_button "Accept invitation to #{mentor.team_names.first}"

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Students find a team" do
       visit student_dashboard_path(anchor: "/find-team")
 
       expect(current_path).to eq(student_dashboard_path)
-      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content(join_request.team_name.titleize)
       expect(page).to have_content("You have asked to join")
     end
   end

--- a/spec/features/student/leave_team_spec.rb
+++ b/spec/features/student/leave_team_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Students leave their own team" do
     student = FactoryBot.create(:student, :on_team, :geocoded)
 
     sign_in(student)
-    click_link "My team"
+    click_link "My Team"
 
     within("##{dom_id(student)}") do
       click_link "remove this member"

--- a/spec/features/student/remove_onboarding_student_spec.rb
+++ b/spec/features/student/remove_onboarding_student_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Remove an onboarding student" do
     TeamRosterManaging.add(team, [onb_student, student])
 
     sign_in(student)
-    click_link "My team"
+    click_link "My Team"
 
     within(".onboarding_students") do
       click_link "remove this member"

--- a/spec/features/student/submission_dev_platform_spec.rb
+++ b/spec/features/student/submission_dev_platform_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Students edit submission development platform" do
 
     sign_in(student)
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Code"
     click_link "Select your development platform"
   end

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Students edit submission pieces" do
   before do
     SeasonToggles.team_submissions_editable!
     sign_in(student)
-    click_link "My team's submission"
+    click_link "My Submission"
   end
 
   scenario "Set the app name" do

--- a/spec/features/student/submission_spec.rb
+++ b/spec/features/student/submission_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Student team submissions" do
     sign_out
     sign_in(team_student)
     expect(page).to have_link(
-      "My team's submission",
+      "My Submission",
       href: new_student_team_submission_path
     )
   end
@@ -29,7 +29,7 @@ RSpec.feature "Student team submissions" do
     student = FactoryBot.create(:student, :on_team, :geocoded)
     sign_in(student)
 
-    click_link "My team's submission"
+    click_link "My Submission"
 
     check "team_submission[integrity_affirmed]"
     click_button "Start now!"
@@ -38,7 +38,7 @@ RSpec.feature "Student team submissions" do
       student_team_submission_section_path(TeamSubmission.last)
     )
     expect(page).to have_link(
-      "My team's submission",
+      "My Submission",
       href: student_team_submission_path(TeamSubmission.last)
     )
   end
@@ -48,7 +48,7 @@ RSpec.feature "Student team submissions" do
     submission = FactoryBot.create(:team_submission, team: student.team)
     sign_in(student)
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Ideation"
 
     expect(page).to have_link(
@@ -120,7 +120,7 @@ RSpec.feature "Student team submissions" do
 
     sign_in(student)
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Business"
 
     expect(page).not_to have_link(
@@ -137,7 +137,7 @@ RSpec.feature "Student team submissions" do
       date_of_birth: senior_dob,
     })
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Business"
 
     expect(page).to have_link(
@@ -155,7 +155,7 @@ RSpec.feature "Student team submissions" do
 
     sign_in(student)
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Regional events"
 
     expect(page).not_to have_link(
@@ -176,7 +176,7 @@ RSpec.feature "Student team submissions" do
     rpe = FactoryBot.create(:regional_pitch_event)
     rpe.teams << student.team
 
-    click_link "My team's submission"
+    click_link "My Submission"
     click_link "Regional events"
 
     expect(page).to have_link(

--- a/spec/features/student/submit_a_project_spec.rb
+++ b/spec/features/student/submit_a_project_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Student submits a project", :js do
   end
 
   def when_they_view_their_submission
-    click_link "My team's submission"
+    click_link "My Submission"
   end
 
   def then_they_see_a_disabled_submit_button

--- a/spec/support/signin_helper.rb
+++ b/spec/support/signin_helper.rb
@@ -23,4 +23,12 @@ module SigninHelper
 
     expect(page).to have_content("See you next time!")
   end
+
+  def student_sign_out
+    find('#student-dropdown-wrapper').click
+    click_link "Logout"
+
+    expect(page).to have_content("See you next time!")
+  end
+
 end

--- a/spec/system/location/team_locations_spec.rb
+++ b/spec/system/location/team_locations_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Team locations", :js do
       team = FactoryBot.create(:team, :chicago)
 
       sign_in(team.students.sample)
-      click_link "My team"
+      click_link "My Team"
 
       click_button "Location"
       expect(page).to have_content("Chicago, Illinois, United States")

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Students request to join a team",
       expect(page).to have_content(team.name)
       expect(page).to have_content(team.primary_location)
       expect(page).to have_content(team.division_name.humanize)
-      expect(page).to have_css("img.thumbnail-md[src*='#{team.team_photo_url}']")
+      expect(page).to have_css("img[src*='#{team.team_photo_url}']")
 
       expect(page).not_to have_link("Find a team")
     end

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Students request to join a team",
     it "student accepts the request" do
       ActionMailer::Base.deliveries.clear
 
-      sign_out
+      student_sign_out
       student = team.students.sample
 
       visit student_join_request_path(
@@ -121,7 +121,7 @@ RSpec.describe "Students request to join a team",
     end
 
     it "student accepts from team page" do
-      sign_out
+      student_sign_out
       sign_in(team.students.sample)
 
       visit student_team_path(team)
@@ -135,7 +135,7 @@ RSpec.describe "Students request to join a team",
     end
 
     it "student declines from team page" do
-      sign_out
+      student_sign_out
       sign_in(team.students.sample)
 
       visit student_team_path(team)
@@ -151,7 +151,7 @@ RSpec.describe "Students request to join a team",
     it "mentor accepts the request" do
       ActionMailer::Base.deliveries.clear
 
-      sign_out
+      student_sign_out
       mentor = team.mentors.sample
       visit mentor_join_request_path(
         JoinRequest.last,
@@ -168,7 +168,7 @@ RSpec.describe "Students request to join a team",
     end
 
     it "mentor accepts from team page" do
-      sign_out
+      student_sign_out
       sign_in(team.mentors.sample)
 
       visit mentor_team_path(team)
@@ -182,7 +182,7 @@ RSpec.describe "Students request to join a team",
     end
 
     it "mentor declines from team page" do
-      sign_out
+      student_sign_out
       sign_in(team.mentors.sample)
 
       visit mentor_team_path(team)
@@ -198,7 +198,7 @@ RSpec.describe "Students request to join a team",
     it "student declines the request" do
       ActionMailer::Base.deliveries.clear
 
-      sign_out
+      student_sign_out
       student = team.students.sample
 
       visit student_join_request_path(
@@ -224,7 +224,7 @@ RSpec.describe "Students request to join a team",
     it "mentor declines the request" do
       ActionMailer::Base.deliveries.clear
 
-      sign_out
+      student_sign_out
       mentor = team.mentors.sample
 
       visit mentor_join_request_path(

--- a/spec/system/student/signup_spec.rb
+++ b/spec/system/student/signup_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "Students signing up", :js do
       fill_in "Password", with: "margeysecret1234"
       click_button "Next"
 
+      find('#student-dropdown-wrapper').click
       click_link "Logout"
 
       fill_in "Email", with: "margeyb@springfield.net"


### PR DESCRIPTION
The student dashboard tab rebranding including the chapter ambassador intro and header chapter ambassador location information is complete. 

A few things to note - 
1. The right-side nav still needs a little reworking with both styling + the "complete my profile" link. The my profile link opens additional links (like data agreement, region, etc) that reuse the vue.js registration components. Initially, we decided that we did not need these options in the dashboard tab since they are available under the my profile tab. There is a little bit of complex routing logic there, so that may take a little bit of time to rework.
2. There are still additional tabs that need rebranding, like Create a Team, Find a Team, & Submissions to name a few
3. This is a larger PR, however, there are not many complex logic changes. Mostly updates to the class names, I have also copied and pasted a lot of the original files and either pasted them in a rebrand directory or have the name rebrand in the file name. There are also updates to the test specs to match new ids, class names, HTML structure, etc. 
4. Something that is a nice to have, is to revisit the tailwind classes and extract the ones that are used consistently and potentially separate the tailwind CSS into more files. 
5. Finally, in order to test this, we need to capture all the potential combinations of student accounts, for example, a student that is on a team vs not on a team, or the different variations of parental consent. I think this will be the trickiest part in trying to capture/test all the variations.