### PR TITLE
Hide mentors age from participants view

### DIFF
--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -43,7 +43,7 @@
             <dt><%= t('models.account.email') %></dt>
             <dd><%= mail_to @account.email %></dd>
 
-            <% if not @account.is_a_mentor? %>
+            <% if !@account.is_a_mentor? %>
               <dt><%= t('models.account.age') %></dt>
               <dd><%= @account.age %></dd>
             <% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -43,8 +43,10 @@
             <dt><%= t('models.account.email') %></dt>
             <dd><%= mail_to @account.email %></dd>
 
-            <dt><%= t('models.account.age') %></dt>
-            <dd><%= @account.age %></dd>
+            <% if not @account.is_a_mentor? %>
+              <dt><%= t('models.account.age') %></dt>
+              <dd><%= @account.age %></dd>
+            <% end %>
 
             <% if @account.student? %>
               <dt><%= t('models.account.division') %></dt>

--- a/app/views/chapter_ambassador/participants/show.en.html.erb
+++ b/app/views/chapter_ambassador/participants/show.en.html.erb
@@ -37,7 +37,7 @@
         <dt><%= t('models.account.email') %></dt>
         <dd><%= mail_to @account.email %></dd>
 
-        <% if not @account.is_a_mentor? %>
+        <% if !@account.is_a_mentor? %>
           <dt><%= t('models.account.age') %></dt>
           <dd><%= @account.age %></dd>
         <% end %>

--- a/app/views/chapter_ambassador/participants/show.en.html.erb
+++ b/app/views/chapter_ambassador/participants/show.en.html.erb
@@ -37,8 +37,10 @@
         <dt><%= t('models.account.email') %></dt>
         <dd><%= mail_to @account.email %></dd>
 
-        <dt><%= t('models.account.age') %></dt>
-        <dd><%= @account.age %></dd>
+        <% if not @account.is_a_mentor? %>
+          <dt><%= t('models.account.age') %></dt>
+          <dd><%= @account.age %></dd>
+        <% end %>
 
         <dt>Seasons</dt>
         <dd><%= @account.seasons.to_sentence %></dd>


### PR DESCRIPTION
Looks like there another places that displays Mentors Age, this PR cover the 'participant view file' and hide the age info for mentors on that.

Changes:
modified: app/views/admin/participants/show.html.erb
modified: app/views/chapter_ambassador/participants/show.en.html.erb

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3219