### PR TITLE
Adjusting the profile form to fit the new brand

### DIFF
--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -15,6 +15,10 @@ class AdminProfile < ActiveRecord::Base
     "admin"
   end
 
+  def rebranded?
+    false
+  end
+
   def method_missing(method_name, *args)
     begin
       account.public_send(method_name, *args)

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -110,6 +110,10 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     secondary_regions
   end
 
+  def rebranded?
+    false
+  end
+  
   def onboarded?
     account.email_confirmed? and
       approved? and

--- a/app/models/judge_profile.rb
+++ b/app/models/judge_profile.rb
@@ -222,6 +222,10 @@ class JudgeProfile < ActiveRecord::Base
     "judge"
   end
 
+  def rebranded?
+    true
+  end
+
   def can_be_marked_onboarded?
     account &&
       account.email_confirmed? &&

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -345,6 +345,10 @@ class MentorProfile < ActiveRecord::Base
     teams.include?(team)
   end
 
+  def rebranded?
+    false
+  end
+
   def onboarding?
     not onboarded?
   end

--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -358,6 +358,10 @@ class StudentProfile < ActiveRecord::Base
     actions
   end
 
+  def rebranded?
+    true
+  end
+  
   def can_be_marked_onboarded?
     account.present? &&
       signed_parental_consent.present? &&

--- a/app/views/location_details/show.en.html.erb
+++ b/app/views/location_details/show.en.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "Location details" %>
 
-<% if (current_profile.is_a? StudentProfile) || (current_profile.is_a? JudgeProfile) %>
+<% if current_profile.rebranded? %>
   <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6">
     <div class="tab-content tw-active">
       <%= render 'signups/location_fields' %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,14 +1,16 @@
 <%
   url ||= send("#{current_scope}_profile_path")
   admin ||= false
+  form = current_profile.rebranded? ? 
+    'signups/rebranded/form' :
+    'signups/form'
 %>
 
-<%= render layout: 'signups/form',
+<%= render layout: form,
   locals: {
     signup: profile,
     url: url,
     title: title,
     admin: admin,
   } do |f| %>
-  <%= f.button :submit, t('views.application.save'), class: "button" %>
 <% end %>

--- a/app/views/signups/_form.html.erb
+++ b/app/views/signups/_form.html.erb
@@ -16,71 +16,15 @@
     <%= simple_form_for(signup, url: url) do |f| %>
       <%= render 'errors', record: signup %>
 
-      <% if admin || signup.used_global_invitation? %>
-        <%= f.fields_for :account do |a| %>
-          <%= a.input :email %>
-
-          <% if signup.account.errors[:email].include?("has already been taken") %>
-            <p>
-              (<%= link_to "try logging in instead",
-               login_path(email: signup.email) %>)
-            </p>
-          <% end %>
-        <% end %>
-      <% elsif signup.new_record? %>
-        <p>
-          <strong>
-            <%= t("views.signups.form.signing_up_email",
-                  email: signup.email) %>
-          </strong>
-        </p>
-      <% end %>
-
-      <%= render 'signups/basic_profile_fields', f: f, admin: admin %>
-
-      <%= render "signups/#{signup.scope_name}_profile_fields", f: f %>
-
-      <% if signup.account.temporary_password? ||
-          signup.used_global_invitation? %>
-        <h6 class="signup-section">
-          <%= t("models.account.password") %>
-        </h6>
-
-        <%= f.fields_for :account do |a| %>
-          <%= a.input :password, label: t("models.account.password") %>
-        <% end %>
-
-        <p class="hint"><%= t("models.account.password_hint") %></p>
-      <% end %>
-
-      <% if f.object.persisted? %>
-        <%= yield(f) %>
-      <% else %>
-        <%= f.fields_for :account do |a| %>
-          <%= a.input :referred_by,
-            collection: Account.referred_bies.keys,
-            label: t('models.account.referred_by') +
-                     t('views.application.optional'),
-            input_html: {
-              data: {
-                toggles: {
-                  "Other": ".referred_by_other",
-                },
-              },
-              class: 'sign-up-referred-by'
-            } %>
-
-          <div class="referred_by_other">
-            <%= a.input :referred_by_other,
-              label: false,
-              placeholder: t("models.account.referred_by_other") %>
-          </div>
-        <% end %>
-
-        <%= f.button :submit,
-          t('views.signups.form.create_account'),
-          class: 'button' %>
-      <% end %>
+      <%= 
+        render 'signups/form_content', 
+        url: url, 
+        title: title, 
+        admin: admin,
+        button_class: "button",
+        signup: signup,
+        f:f 
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/signups/_form_content.html.erb
+++ b/app/views/signups/_form_content.html.erb
@@ -1,0 +1,68 @@
+<% if admin || signup.used_global_invitation? %>
+  <%= f.fields_for :account do |a| %>
+    <%= a.input :email %>
+
+    <% if signup.account.errors[:email].include?("has already been taken") %>
+      <p>
+        (<%= link_to "try logging in instead",
+        login_path(email: signup.email) %>)
+      </p>
+    <% end %>
+  <% end %>
+  <% elsif signup.new_record? %>
+  <p>
+    <strong>
+      <%= t("views.signups.form.signing_up_email",
+            email: signup.email) %>
+    </strong>
+  </p>
+<% end %>
+
+<%= render 'signups/basic_profile_fields', f: f, admin: admin %>
+
+<%= render "signups/#{signup.scope_name}_profile_fields", f: f %>
+
+<% if signup.account.temporary_password? ||
+  signup.used_global_invitation? %>
+  <h6 class="signup-section">
+    <%= t("models.account.password") %>
+  </h6>
+
+  <%= f.fields_for :account do |a| %>
+    <%= a.input :password, label: t("models.account.password") %>
+  <% end %>
+
+  <p class="hint"><%= t("models.account.password_hint") %></p>
+<% end %>
+
+<% if f.object.persisted? %>
+  <%= yield(f) %>
+  <%= f.button :submit, t('views.application.save'), class: button_class %>
+<% else %>
+  <%= f.fields_for :account do |a| %>
+    <%= a.input :referred_by,
+      collection: Account.referred_bies.keys,
+      label: t('models.account.referred_by') +
+              t('views.application.optional'),
+      input_html: {
+        data: {
+          toggles: {
+            "Other": ".referred_by_other",
+          },
+        },
+        class: 'sign-up-referred-by'
+      } %>
+
+    <div class="referred_by_other">
+      <%= a.input :referred_by_other,
+        label: false,
+        placeholder: t("models.account.referred_by_other") %>
+    </div>
+  <% end %>
+
+  <%= 
+    f.button :submit,
+    t('views.signups.form.create_account'),
+    class: button_class 
+  %>
+<% end %>

--- a/app/views/signups/rebranded/_form.html.erb
+++ b/app/views/signups/rebranded/_form.html.erb
@@ -1,0 +1,36 @@
+<%
+  url ||= url_for(signup)
+  title ||= t("views.signups.new.title.#{signup.scope_name}")
+  admin ||= false
+%>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6">
+  <div class="tab-content tw-active">
+    <%= simple_form_for(signup, url: url) do |f| %>
+      <%= render 'errors', record: signup %>
+        <div class="tw-blue-lg-container">
+
+            <div class="sm-header-wrapper bg-energetic-blue text-white p-2">
+                <p class="font-bold">
+                    <%= title %>
+                    <% unless signup.persisted? %>
+                    <%= t("views.signups.new.roles.#{signup.scope_name}") %>
+                    <% end %>
+                </p>
+            </div>
+
+            <div class="p-6" >
+            <%= 
+              render 'signups/form_content', 
+              url: url, 
+              title: title, 
+              admin: admin, 
+              button_class: "tw-green-btn",
+              signup: signup,
+              f:f
+            %>
+            </div>
+        </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Creates a "rebranded?" that allows to simple switch between old and new profiles style.

Changes:
modified: app/views/location_details/show.en.html.erb
modified: app/views/profiles/_form.html.erb
modified: app/views/signups/_form.html.erb
modified: app/views/signups/_form_content.html.erb
modified: app/views/signups/rebranded/_form.html.erb

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3302
PR Discussion: https://github.com/Iridescent-CM/technovation-app/pull/3312