### PR TITLE
Hides mentor age on public profile

### DIFF
--- a/app/views/judge/profiles/rebrand/_basic.en.html.erb
+++ b/app/views/judge/profiles/rebrand/_basic.en.html.erb
@@ -7,7 +7,7 @@
       <dt>Gender identity</dt>
       <dd><%= current_judge.gender || "Not specified" %></dd>
 
-      <dt>Age</dt>
+      <dt>Birthdate</dt>
       <dd><%= current_judge.date_of_birth.strftime("%B %e, %Y") %></dd>
 
       <dt>Company name</dt>

--- a/app/views/profiles/_privileged_show.html.erb
+++ b/app/views/profiles/_privileged_show.html.erb
@@ -41,8 +41,10 @@
           <dt><%= t('models.account.email') %></dt>
           <dd><%= mail_to account.email %></dd>
 
-          <dt><%= t('models.account.age') %></dt>
-          <dd><%= account.age %></dd>
+          <% if !account.mentor_profile.present? %>
+            <dt><%= t('models.account.age') %></dt>
+            <dd><%= account.age %></dd>
+          <% end %>
 
           <% unless account.student_profile.present? %>
             <dt><%= t('models.account.gender') %></dt>


### PR DESCRIPTION
Avoid to display mentors age when its accessed from mentors show profile.

Changes:
modified: app/views/profiles/_privileged_show.html.erb

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3219
Discussion: https://github.com/Iridescent-CM/technovation-app/pull/328