### PR TITLE
Update "delete" pending invite links

### DIFF
--- a/app/views/invites/_unregistered_invitee.en.html.erb
+++ b/app/views/invites/_unregistered_invitee.en.html.erb
@@ -11,7 +11,10 @@
       <small>Unregistered</small><br />
 
       <%= link_to "delete this invitation",
-        send("#{current_scope}_invites_path"),
+        send(
+          "#{current_scope}_team_member_invite_path",
+          invite
+        ),
         class: "danger small",
         data: {
           method: :delete,


### PR DESCRIPTION
The "delete" pending invite link was throwing an error:
`ActionView::Template::Error (undefined method `mentor_invites_path' for #<ActionView::Base:0x00000000079478>`

Because the route it's trying to use doesn't exist, the "delete" link was incorrectly updated during the Rails 6 upgrade.

The update in this PR will resolve the links to use one of these two existing routes:
- student_team_member_invite_path
- mentor_team_member_invite_path

Refs: #3340