### PR TITLE
Allow ambassadors do verify student media consent

### DIFF
--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -273,6 +273,10 @@ class StudentProfile < ActiveRecord::Base
     !!parental_consent && parental_consent.signed?
   end
 
+  def media_consent_signed?
+    !!media_consent && media_consent.signed?
+  end  
+
   def can_search_teams?
     SeasonToggles.team_building_enabled? and
       not is_on_team? and

--- a/app/views/admin/participants/_student_debugging.html.erb
+++ b/app/views/admin/participants/_student_debugging.html.erb
@@ -26,6 +26,16 @@
       <% end %>
     </dd>
 
+    <dt>Media Consent</dt>
+    <dd>
+      <% if profile.media_consent_signed? %>
+        <%= web_icon("check-circle icon-green", text: "Signed! Yay!") %>
+      <% else %>
+        <%= web_icon("exclamation-circle icon-red",
+                     text: "Not signed... boo...") %>
+      <% end %>
+    </dd>
+
     <dt>Location</dt>
     <dd>
       <% if profile.address_details.empty? %>

--- a/app/views/admin/participants/_student_media_consent.html.erb
+++ b/app/views/admin/participants/_student_media_consent.html.erb
@@ -1,0 +1,47 @@
+<% if profile %>
+    <div class="panel">
+        <% media_consent = profile.media_consent %>
+        <% if media_consent&.consent_provided.nil? %>
+            <h5>Has not completed media consent form</h5>
+            <% if admin  %>
+                <%= link_to "GRANT permission",
+                admin_paper_media_consent_path(
+                    id: profile.id,
+                    consent: true
+                ),
+                class: "button button--secondary",
+                data: {
+                    method: :post,
+                    confirm: "You are granting to #{full_name} " +
+                    "media consent on file.",
+                } 
+                %>
+
+                <%= link_to "Do NOT GRANT permission",
+                admin_paper_media_consent_path(
+                    id: profile.id,
+                    consent: false
+                ),
+                class: "button button--secondary",
+                data: {
+                    method: :post,
+                    confirm: "You are denying to #{full_name} " +
+                    "media consent on file.",
+                } 
+                %>
+            <% end %>
+        <% else %>
+            <% if media_consent&.consent_provided? %>
+            <h5>
+                AGREED to media content  via 
+                <%= media_consent.on_file? ? "paper form" : "online form" %>
+            </h5>
+            <% else %>
+            <h5>
+                Did NOT AGREE to media consent via 
+                <%= media_consent.on_file? ? "paper form" : "online form" %>
+            </h5>
+            <% end %>
+        <% end %>
+    </div>
+<% end %>

--- a/app/views/admin/participants/_student_media_consent.html.erb
+++ b/app/views/admin/participants/_student_media_consent.html.erb
@@ -1,47 +1,47 @@
 <% if profile %>
-    <div class="panel">
-        <% media_consent = profile.media_consent %>
-        <% if media_consent&.consent_provided.nil? %>
-            <h5>Has not completed media consent form</h5>
-            <% if admin  %>
-                <%= link_to "GRANT permission",
-                admin_paper_media_consent_path(
-                    id: profile.id,
-                    consent: true
-                ),
-                class: "button button--secondary",
-                data: {
-                    method: :post,
-                    confirm: "You are granting to #{full_name} " +
-                    "media consent on file.",
-                } 
-                %>
+  <div class="panel">
+    <% media_consent = profile.media_consent %>
+    <% if media_consent&.consent_provided.nil? %>
+      <h5>Has not completed media consent form</h5>
+      <% if admin  %>
+        <%= link_to "GRANT permission",
+          admin_paper_media_consent_path(
+            id: profile.id,
+            consent: true
+          ),
+          class: "button button--secondary",
+          data: {
+            method: :post,
+            confirm: "You are granting to #{full_name} " +
+            "media consent on file.",
+          } 
+        %>
 
-                <%= link_to "Do NOT GRANT permission",
-                admin_paper_media_consent_path(
-                    id: profile.id,
-                    consent: false
-                ),
-                class: "button button--secondary",
-                data: {
-                    method: :post,
-                    confirm: "You are denying to #{full_name} " +
-                    "media consent on file.",
-                } 
-                %>
-            <% end %>
-        <% else %>
-            <% if media_consent&.consent_provided? %>
-            <h5>
-                AGREED to media content  via 
-                <%= media_consent.on_file? ? "paper form" : "online form" %>
-            </h5>
-            <% else %>
-            <h5>
-                Did NOT AGREE to media consent via 
-                <%= media_consent.on_file? ? "paper form" : "online form" %>
-            </h5>
-            <% end %>
-        <% end %>
-    </div>
+        <%= link_to "Do NOT GRANT permission",
+          admin_paper_media_consent_path(
+            id: profile.id,
+            consent: false
+          ),
+          class: "button button--secondary",
+          data: {
+            method: :post,
+            confirm: "You are denying to #{full_name} " +
+            "media consent on file.",
+          } 
+        %>
+      <% end %>
+    <% else %>
+      <% if media_consent&.consent_provided? %>
+        <h5>
+          AGREED to media content  via 
+          <%= media_consent.on_file? ? "paper form" : "online form" %>
+        </h5>
+      <% else %>
+        <h5>
+          Did NOT AGREE to media consent via 
+          <%= media_consent.on_file? ? "paper form" : "online form" %>
+        </h5>
+      <% end %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -201,50 +201,11 @@
     <% end %>
 
     <% if @account.student_profile %>
-      <div class="panel">
-        <% media_consent = @account.student_profile.media_consent %>
-        <% if media_consent&.consent_provided.nil? %>
-          <h5>Has not completed media consent form</h5>
-
-          <%= link_to "GRANT permission",
-            admin_paper_media_consent_path(
-              id: @account.student_profile.id,
-              consent: true
-            ),
-            class: "button button--secondary",
-            data: {
-              method: :post,
-              confirm: "You are granting to #{@account.full_name} " +
-              "media consent on file.",
-            } 
-          %>
-
-          <%= link_to "Do NOT GRANT permission",
-            admin_paper_media_consent_path(
-              id: @account.student_profile.id,
-              consent: false
-            ),
-            class: "button button--secondary",
-            data: {
-              method: :post,
-              confirm: "You are denying to #{@account.full_name} " +
-              "media consent on file.",
-            } 
-          %>
-        <% else %>
-          <% if media_consent&.consent_provided? %>
-            <h5>
-              AGREED to media content  via 
-              <%= media_consent.on_file? ? "paper form" : "online form" %>
-            </h5>
-          <% else %>
-            <h5>
-              Did NOT AGREE to media consent via 
-              <%= media_consent.on_file? ? "paper form" : "online form" %>
-            </h5>
-          <% end %>
-        <% end %>
-      </div>
+      <%= render 'admin/participants/student_media_consent',
+        profile: @account.student_profile,
+        full_name: @account.full_name,
+        admin: true
+      %>
     <% end %>
 
     <%= render 'admin/participants/certificates',

--- a/app/views/chapter_ambassador/participants/show.en.html.erb
+++ b/app/views/chapter_ambassador/participants/show.en.html.erb
@@ -85,6 +85,12 @@
 <% if @account.student_profile %>
   <%= render 'admin/participants/student_debugging',
     profile: @account.student_profile %>
+
+  <%= render 'admin/participants/student_media_consent',
+    profile: @account.student_profile,
+    full_name: @account.full_name,
+    admin: false
+  %>
 <% end %>
 
 <% if @account.chapter_ambassador_profile %>


### PR DESCRIPTION
Allow ambassadors only check the student media consent status, but NOT EDIT it.

Changes:
modified: app/models/student_profile.rb
modified: app/views/admin/participants/_student_debugging.html.erb
modified: app/views/admin/participants/_student_media_consent.html.erb
modified: app/views/admin/participants/show.html.erb
modified: app/views/chapter_ambassador/participants/show.en.html.erb

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3339