### PR TITLE
Add new submission type constants

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -4,9 +4,12 @@ class TeamSubmission < ActiveRecord::Base
   MAX_SCREENSHOTS_ALLOWED = 6
   PARTICIPATION_MINIMUM_PERCENT = 50
 
+  MOBILE_APP_SUBMISSION_TYPE = "Mobile App"
+  AI_PROJECT_SUBMISSION_TYPE = "AI Project"
+
   SUBMISSION_TYPES_ENUM = {
-    "Mobile App" => 0,
-    "AI Project" => 1
+    MOBILE_APP_SUBMISSION_TYPE => 0,
+    AI_PROJECT_SUBMISSION_TYPE => 1
   }
 
   SUBMISSION_TYPES = SUBMISSION_TYPES_ENUM.keys
@@ -520,9 +523,9 @@ class TeamSubmission < ActiveRecord::Base
   end
 
   def development_platform_text
-    if submission_type == "Mobile App" && development_platform != "Other"
+    if submission_type == MOBILE_APP_SUBMISSION_TYPE && development_platform != "Other"
       "#{submission_type} - #{development_platform}"
-    elsif submission_type == "Mobile App" && development_platform == "Other"
+    elsif submission_type == MOBILE_APP_SUBMISSION_TYPE && development_platform == "Other"
       "#{submission_type} - #{development_platform} - #{development_platform_other}"
     else
       submission_type
@@ -599,7 +602,7 @@ class TeamSubmission < ActiveRecord::Base
   end
 
   def reset_development_platform_fields_for_ai_projects
-    if submission_type == "AI Project"
+    if submission_type == AI_PROJECT_SUBMISSION_TYPE
       self.development_platform = nil
       self.development_platform_other = nil
       self.app_inventor_app_name = nil

--- a/app/services/judging/twenty_twenty_two/beginner_questions.rb
+++ b/app/services/judging/twenty_twenty_two/beginner_questions.rb
@@ -108,7 +108,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 3,
             text: %(
@@ -119,7 +119,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 3,
             text: %(
@@ -131,7 +131,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 3,
             text: %(
@@ -142,7 +142,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 3,
             text: %(
@@ -154,7 +154,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 3,
             text: %(
@@ -166,7 +166,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 3,
             text: %(

--- a/app/services/judging/twenty_twenty_two/junior_questions.rb
+++ b/app/services/judging/twenty_twenty_two/junior_questions.rb
@@ -122,7 +122,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 5,
             text: %(
@@ -133,7 +133,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 5,
             text: %(
@@ -145,7 +145,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 5,
             text: %(
@@ -156,7 +156,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 5,
             text: %(
@@ -168,7 +168,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 5,
             text: %(
@@ -180,7 +180,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 5,
             text: %(

--- a/app/services/judging/twenty_twenty_two/senior_questions.rb
+++ b/app/services/judging/twenty_twenty_two/senior_questions.rb
@@ -122,7 +122,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 5,
             text: %(
@@ -133,7 +133,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 5,
             text: %(
@@ -145,7 +145,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "mobile_app",
+            submission_type: TeamSubmission::MOBILE_APP_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 5,
             text: %(
@@ -156,7 +156,7 @@ module Judging
           Question.new(
             idx: 1,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_1,
             worth: 5,
             text: %(
@@ -168,7 +168,7 @@ module Judging
           Question.new(
             idx: 2,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_2,
             worth: 5,
             text: %(
@@ -180,7 +180,7 @@ module Judging
           Question.new(
             idx: 3,
             section: "demo",
-            submission_type: "ai",
+            submission_type: TeamSubmission::AI_PROJECT_SUBMISSION_TYPE,
             field: :demo_3,
             worth: 5,
             text: %(


### PR DESCRIPTION
This will create two constants:
- `MOBILE_APP_SUBMISSION_TYPE`
- `AI_PROJECT_SUBMISSION_TYPE`

This will be instead of using the magic strings "Mobile App" and "AI Project". It will also keep the `submission_type` field for the judging questions consistent.