### PR TITLE
Filter Demo questions based on submission type

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,5 @@
 class Question
-  attr_reader :section, :idx, :text, :worth, :score, :field
+  attr_reader :section, :idx, :text, :worth, :score, :field, :submission_type
   attr_writer :score
 
   def initialize(attrs)
@@ -10,5 +10,6 @@ class Question
     @worth = attrs[:worth]
     @score = attrs[:score]
     @field = attrs[:field]
+    @submission_type = attrs[:submission_type]
   end
 end

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -225,6 +225,7 @@ class SubmissionScore < ActiveRecord::Base
            :team_division_name,
            :team_primary_location,
            :team_ages,
+           :submission_type,
     to: :team_submission,
     prefix: true,
     allow_nil: false

--- a/app/services/judge_questions_for_submission_score.rb
+++ b/app/services/judge_questions_for_submission_score.rb
@@ -1,6 +1,7 @@
 class JudgeQuestionsForSubmissionScore
   def initialize(submission_score)
     @submission_score = submission_score
+    @submission_type = submission_score.team_submission_submission_type
     @season = submission_score.seasons.last
     @division = submission_score.team_division_name
     @questions = "Judging::#{season_module_name}::#{questions_class_name}".constantize.new.call
@@ -12,7 +13,7 @@ class JudgeQuestionsForSubmissionScore
 
   private
 
-  attr_reader :submission_score, :season, :division, :questions
+  attr_reader :submission_score, :submission_type, :season, :division, :questions
 
   def season_module_name
     case season
@@ -43,10 +44,16 @@ class JudgeQuestionsForSubmissionScore
   end
 
   def questions_with_scores_populated
-    questions.map do |question|
+    filtered_questions.map do |question|
       question.score = submission_score.instance_eval(question.field.to_s)
 
       question
+    end
+  end
+
+  def filtered_questions
+    questions.delete_if do |question|
+      question.section == "demo" && question.submission_type != submission_type
     end
   end
 end


### PR DESCRIPTION
There are six possible questions for the Demo section - three are for an AI Project and three are for a Mobile App project.

Prior to this update the back-end would have returned all six questions to the front-end.

With this update the back-end will only return the necessary questions based on whether the submission type is an AI Project or a Mobile App project. This will make things simpler for the front-end.