### PR TITLE
Separates the "business plan" from "adoption plan" url on search

### DIFF
--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -33,7 +33,15 @@ class SubmissionsGrid
   column :app_inventor_app_name
   column :app_inventor_gmail
   column :source_code_url
-  column :business_plan_url
+  
+  column :business_plan_url do
+    !team.junior? ? self.business_plan_url : "-"
+  end
+
+  column :adoption_plan_url do
+    team.junior? ? self.business_plan_url : "-"
+  end 
+
   column :pitch_presentation_url
 
   column :team_name,

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -35,7 +35,7 @@ class SubmissionsGrid
   column :source_code_url
   
   column :business_plan_url do
-    !team.junior? ? self.business_plan_url : "-"
+    team.senior? ? self.business_plan_url : "-"
   end
 
   column :adoption_plan_url do


### PR DESCRIPTION
This fix will separate business plan url from adoption plan url on Team Submission searchs.

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3196

