### PR TITLE
Removes de email submission presence validation

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -209,12 +209,10 @@ class TeamSubmission < ActiveRecord::Base
   }
 
   validates :app_inventor_app_name,
-    :app_inventor_gmail,
     presence: true,
     if: ->(s) { s.development_platform == "App Inventor" }
 
-  validates :thunkable_account_email,
-    :thunkable_project_url,
+  validates :thunkable_project_url,
     presence: true,
     if: ->(s) { s.development_platform == "Thunkable" }
 

--- a/spec/features/mentor/submission_dev_platform_spec.rb
+++ b/spec/features/mentor/submission_dev_platform_spec.rb
@@ -27,10 +27,6 @@ RSpec.feature "Mentors edit submission development platform" do
       ".field_with_errors #team_submission_app_inventor_app_name",
     )
 
-    expect(page).to have_css(
-      ".field_with_errors #team_submission_app_inventor_gmail",
-    )
-
     fill_in "What is your App Inventor Project Name?",
       with: "my_exact_app_name"
 
@@ -56,10 +52,6 @@ RSpec.feature "Mentors edit submission development platform" do
 
     expect(page).to have_css(
       ".field_with_errors #team_submission_thunkable_project_url",
-    )
-
-    expect(page).to have_css(
-      ".field_with_errors #team_submission_thunkable_account_email",
     )
 
     fill_in "What is the email address of your team's Thunkable account?",

--- a/spec/features/student/submission_dev_platform_spec.rb
+++ b/spec/features/student/submission_dev_platform_spec.rb
@@ -31,10 +31,6 @@ RSpec.feature "Students edit submission development platform" do
       ".field_with_errors #team_submission_app_inventor_app_name",
     )
 
-    expect(page).to have_css(
-      ".field_with_errors #team_submission_app_inventor_gmail",
-    )
-
     fill_in "What is your App Inventor Project Name?", with: "my_exact_app_name"
 
     fill_in "What is the gmail address of the App Inventor account that your team is using?",
@@ -58,10 +54,6 @@ RSpec.feature "Students edit submission development platform" do
 
     expect(page).to have_css(
       ".field_with_errors #team_submission_thunkable_project_url",
-    )
-
-    expect(page).to have_css(
-      ".field_with_errors #team_submission_thunkable_account_email",
     )
 
     fill_in "What is the email address of your team's Thunkable account?",


### PR DESCRIPTION
Removes de email submission presence validation

Changes:
modified: app/models/team_submission.rb
modified: spec/features/mentor/submission_dev_platform_spec.rb
modified: spec/features/student/submission_dev_platform_spec.rb

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3294