### PR TITLE
Allow additional CSS in application rebrand layout

### DIFF
--- a/app/views/layouts/application_rebrand.html.erb
+++ b/app/views/layouts/application_rebrand.html.erb
@@ -21,7 +21,7 @@
 
     <%#= stylesheet_packs_with_chunks_tag "application" %>
 
-    <%#= yield :css %>
+    <%= yield :additional_css %>
 
     <%= javascript_include_tag determine_manifest,
       'data-turbolinks-track' => true %>
@@ -29,7 +29,6 @@
     <%= javascript_packs_with_chunks_tag "application" %>
     <%= javascript_packs_with_chunks_tag "application_rebrand" %>
     <%= stylesheet_pack_tag 'application_rebrand', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag 'judge', 'data-turbolinks-track': 'reload' %>
 
     <%= yield :js %>
 

--- a/app/views/layouts/judge.html.erb
+++ b/app/views/layouts/judge.html.erb
@@ -6,7 +6,7 @@
 <% content_for :js,
   javascript_packs_with_chunks_tag("judge", data: { turbolinks_track: :reload }) %>
 
-<% provide :css,
+<% provide :additional_css,
   stylesheet_packs_with_chunks_tag("judge", data: { turbolinks_track: :reload }) %>
 
 <%= render template: "layouts/application_rebrand" %>


### PR DESCRIPTION
The fix/hack I made yesterday to get the judging styles working on QA was to just include the judging CSS on every page that uses the application rebrand layout.

This change is a more proper fix and will only include the judging CSS for judging pages (basically making it like it was before).