### PR TITLE
Added new headings to admin score details

### DIFF
--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -25,6 +25,14 @@ class Questions
     end
   end
 
+  def sections_for(division:, season: Season.current.year)
+    JudgeQuestions
+      .new(division: division, season: season)
+      .call
+      .uniq(&:section)
+      .map(&:section)
+  end
+
   def sections
     collection = %w[
       ideation

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -27,18 +27,15 @@ class Questions
 
   def sections
     collection = %w[
+      project_details
       ideation
-      technical
+      pitch
+      demo
     ]
 
-    if submission.senior_division?
+    if submission.senior_division? || submission.junior_division?
       collection << "entrepreneurship"
     end
-
-    collection + %w[
-      pitch
-      overall
-    ]
   end
 
   def as_json(*args, &block)

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -27,15 +27,18 @@ class Questions
 
   def sections
     collection = %w[
-      project_details
       ideation
-      pitch
-      demo
+      technical
     ]
 
-    if submission.senior_division? || submission.junior_division?
+    if submission.senior_division?
       collection << "entrepreneurship"
     end
+
+    collection + %w[
+      pitch
+      overall
+    ]
   end
 
   def as_json(*args, &block)

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -379,41 +379,38 @@ class SubmissionScore < ActiveRecord::Base
     total
   end
 
-  def ideation_total
-    ideation_1 +
-      ideation_2 +
-        ideation_3 +
-          ideation_4
+  def project_details_total
+    project_details_1
   end
 
-  def technical_total
-    technical_1 +
-      technical_2 +
-        technical_3 +
-          technical_4
+  def ideation_total
+    ideation_1 +
+      ideation_2
+  end
+
+  def pitch_total
+    pitch_1 +
+      pitch_2 +
+        pitch_4 +
+          pitch_5 +
+            pitch_6 +
+              pitch_7 +
+                pitch_8
+  end
+
+  def demo_total
+    demo_1 +
+      demo_2 +
+        demo_3
   end
 
   def entrepreneurship_total
-    return 0 if junior_team_division?
+    return 0 if beginner_team_division?
 
     entrepreneurship_1 +
       entrepreneurship_2 +
         entrepreneurship_3 +
           entrepreneurship_4
-  end
-
-  def pitch_total
-    pitch_1 +
-      pitch_2
-  end
-
-  def overall_impression_total
-    overall_1 +
-      overall_2
-  end
-
-  def overall_total
-    overall_impression_total
   end
 
   def total_possible

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -376,6 +376,10 @@ class SubmissionScore < ActiveRecord::Base
   end
 
   def total_for_section(division, section_name)
+    public_send("#{section_name}_total")
+  end
+
+  def total_points_for_section(division, section_name)
     self.class.total_possible_points_for_section(division: division, section: section_name)
   end
 

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -271,6 +271,14 @@ class SubmissionScore < ActiveRecord::Base
       .sum(&:worth)
   end
 
+  def self.total_possible_points_for_section(division:, section:, season: Season.current.year)
+    JudgeQuestions
+      .new(division: division, season: season)
+      .call
+      .select { |question| question.section == section }
+      .sum(&:worth)
+  end
+
   def overall_impression_comment
     overall_comment
   end
@@ -367,8 +375,8 @@ class SubmissionScore < ActiveRecord::Base
     public_send(question.field)
   end
 
-  def total_for_section(section_name)
-    public_send("#{section_name}_total")
+  def total_for_section(division, section_name)
+    self.class.total_possible_points_for_section(division: division, section: section_name)
   end
 
   def comment_for_section(section_name)

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -379,38 +379,41 @@ class SubmissionScore < ActiveRecord::Base
     total
   end
 
-  def project_details_total
-    project_details_1
-  end
-
   def ideation_total
     ideation_1 +
-      ideation_2
+      ideation_2 +
+        ideation_3 +
+          ideation_4
   end
 
-  def pitch_total
-    pitch_1 +
-      pitch_2 +
-        pitch_4 +
-          pitch_5 +
-            pitch_6 +
-              pitch_7 +
-                pitch_8
-  end
-
-  def demo_total
-    demo_1 +
-      demo_2 +
-        demo_3
+  def technical_total
+    technical_1 +
+      technical_2 +
+        technical_3 +
+          technical_4
   end
 
   def entrepreneurship_total
-    return 0 if beginner_team_division?
+    return 0 if junior_team_division?
 
     entrepreneurship_1 +
       entrepreneurship_2 +
         entrepreneurship_3 +
           entrepreneurship_4
+  end
+
+  def pitch_total
+    pitch_1 +
+      pitch_2
+  end
+
+  def overall_impression_total
+    overall_1 +
+      overall_2
+  end
+
+  def overall_total
+    overall_impression_total
   end
 
   def total_possible

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -375,7 +375,7 @@ class SubmissionScore < ActiveRecord::Base
     public_send(question.field)
   end
 
-  def total_for_section(division, section_name)
+  def total_for_section(section_name)
     public_send("#{section_name}_total")
   end
 

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -14,7 +14,7 @@
 
     <h3>
       <span>Division</span>
-      <%=  @score.team.division_name.humanize %>
+      <%= @score.team.division_name.humanize %>
     </h3>
 
     <h3>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -13,8 +13,6 @@
     </h3>
 
     <h3>
-
-    <h3>
       <span>Division</span>
       <%=  @score.team.division_name.humanize %>
     </h3>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -76,7 +76,7 @@
   <% questions = Questions.for(@score) %>
 
   <div class="admin-score-sections">
-    <% questions.sections.each do |section| %>
+    <% questions.sections_for(division: @score.team.division_name).each do |section| %>
       <h3>
         <%= section.titlecase %>
         <span>(<%= @score.total_for_section(@score.team.division_name, section) %>)</span>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -77,7 +77,7 @@
     <% questions.sections_for(division: @score.team.division_name).each do |section| %>
       <h3>
         <%= section.titlecase %>
-        <span>(<%= @score.total_for_section(@score.team.division_name, section) %>)</span>
+        <span>(<%= @score.total_points_for_section(@score.team.division_name, section) %>)</span>
       </h3>
 
       <table>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -79,7 +79,7 @@
     <% questions.sections.each do |section| %>
       <h3>
         <%= section.titlecase %>
-        <span>(<%= @score.total_for_section(section) %>)</span>
+        <span>(<%= @score.total_for_section(@score.team.division_name, section) %>)</span>
       </h3>
 
       <table>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -13,6 +13,13 @@
     </h3>
 
     <h3>
+
+    <h3>
+      <span>Division</span>
+      <%=  @score.team.division_name.humanize %>
+    </h3>
+
+    <h3>
       <span>Submission</span>
       <%= link_to @score.team_submission.app_name,
         app_path(@score.team_submission),
@@ -53,9 +60,12 @@
         <%= @score.downloaded_source_code? ? "Yes" : "No" %>
       </h5>
 
-      <% if @score.team.senior? %>
+      <% if @score.team.senior? || @score.team.junior? %>
         <h5>
-          <span>Downloaded Business Plan</span>
+          <span>
+            Downloaded
+            <%= @score.team.senior? ? "Business Plan" : "User Adoption Plan" %>
+          </span>
           <%= @score.downloaded_business_plan? ? "Yes" : "No" %>
         </h5>
       <% end %>


### PR DESCRIPTION
This change was needed in order to add the new section headings to the admin scores details page. 2 new methods were created that utilize the new approach to the judging process, which requires division and season. 

The `sections_for` method will return all the unique sections for the current season and for that specific division.

The `total_possible_points_for_section` will return the total possible points for that section, based on current season and division.

For future notes, @shaunxp20 has suggested potentially caching these values since they most likely would not change throughout the course of 1 season 