### PR TITLE
Add judge progress icons

### DIFF
--- a/app/javascript/judge/scores/ScoreStepper.vue
+++ b/app/javascript/judge/scores/ScoreStepper.vue
@@ -18,7 +18,7 @@
           :key="i"
           :section-name="section.name"
           :section-title="section.title"
-          :section-score="`${section.pointsTotal} / ${section.pointsPossible}`"
+          :section-score="`${section.pointsTotal}/${section.pointsPossible}`"
           :is-active="$route.name === section.name"
           :is-complete="section.isComplete"
         />
@@ -26,7 +26,7 @@
         <score-stepper-item
           section-name="review-score"
           section-title="Review Score"
-          :section-score="`${totalScore} / ${totalPossibleScore}`"
+          :section-score="`${totalScore}/${totalPossibleScore}`"
           :is-active="$route.name === 'review-score'"
           :is-complete="isScoreComplete"
         />

--- a/app/javascript/judge/scores/ScoreStepper.vue
+++ b/app/javascript/judge/scores/ScoreStepper.vue
@@ -19,6 +19,7 @@
           :section-name="section.name"
           :section-title="section.title"
           :section-score="`${section.pointsTotal}/${section.pointsPossible}`"
+          :show-section-progress="true"
           :is-active="$route.name === section.name"
           :is-complete="section.isComplete"
         />

--- a/app/javascript/judge/scores/ScoreStepperItem.vue
+++ b/app/javascript/judge/scores/ScoreStepperItem.vue
@@ -2,49 +2,61 @@
   <li class="pb-6">
     <router-link
       :to="{ name: this.sectionName }"
-      :class="this.isActive ? 'text-tg-green' : ''"
-      class="flex items-center group truncate hover:text-tg-green"
+      class="hover:text-tg-dark-green"
     >
-      <span class="flex items-center" aria-hidden="true">
-        <span v-if="this.isActive"
-          class="w-6 h-6 flex items-center justify-center bg-white border-2 border-tg-green rounded-full"
-        >
-          <span class="h-2.5 w-2.5 bg-tg-green rounded-full"></span>
+      <div
+        :class="this.isActive ? 'text-tg-green' : ''"
+        class="flex items-center group truncate hover:text-tg-green"
+      >
+        <span class="flex items-center" aria-hidden="true">
+          <span v-if="this.isActive"
+            class="w-6 h-6 flex items-center justify-center bg-white border-2 border-tg-green rounded-full"
+          >
+            <span class="h-2.5 w-2.5 bg-tg-green rounded-full"></span>
+          </span>
+
+          <span v-else-if="this.isComplete"
+            class="w-6 h-6 flex items-center justify-center bg-tg-green rounded-full group-hover:bg-tg-dark-green"
+          >
+            <svg class="w-5 h-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+            </svg>
+          </span>
+
+          <span v-else
+            class="w-6 h-6 flex items-center justify-center bg-white border-2 border-gray-300 rounded-full"
+          >
+          </span>
         </span>
 
-        <span v-else-if="this.isComplete"
-          class="w-6 h-6 flex items-center justify-center bg-tg-green rounded-full group-hover:bg-tg-dark-green"
-        >
-          <svg class="w-5 h-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-          </svg>
-        </span>
+        <div class="ml-3 min-w-0">
+          <h5
+            :class="this.isActive ? 'font-medium' : 'font-normal'"
+            class="text-base tracking-wide"
+          >
+            {{ this.sectionTitle }}
+          </h5>
+        </div>
+      </div>
 
-        <span v-else
-          class="w-6 h-6 flex items-center justify-center bg-white border-2 border-gray-300 rounded-full"
-        >
-        </span>
-      </span>
+      <div class="flex justify-between">
+        <div v-if="showSectionProgress" class="ml-8">
+          <SectionProgressIcons :section="sectionName" />
+        </div>
 
-      <div class="ml-3 min-w-0">
-        <h5
-          :class="this.isActive ? 'font-medium' : 'font-normal'"
-          class="text-base tracking-wide"
-        >
-          {{ this.sectionTitle }}
-        </h5>
+        <p
+          :class="this.isActive ? 'font-semibold text-gray-600' : 'font-normal text-gray-500'"
+          class="ml-auto text-sm text-right">
+          {{ this.sectionScore || "&nbsp;" }}
+        </p>
       </div>
     </router-link>
-
-    <p
-      :class="this.isActive ? 'font-semibold text-gray-600' : 'font-normal text-gray-500'"
-      class="text-sm text-right">
-      {{ this.sectionScore || "&nbsp;" }}
-    </p>
   </li>
 </template>
 
 <script>
+import SectionProgressIcons from './pieces/SectionProgressIcons'
+
 export default {
   props: {
     sectionName: {
@@ -59,6 +71,10 @@ export default {
       type: String,
       required: false
     },
+    showSectionProgress: {
+      type: Boolean,
+      default: false
+    },
     isActive: {
       type: Boolean,
       default: false
@@ -67,6 +83,10 @@ export default {
       type: Boolean,
       default: false
     },
+  },
+
+  components: {
+    SectionProgressIcons
   }
 }
 </script>

--- a/app/javascript/judge/scores/pieces/SectionProgressIcons.vue
+++ b/app/javascript/judge/scores/pieces/SectionProgressIcons.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex">
+    <span v-for="question in questionsForSection(section)">
+      <svg
+        :class="question.score > 0 ? 'text-tg-green' : 'text-gray-300'"
+        class="h-5 w-5"
+        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+      >
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+      </svg>
+    </span>
+
+    <svg
+      :class="commentForSection(section).word_count >= 20 ? 'text-tg-green': 'text-gray-300'"
+      class="h-5 w-5"
+      xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+    >
+      <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd" />
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    section: {
+      type: String,
+      required: true
+    },
+  },
+
+  methods: {
+    questionsForSection(section) {
+      return this.$store.getters.sectionQuestions(section)
+    },
+
+    commentForSection(section) {
+      return this.$store.getters.comment(section)
+    }
+  }
+}
+</script>

--- a/app/javascript/judge/scores/sections/ReviewScore.vue
+++ b/app/javascript/judge/scores/sections/ReviewScore.vue
@@ -39,25 +39,7 @@
                 </p>
               </div>
 
-              <div class="flex">
-                <span v-for="question in questionsForSection(section.name)">
-                  <svg
-                    :class="question.score > 0 ? 'text-tg-green' : 'text-gray-300'"
-                    class="h-5 w-5"
-                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-                  >
-                   <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-                  </svg>
-                </span>
-
-                <svg
-                  :class="commentForSection(section.name).word_count >= 20 ? 'text-tg-green': 'text-gray-300'"
-                  class="h-5 w-5"
-                  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-                >
-                 <path fill-rule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clip-rule="evenodd" />
-                </svg>
-              </div>
+              <SectionProgressIcons :section="section.name" />
             </div>
           </div>
         </router-link>
@@ -102,23 +84,14 @@ import { mapState, mapGetters, mapActions } from 'vuex'
 import EnergeticContainer from "../../components/EnergeticContainer";
 import TeamInfo from "../TeamInfo";
 import ThickRule from "../../components/ThickRule";
+import SectionProgressIcons from '../pieces/SectionProgressIcons'
 
 export default {
   components: {
     EnergeticContainer,
     TeamInfo,
-    ThickRule
-  },
-
-
-  methods: {
-    questionsForSection(section) {
-      return this.$store.getters.sectionQuestions(section)
-    },
-
-    commentForSection(section) {
-      return this.$store.getters.comment(section)
-    }
+    ThickRule,
+    SectionProgressIcons
   },
 
   computed: {


### PR DESCRIPTION
I added a new component for the progress icons - `SectionProgressIcons`. These progress icons will get displayed on the score summary page (like they do now), and now they will get displayed in the score stepper in the sidebar.