### PR TITLE
Auto-redirect to judge dashboard

### DIFF
--- a/app/controllers/admin/participant_sessions_controller.rb
+++ b/app/controllers/admin/participant_sessions_controller.rb
@@ -5,9 +5,13 @@ module Admin
       participant.regenerate_session_token
       set_cookie(CookieNames::SESSION_TOKEN, participant.session_token)
 
-      redirect_to send(
-        "#{participant.scope_name.sub(/^\w+_r/, "r")}_dashboard_path"
-      )
+      if JudgeDashboardRedirector.new(account: participant).enabled?
+        redirect_to judge_dashboard_path
+      else
+        redirect_to send(
+          "#{participant.scope_name}_dashboard_path"
+        )
+      end
     end
 
     def destroy

--- a/app/services/judge_dashboard_redirector.rb
+++ b/app/services/judge_dashboard_redirector.rb
@@ -1,0 +1,16 @@
+class JudgeDashboardRedirector
+  def initialize(account:, season_toggles: SeasonToggles)
+    @account = account
+    @season_toggles = season_toggles
+  end
+
+  def enabled?
+    account.can_switch_to_judge? &&
+      season_toggles.judging_enabled_or_between? &&
+      account.judge_profile.present?
+  end
+
+  private
+
+  attr_reader :account, :season_toggles
+end

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -42,18 +42,19 @@ module SignIn
   def self.after_signin_path(signin, context)
     last_profile_used = context.remove_cookie(CookieNames::LAST_PROFILE_USED)
 
-    if last_profile_used == "regional_ambassador"
-      last_profile_used = "chapter_ambassador"
-    end
-
     if last_profile_used and
         not signin.public_send("#{last_profile_used}_profile").present?
       last_profile_used = nil
     end
 
-    (last_profile_used && "#{last_profile_used}_dashboard_path") or
-      "#{signin.scope_name.sub(/^\w+_chapter_ambassador/, "chapter_ambassador")}_dashboard_path"
-    # TODO --- root out this pending chapter ambassador stuff into something
-    # sensible
+    if last_profile_used.present?
+      "#{last_profile_used}_dashboard_path"
+    elsif JudgeDashboardRedirector.new(account: signin).enabled?
+      "judge_dashboard_path"
+    elsif signin.scope_name == "pending_chapter_ambassador"
+      "chapter_ambassador_dashboard_path"
+    else
+      "#{signin.scope_name}_dashboard_path"
+    end
   end
 end

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -51,8 +51,6 @@ module SignIn
       "#{last_profile_used}_dashboard_path"
     elsif JudgeDashboardRedirector.new(account: signin).enabled?
       "judge_dashboard_path"
-    elsif signin.scope_name == "pending_chapter_ambassador"
-      "chapter_ambassador_dashboard_path"
     else
       "#{signin.scope_name}_dashboard_path"
     end

--- a/spec/services/judge_dashboard_redirector_spec.rb
+++ b/spec/services/judge_dashboard_redirector_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe JudgeDashboardRedirector do
+  let(:judge_dashboard_redirector) {
+    JudgeDashboardRedirector.new(
+      account: account,
+      season_toggles: season_toggles
+    )
+  }
+
+  let(:account) {
+    instance_double(Account,
+      can_switch_to_judge?: account_can_switch_to_judge,
+      judge_profile: account_judge_profile)
+  }
+  let(:account_can_switch_to_judge) { false }
+  let(:account_judge_profile) { instance_double(JudgeProfile) }
+  let(:season_toggles) {
+    double("season toggles",
+      judging_enabled_or_between?: season_toggles_judging_enabled_or_between)
+  }
+  let(:season_toggles_judging_enabled_or_between) { false }
+
+  describe "#enabled?" do
+    context "when the account is able to become a judge" do
+      let(:account_can_switch_to_judge) { true }
+
+      context "when judging is turned on" do
+        let(:season_toggles_judging_enabled_or_between) { true }
+
+        context "when the account has a judge profile" do
+          let(:account_judge_profile) { instance_double(JudgeProfile) }
+
+          it "returns true" do
+            expect(judge_dashboard_redirector.enabled?).to eq(true)
+          end
+        end
+      end
+    end
+
+    context "when the account isn't able to become a judge" do
+      let(:account_can_switch_to_judge) { false }
+
+      it "returns false" do
+        expect(judge_dashboard_redirector.enabled?).to eq(false)
+      end
+    end
+
+    context "when judging is turned off" do
+      let(:season_toggles_judging_enabled_or_between) { false }
+
+      it "returns false" do
+        expect(judge_dashboard_redirector.enabled?).to eq(false)
+      end
+    end
+
+    context "when the account does not have a judge profile" do
+      let(:account_judge_profile) { false }
+
+      it "returns false" do
+        expect(judge_dashboard_redirector.enabled?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
After someone signs in, if certain criteria is met, they will get redirected to their judge dashboard.

This PR introduces a new service `JudgeDashboardRedirector` that contains the conditions for when someone will get automatically redirected to their judge dashboard. This new service will get called (to see if the conditions are met):
- when anyone logs in
- when an admin uses the impersonation functionality.