### PR TITLE
Added rake task to force update the status of queued jobs to failed by owner type

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -6,7 +6,6 @@ namespace :jobs do
     owner_type = args[:owner_type]
     dry_run = args[:dry_run] != "run"
 
-
     puts "DRY RUN: #{dry_run ? 'on' : 'off'}"
     puts "Force failing queued jobs for #{owner_type} that were created before #{(Date.today - num_of_days.days).strftime("%B %d, %Y")}"
 

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,10 +1,20 @@
 namespace :jobs do
-  desc "Force fail queued jobs between today and 1 month ago by owner type"
-  task :force_fail_queued_jobs, [:owner_type] => :environment do |t, args|
-    puts "Force failing queued jobs for #{args[:owner_type]}"
-    Job.where(created_at: (Date.today - 1.month)..Date.today).where(status: "queued").where(owner_type: args[:owner_type]).find_each do |job|
-      puts "Updating job_id #{job.job_id}"
-      job.update_column(:status, "failed")
+  desc "Force fail queued jobs older than 'x' number of days by owner type"
+  task :force_fail_queued_jobs, [:num_of_days, :owner_type, :dry_run] => :environment do |t, args|
+
+    num_of_days = Integer(args[:num_of_days])
+    owner_type = args[:owner_type]
+    dry_run = args[:dry_run] != "run"
+
+
+    puts "DRY RUN: #{dry_run ? 'on' : 'off'}"
+    puts "Force failing queued jobs for #{owner_type} that were created before #{(Date.today - num_of_days.days).strftime("%B %d, %Y")}"
+
+    Job.where(created_at: ...num_of_days.days.ago).where(status: "queued").where(owner_type: owner_type).find_each do |job|
+      puts "Updating job_id #{job.job_id} - created on #{job.created_at.strftime("%B %d, %Y")}"
+      if !dry_run
+        job.update_column(:status, "failed")
+      end
     end
   end
 end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,0 +1,10 @@
+namespace :jobs do
+  desc "Force fail queued jobs between today and 1 month ago by owner type"
+  task :force_fail_queued_jobs, [:owner_type] => :environment do |t, args|
+    puts "Force failing queued jobs for #{args[:owner_type]}"
+    Job.where(created_at: (Date.today - 1.month)..Date.today).where(status: "queued").where(owner_type: args[:owner_type]).find_each do |job|
+      puts "Updating job_id #{job.job_id}"
+      job.update_column(:status, "failed")
+    end
+  end
+end


### PR DESCRIPTION
Created this rake task to address the issue where queued export jobs in the admin profile are causing the "export" popup in admin profile to be stuck in a sort of infinite loop.

Refs #3400 
