### PR TITLE
Registration settings backend endpoint

### DIFF
--- a/app/controllers/api/registration_settings_controller.rb
+++ b/app/controllers/api/registration_settings_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  class RegistrationSettingsController < ApplicationController
+    def index
+      render json: {
+        isRegistrationOpen: SeasonToggles.registration_open?,
+        isStudentRegistrationOpen: SeasonToggles.student_registration_open?,
+        isMentorRegistrationOpen: SeasonToggles.mentor_registration_open?
+      }
+    end
+  end
+end

--- a/app/technovation/season_toggles/signup_toggles.rb
+++ b/app/technovation/season_toggles/signup_toggles.rb
@@ -28,6 +28,8 @@ class SeasonToggles
         define_method("#{scope}_signup?") do
           convert_to_bool(store.get("#{scope}_signup"))
         end
+
+        alias_method "#{scope}_registration_open?", "#{scope}_signup?"
       end
 
       def registration_open?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,10 @@ Rails.application.routes.draw do
     resources :expertises, only: :index
   end
 
+  namespace :api do
+    resources :registration_settings, only: :index
+  end
+
   resource :terms_agreement, only: [:edit, :update]
 
   resources :password_resets, only: [:new, :create]

--- a/spec/system/api/registration_settings_spec.rb
+++ b/spec/system/api/registration_settings_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Registration Settings" do
+  let(:registration_open) { true }
+  let(:student_registration_open) { true }
+  let(:mentor_registration_open) { true }
+
+  before do
+    allow(SeasonToggles).to receive(:registration_open?)
+      .and_return(registration_open)
+    allow(SeasonToggles).to receive(:student_registration_open?)
+      .and_return(student_registration_open)
+    allow(SeasonToggles).to receive(:mentor_registration_open?)
+      .and_return(mentor_registration_open)
+  end
+
+  it "returns registration settings" do
+    get api_registration_settings_path
+
+    expect(JSON.parse(response.body)).to eq(
+      {
+        "isRegistrationOpen" => registration_open,
+        "isStudentRegistrationOpen" => student_registration_open,
+        "isMentorRegistrationOpen" => mentor_registration_open
+      }
+    )
+  end
+end


### PR DESCRIPTION
This will create a new backend endpoint that will return registration settings, these settings will be used to turn on/off student and mentor registrations.

Judges aren't included yet since we don't have an admin setting to control judge registrations yet - this will be done later.

