### PR TITLE
Updated judge sweet alert modal to expand thumbnail size based on judge feedback

### DIFF
--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -123,6 +123,44 @@ $(document).on("click", ".img-modal", function(e) {
   });
 });
 
+$(document).on("click", ".judge-screenshot-modal", function(e) {
+  var html, animation
+
+  if (typeof $(e.target).data("modalIdx") !== 'undefined') {
+    const last = parseInt($("#screenshots-nav").data("modalLast"))
+    const idx = parseInt($(e.target).data("modalIdx"))
+    const nextIdx = idx + 1 > last ? 0 : idx + 1
+    const prevIdx = idx - 1 < 0 ? last : idx - 1
+
+    html =
+      `<div class="screenshot-nav">
+         <div class="screenshot-nav__item" data-go-to=" ${prevIdx}">
+           <img src=https://icongr.am/fontawesome/angle-left.svg alt="Left arrow icon" />
+         </div>
+          
+         <div>
+           <img class="screenshot__img" src="${$(e.target).data("modalUrl")}" alt="Team screenshot" />
+         </div>
+  
+         <div class="screenshot-nav__item" data-go-to="${nextIdx}">
+           <img src="https://icongr.am/fontawesome/angle-right.svg" alt="Right arrow icon" />
+         </div>
+      </div>`
+
+    animation = false
+  } else {
+    html = `<img src="${$(e.target).data("modalUrl")}" width="100%" />`
+    animation = true
+  }
+
+  swal({
+    html: html,
+    confirmButtonText: "Done",
+    animation: animation,
+    customClass: 'judge-sub-screenshot',
+  });
+});
+
 $(document).on("modals.beforeOpen",
   "[data-modal-fetch]",
   function(evt, modal) {

--- a/app/assets/stylesheets/judge.scss
+++ b/app/assets/stylesheets/judge.scss
@@ -53,3 +53,25 @@
     opacity: 1;
   }
 }
+
+.judge-sub-screenshot {
+  width: 100% !important;
+
+  .screenshot-nav {
+    display: flex;
+    justify-content: space-between;
+    height: 100%;
+    align-items: center;
+  }
+
+  .screenshot__img {
+    object-fit: contain;
+    height: 40rem;
+  }
+}
+
+@media only screen and (min-width: 992px){
+  .judge-sub-screenshot {
+    width: 50% !important;
+  }
+}

--- a/app/javascript/judge/scores/pieces/Screenshots.vue
+++ b/app/javascript/judge/scores/pieces/Screenshots.vue
@@ -11,7 +11,7 @@
       class="mx-2"
     >
       <img
-        class="img-modal rounded"
+        class="judge-screenshot-modal rounded"
         :src="screenshot.thumb"
         :data-modal-url="screenshot.full"
         :data-modal-idx="i"


### PR DESCRIPTION
This change was made in order to increase the size of the image/modal when a judge clicks on a screenshot in the learning journey. I added an additional event listener so these changes would only affect these screenshots. The original event listener/sweet alert code affects the student image submissions. 

I explored a few options but ultimately settled on this approach. We may want to discuss this further as part of the 6-9 month clean up tasks. Some things to consider:
1. Sweetalert2 has its own styles/constraints
2. I was unable to add tailwind styles so I had to resort to the original `judge.scss` file
3. Would it make sense in the future to add a custom modal component, especially since this lives in the vue world and we also have access to tailwind components

Refs: #2960 