### PR TITLE
Updated html semifinalist snippet flow to include beginner division

### DIFF
--- a/app/controllers/admin/semifinalist_snippet_controller.rb
+++ b/app/controllers/admin/semifinalist_snippet_controller.rb
@@ -15,6 +15,12 @@ module Admin
         .select { |sub| sub.junior_division? }
       @junior_section = Section.new("junior", junior_submissions)
 
+      beginner_submissions = TeamSubmission
+        .current
+        .semifinalist
+        .select { |sub| sub.beginner_division? }
+      @beginner_section = Section.new("beginner", beginner_submissions)
+
       respond_to :html, :text
     end
 

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -512,6 +512,10 @@ class TeamSubmission < ActiveRecord::Base
     team.division_id
   end
 
+  def beginner_division?
+    team_division_name == "beginner"
+  end
+
   def junior_division?
     team_division_name == "junior"
   end

--- a/app/views/admin/semifinalist_snippet/show.erb
+++ b/app/views/admin/semifinalist_snippet/show.erb
@@ -3,7 +3,8 @@
 <%
   [
     [ "Senior Division", @senior_section ],
-    [ "Junior Division", @junior_section ]
+    [ "Junior Division", @junior_section ],
+    [ "Beginner Division", @beginner_section ]
   ].each do |title, section|
 %>
   <div id="<%= section.id %>" class="row">

--- a/spec/features/admin/semifinalist_snippet_spec.rb
+++ b/spec/features/admin/semifinalist_snippet_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "getting the semifinalist blog post snippet" do
     end
   end
 
-  context "with a junior and a senior semifinalist" do
+  context "with a beginner, junior, and a senior semifinalist" do
     let!(:senior_submission) {
       FactoryBot.create(
         :team_submission,
@@ -35,6 +35,16 @@ RSpec.feature "getting the semifinalist blog post snippet" do
         :team_submission,
         :complete,
         :junior,
+        :brazil,
+        contest_rank: :semifinalist
+      )
+    }
+
+    let!(:beginner_submission) {
+      FactoryBot.create(
+        :team_submission,
+        :complete,
+        :beginner,
         :brazil,
         contest_rank: :semifinalist
       )
@@ -57,6 +67,12 @@ RSpec.feature "getting the semifinalist blog post snippet" do
       within "#junior" do
         expect(page).to have_css("#junior-col-1", count: 1)
         expect(page).to have_css("#junior-col-2", count: 1)
+      end
+
+      expect(page).to have_css("#beginner", count: 1)
+      within "#beginner" do
+        expect(page).to have_css("#beginner-col-1", count: 1)
+        expect(page).to have_css("#beginner-col-2", count: 1)
       end
     end
 


### PR DESCRIPTION
These changes were needed in order to update the semifinal snippet markup to include the beginner division. QA steps are listed in the issue.

Refs: #3408 