### PR TITLE
Added email flow for judges to receive an automatic email post registration

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -89,6 +89,8 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
   def prepare_judge_for_current_season(record)
     subscribe_to_newsletter(record, :judge)
 
+    RegistrationMailer.welcome_judge(record.id).deliver_later
+
     record.judge_profile.update(completed_training_at: nil)
     record.judge_profile.save # fire commit hooks, if needed
   end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -54,6 +54,22 @@ class RegistrationMailer < ApplicationMailer
     end
   end
 
+  def welcome_judge(account_id)
+    account = Account.joins(:judge_profile).find(account_id)
+
+    @first_name = account.first_name
+
+    @root_url = judge_dashboard_url(mailer_token: account.mailer_token)
+
+    @season_year = Season.current.year
+
+    I18n.with_locale(account.locale) do
+      mail to: account.email,
+        subject: t("registration_mailer.welcome_judge.subject",
+                   season_year: Season.current.year)
+    end
+  end
+
   def welcome_student(student)
     @registration_opens = ImportantDates.registration_opens.strftime("%B %Y")
     @official_start_of_season = ImportantDates.official_start_of_season.strftime("%B %d, %Y")

--- a/app/views/registration_mailer/welcome_judge.en.html.erb
+++ b/app/views/registration_mailer/welcome_judge.en.html.erb
@@ -1,0 +1,70 @@
+<tr>
+  <td class="content-wrap">
+    <meta itemprop="name" content="Confirm Email"/>
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td class="content-block">
+          Welcome to Technovation Girls Judging <%= @season_year %>, <%= @first_name %>!
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          Technovation judges are an integral part of the Technovation Girls program,
+          thank you for joining us! The time and commitment that you make to a team
+          goes a long way in helping young changemakers solve real problems in their
+          community.
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          Technovation Girls is the world's largest global tech competition
+          and program offered by You are a part of a community of ~4,000+ judges
+          from around the world scoring and giving feedback to almost 1,700 projects!
+          We maintain this community by using a free communication tool called Slack
+          where you can connect with other judges, ask questions, and stay informed.
+          We also provide newsletters from Technovation to keep you and your team
+          motivated throughout judging.
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          <strong>So, let's get started! This is what you can do in under 40 minutes
+            in order to start matching with teams:</strong>
+
+          <ol>
+            <li>
+              Finish your judge training if you haven’t done so already!
+              You can access the training
+              <%= link_to "here", "https://technovationchallenge.org/judge%20training/", itemprop: "url" %>
+              or from your <%= link_to "dashboard", judge_dashboard_url, itemprop: "url" %>.
+            </li>
+
+            <li>
+              Sign the consent waiver.
+            </li>
+            
+            <li>
+              <%= link_to "Click this link", ENV.fetch("JUDGE_SLACK_SIGNUP_URL"), itemprop: "url" %>
+              to join our online Slack community to meet judges from around the world.
+            </li>
+
+            <li>
+              <%= link_to "Start Scoring!", judge_dashboard_url, itemprop: "url" %>
+              Log on to your dashboard and click “start score” to begin.
+            </li>
+          </ol>
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          <p>Regards,</p>
+          <p>The Technovation Team</p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -34,6 +34,8 @@ en:
       subject: "Welcome to Technovation %{season_year}!"
     welcome_student:
       subject: "Welcome to Technovation %{season_year}!"
+    welcome_judge:
+      subject: "Welcome to Technovation %{season_year}!"
 
   team_mailer:
     invite_member:

--- a/config/locales/mailers.es-MX.yml
+++ b/config/locales/mailers.es-MX.yml
@@ -32,6 +32,8 @@ es-MX:
       subject: "Bienvenido a Technovation %{season_year}!"
     welcome_student:
       subject: "Bienvenido a Technovation %{season_year}!"
+    welcome_judge:
+      subject: "Bienvenido a Technovation %{season_year}!"
 
   team_mailer:
     invite_member:


### PR DESCRIPTION
The program team requested for judges to receive an automatic email after they register. This flow follows the auto mentor email that is sent after an individual registers as a mentor. 

I added a new `welcome_judge` method as well as the email text. I have tried this locally and verified with the email popup in a new tab. 

Refs
#3427 