### PR TITLE
Updated the logic for finding the id for a score in progress to account for "null" string value

### DIFF
--- a/app/technovation/find_eligible_submission_id.rb
+++ b/app/technovation/find_eligible_submission_id.rb
@@ -33,14 +33,16 @@ module FindEligibleSubmissionId
     end
 
     def id_for_score_in_progress(judge, options = {})
-      if (id = options[:score_id])
-        judge.submission_scores.current_round.incomplete.not_recused.find_by(
-          id: id
-        ).try(:team_submission_id)
-      else
+      score_id = options[:score_id]
+
+      if score_id.blank? || score_id == "null"
         judge.submission_scores.current_round.incomplete.not_recused.first.try(
           :team_submission_id
         )
+      else
+        judge.submission_scores.current_round.incomplete.not_recused.find_by(
+          id: score_id
+        ).try(:team_submission_id)
       end
     end
 


### PR DESCRIPTION
This change was made in order to fix the bug where refreshing the new score submission page would load a new eligible submission to judge. Previously, you could also "hack" the URL by removing the score id parameters to load a new eligible submission. This was leaving the application open to unwanted user behavior as well as the opportunity for malicious use.

I found an error with the logic for the `id_for_score_in_progress` method. When a new submission/score was started there was not an associated `score_id` with the parameters (this is to be expected). The if conditions always evaluated to true whether there was an actual score_id or if it was the `score_id` was equal to the string value "null". I reordered the logic by explicitly checking for this in the if statement. I also cleaned up the variable naming by changing `id` to `score_id`. I checked it locally and I believe it is working as expected. I also checked the behavior for when a judge had a score in progress and was also assigned an additional submission to judge from the admin portal.

The expected output for this change is when starting a new score for a new submission, if you refresh the page, the same score/submission should load. If you "hack" the URL by removing everything after `new` the same submission/score should load. If you assign a judge an additional submission the judge should still be able to complete the scoring process for any scores/submissions that are in progress. 

Refs: #3391 