### PR TITLE
Update embed format for Vimeo videos

### DIFF
--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -95,10 +95,10 @@ class Questions
           }
         },
 
-        demo_video_id: submission.video_id(:demo),
+        demo_video_id: submission.video_id(:demo).first(5),
         demo_video_url: judge_embed_code_path(submission, piece: :demo),
 
-        pitch_video_id: submission.video_id(:pitch),
+        pitch_video_id: submission.video_id(:pitch).first(5),
         pitch_video_url: judge_embed_code_path(submission, piece: :pitch),
 
         source_code_url_label: source_code_url_label,

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -558,7 +558,7 @@ class TeamSubmission < ActiveRecord::Base
     video_url = VideoUrl.new(video || video_link_for(video_type))
 
     if video_url.valid?
-      src = "#{video_url.root}#{video_url.video_id}?rel=0&cc_load_policy=1"
+      src = "#{video_url.root}#{video_url.video_id}"
     else
       src = "/video-link-broken.html"
     end

--- a/app/technovation/video_url.rb
+++ b/app/technovation/video_url.rb
@@ -10,7 +10,11 @@ class VideoUrl
     when /youtu/
       url[/(?:youtube(?:-nocookie)?\.com\/(?:[^\/\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/, 1] || ""
     when /vimeo/
-      url[/\/(\d+)$/, 1] || ""
+      if /\/(\d+)\/(\w+)/ =~ url
+        "#{$1}?h=#{$2}"
+      else
+        url[/\/(\d+)$/, 1] || ""
+      end
     when /youku/
       url[/\/v_show\/id_(\w+)(?:==)?(?:\.html)?.*$/, 1] || ""
     else

--- a/spec/system/submissions/review_demo_video_spec.rb
+++ b/spec/system/submissions/review_demo_video_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe "Reviewing the demo video" do
       fill_in "Youtube", with: "youtube.com/watch?v=adGebPmRjxg"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg']"
       )
 
       click_link  "go back"
       fill_in "Youtube", with: "https://vimeo.com/119811742"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://player.vimeo.com/video/119811742?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://player.vimeo.com/video/119811742']"
       )
 
       visit student_dashboard_path
@@ -59,14 +59,14 @@ RSpec.describe "Reviewing the demo video" do
       fill_in "Youtube", with: "youtube.com/watch?v=adGebPmRjxg"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg']"
       )
 
       click_link  "go back"
       fill_in "Youtube", with: "https://vimeo.com/119811742"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://player.vimeo.com/video/119811742?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://player.vimeo.com/video/119811742']"
       )
 
       visit mentor_dashboard_path

--- a/spec/system/submissions/review_pitch_video_spec.rb
+++ b/spec/system/submissions/review_pitch_video_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe "Reviewing the pitch video" do
       fill_in "Youtube", with: "youtube.com/watch?v=adGebPmRjxg"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg']"
       )
 
       click_link  "go back"
       fill_in "Youtube", with: "https://vimeo.com/119811742"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://player.vimeo.com/video/119811742?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://player.vimeo.com/video/119811742']"
       )
 
       visit student_dashboard_path
@@ -59,14 +59,14 @@ RSpec.describe "Reviewing the pitch video" do
       fill_in "Youtube", with: "youtube.com/watch?v=adGebPmRjxg"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://www.youtube.com/embed/adGebPmRjxg']"
       )
 
       click_link  "go back"
       fill_in "Youtube", with: "https://vimeo.com/119811742"
       click_button "Next"
       expect(page).to have_xpath(
-        "//iframe[@src='https://player.vimeo.com/video/119811742?rel=0&cc_load_policy=1']"
+        "//iframe[@src='https://player.vimeo.com/video/119811742']"
       )
 
       visit mentor_dashboard_path

--- a/spec/technovation/video_url_spec.rb
+++ b/spec/technovation/video_url_spec.rb
@@ -56,10 +56,20 @@ describe VideoUrl do
     end
 
     context "Vimeo" do
-      let(:url) { "https://vimeo.com/96816279" }
+      context "when the URL is in the format https://vimeo.com/703480970/a4333a9b0c" do
+        let(:url) { "https://vimeo.com/703480970/a4333a9b0c" }
 
-      it "extracts and returns the video id" do
-        expect(video_url.video_id).to eq("96816279")
+        it "returns the correct format in order to embed the video" do
+          expect(video_url.video_id).to eq("703480970?h=a4333a9b0c")
+        end
+      end
+
+      context "when the URL is in the format https://vimeo.com/96816279" do
+        let(:url) { "https://vimeo.com/96816279" }
+
+        it "extracts and returns the video id" do
+          expect(video_url.video_id).to eq("96816279")
+        end
       end
     end
 


### PR DESCRIPTION
This will make our platform understand Vimeo links in the format: `https://vimeo.com/703480970/a4333a9b0c`.

Let me know if anyone has any questions! It's not the most straight forward one!