### PR TITLE
Updated score headings for student view scores page

### DIFF
--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -391,6 +391,10 @@ class SubmissionScore < ActiveRecord::Base
     total
   end
 
+  def project_details_total
+    project_details_1
+  end
+
   def ideation_total
     ideation_1 +
       ideation_2 +
@@ -406,7 +410,7 @@ class SubmissionScore < ActiveRecord::Base
   end
 
   def entrepreneurship_total
-    return 0 if junior_team_division?
+    return 0 if beginner_team_division?
 
     entrepreneurship_1 +
       entrepreneurship_2 +
@@ -416,7 +420,19 @@ class SubmissionScore < ActiveRecord::Base
 
   def pitch_total
     pitch_1 +
-      pitch_2
+      pitch_2 +
+        pitch_3 +
+          pitch_4 +
+            pitch_5 +
+              pitch_6 +
+                pitch_7 +
+                  pitch_8
+  end
+
+  def demo_total
+    demo_1 +
+      demo_2 +
+        demo_3
   end
 
   def overall_impression_total

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -23,37 +23,9 @@
   <% end %>
 </div>
 
-<div class="grid judging-banner">
-  <div class="grid__col-6">
-    <h3 class="judging-banner__header">
-      Scores Explained
-    </h3>
-
-    <dl>
-      <dt>1: Incomplete</dt>
-      <dd>The work is missing.</dd>
-
-      <dt>2: Needs Improvement.</dt>
-      <dd>The work needs major improvement.</dd>
-    </dl>
-  </div>
-
-  <div class="grid__col-6">
-    <dl>
-      <dt>3: Acceptable.</dt>
-      <dd>The work needs minor improvement.</dd>
-
-      <dt>4: Good.</dt>
-      <dd>The work is of good quality.</dd>
-
-      <dt>5: Excellent.</dt>
-      <dd>The work is of excellent quality.</dd>
-    </dl>
-  </div>
-</div>
-
 <div class="grid">
   <% scores.sort_by(&:total).reverse.each do |score| %>
+    <% questions = Questions.for(score) %>
     <% globes = %w{🌍 🌎 🌏}.shuffle %>
 
     <div class="grid__col-6">
@@ -71,64 +43,25 @@
       </div>
 
       <dl class="accordion">
-        <dt>Ideation
+        <% questions.sections_for(division: score.team.division_name).each do |section| %>
+          <dt>
+            <% if section === "ideation" %>
+              Learning Journey
+            <% elsif section === "entrepreneurship" %>
+              <%= current_team.senior? ? "Business Plan" : "User Adoption Plan" %>
+            <% else %>
+              <%= section.titlecase %>
+            <% end %>
+            (<%= score.total_points_for_section(score.team.division_name,section) %>)
             <span class="custom-dropdown"> <img  src="https://icongr.am/fontawesome/chevron-down.svg?color=903D54" /></span>
-            <span class="numeric-score"><%= score.ideation_total %></span>
-        </dt>
-
-        <dd>
-          <%= render "student/scores/section",
-            score: score,
-            section: :ideation %>
-        </dd>
-
-        <dt>Technical
-          <span class="custom-dropdown"> <img  src="https://icongr.am/fontawesome/chevron-down.svg?color=903D54" /></span>
-          <span class="numeric-score">
-            <%= score.technical_total %>
-          </span>
-        </dt>
-
-        <dd>
-          <%= render "student/scores/section",
-            score: score,
-            section: :technical %>
-        </dd>
-
-        <% if current_team.senior? %>
-          <dt>Entrepreneurship
-            <span class="custom-dropdown"> <img  src="https://icongr.am/fontawesome/chevron-down.svg?color=903D54" /></span>
-            <span class="numeric-score"><%= score.entrepreneurship_total %></span>
+            <span class="numeric-score"><%= score.total_for_section(section)%></span>
           </dt>
-
           <dd>
             <%= render "student/scores/section",
-              score: score,
-              section: :entrepreneurship %>
+                       score: score,
+                       section: section %>
           </dd>
-        <% end %>
-
-        <dt>Pitch
-          <span class="custom-dropdown"> <img  src="https://icongr.am/fontawesome/chevron-down.svg?color=903D54" /></span>
-          <span class="numeric-score"><%= score.pitch_total %></span>
-        </dt>
-
-        <dd>
-          <%= render "student/scores/section",
-            score: score,
-            section: :pitch %>
-        </dd>
-
-        <dt>Overall Impression
-          <span class="custom-dropdown"> <img  src="https://icongr.am/fontawesome/chevron-down.svg?color=903D54" /></span>
-          <span class="numeric-score"><%= score.overall_impression_total %></span>
-        </dt>
-
-        <dd>
-          <%= render "student/scores/section",
-            score: score,
-            section: :overall %>
-        </dd>
+        <%end %>
       </dl>
     </div>
   <% end %>

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -8,6 +8,21 @@
   </div>
 </div>
 
+<div>
+  <h3 class="text-3xl">Scores Explained</h3>
+  <% if current_submission.beginner_division? %>
+    <p>1. Not there yet</p>
+    <p>2. Good</p>
+    <p>3. Amazing</p>
+  <% elsif current_submission.junior_division? || current_submission.senior_division? %>
+    <p>1. Not there yet</p>
+    <p>2. Getting there</p>
+    <p>3. Good</p>
+    <p>4. A cut above</p>
+    <p>5. Amazing</p>
+  <% end %>
+</div>
+
 <div class="grid judging-banner">
   <div class="grid__col-6">
     <h3 class="judging-banner__header">

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Students view scores", :js do
     submission = FactoryBot.create(:submission, :incomplete)
 
     sign_in(submission.team.students.sample)
+    visit student_dashboard_path
     click_button "Find your scores & certificates"
 
     expect(page).to have_content("Thank you for your participation")


### PR DESCRIPTION
This change was made to account for new rubric sections as well as the mismatched names (Ideation = Learning Journey, Entrepreneurship = User Adoption Plan VS Business Plan).

The same concern from #3380 came up again, where we need to have one "source of truth" for the naming issues. We have had to use a lot of view layer logic to display the correct names for the section. 

We should also discuss how we can "total" up the section points so it can be more dynamic compared to how the section points are totaled now in `app/models/submission_score.rb`

Refs Issue #3446 