### PR TITLE
Updated team link for mentor scope on the score details view in the judge portal

### DIFF
--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -8,7 +8,7 @@
       <span>Team</span>
       <%= link_to_if current_scope == "mentor",
         @score.team_name,
-        send("#{current_scope}_team_path", @score.team)
+        send("mentor_team_path", @score.team)
       %>
     </h3>
 


### PR DESCRIPTION
When the app is switched to Semifinals, as a judge I can view score details for finished quarterfinals scores. Right now, when I click the "view score" button, the app will error out.

The change was made in `app/views/admin/scores/show.en.html.erb`. I think the bug was happening at `send("#{current_scope}_team_path", @score.team)` because when logged in as a judge, the link would be `judge_team_path`, which does not exist. 

Refs #3463 

