### PR TITLE
Redirect signups route to homepage

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,7 +369,7 @@ Rails.application.routes.draw do
   get 'login', to: 'signins#new', as: :login
   get 'signin', to: 'signins#new', as: :signin
 
-  get "signup", to: "new_registration#show", as: :signup
+  get "signup", to: redirect("/"), as: :signup
   post '/new-registration', to: 'new_registration#create'
 
   match 'logout',

--- a/spec/system/judge_special_signup_spec.rb
+++ b/spec/system/judge_special_signup_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Judges sign up at special link", :js do
+RSpec.xdescribe "Judges sign up at special link", :js do
   it "visit the normal url" do
     visit judge_signup_path
     expect(current_path).to eq(root_path)


### PR DESCRIPTION
After this gets merged/deployed, it will redirect "signups" to go to the home page (as a way to disable registrations for everyone).

Refs: #3485