### PR TITLE
Updated home page text for when registration is closed and judging is finished

### DIFF
--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -4,15 +4,20 @@
 
 <p>Thanks for your interest in Technovation Girls — we can't wait for you to be part of our global community!</p>
 
+<p>Scores and certificates are available for teams who submitted a project by logging in between July 12 and September 1.</p>
+
 <p>
-  <strong>
-    Registration for Technovation Girls will open again in late 2021. Please
-    <%= link_to "sign up", "http://eepurl.com/hvwHLP" %>
-    to receive a reminder email when registration opens.
-  </strong>
+  Registration for Technovation Girls will open again by October. Please
+  <%= link_to "sign up", "http://eepurl.com/hvwHLP" %>
+  to receive a reminder email when registration opens.
+  You can start working on your next project now by checking out the
+  <%= link_to "curriculum", "https://technovationchallenge.org/curriculum-intro/registered/new/" %>!
 </p>
 
-<p>Until then, you can join the Technovation community by following:</p>
+<p>
+  You can learn more about <%= link_to "Technovation", "https://technovationchallenge.org/" %>
+  on our website or follow us at:
+</p>
 
 <ul class="unstyled">
   <li>

--- a/app/views/public/dashboards/show.en.html.erb
+++ b/app/views/public/dashboards/show.en.html.erb
@@ -9,7 +9,11 @@
 <% else %>
   <div class="grid grid--justify-space-around">
     <div class="panel grid__col-12 grid__col-md-6">
-      <%= render 'judging_open_splash' %>
+      <% if SeasonToggles.judging_finished? %>
+        <%= render 'off_season_splash' %>
+      <% else %>
+        <%= render 'judging_open_splash' %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
This change is a sort of "band-aid" until the rest of the registration toggles are hooked up. I think there will be some updates to this flow once that is complete. This change will update the text on the landing page once registration toggles are closed and judging is set to off. We already had the `off_season_splash` which I added back in and I also updated the text on that page.

Refs #3486 