### PR TITLE
Added student view score details functionality + created score details page with rebrand

### DIFF
--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -22,5 +22,17 @@ module Student
 
       render template: 'student/scores/index'
     end
+
+    def show
+      submission_id = TeamSubmission.where(team_id: current_team.id)
+
+      @score = SubmissionScore.where(team_submission_id: submission_id).find(params[:id])
+      @team = @score.team
+      @team_submission = @team.submission
+
+      # TODO: Create rebranded template for student score details
+      render 'admin/scores/show'
+    end
+
   end
 end

--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -30,8 +30,7 @@ module Student
       @team = @score.team
       @team_submission = @team.submission
 
-      # TODO: Create rebranded template for student score details
-      render 'admin/scores/show'
+      render 'student/scores/score_details'
     end
 
   end

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -36,7 +36,10 @@
                   <%= score.total %>/<%= score.total_possible %>
                 </td>
                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-base font-medium sm:pr-6">
-                  <a class="tw-green-btn">View Details</a>
+                  <%= link_to 'View details',
+                              send("#{current_scope}_score_path", score),
+                              class: "tw-green-btn cursor-pointer",
+                              target: "_blank"%>
                 </td>
               </tr>
             <% end %>

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -38,8 +38,7 @@
                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-base font-medium sm:pr-6">
                   <%= link_to 'View details',
                               send("#{current_scope}_score_path", score),
-                              class: "tw-green-btn cursor-pointer",
-                              target: "_blank"%>
+                              class: "tw-green-btn cursor-pointer" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/student/scores/_section_score.html.erb
+++ b/app/views/student/scores/_section_score.html.erb
@@ -1,0 +1,32 @@
+<div class="mb-10">
+  <div class="flex justify-between items-center text-xl font-bold mb-8">
+    <span>
+      <% if section === "ideation" %>
+        Learning Journey
+      <% elsif section === "entrepreneurship" %>
+        <%= score.team.senior? ? "Business Plan" : "User Adoption Plan" %>
+      <% else %>
+        <%= section.titlecase %>
+      <% end %>
+    </span>
+  </div>
+
+  <div class="flex-col mb-6 ml-8">
+    <% questions.in_section(section).each do |question| %>
+      <div class="flex justify-between my-2">
+        <p><%= question.text.html_safe %></p>
+        <p><%= score.total_for_question(question) %></p>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="flex justify-between items-center font-semibold border-t border-energetic-blue ml-8 mb-8">
+    <span class="mt-2">Section Total</span>
+    <span><%= score.total_for_section(section)%></span>
+  </div>
+
+  <div class="ml-8">
+    <p class="font-semibold">Judge Feedback</p>
+    <p><%= simple_format score.comment_for_section(section) %></p>
+  </div>
+</div>

--- a/app/views/student/scores/score_details.en.html.erb
+++ b/app/views/student/scores/score_details.en.html.erb
@@ -20,7 +20,7 @@
         <%= render 'student/scores/section_score',
                     score: @score,
                     section: section,
-                    questions: questions%>
+                    questions: questions %>
       <% end %>
     </section>
   <% end %>

--- a/app/views/student/scores/score_details.en.html.erb
+++ b/app/views/student/scores/score_details.en.html.erb
@@ -1,0 +1,27 @@
+<% provide :title, "Score Details" %>
+
+<% globes = %w{🌍 🌎 🌏}.shuffle %>
+
+<div class="container mx-auto w-8/12" id="student-score-details">
+  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Score Details'} do %>
+    <div class="bg-gray-200 rounded shadow-md w-full mx-auto mb-8 text-center">
+      <div class="p-6">
+        <p class="text-4xl font-bold"> <%= @score.total %> / <%= @score.total_possible %></p>
+        from<br />
+        <%= globes.pop %>
+        <strong><%= @score.judge_profile.address_details %></strong>
+        <%= globes.pop %>
+      </div>
+    </div>
+
+    <% questions = Questions.for(@score) %>
+    <section class="w-full px-0 lg:px-8 mx-auto">
+      <% questions.sections_for(division: @score.team.division_name).each do |section| %>
+        <%= render 'student/scores/section_score',
+                    score: @score,
+                    section: section,
+                    questions: questions%>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     resource :regional_pitch_event_selection, only: :create
 
     resources :regional_pitch_events, only: [:show, :index]
-    resources :scores, only: :index
+    resources :scores, only: [:index, :show]
 
     resources :image_process_jobs, only: :create
     resources :job_statuses, only: :show


### PR DESCRIPTION
This change completes the student view scores/certs rebranded functionality. This change specifically includes the creation of the student score details page using the new rebrand. This approach was selected because originally we thought we could reuse the admin score details view. Ultimately we decided to go with a new rebranded version of the score details page since we are in this in between stage where not all user types are rebranded. The specs still need to be updated to account for these changes which has been captured in #3476 .

Refs: #3495 