### PR TITLE
Rebrands search result card component

### DIFF
--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card-result grid__col--bleed">
+  <div class="card-result">
     <img :src="cardImage" class="w-full" @error="imgBroken" />
 
     <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
@@ -11,13 +11,13 @@
       <div class="search-card-subtitle py-1 text-base">{{ cardSubtitle }}</div>
       <div class="search-card-content py-1 text-base mb-2">{{ cardContent }}</div>
 
-      <div v-if="declined" class="search-card-footer text-right mt-6">
-          <p class="text-base text-red-500">You asked to join {{ name }}, and they declined.</p>
+      <div v-if="declined" class="search-card-footer">
+          <p>You asked to join {{ name }}, and they declined.</p>
       </div>
-      <div v-else-if="full" class="search-card-footer text-right mt-6">
-        <p class="text-base text-red-500">This team is currently full.</p>
+      <div v-else-if="full" class="search-card-footer">
+        <p>This team is currently full.</p>
       </div>
-      <div v-else class="search-card-footer text-right mt-6">
+      <div v-else class="search-card-footer">
         <a :href="linkPath" class="tw-link text-lg" >{{ linkText }}</a>
       </div>
     </div>
@@ -88,8 +88,13 @@
   .card-result {
     @apply max-w-sm rounded-lg overflow-hidden shadow-lg mb-5
   }
-  
   .card-photo-placeholder {
     @apply bg-slate-300 w-full items-center justify-center pt-[33.5%] pb-[33.5%]
+  }
+  .search-card-footer {
+    @apply text-right mt-6
+  }
+  .search-card-footer p {
+    @apply text-base text-red-500
   }
 </style>

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="card-result max-w-sm rounded-lg overflow-hidden shadow-lg grid__col--bleed">
+  <div class="card-result grid__col--bleed">
     <img :src="cardImage" class="w-full" @error="imgBroken" />
 
-    <div class="card-photo-placeholder" :id="imgPlaceholderId">
+    <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
       <p class="text-xl font-bold text-black-200">No picture<p/>
     </div>
     
-    <div class="px-6 py-4">
+    <div class="body px-6 py-4">
       <div class="search-card-title font-bold text-xl mb-1">{{ cardTitle }}</div>
       <div class="search-card-subtitle py-1 text-base">{{ cardSubtitle }}</div>
       <div class="search-card-content py-1 text-base mb-2">{{ cardContent }}</div>
@@ -20,7 +20,6 @@
       <div v-else class="search-card-footer text-right mt-6">
         <a :href="linkPath" class="tw-link text-lg" >{{ linkText }}</a>
       </div>
-
     </div>
   </div>
 </template>
@@ -30,8 +29,9 @@
     name: 'result-card',
     methods: {
       imgBroken(e) {
-        e.target.style = 'display:none';
-        e.target.nextElementSibling.style = 'display:flex';
+        e.target.classList.add("hidden")
+        e.target.nextElementSibling.classList.remove("hidden")
+        e.target.nextElementSibling.classList.add("flex")
       }
     },
     props: {
@@ -85,13 +85,11 @@
 </script>
 
 <style lang="scss">
+  .card-result {
+    @apply max-w-sm rounded-lg overflow-hidden shadow-lg mb-5
+  }
+  
   .card-photo-placeholder {
-    display: none;
-    background-color: #aeaeae;
-    width: 100%;
-    align-items: center;
-    justify-content: center;
-    padding-top:33.5%;
-    padding-bottom:33.5%;
+    @apply bg-slate-300 w-full items-center justify-center pt-[33.5%] pb-[33.5%]
   }
 </style>

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="card-result max-w-sm rounded-lg overflow-hidden shadow-lg grid__col--bleed">
+    <img :src="cardImage" class="w-full" @error="imgBroken" />
+
+    <div class="card-photo-placeholder" :id="imgPlaceholderId">
+      <p class="text-xl font-bold text-black-200">No picture<p/>
+    </div>
+    
+    <div class="px-6 py-4">
+      <div class="search-card-title font-bold text-xl mb-1">{{ cardTitle }}</div>
+      <div class="search-card-subtitle py-1 text-base">{{ cardSubtitle }}</div>
+      <div class="search-card-content py-1 text-base mb-2">{{ cardContent }}</div>
+
+      <div v-if="declined" class="search-card-footer text-right mt-6">
+          <p class="text-base text-red-500">You asked to join {{ name }}, and they declined.</p>
+      </div>
+      <div v-else-if="full" class="search-card-footer text-right mt-6">
+        <p class="text-base text-red-500">This team is currently full.</p>
+      </div>
+      <div v-else class="search-card-footer text-right mt-6">
+        <a :href="linkPath" class="tw-link text-lg" >{{ linkText }}</a>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'result-card',
+    methods: {
+      imgBroken(e) {
+        e.target.style = 'display:none';
+        e.target.nextElementSibling.style = 'display:flex';
+      }
+    },
+    props: {
+      cardId: {
+        type: String,
+        required: true,
+      },
+      cardImage: {
+        type: String,
+        required: false,
+      },
+      cardTitle: {
+        type: String,
+        required: false,
+      },
+      cardSubtitle: {
+        type: String,
+        required: false,
+      },
+      cardContent: {
+        type: String,
+        required: false,
+      },
+      name: {
+        type: String,
+        required: false,
+      },
+      declined: {
+        type: Boolean,
+        required: false,
+      },
+      full: {
+        type: Boolean,
+        required: false,
+      },
+      linkText: {
+        type: String,
+        required: false,
+      },
+      linkPath: {
+        type: String,
+        required: false,
+      },
+    },
+    computed: {
+      imgPlaceholderId() {
+        return `img-ph-${this.cardId}`;
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  .card-photo-placeholder {
+    display: none;
+    background-color: #aeaeae;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    padding-top:33.5%;
+    padding-bottom:33.5%;
+  }
+</style>

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -1,0 +1,109 @@
+// Module imports
+import { shallowMount } from '@vue/test-utils'
+import ResultCard from 'components/ResultCard'
+
+describe('ResultCard Vue component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(ResultCard, {
+      attachToDocument: true,
+      propsData: {
+        cardId: 'team-123',
+        cardImage: 'path/to/my/image.jpg',
+        cardTitle:'My Cool Team',
+        cardSubtitle:'Los Angeles, California, United States',
+        cardContent:'Division: None assigned yet',
+        name:'My Cool Team',
+        declined:false,
+        full:false,
+        linkText:'More Details >',
+        linkPath:'path/to/team/123',
+      },
+    })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  describe('props', () => {
+    it('contains valid props', () => {
+      expect(ResultCard.props).toEqual({
+        cardId: {
+          type: String,
+          required: true,
+        },
+        cardImage: {
+          type: String,
+          required: false,
+        },
+        cardTitle: {
+          type: String,
+          required: false,
+        },
+        cardSubtitle: {
+          type: String,
+          required: false,
+        },
+        cardContent: {
+          type: String,
+          required: false,
+        },
+        name: {
+          type: String,
+          required: false,
+        },
+        declined: {
+          type: Boolean,
+          required: false,
+        },
+        full: {
+          type: Boolean,
+          required: false,
+        },
+        linkText: {
+          type: String,
+          required: false,
+        },
+        linkPath: {
+          type: String,
+          required: false,
+        },
+      })
+    })
+  })
+
+  describe('computed properties', () => {
+    describe('imgPlaceholderId', () => {
+      it('set placeHolder id correctly', () => {
+        expect(wrapper.vm.imgPlaceholderId).toEqual('img-ph-team-123')
+      })
+    })
+  })
+
+  describe('component states', () => {
+    it('card has a footer', () => {
+      let ResultCardFooter = wrapper.find('.search-card-footer')
+      expect(ResultCardFooter.exists()).toBe(true)
+    })
+
+    it('card link text', () => {
+      let ResultCardFooter = wrapper.find('.search-card-footer')
+      expect(ResultCardFooter.text()).toContain('More Details >')
+    })
+
+    it('team declined the invite', async () => {
+      await wrapper.setProps({ declined: true })
+      let ResultCardFooter = wrapper.find('.search-card-footer')
+      expect(ResultCardFooter.text()).toContain('they declined')
+    })
+
+    it('team is full', async () => {
+      await wrapper.setProps({ full: true })
+      let ResultCardFooter = wrapper.find('.search-card-footer')
+      expect(ResultCardFooter.exists()).toBe(true)
+      expect(ResultCardFooter.text()).toContain('This team is currently full.')
+    })
+  })
+})


### PR DESCRIPTION
This card will be used on the student rebranded search for Teams and Mentors. This issue scope is the card creation and tests, but the visual feedback will be available when we merge the PR #3503

Changes:
modified: app/javascript/components/ResultCard.vue
modified: spec/javascript/components/ResultCard.spec.js

![Captura de tela de 2022-06-28 13-37-26](https://user-images.githubusercontent.com/99268176/176233875-e8530763-a3b6-49b8-9d71-b2a20034b205.png)

Refs: https://github.com/Iridescent-CM/technovation-app/issues/3504