### PR TITLE
Admin controls for judge registration

### DIFF
--- a/app/javascript/admin/content-settings/components/Registration.vue
+++ b/app/javascript/admin/content-settings/components/Registration.vue
@@ -4,7 +4,7 @@
     <div v-for="(label, scope) in checkboxes" :key="scope">
       <p class="inline-checkbox">
         <input
-          v-if="judgingEnabled"
+          v-if="isRegistrationClosed(scope)"
           :id="`season_toggles_${scope}_signup`"
           type="checkbox"
           :value="0"
@@ -18,10 +18,10 @@
         >
         <label
           :for="`season_toggles_${scope}_signup`"
-          :class="{ 'label--disabled': judgingEnabled }"
+          :class="{ 'label--disabled': isRegistrationClosed(scope) }"
         >{{ label }}</label>
       </p>
-      <div v-if="judgingEnabled" class="notice info hint user-notice">
+      <div v-if="isRegistrationClosed(scope)" class="notice info hint user-notice">
         <icon name="exclamation-circle" :size="16" color="00529B" />
         When judging is enabled, {{ `${scope}s` }} cannot sign up
       </div>
@@ -46,6 +46,7 @@ export default {
       checkboxes: {
         student: 'Students',
         mentor: 'Mentors',
+        judge: 'Judges',
       },
     }
   },
@@ -55,6 +56,12 @@ export default {
       'judgingEnabled',
     ])
   },
+
+  methods: {
+    isRegistrationClosed(scope) {
+      return (scope == 'student' || scope == 'mentor') && this.judgingEnabled
+    }
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -26,6 +26,20 @@
             </strong>
           </p>
         </div>
+
+        <div ref="signupFieldJudges" class="review-label">
+          <p>
+            Judges
+            <strong
+              :class="{
+                on: formData.judge_signup,
+                off: !formData.judge_signup
+              }"
+            >
+              {{ formData.judge_signup ? 'yes' : 'no' }}
+            </strong>
+          </p>
+        </div>
       </div>
 
       <div class="review-panel">

--- a/app/javascript/admin/content-settings/store/getters.js
+++ b/app/javascript/admin/content-settings/store/getters.js
@@ -12,7 +12,7 @@ export default {
       // Registration
       student_signup: Boolean(!judgingRoundEnabled && state.student_signup),
       mentor_signup: Boolean(!judgingRoundEnabled && state.mentor_signup),
-      judge_signup: Boolean(!judgingRoundEnabled && state.judge_signup),
+      judge_signup: Boolean(state.judge_signup),
       chapter_ambassador_signup: Boolean(
         !judgingRoundEnabled && state.chapter_ambassador_signup
       ),

--- a/app/serializers/season_toggles_serializer.rb
+++ b/app/serializers/season_toggles_serializer.rb
@@ -13,6 +13,10 @@ class SeasonTogglesSerializer
     season_toggles.signup_enabled?('mentor')
   end
 
+  attribute :judge_signup do |season_toggles|
+    season_toggles.signup_enabled?('judge')
+  end
+
   attribute :student_dashboard_text do |season_toggles|
     season_toggles.dashboard_text('student')
   end

--- a/spec/javascript/admin/content-settings/components/Registration.spec.js
+++ b/spec/javascript/admin/content-settings/components/Registration.spec.js
@@ -33,6 +33,7 @@ describe('Admin Content & Settings - Registration component', () => {
         checkboxes: {
           student: 'Students',
           mentor: 'Mentors',
+          judge: 'Judges',
         },
       })
     })
@@ -48,6 +49,9 @@ describe('Admin Content & Settings - Registration component', () => {
       const mentorCheckbox = wrapper.find('#season_toggles_mentor_signup')
       const mentorCheckboxLabel = wrapper
         .find('label[for="season_toggles_mentor_signup"]')
+      const judgeCheckbox = wrapper.find('#season_toggles_judge_signup')
+      const judgeCheckboxLabel = wrapper
+        .find('label[for="season_toggles_judge_signup"]')
 
       expect(wrapper.vm.judgingEnabled).toBe(false)
 
@@ -55,6 +59,8 @@ describe('Admin Content & Settings - Registration component', () => {
       expect(studentCheckboxLabel.exists()).toBe(true)
       expect(mentorCheckbox.exists()).toBe(true)
       expect(mentorCheckboxLabel.exists()).toBe(true)
+      expect(judgeCheckbox.exists()).toBe(true)
+      expect(judgeCheckboxLabel.exists()).toBe(true)
     })
 
     it('disables checkboxes and sets values to 0 is judging is enabled', () => {
@@ -106,6 +112,49 @@ describe('Admin Content & Settings - Registration component', () => {
       )
 
       expect(mentorCheckboxLabel.attributes()).toEqual(
+        expect.objectContaining({
+          class: 'label--disabled',
+        })
+      )
+    })
+
+    it('allows judge registraitons when juding is enabled', () => {
+      wrapper = shallowMount(
+        Registration,
+        {
+          localVue,
+          store: mockStore.createMocks({
+            getters: {
+              judgingEnabled: () => {
+                return true
+              },
+            },
+          }).store,
+        }
+      )
+
+      const judgeCheckbox = wrapper.find('#season_toggles_judge_signup')
+      const judgeCheckboxLabel = wrapper
+        .find('label[for="season_toggles_judge_signup"]')
+
+      expect(wrapper.vm.judgingEnabled).toBe(true)
+
+      expect(judgeCheckbox.attributes()).toEqual(
+        expect.objectContaining({
+          id: 'season_toggles_judge_signup',
+          type: 'checkbox',
+        })
+      )
+
+      expect(judgeCheckbox.attributes()).not.toEqual(
+        expect.objectContaining({
+          id: 'season_toggles_judge_signup',
+          type: 'checkbox',
+          disabled: 'disabled',
+        })
+      )
+
+      expect(judgeCheckboxLabel.attributes()).not.toEqual(
         expect.objectContaining({
           class: 'label--disabled',
         })


### PR DESCRIPTION
This will give admins the ability to turn on or off judge registrations.

This is only the admin controls, #3421 will incorporate this new setting into the new registration flow.



