### PR TITLE
Rebrand homepage and login page

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,4 +1,4 @@
-label {
+label:not(.tw-label) {
   display: block;
   cursor: pointer;
   font-family: "Source Sans Pro", sans-serif;

--- a/app/controllers/public/dashboards_controller.rb
+++ b/app/controllers/public/dashboards_controller.rb
@@ -1,6 +1,7 @@
 module Public
   class DashboardsController < ApplicationController
     include LocationStorageController
+    layout "application_rebrand"
 
     def show
       set_cookie(CookieNames::SIGNUP_WIZARD_MODE, true)

--- a/app/controllers/signins_controller.rb
+++ b/app/controllers/signins_controller.rb
@@ -1,5 +1,6 @@
 class SigninsController < ApplicationController
   before_action :require_unauthenticated, except: :destroy
+  layout "application_rebrand"
 
   def new
     @signin = Account.new(email: params[:email])

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -4,6 +4,10 @@
     font-family: 'RUBIK', sans-serif;
 }
 
+.poppins {
+    font-family: 'Poppins', sans-serif;
+}
+
 html{
     @apply bg-white
 }

--- a/app/views/application/_judging_open_splash.en.html.erb
+++ b/app/views/application/_judging_open_splash.en.html.erb
@@ -19,26 +19,6 @@
   or follow us at:
 </p>
 
-<ul class="unstyled">
-  <li>
-    <%= web_icon("facebook-square") %>
-    <%= link_to "Facebook", 'https://www.facebook.com/technovationglobal' %>
-  </li>
-
-  <li>
-    <%= web_icon("twitter-square") %>
-    <%= link_to "Twitter", 'https://twitter.com/technovation' %>
-  </li>
-
-  <li>
-    <%= web_icon("instagram") %>
-    <%= link_to "Instagram", 'https://www.instagram.com/technovationglobal' %>
-  </li>
-
-  <li>
-    <%= web_icon("youtube") %>
-    <%= link_to "YouTube", 'https://www.youtube.com/channel/UCvxNjrhfz_M68fwT2QcurjQ' %>
-  </li>
-</ul>
+<%= render 'application_rebrand/social_links' %>
 
 <p>Let's learn and build a better world together!</p>

--- a/app/views/application/_judging_open_splash.en.html.erb
+++ b/app/views/application/_judging_open_splash.en.html.erb
@@ -1,21 +1,32 @@
-<h1 class="appy-title">Technovation Girls</h1>
+<div class="font-bold text-center mb-8">
+  <h1 class="text-4xl">Technovation Girls</h1>
 
-<h2>Registration is currently open for judges</h2>
+  <h2 class="text-3xl text-tg-magenta">Registration is currently open for judges</h2>
+</div>
 
-<p>
-  Thank you for your interest in Technovation Girls. Register <%= link_to "here", signup_path, data: { turbolinks: false } %> to judge projects.
+<p class="mb-4">
+  Thank you for your interest in Technovation Girls. Register
+  <%= link_to "here",
+              signup_path,
+              data: { turbolinks: false },
+              class: "tw-link"%>
+  to judge projects.
+</p>
+
+<p class="mb-4">
+  Registration is currently closed for students and mentors,
+  although students with existing accounts are welcome to
+  <%= link_to "log-in", login_path,
+              data: { turbolinks: false },
+              class: "tw-link" %>
+  and review their existing projects.
 </p>
 
 <p>
-  <strong>
-    Registration is currently closed for students and mentors, 
-    although students with existing accounts are welcome to 
-    <%= link_to "log-in", login_path, data: { turbolinks: false } %> and review their existing projects.
-  </strong>
-</p>
-
-<p>
-  You can learn more about Technovation on our <%= link_to "website", "https://www.technovation.org/" %> 
+  You can learn more about Technovation on our
+  <%= link_to "website",
+              "https://www.technovation.org/",
+              class: "tw-link" %>
   or follow us at:
 </p>
 

--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -1,43 +1,49 @@
-<h1 class="appy-title">Technovation Girls</h1>
+<div class="font-bold text-center mb-8">
+  <h1 class="text-4xl">Technovation Girls</h1>
 
-<h2>Registration is currently closed</h2>
+  <h2 class="text-3xl text-energetic-blue">Registration is currently closed</h2>
+</div>
 
-<p>Thanks for your interest in Technovation Girls — we can't wait for you to be part of our global community!</p>
+<p class="mb-4">Thanks for your interest in Technovation Girls — we can't wait for you to be part of our global community!</p>
 
-<p>Teams who submitted a project, mentors, and judges may log in between July 12 and Sept 1 to view scores and download certificates.</p>
+<p class="mb-4">Teams who submitted a project, mentors, and judges may log in between July 12 and Sept 1 to view scores and download certificates.</p>
 
-<p>
+<p class="mb-4">
   Registration for Technovation Girls will open again by October. Please
-  <%= link_to "sign up", "https://eepurl.com/hZMS2n" %>
+  <%= link_to "sign up", "https://eepurl.com/hZMS2n", class: 'tw-link-magenta' %>
   to receive a reminder email when registration opens.
   You can start working on your next project now by checking out the
-  <%= link_to "curriculum", "https://technovationchallenge.org/curriculum-intro/registered/new/" %>!
+  <%= link_to "curriculum", "https://technovationchallenge.org/curriculum-intro/registered/new/", class: "tw-link-magenta" %>!
 </p>
 
 <p>
-  You can learn more about <%= link_to "Technovation", "https://technovationchallenge.org/" %>
+  You can learn more about <%= link_to "Technovation", "https://technovationchallenge.org/", class: "tw-link-magenta" %>
   on our website or follow us at:
 </p>
 
-<ul class="unstyled">
+<ul class="unstyled mb-4">
   <li>
     <%= web_icon("facebook-square") %>
-    <%= link_to "Facebook", 'https://www.facebook.com/technovationglobal' %>
+    <%= link_to "Facebook", 'https://www.facebook.com/technovationglobal',
+                class: 'tw-link-magenta' %>
   </li>
 
   <li>
     <%= web_icon("twitter-square") %>
-    <%= link_to "Twitter", 'https://twitter.com/technovation' %>
+    <%= link_to "Twitter", 'https://twitter.com/technovation',
+                class: 'tw-link-magenta' %>
   </li>
 
   <li>
     <%= web_icon("instagram") %>
-    <%= link_to "Instagram", 'https://www.instagram.com/technovationglobal' %>
+    <%= link_to "Instagram", 'https://www.instagram.com/technovationglobal',
+                class: 'tw-link-magenta' %>
   </li>
 
   <li>
     <%= web_icon("youtube") %>
-    <%= link_to "YouTube", 'https://www.youtube.com/channel/UCvxNjrhfz_M68fwT2QcurjQ' %>
+    <%= link_to "YouTube", 'https://www.youtube.com/channel/UCvxNjrhfz_M68fwT2QcurjQ',
+                class: 'tw-link-magenta' %>
   </li>
 </ul>
 

--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -1,7 +1,7 @@
 <div class="font-bold text-center mb-8">
   <h1 class="text-4xl">Technovation Girls</h1>
 
-  <h2 class="text-3xl text-energetic-blue">Registration is currently closed</h2>
+  <h2 class="text-3xl text-tg-magenta">Registration is currently closed</h2>
 </div>
 
 <p class="mb-4">Thanks for your interest in Technovation Girls — we can't wait for you to be part of our global community!</p>
@@ -10,14 +10,21 @@
 
 <p class="mb-4">
   Registration for Technovation Girls will open again by October. Please
-  <%= link_to "sign up", "https://eepurl.com/hZMS2n", class: 'tw-link-magenta' %>
+  <%= link_to "sign up",
+              "https://eepurl.com/hZMS2n",
+              class: "tw-link" %>
   to receive a reminder email when registration opens.
   You can start working on your next project now by checking out the
-  <%= link_to "curriculum", "https://technovationchallenge.org/curriculum-intro/registered/new/", class: "tw-link-magenta" %>!
+  <%= link_to "curriculum",
+              "https://technovationchallenge.org/curriculum-intro/registered/new/",
+              class: "tw-link" %>!
 </p>
 
 <p>
-  You can learn more about <%= link_to "Technovation", "https://technovationchallenge.org/", class: "tw-link-magenta" %>
+  You can learn more about
+  <%= link_to "Technovation",
+              "https://technovationchallenge.org/",
+              class: "tw-link" %>
   on our website or follow us at:
 </p>
 

--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -21,30 +21,6 @@
   on our website or follow us at:
 </p>
 
-<ul class="unstyled mb-4">
-  <li>
-    <%= web_icon("facebook-square") %>
-    <%= link_to "Facebook", 'https://www.facebook.com/technovationglobal',
-                class: 'tw-link-magenta' %>
-  </li>
-
-  <li>
-    <%= web_icon("twitter-square") %>
-    <%= link_to "Twitter", 'https://twitter.com/technovation',
-                class: 'tw-link-magenta' %>
-  </li>
-
-  <li>
-    <%= web_icon("instagram") %>
-    <%= link_to "Instagram", 'https://www.instagram.com/technovationglobal',
-                class: 'tw-link-magenta' %>
-  </li>
-
-  <li>
-    <%= web_icon("youtube") %>
-    <%= link_to "YouTube", 'https://www.youtube.com/channel/UCvxNjrhfz_M68fwT2QcurjQ',
-                class: 'tw-link-magenta' %>
-  </li>
-</ul>
+<%= render 'application_rebrand/social_links' %>
 
 <p>Let's learn and build a better world together!</p>

--- a/app/views/application/templates/_tg_green_header.html.erb
+++ b/app/views/application/templates/_tg_green_header.html.erb
@@ -1,6 +1,6 @@
 <div class="tg-green-stripes rubik h-auto mx-auto pt-16 flex flex-col">
   <div class="banner-text-wrapper w-full lg:w-3/4 mx-auto pb-16">
-    <div class="text-white text-4xl md:text-6xl font-black mb-8 uppercase">Technovation Girls</div>
+    <div class="text-white text-4xl md:text-6xl font-black mb-8 uppercase"><%= heading %></div>
   </div>
   <% if current_scope == 'judge' %>
     <%= render 'judge/navigation/rebrand/tg_sub_nav' %>

--- a/app/views/application_rebrand/_global_nav.html.erb
+++ b/app/views/application_rebrand/_global_nav.html.erb
@@ -6,57 +6,58 @@
           <%= image_tag "new_registration/tg-girls-logo.png", alt:"Technovation Girls Logo", id:"tg-logo", class:"w-44 md:w-52"%>
         </a>
       </div>
-
-      <% if current_account.present? %>
         <div class="flex space-x-7 py-4" id="global-nav">
           <div class="flex items-center space-x-1" id="global-nav-wrapper">
+            <a class="tw-sm-hidden" href="https://www.technovation.org/about/" target="_blank">About</a>
+
             <% if content_for?(:global_nav_links) %>
               <%= yield :global_nav_links %>
             <% end %>
-            <a class="tw-sm-hidden" href="https://www.technovation.org/about/" target="_blank">About</a>
-            <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>
-              <%= link_to SeasonToggles.survey_link(current_scope, "text"),
-                          SeasonToggles.survey_link(
-                            current_scope, "url",
-                            format_url: true,
-                            account: current_account
-                          ),
-                          target: "_blank",
-                          class: "tw-sm-hidden"
-              %>
-            <% end %>
-            <div class="flex items-center justify-center">
-              <div class="relative inline-block text-left tw-dropdown" id="global-dropdown-wrapper">
-                <span class="flex cursor-pointer hover:text-energetic-blue"><%= current_account.first_name %>
-                  <img src="https://icongr.am/fontawesome/caret-down.svg?size=12" alt="Drop down caret">
-                </span>
 
-                <div class="tw-dropdown-menu">
-                  <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
-                    <div class="p-4">
-                      <ul class="text-sm" id="global-dropdown-list">
-                        <% if content_for?(:drop_down) %>
-                          <%= yield :drop_down %>
-                        <% elsif current_account.authenticated? %>
-                          <%= link_to t('views.application.signout'), signout_path %>
-                        <% else %>
-                          <%= link_to t('views.application.signin'),
-                                      signin_path,
-                                      class: al(signin_path) %>
-                        <% end %>
-                      </ul>
+            <% if current_account.present? %>
+              <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>
+                <%= link_to SeasonToggles.survey_link(current_scope, "text"),
+                            SeasonToggles.survey_link(
+                              current_scope, "url",
+                              format_url: true,
+                              account: current_account
+                            ),
+                            target: "_blank",
+                            class: "tw-sm-hidden"
+                %>
+              <% end %>
+              <div class="flex items-center justify-center">
+                <div class="relative inline-block text-left tw-dropdown" id="global-dropdown-wrapper">
+                  <span class="flex cursor-pointer hover:text-energetic-blue"><%= current_account.first_name %>
+                    <img src="https://icongr.am/fontawesome/caret-down.svg?size=12" alt="Drop down caret">
+                  </span>
+
+                  <div class="tw-dropdown-menu">
+                    <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
+                      <div class="p-4">
+                        <ul class="text-sm" id="global-dropdown-list">
+                          <% if content_for?(:drop_down) %>
+                            <%= yield :drop_down %>
+                          <% elsif current_account.authenticated? %>
+                            <%= link_to t('views.application.signout'), signout_path %>
+                          <% else %>
+                            <%= link_to t('views.application.signin'),
+                                        signin_path,
+                                        class: al(signin_path) %>
+                          <% end %>
+                        </ul>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
 
-              <%= image_tag current_account.profile_image_url,
-                            class: "rounded-bl-3xl rounded-tr-3xl w-14",
-                            id: "profile-image" %>
-            </div>
+                <%= image_tag current_account.profile_image_url,
+                              class: "rounded-bl-3xl rounded-tr-3xl w-14",
+                              id: "profile-image" %>
+              </div>
+            <% end %>
           </div>
         </div>
-    <% end %>
     </div>
   </div>
 </nav>

--- a/app/views/application_rebrand/_global_nav_links.html.erb
+++ b/app/views/application_rebrand/_global_nav_links.html.erb
@@ -1,0 +1,47 @@
+<a class="tw-sm-hidden" href="https://www.technovation.org/about/" target="_blank">Get Started</a>
+<a class="tw-sm-hidden" href="https://www.technovation.org/about/" target="_blank">Chapters</a>
+
+<%= link_to t('views.application.signin'),
+            signin_path,
+            class: al(signin_path) + 'tw-sm-hidden' %>
+
+<%= link_to t('views.application.signup'),
+            signup_path,
+            class: al(signup_path) + 'tw-sm-hidden' %>
+
+<a href="https://www.technovation.org/donate-today/" class="py-2 px-2 text-white font-black
+              rounded transition duration-300 bg-energetic-blue tw-sm-hidden">DONATE</a>
+
+
+<div class="flex items-center justify-center md:hidden">
+  <div class="relative inline-block text-left tw-dropdown" id="global-dropdown-wrapper">
+                  <span class="flex cursor-pointer hover:text-energetic-blue"> Menu
+                    <img src="https://icongr.am/fontawesome/caret-down.svg?size=12" alt="Drop down caret">
+                  </span>
+    <div class="tw-dropdown-menu">
+      <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none">
+        <div class="p-4">
+          <ul class="text-sm" id="global-dropdown-list">
+            <li class="md-hidden">
+              <a href="https://www.technovation.org/about/" target="_blank">Get Started</a>
+            </li>
+            <li class="md-hidden">
+              <a href="https://www.technovation.org/about/" target="_blank">Chapters</a>
+            </li>
+            <li class="md-hidden">
+              <%= link_to t('views.application.signin'),
+                          signin_path,
+                          class: al(signin_path) %>
+            </li>
+            <li class="md-hidden">
+              <%= link_to t('views.application.signup'),
+                          signup_path,
+                          class: al(signup_path) %>
+            </li>
+            <li class="md-hidden"><a href="">DONATE</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/application_rebrand/_social_links.en.html.erb
+++ b/app/views/application_rebrand/_social_links.en.html.erb
@@ -1,0 +1,29 @@
+<ul class="unstyled mb-4">
+  <li>
+    <%= web_icon("facebook-square") %>
+    <%= link_to "Facebook", "https://www.facebook.com/technovationglobal",
+                class: "tw-link",
+                target: :_blank %>
+  </li>
+
+  <li>
+    <%= web_icon("twitter-square") %>
+    <%= link_to "Twitter", "https://twitter.com/technovation",
+                class: "tw-link",
+                target: :_blank %>
+  </li>
+
+  <li>
+    <%= web_icon("instagram") %>
+    <%= link_to "Instagram", "https://www.instagram.com/technovationglobal",
+                class: "tw-link",
+                target: :_blank %>
+  </li>
+
+  <li>
+    <%= web_icon("youtube") %>
+    <%= link_to "YouTube", "https://www.youtube.com/channel/UCvxNjrhfz_M68fwT2QcurjQ",
+                class: "tw-link",
+                target: :_blank %>
+  </li>
+</ul>

--- a/app/views/layouts/judge.html.erb
+++ b/app/views/layouts/judge.html.erb
@@ -1,7 +1,7 @@
 <% provide :root_path, judge_dashboard_path %>
 <% provide :global_nav_links, render('judge/navigation/rebrand/global_nav_links') %>
 <% provide :drop_down, render('judge/navigation/rebrand/dropdown_nav') %>
-<% provide :main_header, render('application/templates/tg_green_header') %>
+<% provide :main_header, render('application/templates/tg_green_header', heading: "Technovation Girls") %>
 
 <% content_for :js,
   javascript_packs_with_chunks_tag("judge", data: { turbolinks_track: :reload }) %>

--- a/app/views/public/dashboards/_landing.en.html.erb
+++ b/app/views/public/dashboards/_landing.en.html.erb
@@ -1,31 +1,23 @@
 <% provide :html_id, "registration-landing" %>
 
-<div class="grid grid--justify-space-around">
-  <div class="grid__col-sm-6 grid__col-xs-10 panel">
-    <h1>Join the movement</h1>
+<h1 class="text-3xl font-bold mb-6">Join the movement.</h1>
+<p class="mb-8">
+  We're entrepreneurs, mentors, and educators looking to teach girls everywhere
+  the skills they need to change the world with technology.
+</p>
 
-    <div class="text-align--center">
-      <%= image_tag asset_path('tc-landing-globe.svg'),
-        alt: 'Illustration of a globe',
-        width: "40%" %>
-    </div>
+<p class="mb-6">
+  <%= link_to "Sign up today",
+    signup_path,
+    class: "tw-green-btn",
+    data: { turbolinks: false } %>
+</p>
 
-    <p>
-      We're entrepreneurs, mentors, and educators looking to teach girls everywhere
-      the skills they need to change the world with technology.
-    </p>
+<p>
+  Already have an account?
+  <%= link_to raw("Please log in &#8227"),
+    login_path,
+    data: { turbolinks: false },
+    class: "tw-link" %>
+</p>
 
-    <p>
-      <%= link_to "Sign up today",
-        signup_path,
-        class: "button",
-        data: { turbolinks: false } %>
-
-      or
-
-      <%= link_to "Log in",
-        login_path,
-        data: { turbolinks: false } %>
-    </p>
-  </div>
-</div>

--- a/app/views/public/dashboards/show.en.html.erb
+++ b/app/views/public/dashboards/show.en.html.erb
@@ -1,19 +1,18 @@
+<% provide :main_header, render('application/templates/tg_green_header', heading: "Technovation Girls") %>
+<% provide :global_nav_links, render('application_rebrand/global_nav_links') %>
+
 <%= render 'public/dashboards/homepage_banner' if ENV.fetch("ENABLE_HOMEPAGE_BANNER", false) %>
 
-<% if SeasonToggles.registration_open? %>
-  <div class="grid grid--justify-space-around margin--t-xxlarge">
-    <div class="grid__col-12 grid__col-md-10">
+<div class="w-full lg:w-1/2 mx-auto border-2 shadow-md rounded">
+  <div class="p-8">
+    <% if SeasonToggles.registration_open? %>
       <%= render 'landing' %>
-    </div>
-  </div>
-<% else %>
-  <div class="grid grid--justify-space-around">
-    <div class="panel grid__col-12 grid__col-md-6">
+    <% else %>
       <% if SeasonToggles.judging_finished? %>
         <%= render 'off_season_splash' %>
       <% else %>
         <%= render 'judging_open_splash' %>
       <% end %>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/signins/new.html.erb
+++ b/app/views/signins/new.html.erb
@@ -1,34 +1,38 @@
 <% provide :title, "Sign in" %>
+<% provide :main_header, render('application/templates/tg_green_header', heading: "Welcome Back") %>
+<% provide :global_nav_links, render('application_rebrand/global_nav_links') %>
 
 <%= render 'public/dashboards/homepage_banner' if ENV.fetch("ENABLE_HOMEPAGE_BANNER", false) %>
 
-<div class="grid grid--justify-space-around">
-  <div class="panel grid__col-sm-8 grid__col-md-5">
-    <h2><%= t('views.signins.new.title') %></h2>
-
+<div class="w-full lg:w-1/2 mx-auto">
+  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: t('views.signins.new.title')} do %>
     <%= simple_form_for @signin, url: signins_path do |f| %>
-      <%= f.input :email %>
-      <%= f.input :password %>
+
+      <%= f.input :email, label_html: {class: 'tw-label'} %>
+      <%= f.input :password,label_html: {class: 'tw-label'} %>
 
       <p>
         <%= check_box_tag :remember_me, '1', true %>
-        <%= label_tag nil, "Remember me for future visits", for: :remember_me %>
+        <%= label_tag nil, "Remember me for future visits", for: :remember_me, class: 'tw-label' %>
       </p>
 
       <%= f.button :submit,
-        t('views.signins.form.signin'),
-        class: "button" %>
+                   t('views.signins.form.signin'),
+                   class: "tw-green-btn my-8 cursor-pointer" %>
 
       <p>
         <%= t("controllers.signins.new.no_account") %>
-        <%= link_to t("controllers.signups.new.link"), signup_path, data: { turbolinks: false } %>
+        <%= link_to t("controllers.signups.new.link"), signup_path,
+                    data: { turbolinks: false },
+                    class: "tw-link" %>
       </p>
 
       <p>
         <%= t("controllers.password_resets.new.text") %>
         <%= link_to t("controllers.password_resets.new.link"),
-          new_password_reset_path %>
+                    new_password_reset_path,
+                    class: "tw-link" %>
       </p>
     <% end %>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Refs #3159 

This pull request includes changes that were needed to complete rebranding for the home page and login page. Most of the changes are basic styling changes - like converting old class names to tailwind.

New Additions include
- `app/views/application_rebrand/_global_nav_links.html.erb` which are the links for the navbar on the homepage and login page
- `app/views/application_rebrand/_social_links.en.html.erb` includes the social links like facebook, IG, youtube, etc. I though this would be useful since this chunk of html/links are used in multiple places

Blockers right now include loading the hero image. I am having trouble loading the background image with the tailwind/rails asset configuration. I don't want this to hold up the PR since these changes will be reviewed on Friday. I will make an additional PR to solve this issue. I also need to update the links for the navbar. Will verify these with Deb.

Followup tickets
- Standardize the navbars between the vue world and rails world. I also think the navbar rails navbar partial can be cleaned up. 
- Update logic once the registration toggles are complete

Here are some screenshots of the changes

**Judging set to Finished & Registration OFF**
![JudgingFINISHED RegistrationOFF](https://user-images.githubusercontent.com/29210380/178806156-0ba740b7-bd51-4bef-b983-2454e3de0e53.png)

**Judging off & Registration "Off" (students and mentors toggled off currently)**
![JudgingOFF RegistrationOFF](https://user-images.githubusercontent.com/29210380/178806379-9e98ad2a-879c-41b2-9f92-9c1110553283.png)

**Registration Toggled On**
![RegistrationToggledOn](https://user-images.githubusercontent.com/29210380/178806467-951c0190-bc74-4c30-a656-b1a85096490b.png)
