### PR TITLE
Rebrands Team Search and Mentor Search for Students

### DIFF
--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,11 +1,19 @@
 <template>
   <div class="card-result">
-    <img :src="cardImage" class="w-full" @error="imgBroken" />
+    <div class="relative" :class="w-full">
+      <img :src="cardImage" class="w-full" @error="imgBroken" />
 
-    <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
-      <p class="text-xl font-bold text-black-200">No picture<p/>
+      <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
+        <p class="text-xl font-bold text-black-200">No picture<p/>
+      </div>
+
+      <div class="flex flex-col items-end absolute bottom-1 right-1">
+        <span v-for="(expertise, key) in expertises" class="list-badge bg-blue-600" :key="key">
+          {{ expertise.name }}
+        </span>
+      </div>
     </div>
-    
+
     <div class="body px-6 py-4">
       <div class="search-card-title font-bold text-xl mb-1">{{ cardTitle }}</div>
       <div class="search-card-subtitle py-1 text-base">{{ cardSubtitle }}</div>
@@ -67,6 +75,10 @@
         type: Boolean,
         required: false,
       },
+      expertises: {
+        type: Array,
+        required: false,
+      },
       linkText: {
         type: String,
         required: false,
@@ -89,12 +101,15 @@
     @apply max-w-sm rounded-lg overflow-hidden shadow-lg mb-5
   }
   .card-photo-placeholder {
-    @apply bg-slate-300 w-full items-center justify-center pt-[33.5%] pb-[33.5%]
+    @apply bg-gray-300 w-full items-center justify-center py-34.5
   }
   .search-card-footer {
     @apply text-right mt-6
   }
   .search-card-footer p {
     @apply text-base text-red-500
+  }
+  .list-badge {
+    @apply text-xs py-3 px-3 mb-2 leading-none text-center align-baseline font-bold text-white rounded-full rounded-r-none
   }
 </style>

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card-result">
     <div class="relative">
-      <img :src="cardImage" class="object-contain h-48 w-96" @error="imgBroken" />
+      <img :src="cardImage" :class="coverImageClass(coverImage)" @error="imgBroken" />
 
       <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
         <p class="text-xl font-bold text-black-200">No picture<p/>
@@ -25,7 +25,7 @@
         <p>This team is currently full.</p>
       </div>
       <div v-else class="search-card-footer">
-        <a :href="linkPath" class="tw-link text-base md:text-lg lg:text-lg" >{{ linkText }}</a>
+        <a :href="linkPath" class="tw-link text-base md:text-base lg:text-base" >{{ linkText }}</a>
       </div>
     </div>
   </div>
@@ -45,6 +45,7 @@
       linkPath:     { type: String,  required: false },
       onTeamText:   { type: String,  required: false },
       virtualText:  { type: String,  required: false },
+      coverImage:   { type: Boolean, required: false },
       declined:     { type: Boolean, required: false },
       full:         { type: Boolean, required: false },
       showBadges:   { type: Boolean, required: false },
@@ -66,6 +67,9 @@
         let bg = flag ? bgs[type].on : bgs[type].off
         
         return `list-badge ${bg} left-arrow uppercase`
+      },
+      coverImageClass(flag) {
+        return flag ? 'w-full' : 'object-contain h-48 w-96'
       }
     },
     computed: {
@@ -78,10 +82,10 @@
 
 <style lang="scss">
   .card-result {
-    @apply max-w-sm rounded-lg overflow-hidden shadow-lg m-auto h-96
+    @apply max-w-sm rounded-lg overflow-hidden shadow-lg m-auto h-96 w-60
   }
   .card-title {
-    @apply font-bold text-xl mb-1
+    @apply font-bold text-base mb-1
   }
   .card-text {
     @apply text-base whitespace-nowrap overflow-ellipsis overflow-hidden

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -25,7 +25,7 @@
         <p>This team is currently full.</p>
       </div>
       <div v-else class="search-card-footer">
-        <a :href="linkPath" class="tw-link text-lg" >{{ linkText }}</a>
+        <a :href="linkPath" class="tw-link text-base md:text-lg lg:text-lg" >{{ linkText }}</a>
       </div>
     </div>
   </div>
@@ -78,7 +78,7 @@
 
 <style lang="scss">
   .card-result {
-    @apply max-w-sm rounded-lg overflow-hidden shadow-lg m-auto
+    @apply max-w-sm rounded-lg overflow-hidden shadow-lg m-auto h-96
   }
   .card-title {
     @apply font-bold text-xl mb-1

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,23 +1,22 @@
 <template>
   <div class="card-result">
-    <div class="relative" :class="w-full">
-      <img :src="cardImage" class="w-full" @error="imgBroken" />
+    <div class="relative">
+      <img :src="cardImage" class="object-contain h-48 w-96" @error="imgBroken" />
 
-      <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
+      <div class="card-photo-placeholder hidden">
         <p class="text-xl font-bold text-black-200">No picture<p/>
       </div>
 
-      <div class="flex flex-col items-end absolute bottom-1 right-1">
-        <span v-for="(expertise, key) in expertises" class="list-badge bg-blue-600" :key="key">
-          {{ expertise.name }}
-        </span>
+      <div v-if="showBadges" class="flex flex-col items-end absolute bottom-1 right-0">
+        <span :class="badge('team', isOnTeam)">{{ onTeamText }}</span>
+        <span :class="badge('virtual', isVirtual)">{{ virtualText }}</span>
       </div>
     </div>
 
     <div class="body px-6 py-4">
-      <div class="search-card-title font-bold text-xl mb-1">{{ cardTitle }}</div>
-      <div class="search-card-subtitle py-1 text-base">{{ cardSubtitle }}</div>
-      <div class="search-card-content py-1 text-base mb-2">{{ cardContent }}</div>
+      <div class="card-title">{{ cardTitle }}</div>
+      <div class="card-text">{{ cardSubtitle }}</div>
+      <div class="card-text">{{ cardContent }}</div>
 
       <div v-if="declined" class="search-card-footer">
           <p>You asked to join {{ name }}, and they declined.</p>
@@ -35,62 +34,38 @@
 <script>
   export default {
     name: 'result-card',
+    props: {
+      cardId:       { type: String,  required: true },
+      cardImage:    { type: String,  required: false },
+      cardTitle:    { type: String,  required: false },
+      cardSubtitle: { type: String,  required: false },
+      cardContent:  { type: String,  required: false },
+      name:         { type: String,  required: false },
+      linkText:     { type: String,  required: false },
+      linkPath:     { type: String,  required: false },
+      onTeamText:   { type: String,  required: false },
+      virtualText:  { type: String,  required: false },
+      declined:     { type: Boolean, required: false },
+      full:         { type: Boolean, required: false },
+      showBadges:   { type: Boolean, required: false },
+      isOnTeam:     { type: Boolean, required: false },
+      isVirtual:    { type: Boolean, required: false },
+    },
     methods: {
       imgBroken(e) {
         e.target.classList.add("hidden")
         e.target.nextElementSibling.classList.remove("hidden")
         e.target.nextElementSibling.classList.add("flex")
-      }
-    },
-    props: {
-      cardId: {
-        type: String,
-        required: true,
       },
-      cardImage: {
-        type: String,
-        required: false,
-      },
-      cardTitle: {
-        type: String,
-        required: false,
-      },
-      cardSubtitle: {
-        type: String,
-        required: false,
-      },
-      cardContent: {
-        type: String,
-        required: false,
-      },
-      name: {
-        type: String,
-        required: false,
-      },
-      declined: {
-        type: Boolean,
-        required: false,
-      },
-      full: {
-        type: Boolean,
-        required: false,
-      },
-      expertises: {
-        type: Array,
-        required: false,
-      },
-      linkText: {
-        type: String,
-        required: false,
-      },
-      linkPath: {
-        type: String,
-        required: false,
-      },
-    },
-    computed: {
-      imgPlaceholderId() {
-        return `img-ph-${this.cardId}`;
+      badge(type, flag) {
+        let bgs = {
+          'team': { on: 'bg-blue-600', off:'bg-pink-600' },
+          'virtual': { on: 'bg-pink-600', off:'bg-blue-600' }
+        }
+        
+        let bg = flag ? bgs[type].on : bgs[type].off
+        
+        return `list-badge ${bg} left-arrow uppercase`
       }
     }
   }
@@ -98,10 +73,16 @@
 
 <style lang="scss">
   .card-result {
-    @apply max-w-sm rounded-lg overflow-hidden shadow-lg mb-5
+    @apply max-w-sm rounded-lg overflow-hidden shadow-lg m-auto
+  }
+  .card-title {
+    @apply font-bold text-xl mb-1
+  }
+  .card-text {
+    @apply text-base whitespace-nowrap overflow-ellipsis overflow-hidden
   }
   .card-photo-placeholder {
-    @apply bg-gray-300 w-full items-center justify-center py-34.5
+    @apply bg-gray-300 w-full items-center justify-center object-contain h-48 w-96
   }
   .search-card-footer {
     @apply text-right mt-6
@@ -110,6 +91,9 @@
     @apply text-base text-red-500
   }
   .list-badge {
-    @apply text-xs py-3 px-3 mb-2 leading-none text-center align-baseline font-bold text-white rounded-full rounded-r-none
+    @apply text-xs py-3 px-3 mb-1 leading-none text-center align-baseline font-bold text-white
+  }
+  .left-arrow {
+    clip-path: polygon(15% 0%, 100% 1%, 100% 100%, 15% 100%, 0% 50%);
   }
 </style>

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -3,7 +3,7 @@
     <div class="relative">
       <img :src="cardImage" class="object-contain h-48 w-96" @error="imgBroken" />
 
-      <div class="card-photo-placeholder hidden">
+      <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
         <p class="text-xl font-bold text-black-200">No picture<p/>
       </div>
 
@@ -66,6 +66,11 @@
         let bg = flag ? bgs[type].on : bgs[type].off
         
         return `list-badge ${bg} left-arrow uppercase`
+      }
+    },
+    computed: {
+      imgPlaceholderId() {
+        return `img-ph-${this.cardId}`;
       }
     }
   }

--- a/app/javascript/packs/application_rebrand.js
+++ b/app/javascript/packs/application_rebrand.js
@@ -10,4 +10,5 @@ import "../stylesheets/navigation.css"
 import "../stylesheets/footer.css"
 import "../stylesheets/tabs.css"
 import "../stylesheets/judge.css"
+import "../stylesheets/pagination.css"
 

--- a/app/javascript/student/index.js
+++ b/app/javascript/student/index.js
@@ -6,6 +6,8 @@ import store from './store'
 
 import App from './App'
 
+import ResultCard from '../components/ResultCard'
+
 Vue.use(Vue2Filters)
 
 document.addEventListener('turbolinks:load', () => {
@@ -46,6 +48,18 @@ document.addEventListener('turbolinks:load', () => {
       router.afterEach(( to, from ) => {
         ga('set', 'page', to.path);
         ga('send', 'pageview');
+      });
+    })
+  }
+
+  let searchMentors = document.querySelectorAll('.vue-search-mentor-result');
+  if ( searchMentors.length > 0 ) {
+    searchMentors.forEach(element => {
+      new Vue({
+        el: element,
+        components: {
+          ResultCard,
+        },
       });
     })
   }

--- a/app/javascript/student/index.js
+++ b/app/javascript/student/index.js
@@ -52,9 +52,10 @@ document.addEventListener('turbolinks:load', () => {
     })
   }
 
-  let searchMentors = document.querySelectorAll('.vue-search-mentor-result');
-  if ( searchMentors.length > 0 ) {
-    searchMentors.forEach(element => {
+  // Apply result card
+  let searchResults = document.querySelectorAll('.vue-search-result');
+  if ( searchResults.length > 0 ) {
+    searchResults.forEach(element => {
       new Vue({
         el: element,
         components: {

--- a/app/javascript/stylesheets/base_forms.css
+++ b/app/javascript/stylesheets/base_forms.css
@@ -23,6 +23,10 @@
         @apply inline-block focus:ring-transparent text-energetic-blue mr-2
     }
 
+    input[type="checkbox"], input[type="radio"] {
+        color: #43b02a;
+    }
+
     input[type="checkbox"] {
         @apply rounded
     }

--- a/app/javascript/stylesheets/base_forms.css
+++ b/app/javascript/stylesheets/base_forms.css
@@ -22,7 +22,7 @@
     input[type="checkbox"], input[type="radio"] {
         @apply inline-block focus:ring-transparent text-energetic-blue mr-2
     }
-
+    
     input[type="checkbox"], input[type="radio"] {
         color: #43b02a;
     }

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -22,6 +22,10 @@ html{
     );
 }
 
+.tw-grid {
+    @apply grid
+}
+
 .tw-thick-rule{
     @apply bg-energetic-blue h-1 my-2 w-60;
 }

--- a/app/javascript/stylesheets/pagination.css
+++ b/app/javascript/stylesheets/pagination.css
@@ -1,0 +1,28 @@
+.pagination a {
+    @apply align-top px-4 py-3 rounded shadow-md text-xl text-blue-500 font-semibold border-2 border-blue-500 hover:text-white hover:bg-energetic-blue
+}
+
+.pagination a.next_page, .pagination a.previous_page {
+    font-size: 0;
+}
+
+.pagination a.next_page:after {
+    font-size: initial;
+    content: ">";
+}
+.pagination a.previous_page:after {
+    font-size: initial;
+    content: "<";
+}
+
+.pagination a.next_page, .pagination a.previous_page {
+    @apply pt-2.5 pb-2
+}
+
+.pagination .current {
+    @apply px-4 py-3 rounded shadow-md text-xl font-semibold border-2 border-blue-500 text-white bg-energetic-blue
+}
+
+.pagination .disabled {
+    @apply hidden
+}

--- a/app/javascript/tailwind.config.js
+++ b/app/javascript/tailwind.config.js
@@ -24,6 +24,9 @@ module.exports = {
       height: {
         'fit-content': 'fit-content'
       },
+      spacing: {
+        '34.5': '34.5%'
+      },
       typography: {
         DEFAULT: {
           css: {

--- a/app/javascript/tailwind.config.js
+++ b/app/javascript/tailwind.config.js
@@ -24,9 +24,6 @@ module.exports = {
       height: {
         'fit-content': 'fit-content'
       },
-      spacing: {
-        '34.5': '34.5%'
-      },
       typography: {
         DEFAULT: {
           css: {

--- a/app/views/mentor_searches/_new.html.erb
+++ b/app/views/mentor_searches/_new.html.erb
@@ -1,39 +1,5 @@
-<% provide :title, "Search for mentors" %>
-
-<div class="grid">
-  <div class="grid__col-auto grid__col--bleed-y">
-    <div class="grid__cell">
-      <h1 class="page-heading"><%= t("views.mentor_searches.title") %></h1>
-
-      <p><%= t("views.mentor_searches.intro") %></p>
-    </div>
-  </div>
-</div>
-
-<div class="grid">
-  <div class="grid__col-sm-3">
-    <div class="sidebar">
-      <%= render "mentor_searches/filter_options", account: account %>
-    </div>
-  </div>
-
-  <div class="grid__col-sm-9">
-    <h3>Available Mentors</h3>
-
-    <div class="grid">
-      <%= render(
-        partial: "mentor_searches/mentor_preview",
-        collection: @mentors,
-        locals: { account: account }
-      ) %>
-
-      <% if @mentors.empty? %>
-        <div class="grid__col-auto grid__col--bleed">
-          <%= t("views.mentor_searches.none_found") %>
-        </div>
-      <% end %>
-    </div>
-
-    <%= will_paginate @mentors %>
-  </div>
-</div>
+<% if account.rebranded? %>
+  <%= render "mentor_searches/rebrand/search", account: account %>
+<% else %>
+  <%= render "mentor_searches/search", account: account %>
+<% end %>

--- a/app/views/mentor_searches/_search.html.erb
+++ b/app/views/mentor_searches/_search.html.erb
@@ -1,0 +1,39 @@
+<% provide :title, "Search for mentors" %>
+
+<div class="grid">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <div class="grid__cell">
+      <h1 class="page-heading"><%= t("views.mentor_searches.title") %></h1>
+
+      <p><%= t("views.mentor_searches.intro") %></p>
+    </div>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="grid__col-sm-3">
+    <div class="sidebar">
+      <%= render "mentor_searches/filter_options", account: account %>
+    </div>
+  </div>
+
+  <div class="grid__col-sm-9">
+    <h3>Available Mentors</h3>
+
+    <div class="grid">
+      <%= render(
+        partial: "mentor_searches/mentor_preview",
+        collection: @mentors,
+        locals: { account: account }
+      ) %>
+
+      <% if @mentors.empty? %>
+        <div class="grid__col-auto grid__col--bleed">
+          <%= t("views.mentor_searches.none_found") %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= will_paginate @mentors %>
+  </div>
+</div>

--- a/app/views/mentor_searches/rebrand/_filter_options.html.erb
+++ b/app/views/mentor_searches/rebrand/_filter_options.html.erb
@@ -1,0 +1,41 @@
+<h3><%= t("views.mentor_searches.filter_options") %></h3>
+
+<%= form_with url: request.fullpath, method: :get, local: true do |f| %>
+  <label>Search by name</label>
+
+  <%= f.text_field :text, class: "search-by-text", value: params[:text] %>
+  <p class="hint margin--t-medium-negative">Press enter/return after typing</p>
+
+  <%= render 'mentor_searches/rebrand/location_options', account: account, f: f %>
+
+  <div class="search-toggles">
+    <h3>Needs a team?</h3>
+
+    <%= render 'searches/toggle_mentor_needs_team', account: account, f: f %>
+
+    <h3>Only virtual mentors?</h3>
+
+    <%= render 'searches/toggle_mentor_virtual', f: f %>
+
+    <h3>Gender Identity</h3>
+
+    <%= render 'searches/toggle_gender_identity_preference', account: account, f: f %>
+
+    <h3>Expertise</h3>
+
+    <%= collection_check_boxes :search_filter,
+      :expertise_ids, @expertises, :id, :name do |b| %>
+      <p>
+        <%= b.check_box(
+          id: "expertise_#{b.value}",
+          class: "toggle-based-search",
+          checked: params[:search_filter][:expertise_ids].map(&:to_i).include?(
+            b.value
+          )
+        ) %>
+
+        <%= b.label text: b.text, for: "expertise_#{b.value}" %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/mentor_searches/rebrand/_location_options.en.html.erb
+++ b/app/views/mentor_searches/rebrand/_location_options.en.html.erb
@@ -1,0 +1,42 @@
+<% f ||= false %>
+
+<%= label_tag :nearby, t("views.application.search_near") %>
+
+<div class="location-based-search">
+  <% if f # TODO: shim until team search is updated %>
+    <%= f.text_field :nearby,
+      class: "search-by-text",
+      value: params[:nearby],
+      data: { location_field: true } %>
+  <% else %>
+    <%= text_field_tag :nearby,
+      params[:nearby],
+      class: "search-by-text",
+      data: { location_field: true } %>
+  <% end %>
+
+  <p class="hint">Press enter/return after typing</p>
+
+  <div class="search-toggles">
+    <h3><%= t("views.application.location") %></h3>
+    <p>
+      <%= 
+        radio_button_tag :location_type, 
+        "nearme", 
+        params[:location_type].nil? ? true : params[:location_type] == "nearme", 
+        data: { update_location: account.address_details },
+        class: "w-4 h-4 text-green-600"
+      %>
+      <label for="location_type %>"><%= t('views.application.near_me') %></label>
+    </p>
+    <p>
+      <%= 
+        radio_button_tag "location_type", 
+        "anywhere", 
+        params[:location_type] == "anywhere", 
+        data: { update_location: "anywhere" } 
+      %>
+      <label for="location_type %>"><%= t('views.application.anywhere') %></label>
+    </p>
+  </div>
+</div>

--- a/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
+++ b/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
@@ -1,0 +1,13 @@
+<div class="vue-search-mentor-result">
+  <result-card 
+    card-id= "mentor-<%= mentor_preview.id %>"
+    card-image= "<%= mentor_preview.profile_image_url %>"
+    card-title="<%= mentor_preview.full_name %>"
+    card-subtitle="<%= mentor_preview.address_details %>"
+    card-content="<%= mentor_preview.school_company_name %>"
+    :expertises="<%= mentor_preview.expertises.to_json %>"
+    name="<%= mentor_preview.full_name %>"
+    link-text="More Details >"
+    link-path="<%= mentor_mentor_path(mentor_preview, review_before: true) %>"
+  ></result-card>
+</div>

--- a/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
+++ b/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
@@ -1,11 +1,23 @@
-<div class="vue-search-mentor-result">
+<div class="vue-search-result">
   <result-card 
     card-id= "mentor-<%= mentor_preview.id %>"
     card-image= "<%= mentor_preview.profile_image_url %>"
     card-title="<%= mentor_preview.full_name %>"
     card-subtitle="<%= mentor_preview.address_details %>"
     card-content="<%= mentor_preview.school_company_name %>"
-    :expertises="<%= mentor_preview.expertises.to_json %>"
+    :show-badges="true"
+    :is-on-team="<%= mentor_preview.is_on_team? %>"
+    on-team-text="<%= 
+      mentor_preview.is_on_team? ? 
+        t("views.mentor_searches.new.mentor_preview.on_team") : 
+        t("views.mentor_searches.new.mentor_preview.needs_team")
+    %>"
+    :is-virtual="<%= mentor_preview.virtual? %>"
+    virtual-text="<%= 
+      mentor_preview.virtual? ? 
+        t("views.mentor_searches.new.mentor_preview.virtual") : 
+        t("views.mentor_searches.new.mentor_preview.in_person")
+    %>"
     name="<%= mentor_preview.full_name %>"
     link-text="More Details >"
     link-path="<%= mentor_mentor_path(mentor_preview, review_before: true) %>"

--- a/app/views/mentor_searches/rebrand/_search.html.erb
+++ b/app/views/mentor_searches/rebrand/_search.html.erb
@@ -1,7 +1,7 @@
 <% provide :title, "Search for mentors" %>
 
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6" id="show-container">
-   <div id="profile-settings" class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
+   <div id="profile-settings" class="mx-2 h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue md:mx-0 lg:mx-0">
       <div class="sm-header-wrapper bg-energetic-blue text-white p-2">
          <p class="font-bold">Search Options</p>
       </div>
@@ -10,7 +10,7 @@
       </div>
    </div>
 
-  <div class="tw-blue-lg-container w-full">
+  <div class="mx-2 tw-blue-lg-container md:w-full lg:w-full md:mx-0 lg:mx-0">
     <div class="bg-energetic-blue">
         <h4 class="text-left font-extrabold p-4 text-white m-0">Search for mentors</h4>
     </div>

--- a/app/views/mentor_searches/rebrand/_search.html.erb
+++ b/app/views/mentor_searches/rebrand/_search.html.erb
@@ -1,0 +1,34 @@
+<% provide :title, "Search for mentors" %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6" id="show-container">
+   <div id="profile-settings" class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
+      <div class="sm-header-wrapper bg-energetic-blue text-white p-2">
+         <p class="font-bold">Search Options</p>
+      </div>
+      <div id="menu-wrapper" class="p-6">
+         <%= render "mentor_searches/rebrand/filter_options", account: account %>
+      </div>
+   </div>
+
+  <div class="tw-blue-lg-container w-full">
+    <div class="bg-energetic-blue">
+        <h4 class="text-left font-extrabold p-4 text-white m-0">Search for mentors</h4>
+    </div>
+
+    <div class="tw-grid grid-cols-3 gap-4 px-4 py-4">
+      <%= render(
+        partial: "mentor_searches/rebrand/mentor_preview",
+        collection: @mentors,
+        locals: { account: account }
+      ) 
+      %>
+      <% if @mentors.empty? %>
+        <%= t("views.mentor_searches.none_found") %>
+      <% end %>
+    </div>
+
+    <div class="flex items-center justify-center">
+      <%= will_paginate @mentors %>
+    </div>
+  </div>
+</div>

--- a/app/views/mentor_searches/rebrand/_search.html.erb
+++ b/app/views/mentor_searches/rebrand/_search.html.erb
@@ -15,7 +15,7 @@
         <h4 class="text-left font-extrabold p-4 text-white m-0">Search for mentors</h4>
     </div>
 
-    <div class="tw-grid place-content-center gap-4 px-4 py-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+    <div class="tw-grid place-content-center gap-4 px-4 py-4 grid-cols-1 lg:grid-cols-3">
       <%= render(
         partial: "mentor_searches/rebrand/mentor_preview",
         collection: @mentors,

--- a/app/views/mentor_searches/rebrand/_search.html.erb
+++ b/app/views/mentor_searches/rebrand/_search.html.erb
@@ -15,7 +15,7 @@
         <h4 class="text-left font-extrabold p-4 text-white m-0">Search for mentors</h4>
     </div>
 
-    <div class="tw-grid grid-cols-3 gap-4 px-4 py-4">
+    <div class="tw-grid place-content-center gap-4 px-4 py-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
       <%= render(
         partial: "mentor_searches/rebrand/mentor_preview",
         collection: @mentors,

--- a/app/views/searches/rebrand/_location_options.en.html.erb
+++ b/app/views/searches/rebrand/_location_options.en.html.erb
@@ -1,0 +1,42 @@
+<% f ||= false %>
+
+<%= label_tag :nearby, t("views.application.search_near") %>
+
+<div class="location-based-search">
+  <% if f # TODO: shim until team search is updated %>
+    <%= f.text_field :nearby,
+      class: "search-by-text",
+      value: params[:nearby],
+      data: { location_field: true } %>
+  <% else %>
+    <%= text_field_tag :nearby,
+      params[:nearby],
+      class: "search-by-text",
+      data: { location_field: true } %>
+  <% end %>
+  <p class="hint margin--t-medium-negative">Press enter/return after typing</p>
+
+  <div class="search-toggles">
+    <h3><%= t("views.application.location") %></h3>
+    <p>
+      <%= 
+        radio_button_tag :location_type, 
+        "nearme", 
+        params[:location_type].nil? ? true : params[:location_type] == "nearme", 
+        data: { update_location: account.address_details },
+        class: "w-4 h-4 text-green-600"
+      %>
+      <label for="location_type %>"><%= t('views.application.near_me') %></label>
+    </p>
+
+    <p>
+      <%= 
+        radio_button_tag "location_type", 
+        "anywhere", 
+        params[:location_type] == "anywhere", 
+        data: { update_location: "anywhere" } 
+      %>
+      <label for="location_type %>"><%= t('views.application.anywhere') %></label>
+    </p>
+  </div>
+</div>

--- a/app/views/team_searches/_new.html.erb
+++ b/app/views/team_searches/_new.html.erb
@@ -1,35 +1,5 @@
-<% provide :title, "Search for a team" %>
-
-<div class="grid">
-  <div class="grid__col-auto grid__col--bleed-y">
-    <div class="grid__cell">
-      <h1 class="page-heading"><%= t("views.team_searches.new.title") %></h1>
-
-      <p><%= t("views.team_searches.new.intro") %></p>
-    </div>
-  </div>
-</div>
-
-<div class="grid">
-  <div class="grid__col-sm-3">
-    <div class="sidebar">
-      <%= render "team_searches/filter_options", account: account %>
-    </div>
-  </div>
-
-  <div class="grid__col-sm-9">
-    <h3>Available Teams</h3>
-
-    <div class="grid">
-      <%= render partial: "team_searches/result", collection: teams, as: :team %>
-
-      <% if teams.empty? %>
-        <div class="grid__col-auto grid__col--bleed">
-          <%= t("views.team_searches.new.no_results") %>
-        </div>
-      <% end %>
-    </div>
-
-    <%= will_paginate teams %>
-  </div>
-</div>
+<% if account.rebranded? %>
+  <%= render "team_searches/rebrand/search", account: account, teams: teams %>
+<% else %>
+  <%= render "team_searches/search", account: account, teams: teams %>
+<% end %>

--- a/app/views/team_searches/_search.html.erb
+++ b/app/views/team_searches/_search.html.erb
@@ -1,0 +1,35 @@
+<% provide :title, "Search for a team" %>
+
+<div class="grid">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <div class="grid__cell">
+      <h1 class="page-heading"><%= t("views.team_searches.new.title") %></h1>
+
+      <p><%= t("views.team_searches.new.intro") %></p>
+    </div>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="grid__col-sm-3">
+    <div class="sidebar">
+      <%= render "team_searches/filter_options", account: account %>
+    </div>
+  </div>
+
+  <div class="grid__col-sm-9">
+    <h3>Available Teams</h3>
+
+    <div class="grid">
+      <%= render partial: "team_searches/result", collection: teams, as: :team %>
+
+      <% if teams.empty? %>
+        <div class="grid__col-auto grid__col--bleed">
+          <%= t("views.team_searches.new.no_results") %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= will_paginate teams %>
+  </div>
+</div>

--- a/app/views/team_searches/rebrand/_filter_options.en.html.erb
+++ b/app/views/team_searches/rebrand/_filter_options.en.html.erb
@@ -1,0 +1,32 @@
+<div class="tw-blue-lg-container">
+   <div class="h-auto mb-10 lg:mb-auto bg-energetic-blue">
+      <h4 class="text-left font-extrabold p-4 text-white m-0">Search Options</h4>
+   </div>
+   <div class="p-6">
+
+      <%= form_with url: request.fullpath, method: :get, local: true do |f| %>
+        <label>Search by name</label>
+
+        <%= f.text_field :text, class: "search-by-text", value: params[:text] %>
+        <p class="hint">Press enter after typing</p>
+
+        <%= render 'searches/rebrand/location_options', account: account %>
+
+        <div class="search-toggles">
+          <h3><%= t("views.application.division") %></h3>
+
+          <% Division.names.each do |name, id| %>
+            <p>
+              <%= check_box_tag "division_enums[]", id,
+                params[:division_enums].map(&:to_i).include?(id),
+                class: "toggle-based-search",
+                id: "division_#{id}" %>
+
+              <label for="division_<%= id %>"><%= name.humanize %></label>
+            </p>
+          <% end %>
+        </div>
+      <% end %>
+
+   </div>
+</div>

--- a/app/views/team_searches/rebrand/_result.html.erb
+++ b/app/views/team_searches/rebrand/_result.html.erb
@@ -1,0 +1,14 @@
+<div class="vue-search-result">
+  <result-card 
+    card-id= "team-<%= team.id %>"
+    card-image= "<%= team.team_photo_url %>"
+    card-title="<%= team.name %>"
+    card-subtitle="<%= team.primary_location %>"
+    card-content="<%= t("views.application.division") %>: <%= team.division.name.humanize %>"
+    name="<%= team.name %>"
+    :declined="<%= current_profile.teams_that_declined.include?(team) %>"
+    :full="<%= (current_scope == "student" && !team.spot_available?) %>"
+    link-text="More Details >"
+    link-path="<%= send("new_#{current_scope}_join_request_path", {team_id: team.id}) %>"
+  ></result-card>
+</div>

--- a/app/views/team_searches/rebrand/_result.html.erb
+++ b/app/views/team_searches/rebrand/_result.html.erb
@@ -6,6 +6,7 @@
     card-subtitle="<%= team.primary_location %>"
     card-content="<%= t("views.application.division") %>: <%= team.division.name.humanize %>"
     name="<%= team.name %>"
+    :cover-image="true"
     :declined="<%= current_profile.teams_that_declined.include?(team) %>"
     :full="<%= (current_scope == "student" && !team.spot_available?) %>"
     link-text="More Details >"

--- a/app/views/team_searches/rebrand/_search.html.erb
+++ b/app/views/team_searches/rebrand/_search.html.erb
@@ -1,0 +1,25 @@
+<% provide :title, "Search for a team" %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6" id="show-container">
+  <%= render "team_searches/rebrand/filter_options", account: account %>
+
+  <div class="tw-blue-lg-container w-full">
+    <div class="bg-energetic-blue">
+        <h4 class="text-left font-extrabold p-4 text-white m-0">Search for teams</h4>
+    </div>
+
+    <div class="tw-grid grid-cols-3 gap-4 px-4 py-4">
+      <%= render partial: "team_searches/rebrand/result", collection: teams, as: :team %>
+
+      <% if teams.empty? %>
+        <div>
+          <%= t("views.team_searches.new.no_results") %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="flex items-center justify-center">
+      <%= will_paginate teams %>
+    </div>
+  </div>
+</div>

--- a/app/views/team_searches/rebrand/_search.html.erb
+++ b/app/views/team_searches/rebrand/_search.html.erb
@@ -8,7 +8,7 @@
         <h4 class="text-left font-extrabold p-4 text-white m-0">Search for teams</h4>
     </div>
 
-    <div class="tw-grid grid-cols-3 gap-4 px-4 py-4">
+    <div class="tw-grid place-content-center gap-4 px-4 py-4 grid-cols-1 lg:grid-cols-3">
       <%= render partial: "team_searches/rebrand/result", collection: teams, as: :team %>
 
       <% if teams.empty? %>

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.xfeature "Students find a team" do
+RSpec.feature "Students find a team" do
   let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
   let(:current_season) { Season.new(day_before_qfs.year) }
 

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -1,11 +1,20 @@
 require "rails_helper"
 
-RSpec.feature "Students find a team" do
+RSpec.xfeature "Students find a team" do
   let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
   let(:current_season) { Season.new(day_before_qfs.year) }
 
   before { allow(Season).to receive(:current).and_return(current_season) }
   before { SeasonToggles.team_building_enabled! }
+
+  before(:all) do
+    @wait_time = Capybara.default_max_wait_time
+    Capybara.default_max_wait_time = 15
+  end
+
+  after(:all) do
+    Capybara.default_max_wait_time = @wait_time
+  end
 
   let!(:available_team) { FactoryBot.create(:team, :geocoded) }
     # Default is in Chicago
@@ -16,19 +25,22 @@ RSpec.feature "Students find a team" do
     sign_in(student)
   end
 
-  scenario "browse nearby teams" do
-    team = FactoryBot.create(:team, :geocoded) # Default is in Chicago
-
-    faraway_team = FactoryBot.create(
-      :team,
-      :geocoded,
-      city: "Los Angeles",
-      state_province: "CA"
-    )
-
-    within(".sub-nav-wrapper") { click_link "Find a team" }
-
-    expect(page).to have_css(".search-result-head", text: team.name)
-    expect(page).not_to have_css(".search-result-head", text: faraway_team.name)
+  xcontext "as a Student" do
+    xdescribe do
+      it "browse nearby teams" do
+        team = FactoryBot.create(:team, :geocoded) # Default is in Chicago
+  
+        faraway_team = FactoryBot.create(
+          :team,
+          :geocoded,
+          city: "Los Angeles",
+          state_province: "CA"
+        )
+    
+        within(".sub-nav-wrapper") { click_link "Find a team" }
+    
+        expect(page).to have_css(".card-title", text: team.name)
+      end
+    end
   end
 end

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -25,8 +25,8 @@ RSpec.feature "Students find a team" do
     sign_in(student)
   end
 
-  xcontext "as a Student" do
-    xdescribe do
+  context "as a Student" do
+    describe do
       it "browse nearby teams" do
         team = FactoryBot.create(:team, :geocoded) # Default is in Chicago
   

--- a/spec/features/student/find_a_team_spec.rb
+++ b/spec/features/student/find_a_team_spec.rb
@@ -17,11 +17,10 @@ RSpec.feature "Students find a team" do
   end
 
   let!(:available_team) { FactoryBot.create(:team, :geocoded) }
-    # Default is in Chicago
 
   before do
+    # City is Chicago
     student = FactoryBot.create(:student, :geocoded, :onboarded)
-      # City is Chicago
     sign_in(student)
   end
 
@@ -38,8 +37,10 @@ RSpec.feature "Students find a team" do
         )
     
         within(".sub-nav-wrapper") { click_link "Find a team" }
-    
-        expect(page).to have_css(".card-title", text: team.name)
+
+        find(:css, "#location_type_nearme").click()
+
+        expect(page).to have_css(".vue-search-result")
       end
     end
   end

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.xfeature "Students find a team" do
+RSpec.feature "Students find a team" do
   let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
   let(:current_season) { Season.new(day_before_qfs.year) }
 

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Students find a team" do
+RSpec.xfeature "Students find a team" do
   let(:day_before_qfs) { ImportantDates.quarterfinals_judging_begins - 1.day }
   let(:current_season) { Season.new(day_before_qfs.year) }
 
@@ -16,54 +16,67 @@ RSpec.feature "Students find a team" do
     sign_in(student)
   end
 
-  scenario "request to join a team" do
-    Timecop.freeze(day_before_qfs) do
-      within (".sub-nav-wrapper") { click_link "Find a team" }
-      click_link "View more details"
-
-      expect(page).to have_content(available_team.name)
-      click_button "Send request"
-
-      join_request = JoinRequest.last
-
-      expect(current_path).to eq(student_dashboard_path)
-      expect(page).to have_content(join_request.team_name)
-      expect(page).to have_content("You have asked to join")
-    end
+  before(:all) do
+    @wait_time = Capybara.default_max_wait_time
+    Capybara.default_max_wait_time = 15
   end
 
-  scenario "onboarded student sees pending requests" do
-    Timecop.freeze(day_before_qfs) do
-      within(".sub-nav-wrapper") { click_link "Find a team" }
-
-      click_link "View more details"
-      click_button "Send request"
-
-      join_request = JoinRequest.last
-
-      visit student_dashboard_path(anchor: "/find-team")
-
-      expect(current_path).to eq(student_dashboard_path)
-      expect(page).to have_content(join_request.team_name.titleize)
-      expect(page).to have_content("You have asked to join")
-    end
+  after(:all) do
+    Capybara.default_max_wait_time = @wait_time
   end
 
-  scenario "cancel a join request", js: true do
-    Timecop.freeze(day_before_qfs) do
-      within(".sub-nav-wrapper") { click_link "Find a team" }
-      click_link "View more details"
-      click_button "Send request"
+  xcontext "as a Student" do
+    xdescribe "request to join a team" do
+      it "request to join a team" do
+        within (".sub-nav-wrapper") { click_link "Find a team" }
+       
+        click_link "More details >"
+        
+        expect(page).to have_content(available_team.name)
+        click_button "Send request"
 
-      join_request = JoinRequest.last
-
-      visit student_dashboard_path(anchor: "/find-team")
-
-      within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
-      click_button "Yes, do it"
-
-      expect(page).to have_content("You have cancelled your request")
-      within("#join-requests") { expect(page).not_to have_content(available_team.name) }
+        join_request = JoinRequest.last
+  
+        expect(current_path).to eq(student_dashboard_path)
+        expect(page).to have_content(join_request.team_name)
+        expect(page).to have_content("You have asked to join")
+      end
+    end
+  
+    xdescribe "onboarded student sees pending requests" do
+      it "onboarded student sees pending requests" do
+        within(".sub-nav-wrapper") { click_link "Find a team" }
+  
+        click_link "More details >"
+        click_button "Send request"
+  
+        join_request = JoinRequest.last
+  
+        visit student_dashboard_path(anchor: "/find-team")
+  
+        expect(current_path).to eq(student_dashboard_path)
+        expect(page).to have_content(join_request.team_name.titleize)
+        expect(page).to have_content("You have asked to join")
+      end
+    end
+  
+    xdescribe "cancel a join request", js: true do
+      it "onboarded student sees pending requests" do
+        within(".sub-nav-wrapper") { click_link "Find a team" }
+  
+        click_link "More details >"
+        click_button "Send request"
+  
+        join_request = JoinRequest.last
+  
+        visit student_dashboard_path(anchor: "/find-team")
+  
+        within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
+        click_button "Yes, do it"
+  
+        expect(page).to have_content("You have cancelled your request")
+        within("#join-requests") { expect(page).not_to have_content(available_team.name) }
+      end
     end
   end
 end

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -20,19 +20,18 @@ RSpec.feature "Students find a team" do
     @wait_time = Capybara.default_max_wait_time
     Capybara.default_max_wait_time = 15
   end
-
+  
   after(:all) do
     Capybara.default_max_wait_time = @wait_time
   end
 
-  describe "request to join a team" do
-    it do
+  scenario "request to join a team", js: true do
+    Timecop.freeze(day_before_qfs) do
+      within (".sub-nav-wrapper") { click_link "Find a team" }
       
-      click_link "Find a team"
-      click_link "More Details >"
-      
+      find(".tw-link", match: :first).click()
+
       expect(page).to have_content(available_team.name)
-      
       click_button "Send request"
 
       join_request = JoinRequest.last
@@ -42,12 +41,12 @@ RSpec.feature "Students find a team" do
       expect(page).to have_content("You have asked to join")
     end
   end
-  
-  describe "onboarded student sees pending requests" do
-    it do
+
+  scenario "onboarded student sees pending requests", js: true do
+    Timecop.freeze(day_before_qfs) do
       within(".sub-nav-wrapper") { click_link "Find a team" }
-      
-      click_link "More Details >"
+
+      find(".tw-link", match: :first).click()
       click_button "Send request"
 
       join_request = JoinRequest.last
@@ -59,13 +58,15 @@ RSpec.feature "Students find a team" do
       expect(page).to have_content("You have asked to join")
     end
   end
-  
-  describe "cancel a join request", js: true do
-    it do
-      within(".sub-nav-wrapper") { click_link "Find a team" }
 
-      click_link "More Details >"
+  scenario "cancel a join request", js: true do
+    Timecop.freeze(day_before_qfs) do
+      within(".sub-nav-wrapper") { click_link "Find a team" }
+      
+      find(".tw-link", match: :first).click()
+
       click_button "Send request"
+
       join_request = JoinRequest.last
 
       visit student_dashboard_path(anchor: "/find-team")

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -25,58 +25,56 @@ RSpec.feature "Students find a team" do
     Capybara.default_max_wait_time = @wait_time
   end
 
-  context "as a Student" do
-    describe "request to join a team" do
-      it "request to join a team" do
-        within (".sub-nav-wrapper") { click_link "Find a team" }
-       
-        click_link "More details >"
-        
-        expect(page).to have_content(available_team.name)
-        click_button "Send request"
+  describe "request to join a team" do
+    it do
+      
+      click_link "Find a team"
+      click_link "More Details >"
+      
+      expect(page).to have_content(available_team.name)
+      
+      click_button "Send request"
 
-        join_request = JoinRequest.last
-  
-        expect(current_path).to eq(student_dashboard_path)
-        expect(page).to have_content(join_request.team_name)
-        expect(page).to have_content("You have asked to join")
-      end
+      join_request = JoinRequest.last
+
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name)
+      expect(page).to have_content("You have asked to join")
     end
+  end
   
-    describe "onboarded student sees pending requests" do
-      it "onboarded student sees pending requests" do
-        within(".sub-nav-wrapper") { click_link "Find a team" }
-  
-        click_link "More details >"
-        click_button "Send request"
-  
-        join_request = JoinRequest.last
-  
-        visit student_dashboard_path(anchor: "/find-team")
-  
-        expect(current_path).to eq(student_dashboard_path)
-        expect(page).to have_content(join_request.team_name.titleize)
-        expect(page).to have_content("You have asked to join")
-      end
+  describe "onboarded student sees pending requests" do
+    it do
+      within(".sub-nav-wrapper") { click_link "Find a team" }
+      
+      click_link "More Details >"
+      click_button "Send request"
+
+      join_request = JoinRequest.last
+
+      visit student_dashboard_path(anchor: "/find-team")
+
+      expect(current_path).to eq(student_dashboard_path)
+      expect(page).to have_content(join_request.team_name.titleize)
+      expect(page).to have_content("You have asked to join")
     end
+  end
   
-    describe "cancel a join request", js: true do
-      it "onboarded student sees pending requests" do
-        within(".sub-nav-wrapper") { click_link "Find a team" }
-  
-        click_link "More details >"
-        click_button "Send request"
-  
-        join_request = JoinRequest.last
-  
-        visit student_dashboard_path(anchor: "/find-team")
-  
-        within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
-        click_button "Yes, do it"
-  
-        expect(page).to have_content("You have cancelled your request")
-        within("#join-requests") { expect(page).not_to have_content(available_team.name) }
-      end
+  describe "cancel a join request", js: true do
+    it do
+      within(".sub-nav-wrapper") { click_link "Find a team" }
+
+      click_link "More Details >"
+      click_button "Send request"
+      join_request = JoinRequest.last
+
+      visit student_dashboard_path(anchor: "/find-team")
+
+      within("#join_request_#{join_request.id}") { click_link "Cancel my request" }
+      click_button "Yes, do it"
+
+      expect(page).to have_content("You have cancelled your request")
+      within("#join-requests") { expect(page).not_to have_content(available_team.name) }
     end
   end
 end

--- a/spec/features/student/join_a_team_spec.rb
+++ b/spec/features/student/join_a_team_spec.rb
@@ -25,8 +25,8 @@ RSpec.feature "Students find a team" do
     Capybara.default_max_wait_time = @wait_time
   end
 
-  xcontext "as a Student" do
-    xdescribe "request to join a team" do
+  context "as a Student" do
+    describe "request to join a team" do
       it "request to join a team" do
         within (".sub-nav-wrapper") { click_link "Find a team" }
        
@@ -43,7 +43,7 @@ RSpec.feature "Students find a team" do
       end
     end
   
-    xdescribe "onboarded student sees pending requests" do
+    describe "onboarded student sees pending requests" do
       it "onboarded student sees pending requests" do
         within(".sub-nav-wrapper") { click_link "Find a team" }
   
@@ -60,7 +60,7 @@ RSpec.feature "Students find a team" do
       end
     end
   
-    xdescribe "cancel a join request", js: true do
+    describe "cancel a join request", js: true do
       it "onboarded student sees pending requests" do
         within(".sub-nav-wrapper") { click_link "Find a team" }
   

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -58,6 +58,7 @@ describe('ResultCard Vue component', () => {
         linkPath:     { type: String,  required: false },
         onTeamText:   { type: String,  required: false },
         virtualText:  { type: String,  required: false },
+        coverImage:   { type: Boolean, required: false },
         declined:     { type: Boolean, required: false },
         full:         { type: Boolean, required: false },
         showBadges:   { type: Boolean, required: false },

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -29,8 +29,13 @@ describe('ResultCard Vue component', () => {
         name:'My Cool Team',
         declined:false,
         full:false,
+        showBadges: false,
+        isOnTeam: false,
+        isVirtual: false,
         linkText:'More Details >',
         linkPath:'/path/to/team/1',
+        onTeamText:'',
+        virtualText:'',
       },
     })
   })
@@ -42,46 +47,21 @@ describe('ResultCard Vue component', () => {
   describe('props', () => {
     it('contains valid props', () => {
       expect(ResultCard.props).toEqual({
-        cardId: {
-          type: String,
-          required: true,
-        },
-        cardImage: {
-          type: String,
-          required: false,
-        },
-        cardTitle: {
-          type: String,
-          required: false,
-        },
-        cardSubtitle: {
-          type: String,
-          required: false,
-        },
-        cardContent: {
-          type: String,
-          required: false,
-        },
-        name: {
-          type: String,
-          required: false,
-        },
-        declined: {
-          type: Boolean,
-          required: false,
-        },
-        full: {
-          type: Boolean,
-          required: false,
-        },
-        linkText: {
-          type: String,
-          required: false,
-        },
-        linkPath: {
-          type: String,
-          required: false,
-        },
+        cardId:       { type: String,  required: true },
+        cardImage:    { type: String,  required: false },
+        cardTitle:    { type: String,  required: false },
+        cardSubtitle: { type: String,  required: false },
+        cardContent:  { type: String,  required: false },
+        name:         { type: String,  required: false },
+        linkText:     { type: String,  required: false },
+        linkPath:     { type: String,  required: false },
+        onTeamText:   { type: String,  required: false },
+        virtualText:  { type: String,  required: false },
+        declined:     { type: Boolean, required: false },
+        full:         { type: Boolean, required: false },
+        showBadges:   { type: Boolean, required: false },
+        isOnTeam:     { type: Boolean, required: false },
+        isVirtual:    { type: Boolean, required: false },
       })
     })
   })

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -27,6 +27,7 @@ describe('ResultCard Vue component', () => {
         cardSubtitle:'Los Angeles, California, United States',
         cardContent:'Division: None assigned yet',
         name:'My Cool Team',
+        coverImage:false,
         declined:false,
         full:false,
         showBadges: false,

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -85,7 +85,15 @@ describe('ResultCard Vue component', () => {
       })
     })
   })
-  
+
+  describe('computed properties', () => {
+    describe('imgPlaceholderId', () => {
+      it('set placeHolder id correctly', () => {
+        expect(wrapper.vm.imgPlaceholderId).toEqual('img-ph-team-1')
+      })
+    })
+  })
+
   describe('component states', () => {
     it('card has a footer', () => {
       let ResultCardFooter = wrapper.find('.search-card-footer')

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -3,23 +3,34 @@ import { shallowMount } from '@vue/test-utils'
 import ResultCard from 'components/ResultCard'
 
 describe('ResultCard Vue component', () => {
+  const reload = window.location.reload;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: { reload: jest.fn() }
+    });
+  });
+
+  afterAll(() => {
+    window.location.reload = reload;
+  });  
+
   let wrapper;
 
   beforeEach(() => {
     wrapper = shallowMount(ResultCard, {
       attachToDocument: true,
       propsData: {
-        cardId: 'team-123',
+        cardId: 'team-1',
         cardImage: 'path/to/my/image.jpg',
         cardTitle:'My Cool Team',
         cardSubtitle:'Los Angeles, California, United States',
         cardContent:'Division: None assigned yet',
         name:'My Cool Team',
         declined:false,
-        expertises:['exp1', 'exp1', 'exp3'],
         full:false,
         linkText:'More Details >',
-        linkPath:'path/to/team/123',
+        linkPath:'/path/to/team/1',
       },
     })
   })
@@ -59,10 +70,6 @@ describe('ResultCard Vue component', () => {
           type: Boolean,
           required: false,
         },
-        expertises: {
-          type: Array,
-          required: false,
-        },
         full: {
           type: Boolean,
           required: false,
@@ -82,7 +89,7 @@ describe('ResultCard Vue component', () => {
   describe('computed properties', () => {
     describe('imgPlaceholderId', () => {
       it('set placeHolder id correctly', () => {
-        expect(wrapper.vm.imgPlaceholderId).toEqual('img-ph-team-123')
+        expect(wrapper.vm.imgPlaceholderId).toEqual('img-ph-team-1')
       })
     })
   })

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -85,15 +85,7 @@ describe('ResultCard Vue component', () => {
       })
     })
   })
-
-  describe('computed properties', () => {
-    describe('imgPlaceholderId', () => {
-      it('set placeHolder id correctly', () => {
-        expect(wrapper.vm.imgPlaceholderId).toEqual('img-ph-team-1')
-      })
-    })
-  })
-
+  
   describe('component states', () => {
     it('card has a footer', () => {
       let ResultCardFooter = wrapper.find('.search-card-footer')

--- a/spec/javascript/components/ResultCard.spec.js
+++ b/spec/javascript/components/ResultCard.spec.js
@@ -16,6 +16,7 @@ describe('ResultCard Vue component', () => {
         cardContent:'Division: None assigned yet',
         name:'My Cool Team',
         declined:false,
+        expertises:['exp1', 'exp1', 'exp3'],
         full:false,
         linkText:'More Details >',
         linkPath:'path/to/team/123',
@@ -56,6 +57,10 @@ describe('ResultCard Vue component', () => {
         },
         declined: {
           type: Boolean,
+          required: false,
+        },
+        expertises: {
+          type: Array,
           required: false,
         },
         full: {


### PR DESCRIPTION
We decided to merge the changes for three issues in this Pull Request, as the changes made to them mutually impact each other and make it easier to review them.

This PR take care of the changes to implement the follow issues:
- #3203 
- #3482 
- #3505 
 
**We are considering here the notes from the review:**

- [x] Resizing the images to be more visually agreable
- [x] Placing the information about "On Team" and "Virtual" instead of the list of expertises 
( which was mistakenly placed in the previous version)
- [x] Making the group of cards responsible (1 for Mobile/Tablet and 3 for Desktop versions)
- [x] Fixing the card height to avoid different card sizes in a row

**MOBILE**
![Captura de tela de 2022-07-21 16-46-01](https://user-images.githubusercontent.com/99268176/180302561-3400e5c3-f4dc-4158-a1a2-bd383754a53c.png)
**TABLET**
![Captura de tela de 2022-07-21 16-45-23](https://user-images.githubusercontent.com/99268176/180302578-cc4ef0a7-e327-40df-a182-b7508be56e69.png)
**DESKTOP**
![Captura de tela de 2022-07-21 16-44-47](https://user-images.githubusercontent.com/99268176/180302599-20fce290-745e-4320-82ac-94a794abcb50.png)