### PR TITLE
Allow admins to control judge registration option

### DIFF
--- a/app/controllers/api/registration_settings_controller.rb
+++ b/app/controllers/api/registration_settings_controller.rb
@@ -3,7 +3,8 @@ module Api
     def index
       render json: {
         isStudentRegistrationOpen: SeasonToggles.student_registration_open?,
-        isMentorRegistrationOpen: SeasonToggles.mentor_registration_open?
+        isMentorRegistrationOpen: SeasonToggles.mentor_registration_open?,
+        isJudgeRegistrationOpen: SeasonToggles.judge_registration_open?
       }
     end
   end

--- a/app/javascript/new_registration/components/StepOne.vue
+++ b/app/javascript/new_registration/components/StepOne.vue
@@ -59,6 +59,7 @@ export default {
       profileTypes: [],
       isStudentRegistrationOpen: false,
       isMentorRegistrationOpen: false,
+      isJudgeRegistrationOpen: false,
       anyDisabledProfileTypes: false,
       disabledProfileTypes: '',
       hasValidationErrors: true
@@ -71,6 +72,7 @@ export default {
 
         this.isStudentRegistrationOpen = response.data.isStudentRegistrationOpen
         this.isMentorRegistrationOpen = response.data.isMentorRegistrationOpen
+        this.isJudgeRegistrationOpen = response.data.isJudgeRegistrationOpen
       }
       catch(error) {
         airbrake.notify({
@@ -88,7 +90,9 @@ export default {
         this.profileTypes.push(this.mentorProfileType())
       }
 
-      this.profileTypes.push(this.judgeProfileType())
+      if (this.isJudgeRegistrationOpen) {
+        this.profileTypes.push(this.judgeProfileType())
+      }
     },
     setupDisabledProfileTypes() {
       let disabledProfiles = []
@@ -99,6 +103,10 @@ export default {
 
       if (!this.isMentorRegistrationOpen) {
         disabledProfiles.push('mentors')
+      }
+
+      if (!this.isJudgeRegistrationOpen) {
+        disabledProfiles.push('judges')
       }
 
       if (disabledProfiles.length > 0) {

--- a/spec/system/api/registration_settings_spec.rb
+++ b/spec/system/api/registration_settings_spec.rb
@@ -1,15 +1,17 @@
 require "rails_helper"
 
 RSpec.describe "Registration Settings" do
-  let(:registration_open) { true }
   let(:student_registration_open) { true }
   let(:mentor_registration_open) { true }
+  let(:judge_registration_open) { true }
 
   before do
     allow(SeasonToggles).to receive(:student_registration_open?)
       .and_return(student_registration_open)
     allow(SeasonToggles).to receive(:mentor_registration_open?)
       .and_return(mentor_registration_open)
+    allow(SeasonToggles).to receive(:judge_registration_open?)
+      .and_return(judge_registration_open)
   end
 
   it "returns registration settings" do
@@ -18,7 +20,8 @@ RSpec.describe "Registration Settings" do
     expect(JSON.parse(response.body)).to eq(
       {
         "isStudentRegistrationOpen" => student_registration_open,
-        "isMentorRegistrationOpen" => mentor_registration_open
+        "isMentorRegistrationOpen" => mentor_registration_open,
+        "isJudgeRegistrationOpen" => judge_registration_open
       }
     )
   end

--- a/spec/system/registration/profile_selection_spec.rb
+++ b/spec/system/registration/profile_selection_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Registration Step 1 - Selecting a Profile", :js do
+  context "when registration is open" do
+    before do
+      allow(SeasonToggles).to receive(:registration_closed?).and_return(false)
+    end
+
+    context "when student registration is open" do
+      before do
+        allow(SeasonToggles).to receive(:student_registration_open?).and_return(true)
+      end
+
+      it "displays student registration options" do
+        visit signup_path
+
+        expect(page).to have_content("I am registering myself and am 13-18 years old")
+        expect(page).to have_content("I am registering my 8-12 year old* daughter")
+      end
+    end
+
+    context "when student registration is closed" do
+      before do
+        allow(SeasonToggles).to receive(:student_registration_open?).and_return(false)
+      end
+      it "does not display student registration options" do
+        visit signup_path
+
+        expect(page).not_to have_content("I am registering myself and am 13-18 years old")
+        expect(page).not_to have_content("I am registering my 8-12 year old* daughter")
+      end
+    end
+
+    context "when mentor registration is open" do
+      before do
+        allow(SeasonToggles).to receive(:mentor_registration_open?).and_return(true)
+      end
+
+      it "displays a mentor registration option" do
+        visit signup_path
+
+        expect(page).to have_content("I am over 18 years old and will guide a team")
+      end
+    end
+
+    context "when mentor registration is closed" do
+      before do
+        allow(SeasonToggles).to receive(:mentor_registration_open?).and_return(false)
+      end
+
+      it "does not display a mentor registration option" do
+        visit signup_path
+
+        expect(page).not_to have_content("I am over 18 years old and will guide a team")
+      end
+    end
+
+    context "when judge registration is open" do
+      before do
+        allow(SeasonToggles).to receive(:judge_registration_open?).and_return(true)
+      end
+
+      it "displays a judge registration option" do
+        visit signup_path
+
+        expect(page).to have_content("I am over 18 years old and will judge submissions")
+      end
+    end
+
+    context "when judge registration is closed" do
+      before do
+        allow(SeasonToggles).to receive(:judge_registration_open?).and_return(false)
+      end
+
+      it "does not display a judge registration option" do
+        visit signup_path
+
+        expect(page).not_to have_content("I am over 18 years old and will judge submissions")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the last piece to get the frontend judge registration options hooked up to the admin controls. Basically, the admin controls for "judge registration" will now control whether or not judges can register.