### PR TITLE
Updates to homepage text when judging is enabled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,4 +91,16 @@ module ApplicationHelper
     )
     web_icon(*args)
   end
+
+  def determine_homepage_content
+    if SeasonToggles.judging_enabled_or_between?
+      render partial: "judging_open_splash"
+    elsif SeasonToggles.judging_finished?
+      render partial: "off_season_splash"
+    elsif SeasonToggles.registration_open?
+      render partial: "landing"
+    else
+      render partial: "off_season_splash"
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,8 +95,6 @@ module ApplicationHelper
   def determine_homepage_content
     if SeasonToggles.judging_enabled_or_between?
       render partial: "judging_open_splash"
-    elsif SeasonToggles.judging_finished?
-      render partial: "off_season_splash"
     elsif SeasonToggles.registration_open?
       render partial: "landing"
     else

--- a/app/views/application/_judging_open_splash.en.html.erb
+++ b/app/views/application/_judging_open_splash.en.html.erb
@@ -1,17 +1,21 @@
-<div class="font-bold text-center mb-8">
+<div class="font-bold text-center mb-4">
   <h1 class="text-4xl">Technovation Girls</h1>
-
-  <h2 class="text-3xl text-tg-magenta">Registration is currently open for judges</h2>
 </div>
 
-<p class="mb-4">
-  Thank you for your interest in Technovation Girls. Register
-  <%= link_to "here",
-              signup_path,
-              data: { turbolinks: false },
-              class: "tw-link"%>
-  to judge projects.
-</p>
+<% if SeasonToggles.judge_registration_open? %>
+  <h2 class="text-3xl text-tg-magenta font-bold text-center mb-4">Registration is currently open for judges</h2>
+
+  <p class="mb-4">
+    Thank you for your interest in Technovation Girls. Register
+    <%= link_to "here",
+                signup_path,
+                data: { turbolinks: false },
+                class: "tw-link"%>
+    to judge projects.
+  </p>
+<% else%>
+  <h2 class="text-3xl text-tg-magenta font-bold text-center mb-4">Judging is open</h2>
+<% end %>
 
 <p class="mb-4">
   Registration is currently closed for students and mentors,
@@ -19,7 +23,7 @@
   <%= link_to "log-in", login_path,
               data: { turbolinks: false },
               class: "tw-link" %>
-  and review their existing projects.
+  and review their existing projects. Existing judges may also log-in to finish judging submissions.
 </p>
 
 <p>

--- a/app/views/public/dashboards/show.en.html.erb
+++ b/app/views/public/dashboards/show.en.html.erb
@@ -5,14 +5,6 @@
 
 <div class="w-full lg:w-1/2 mx-auto border-2 shadow-md rounded">
   <div class="p-8">
-    <% if SeasonToggles.judging_enabled_or_between? %>
-      <%= render 'judging_open_splash' %>
-    <% elsif SeasonToggles.judging_finished? %>
-        <%= render 'off_season_splash' %>
-    <% elsif  SeasonToggles.registration_open? %>
-        <%= render 'landing' %>
-    <% else %>
-        <%= render 'off_season_splash' %>
-    <% end %>
+    <%= determine_homepage_content %>
   </div>
 </div>

--- a/app/views/public/dashboards/show.en.html.erb
+++ b/app/views/public/dashboards/show.en.html.erb
@@ -5,14 +5,14 @@
 
 <div class="w-full lg:w-1/2 mx-auto border-2 shadow-md rounded">
   <div class="p-8">
-    <% if SeasonToggles.registration_open? %>
-      <%= render 'landing' %>
-    <% else %>
-      <% if SeasonToggles.judging_finished? %>
+    <% if SeasonToggles.judging_enabled_or_between? %>
+      <%= render 'judging_open_splash' %>
+    <% elsif SeasonToggles.judging_finished? %>
         <%= render 'off_season_splash' %>
-      <% else %>
-        <%= render 'judging_open_splash' %>
-      <% end %>
+    <% elsif  SeasonToggles.registration_open? %>
+        <%= render 'landing' %>
+    <% else %>
+        <%= render 'off_season_splash' %>
     <% end %>
   </div>
 </div>

--- a/spec/features/admin/judging_open_splash_spec.rb
+++ b/spec/features/admin/judging_open_splash_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Judging open splash page" do
+  scenario "Judging is set to QF and judge registration is enabled" do
+    SeasonToggles.set_judging_round(:qf)
+    SeasonToggles.enable_signup(:judge)
+
+    visit root_path
+    expect(page).not_to have_css("#registration-landing")
+    expect(page).to have_content("Registration is currently open for judges")
+    expect(page).to have_content("Registration is currently closed for students and mentors")
+  end
+
+  scenario "Judging is set to QF and judge registration is enabled" do
+    SeasonToggles.set_judging_round(:qf)
+    SeasonToggles.disable_signups!
+
+    visit root_path
+    expect(page).not_to have_css("#registration-landing")
+    expect(page).to have_content("Judging is open")
+    expect(page).to have_content("Registration is currently closed for students and mentors")
+  end
+end

--- a/spec/features/admin/judging_open_splash_spec.rb
+++ b/spec/features/admin/judging_open_splash_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Judging open splash page" do
     expect(page).to have_content("Registration is currently closed for students and mentors")
   end
 
-  scenario "Judging is set to QF and judge registration is enabled" do
+  scenario "Judging is set to QF and judge registration is disabled" do
     SeasonToggles.set_judging_round(:qf)
     SeasonToggles.disable_signups!
 

--- a/spec/features/admin/off_season_splash_spec.rb
+++ b/spec/features/admin/off_season_splash_spec.rb
@@ -15,6 +15,6 @@ RSpec.feature "Off-season splash page" do
     SeasonToggles.disable_signups!
     visit root_path
     expect(page).not_to have_css("#registration-landing")
-    expect(page).to have_content("Registration is currently open for judges")
+    expect(page).to have_content("Registration is currently closed")
   end
 end


### PR DESCRIPTION
Refs #3544 

This change was needed due to the inaccurate judging open splash text on the homepage. Once the judge registration season toggles were completed, the logic on the homepage which determined what text was displayed became outdated. 

I decided to add a helper method `determine_homepage_content` in `app/helpers/application_helpers.rb` because the view for the homepage seemed heavy with all of the season toggle logic there. I also updated existing tests and added testing specs for `judging_open_splash`