### PR TITLE
Handle student invite form validation errors

### DIFF
--- a/app/controllers/concerns/team_member_invite_controller.rb
+++ b/app/controllers/concerns/team_member_invite_controller.rb
@@ -47,7 +47,15 @@ module TeamMemberInviteController
         )
       end
     else
-      render :new
+      if current_scope == "student"
+        @team = current_profile.teams.find(@team_member_invite.team.id)
+        @mentor_invite = MentorInvite.new(team_id: @team.id)
+        @uploader = ImageDirectUploader.new
+
+        render "student/teams/show"
+      else
+        render :new
+      end
     end
   end
 

--- a/app/controllers/concerns/team_member_invite_controller.rb
+++ b/app/controllers/concerns/team_member_invite_controller.rb
@@ -52,6 +52,7 @@ module TeamMemberInviteController
         @mentor_invite = MentorInvite.new(team_id: @team.id)
         @uploader = ImageDirectUploader.new
 
+        flash.now[:error] = t("controllers.team_member_invites.create.failure")
         render "student/teams/show"
       else
         render :new

--- a/app/controllers/student/team_member_invites_controller.rb
+++ b/app/controllers/student/team_member_invites_controller.rb
@@ -2,6 +2,10 @@ module Student
   class TeamMemberInvitesController < StudentController
     include TeamMemberInviteController
 
+    def index
+      redirect_to student_teams_path(current_student.team)
+    end
+
     def update
       invite = current_student.team_member_invites.pending.find_by(
         invite_token: params.fetch(:id)

--- a/app/views/student/teams/_mentors.html.erb
+++ b/app/views/student/teams/_mentors.html.erb
@@ -13,13 +13,13 @@
         You can add as many mentors as your team needs.
       </p>
 
-      <%= render "mentors_list",
+      <%= render "student/teams/mentors_list",
         mentors: team.mentors,
         team: team %>
     </div>
 
     <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
-      <%= render "pending_mentor_invites",
+      <%= render "student/teams/pending_mentor_invites",
         team: team,
         invites: team.pending_mentor_invites %>
 
@@ -37,7 +37,7 @@
         ) %>
       </div>
 
-      <%= render "pending_mentor_join_requests",
+      <%= render "student/teams/pending_mentor_join_requests",
         team: team,
         join_requests: team.pending_mentor_join_requests %>
 

--- a/app/views/student/teams/_students.en.html.erb
+++ b/app/views/student/teams/_students.en.html.erb
@@ -12,13 +12,13 @@
       Your team can have up to five students.
     </p>
 
-    <%= render "students_list",
+    <%= render "student/teams/students_list",
       students: team.students,
       team: team
     %>
 
     <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
-      <%= render "pending_student_invites",
+      <%= render "student/teams/pending_student_invites",
         team: team,
         preview_method: :invitee_email,
         invites: team.pending_student_invites %>
@@ -29,7 +29,7 @@
         </div>
       <% end %>
 
-      <%= render "pending_student_join_requests",
+      <%= render "student/teams/pending_student_join_requests",
         team: team,
         join_requests: team.pending_student_join_requests
       %>

--- a/app/views/student/teams/show.html.erb
+++ b/app/views/student/teams/show.html.erb
@@ -2,27 +2,27 @@
 
 <div class="lg:flex lg:justify-around">
   <div class="flex flex-col lg:flex-row gap-6">
-    <%= render "menu" %>
+    <%= render "student/teams/menu" %>
 
     <div class="tab">
       <div id="student-tab-content" class="tab-content tw-active">
-        <%= render "students", team: @team %>
+        <%= render "student/teams/students", team: @team %>
       </div>
 
       <div id="mentor-tab-content" class="tab-content">
-        <%= render "mentors", team: @team %>
+        <%= render "student/teams/mentors", team: @team %>
       </div>
 
       <div id="summary-tab-content" class="tab-content">
-        <%= render "summary", team: @team %>
+        <%= render "student/teams/summary", team: @team %>
       </div>
 
       <div id="location-tab-content" class="tab-content">
-        <%= render "location", team: @team %>
+        <%= render "student/teams/location", team: @team %>
       </div>
 
       <div id="division-tab-content" class="tab-content">
-        <%= render "division", team: @team %>
+        <%= render "student/teams/division", team: @team %>
       </div>
     </div>
   </div>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -190,6 +190,7 @@ en:
     team_member_invites:
       create:
         success: "Your team invite was sent!"
+        failure: "There was an issue sending your invite, please check the error message below."
       update:
         accept: "Accept invitation to %{name}"
         already_on_team: "You are already on a team, so you cannot accept that invite."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
     resources :mentors, only: :show
     resources :students, only: :show
 
-    resources :team_member_invites, except: [:edit, :index]
+    resources :team_member_invites, except: [:edit]
     resources :mentor_invites, only: [:create, :destroy]
     resources :join_requests, only: [:new, :show, :create, :update, :destroy]
 


### PR DESCRIPTION
If there is a validation error when inviting a student to a team (b/c of an invalid email for example), we will render the "My Team" page again, and show a flash error message and the validation error message below the text input field.

Also, I added a comment in #3515 about the old styling on the error messages.

![student-invite-form-errors](https://user-images.githubusercontent.com/58957909/181356168-9e40ca6a-cc89-41dd-817f-cf768429e7ab.png)

