### PR TITLE
Change de accepting team invites opt-in for new mentors

### DIFF
--- a/db/migrate/20220809170821_change_mentor_accepting_team_invites_default_value.rb
+++ b/db/migrate/20220809170821_change_mentor_accepting_team_invites_default_value.rb
@@ -1,0 +1,5 @@
+class ChangeMentorAcceptingTeamInvitesDefaultValue < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :mentor_profiles, :accepting_team_invites, from: true, to: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -864,7 +864,7 @@ CREATE TABLE public.mentor_profiles (
     updated_at timestamp without time zone NOT NULL,
     bio text,
     searchable boolean DEFAULT false NOT NULL,
-    accepting_team_invites boolean DEFAULT true NOT NULL,
+    accepting_team_invites boolean DEFAULT false NOT NULL,
     virtual boolean DEFAULT true NOT NULL,
     connect_with_mentors boolean DEFAULT true NOT NULL,
     user_invitation_id bigint,
@@ -3164,6 +3164,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220405040709'),
 ('20220406163528'),
 ('20220406164442'),
-('20220426020533');
+('20220426020533'),
+('20220809170821');
 
 

--- a/spec/factories/mentors.rb
+++ b/spec/factories/mentors.rb
@@ -6,7 +6,8 @@ FactoryBot.define do
     job_title { "Engineer" }
     mentor_type { MentorProfile.mentor_types.keys.sample }
     bio { "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ut diam vel felis fringilla amet." }
-
+    accepting_team_invites { true }
+    
     transient do
       first_name { "Mentor" }
       last_name { nil }


### PR DESCRIPTION
Currently the default value for "accepting_team_invites" for mentors is "True". This PR changes this value to "False", so each mentor have a choice do decide if want to accept or not invitations.

Refs.: #3249