### PR TITLE
Fixes the student URL on mentor search card

### DIFF
--- a/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
+++ b/app/views/mentor_searches/rebrand/_mentor_preview.html.erb
@@ -20,6 +20,10 @@
     %>"
     name="<%= mentor_preview.full_name %>"
     link-text="More Details >"
-    link-path="<%= mentor_mentor_path(mentor_preview, review_before: true) %>"
+    link-path="<%= 
+      current_scope == "mentor" ? 
+      mentor_mentor_path(mentor_preview, review_before: true) : 
+      student_mentor_path(mentor_preview, review_before: true) 
+    %>"
   ></result-card>
 </div>


### PR DESCRIPTION
This PR correct the mentor search URL on student search for mentors card.
(the discussion is on related issue)

Refs.: #3576 