### PR TITLE
Remove the guardian email constraint for junior division

### DIFF
--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -246,7 +246,7 @@ class StudentProfile < ActiveRecord::Base
       errors.add(a, :blank)
     end
 
-    if (account.division.junior? || account.division.senior?) &&
+    if account.division.senior? &&
         (parent_guardian_email == account.email)
 
       errors.add(:parent_guardian_email, :matches_student_email)
@@ -392,7 +392,8 @@ class StudentProfile < ActiveRecord::Base
     if Account.joins(:student_profile).where(
          "lower(email) = ?",
          parent_guardian_email.downcase
-       ).any?
+       ).any? && account&.division&.senior?
+
       errors.add(:parent_guardian_email, :found_in_student_accounts)
     end
 

--- a/spec/features/allow_beginner_email_to_be_parent.rb
+++ b/spec/features/allow_beginner_email_to_be_parent.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.feature "Allow beginner to be parent", :js do
+  before { SeasonToggles.enable_signups! }
+
+  let(:beginner_profile) { FactoryBot.create(:student, :beginner ) }
+  let(:beginner_account) { beginner_profile.account }
+
+  let(:junior_birthdate) {
+    Division.cutoff_date - (Division::SENIOR_DIVISION_AGE - 1).years
+  }
+
+  context "Beginner account is Parent/Guardian" do
+    scenario 'Creates junior with beginner as parent' do
+      visit("/signup")
+
+      # Check if first page was loaded
+      expect(page).to have_content("Your Profile Type")
+      
+      # Selecting 13-18 years old student
+      find(:css, "#formulate-global-1_student[value='student']").set(true)
+  
+      # Click to load next screen
+      click_button("Next")
+  
+      # Check if FORM was loaded
+      expect(page).to have_content("Basic Profile")
+  
+      # Fill the form
+      fill_in("firstName",                  with: "Junior")
+      fill_in("lastName",                   with: "Student")
+      fill_in("dateOfBirth",                with: junior_birthdate)
+      fill_in("studentSchoolName",          with: "Junior School")
+      fill_in("studentParentGuardianName",  with: "%s %s" % [ beginner_account.first_name, beginner_account.last_name] )
+      fill_in("studentParentGuardianEmail", with: beginner_account.email)
+      select "Friend", :from => "referredBy"
+  
+      # Click to load next screen
+      click_button("Next")
+  
+      # Check if USE TERMS was loaded
+      expect(page).to have_content("Use Terms")
+  
+      # Agree with use terms
+      find(:css, "#dataTermsAgreedTo").set(true)
+  
+      # Click to load next screen
+      click_button("Next")
+      
+      # Check if Mail/Password screen was loaded
+      expect(page).to have_content("Set your email and password")
+      
+      # Fill email and password
+      fill_in("email", with: "junior-student@email.com")
+      fill_in("password", with: "@student1234")
+  
+      # Submit the form
+      find(:css, '#formulate-global-13').click()
+  
+      # Testing for error message
+      expect(page).not_to have_content("Parent guardian email cannot match your (or any other student's) email")
+    end
+  end
+end

--- a/spec/requests/student/profile_requests_spec.rb
+++ b/spec/requests/student/profile_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Student Profile Requests", type: :request do
   let(:student_account) { FactoryBot.create(:account, email: student_email_address) }
   let(:student_email_address) { "harry@example.com"  }
   let(:student_profile) {
-    FactoryBot.create(:student_profile, :geocoded,
+    FactoryBot.create(:student_profile, :geocoded, :senior,
       account: student_account,
       parent_guardian_email: parent_guardian_email_address)
   }


### PR DESCRIPTION
The changes inj this  PR allows a Junior Student to be a Guardian of a Beginner Student.

The details are in the related issue: #3165 