### PR TITLE
3577 rebrand student mentor details

### DIFF
--- a/app/views/mentor/profiles/rebrand/_public_profile.html.erb
+++ b/app/views/mentor/profiles/rebrand/_public_profile.html.erb
@@ -1,0 +1,8 @@
+<p class="font-bold"><%= t('models.mentor_profile.school_company_name') %></p>
+<p><%= account.school_company_name %></p>
+
+<p class="font-bold"><%= t('models.mentor_profile.job_title') %></p>
+<p><%= account.job_title %></p>
+
+<p class="font-bold"><%= t('models.mentor_profile.expertise_names') %></p>
+<p><%= account.expertise_names.present? ? account.expertise_names.to_sentence : 'No expertises selected'%></p>

--- a/app/views/profiles/rebrand/_public_show.html.erb
+++ b/app/views/profiles/rebrand/_public_show.html.erb
@@ -1,0 +1,33 @@
+<% title ||= t("views.accounts.show.title") %>
+
+<section class="mb-8">
+
+  <h3 class="text-3xl font-bold mb-4"><%= account.full_name %></h3>
+
+  <div class="flex flex-col lg:flex-row lg:space-x-12 mb-4">
+    <%= image_tag account.profile_image_url,
+                  class: "rounded-tr-3xl rounded-bl-3xl w-1/4" %>
+
+    <div class="mt-auto">
+        <p class="font-bold">Location</p>
+        <p><%= account.address_details %></p>
+
+      <% unless account.student_profile.present? %>
+        <p class="font-bold"><%= t('models.account.gender') %></p>
+        <p><%= account.gender %></p>
+      <% end %>
+
+      <%= render "#{account.scope_name}/profiles/rebrand/public_profile",
+                 account: account %>
+    </div>
+  </div>
+
+  <div>
+    <p class="font-bold">Bio</p>
+    <% if account.respond_to?(:bio) %>
+      <p><%= simple_format account.bio %></p>
+    <% else %>
+      <p> This mentor has not written a bio.</p>
+    <% end %>
+  </div>
+</section>

--- a/app/views/profiles/rebrand/_public_show.html.erb
+++ b/app/views/profiles/rebrand/_public_show.html.erb
@@ -9,8 +9,8 @@
                   class: "rounded-tr-3xl rounded-bl-3xl w-1/4" %>
 
     <div class="mt-auto">
-        <p class="font-bold">Location</p>
-        <p><%= account.address_details %></p>
+      <p class="font-bold">Location</p>
+      <p><%= account.address_details %></p>
 
       <% unless account.student_profile.present? %>
         <p class="font-bold"><%= t('models.account.gender') %></p>

--- a/app/views/student/mentors/_already_invited.en.html.erb
+++ b/app/views/student/mentors/_already_invited.en.html.erb
@@ -1,1 +1,2 @@
+<h3 class="font-bold text-2xl mb-4">Status</h3>
 <p><%= t("views.mentors.show.already_invited", name: mentor.first_name) %></p>

--- a/app/views/student/mentors/_invite_mentor.en.html.erb
+++ b/app/views/student/mentors/_invite_mentor.en.html.erb
@@ -3,17 +3,10 @@
 </h3>
 
 <div class="mb-4">
-  <% if mentor.virtual? %>
     <p>
-      <span class="italic"><%= mentor.first_name %></span>
-      will mentor teams from anywhere.
+      <span class="italic"><%= mentor.first_name %></span> will mentor teams from
+      <%= mentor.virtual? ? "anywhere" : mentor.address_details %>
     </p>
-  <% else %>
-    <p>
-      <span class="italic"><%= mentor.first_name %></span>
-      will only mentor teams from <%= mentor.address_details %>.
-    </p>
-  <% end %>
 </div>
 
 <%= form_for [:student, mentor_invite] do |f| %>

--- a/app/views/student/mentors/_invite_mentor.en.html.erb
+++ b/app/views/student/mentors/_invite_mentor.en.html.erb
@@ -1,13 +1,23 @@
-<strong><%= t("views.application.availability") %>:</strong>
+<h3 class="font-bold text-2xl mb-4">
+  <%= t("views.application.availability") %>
+</h3>
 
-<% if mentor.virtual? %>
-  <p><%= mentor.first_name %> will mentor teams from anywhere.</p>
-<% else %>
-  <p><%= mentor.first_name %> will only mentor teams from <%= mentor.address_details %>.</p>
-<% end %>
+<div class="mb-4">
+  <% if mentor.virtual? %>
+    <p>
+      <span class="italic"><%= mentor.first_name %></span>
+      will mentor teams from anywhere.
+    </p>
+  <% else %>
+    <p>
+      <span class="italic"><%= mentor.first_name %></span>
+      will only mentor teams from <%= mentor.address_details %>.
+    </p>
+  <% end %>
+</div>
 
 <%= form_for [:student, mentor_invite] do |f| %>
   <%= f.hidden_field :invitee_email, value: mentor.email %>
   <%= f.submit "Ask #{mentor.first_name} to mentor your team",
-    class: "button" %>
+    class: "tw-green-btn" %>
 <% end %>

--- a/app/views/student/mentors/show.html.erb
+++ b/app/views/student/mentors/show.html.erb
@@ -1,21 +1,21 @@
 <% provide :title, t("views.student.mentors.show.title") %>
 
-<%= render 'profiles/public_show',
-  title: t("views.student.mentors.show.title"),
-  account: @mentor %>
+<div class="container mx-auto flex flex-col lg:flex-row justify-around w-full lg:w-1/2">
+  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Mentor Details'} do %>
+    <%= render 'profiles/rebrand/public_show',
+               title: t("views.student.mentors.show.title"),
+               account: @mentor %>
 
-<div class="grid grid--justify-space-around">
-  <div class="grid__col-sm-8 grid__col--bleed-y">
-    <div class="panel">
-      <strong>
-        <%= t("views.student.mentors.show.teams", name: @mentor.first_name) %>
-      </strong>
+    <%= render "application/templates/tw_thick_rule" %>
+
+    <section class="my-8">
+      <h3 class="font-bold text-2xl"><%= t("views.student.mentors.show.teams", name: @mentor.first_name) %></h3>
 
       <% if @mentor.teams.current.any? %>
         <ul class="unstyled">
-          <%= render partial: 'student/mentors/team_preview',
-            collection: @mentor.teams.current,
-            locals: { profile: @mentor } %>
+          <%= render partial: "student/mentors/team_preview",
+                     collection: @mentor.teams.current,
+                     locals: { profile: @mentor } %>
         </ul>
       <% else %>
         <p>
@@ -23,18 +23,22 @@
                 name: @mentor.first_name) %>
         </p>
       <% end %>
+    </section>
 
+    <%= render "application/templates/tw_thick_rule" %>
+
+    <section class="my-8">
       <% if current_team.present? and SeasonToggles.team_building_enabled? %>
         <%= render(
-          "student/mentors/#{mentor_invitation_template(current_team, @mentor)}",
-          mentor_invite: @mentor_invite,
-          mentor: @mentor,
-          team: current_team
-        ) # `mentor_invitation_template`
-          # is defined in 
-          # app/helpers/student_helper.rb
+              "student/mentors/#{mentor_invitation_template(current_team, @mentor)}",
+              mentor_invite: @mentor_invite,
+              mentor: @mentor,
+              team: current_team
+            ) # `mentor_invitation_template`
+            # is defined in
+            # app/helpers/student_helper.rb
         %>
       <% end %>
-    </div>
-  </div>
+    </section>
+  <% end %>
 </div>

--- a/app/views/student/mentors/show.html.erb
+++ b/app/views/student/mentors/show.html.erb
@@ -34,10 +34,7 @@
               mentor_invite: @mentor_invite,
               mentor: @mentor,
               team: current_team
-            ) # `mentor_invitation_template`
-            # is defined in
-            # app/helpers/student_helper.rb
-        %>
+            ) %>
       <% end %>
     </section>
   <% end %>


### PR DESCRIPTION
Refs Issue #3577 and [PR #3612](https://github.com/Iridescent-CM/technovation-app/pull/3612). Once this is merged we will be able to close PR3612. 

This change includes the rebranding of the student mentor details view. This view follows the same pattern for team details. No major changes to the views, just mostly updated styles and markup structure. I tried to follow previous patterns for approaching the mixed profile rebranding. For example I created the rebrand directory with the updated files `app/views/mentor/profiles/rebrand/_public_profile.html.erb` and `app/views/profiles/rebrand/_public_show.html.erb`

![student_profile_mentor_details_view](https://user-images.githubusercontent.com/29210380/189439042-0cc2e46e-eeee-4a21-b2c6-1417b32e1560.png)
 