### PR TITLE
3249 Sets the default value for mentors connecting with other mentors to false

### DIFF
--- a/db/migrate/20220914184120_change_default_connect_with_mentors_to_false.rb
+++ b/db/migrate/20220914184120_change_default_connect_with_mentors_to_false.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultConnectWithMentorsToFalse < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :mentor_profiles, :connect_with_mentors, from: true, to: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -866,7 +866,7 @@ CREATE TABLE public.mentor_profiles (
     searchable boolean DEFAULT false NOT NULL,
     accepting_team_invites boolean DEFAULT true NOT NULL,
     virtual boolean DEFAULT true NOT NULL,
-    connect_with_mentors boolean DEFAULT true NOT NULL,
+    connect_with_mentors boolean DEFAULT false NOT NULL,
     user_invitation_id bigint,
     mentor_type integer,
     training_completed_at timestamp without time zone,
@@ -3164,6 +3164,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220405040709'),
 ('20220406163528'),
 ('20220406164442'),
-('20220426020533');
+('20220426020533'),
+('20220914184120');
 
 

--- a/spec/controllers/mentor/mentor_searches_controller_spec.rb
+++ b/spec/controllers/mentor/mentor_searches_controller_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe Mentor::MentorSearchesController do
   describe "GET #new" do
     it "does not include mentors who don't want to connect" do
       mentor = FactoryBot.create(:mentor, :onboarded, :geocoded)
-      find_mentor = FactoryBot.create(:mentor, :onboarded, :geocoded)
+      find_mentor = FactoryBot.create(:mentor, :onboarded, :geocoded, :connected_with_mentors)
       no_find = FactoryBot.create(
         :mentor,
-        :geocoded,
-        connect_with_mentors: false
+        :geocoded
       )
 
       sign_in(mentor)

--- a/spec/controllers/mentor/mentor_searches_controller_spec.rb
+++ b/spec/controllers/mentor/mentor_searches_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Mentor::MentorSearchesController do
   describe "GET #new" do
     it "does not include mentors who don't want to connect" do
       mentor = FactoryBot.create(:mentor, :onboarded, :geocoded)
-      find_mentor = FactoryBot.create(:mentor, :onboarded, :geocoded, :connected_with_mentors)
+      find_mentor = FactoryBot.create(:mentor, :onboarded, :geocoded, :searchable_by_other_mentors)
       no_find = FactoryBot.create(
         :mentor,
         :geocoded

--- a/spec/factories/mentors.rb
+++ b/spec/factories/mentors.rb
@@ -36,6 +36,10 @@ FactoryBot.define do
       training_completed_at { nil }
     end
 
+    trait :connected_with_mentors do
+      connect_with_mentors { true }
+    end
+
     trait :chicago do
       city { "Chicago" }
       state_province { "IL" }

--- a/spec/factories/mentors.rb
+++ b/spec/factories/mentors.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
       training_completed_at { nil }
     end
 
-    trait :connected_with_mentors do
+    trait :searchable_by_other_mentors do
       connect_with_mentors { true }
     end
 

--- a/spec/features/mentor/connect_with_mentors_spec.rb
+++ b/spec/features/mentor/connect_with_mentors_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.feature "Mentors connect with other mentors" do
+  scenario "A mentor has finished onboarding and views their profile for the first time" do
+    mentor = FactoryBot.create(:mentor, :onboarded)
+
+    sign_in(mentor)
+    visit mentor_profile_path
+
+    expect(page).to have_unchecked_field("mentor_profile_connect_with_mentors")
+  end
+end

--- a/spec/features/mentor/connect_with_mentors_spec.rb
+++ b/spec/features/mentor/connect_with_mentors_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Mentors connect with other mentors" do
-  scenario "A mentor has finished onboarding and views their profile for the first time" do
+  scenario "A newly onboarded mentor is not searchable by other mentors by default" do
     mentor = FactoryBot.create(:mentor, :onboarded)
 
     sign_in(mentor)

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   let!(:find_mentor) do
-    FactoryBot.create(:mentor, :onboarded, :geocoded, :connected_with_mentors, first_name: "Findme") # City is Chicago
+    FactoryBot.create(:mentor, :onboarded, :geocoded, :searchable_by_other_mentors, first_name: "Findme") # City is Chicago
   end
 
   after do
@@ -61,7 +61,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
-      :connected_with_mentors,
+      :searchable_by_other_mentors,
       first_name: "Faraway",
       last_name: "Mentor",
       city: "Los Angeles",
@@ -83,7 +83,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
-      :connected_with_mentors,
+      :searchable_by_other_mentors,
       first_name: "Faraway",
       last_name: "Mentor",
       city: "Los Angeles",
@@ -105,7 +105,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
-      :connected_with_mentors,
+      :searchable_by_other_mentors,
       first_name: "Traditional Mexican",
       last_name: "Family Name",
       city: "Los Angeles",

--- a/spec/features/mentor/find_a_mentor_spec.rb
+++ b/spec/features/mentor/find_a_mentor_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Mentors find a team" do
   end
 
   let!(:find_mentor) do
-    FactoryBot.create(:mentor, :onboarded, :geocoded, first_name: "Findme") # City is Chicago
+    FactoryBot.create(:mentor, :onboarded, :geocoded, :connected_with_mentors, first_name: "Findme") # City is Chicago
   end
 
   after do
@@ -61,6 +61,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
+      :connected_with_mentors,
       first_name: "Faraway",
       last_name: "Mentor",
       city: "Los Angeles",
@@ -82,6 +83,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
+      :connected_with_mentors,
       first_name: "Faraway",
       last_name: "Mentor",
       city: "Los Angeles",
@@ -103,6 +105,7 @@ RSpec.feature "Mentors find a team" do
       :mentor,
       :onboarded,
       :geocoded,
+      :connected_with_mentors,
       first_name: "Traditional Mexican",
       last_name: "Family Name",
       city: "Los Angeles",


### PR DESCRIPTION
Refs #3249 

This change was needed so mentors would not be automatically opted in to the "connect with mentors" feature. Now a mentor will have to check the appropriate checkbox to connect with other mentors.

Once this is merged, we can delete/close PR #3580 since this change will update the DB