### PR TITLE
3603 - Email text updates for season opening

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -9,7 +9,7 @@ class Season
   end
 
   def self.deadline
-    day = ImportantDates.submission_deadline.day.ordinalize
+    day = ImportantDates.submission_deadline.day
     ImportantDates.submission_deadline.strftime("%B #{day}")
   end
 

--- a/app/views/parent_mailer/thank_you.en.html.erb
+++ b/app/views/parent_mailer/thank_you.en.html.erb
@@ -48,7 +48,7 @@
           After all of the submissions have been judged, finalist teams are invited to pitch 
           their ideas live to finalist judges to see who will win a special prize, and all 
           participants and their families (including you!) are invited to attend our 
-          virtual World Summit.
+          virtual World Summit celebration.
         </td>
       </tr>
 

--- a/app/views/team_mailer/join_request_accepted.en.html.erb
+++ b/app/views/team_mailer/join_request_accepted.en.html.erb
@@ -22,6 +22,34 @@
           <%= link_to "Visit Your New Team", @url, class: "btn-primary", itemprop: "url" %>
         </td>
       </tr>
+      <% if @role_name.include? 'mentor' %>
+        <tr>
+          <td class="content-block">
+            <p>
+              Next steps:
+              <br>
+              Now that you have joined the team, it is time to introduce yourself via email. Here is an example:
+            </p>
+            <p>Hi <%= @team_name %>,</p>
+            <p>
+              It is wonderful that you have taken the initiative to join Technovation, there is a lot that we can learn together!
+              I am excited to help you along this journey and want to set up our first meeting so we can get to know each other.
+            </p>
+            <p>
+              <%= link_to "Here", "https://www.technovation.org/wp-content/uploads/2019/10/Mentorship-Communications-Parental-Consent.pdf" %>
+              is a form that will help me set-up our communication, please share this with your parents as well so we can make
+              sure that everyone is comfortable moving forward. [Share your schedule/times that you can meet and if you will meet in
+              person or virtually]. Looking forward to working with you!
+            </p>
+
+            <p>
+              Best,
+              <br>
+              <%= @first_name %>
+            </p>
+          </td>
+        </tr>
+      <% end %>
       <tr>
         <td class="content-block">
           Best,<br />

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Season do
     it "returns human-readable month and day" do
       deadline = Date.new(2019, 4, 25)
       expect(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
-      expect(Season.deadline).to eq("April 25th")
+      expect(Season.deadline).to eq("April 25")
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe Season do
     it "returns human-readable date" do
       deadline = Date.new(2019, 4, 25)
       expect(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
-      expect(Season.submission_deadline).to eq("April 25th, 2019")
+      expect(Season.submission_deadline).to eq("April 25, 2019")
     end
   end
 end


### PR DESCRIPTION
Refs #3603 

The biggest change here is in `app/views/team_mailer/join_request_accepted.en.html.erb`

A request was made to add additional text including next steps once a mentor is approved/accepted to join a team. This was a bit trickier than the other email updates because this email template is triggered after different actions. I added a conditional to check the `role_name` (which is also dynamic and set in `config/locales/mailers.en.yml`. In this case, the role_name is `their_mentor`.

I am requesting review on this since it was a little more involved than just a text change :) 