### PR TITLE
Remove "profile detail" section for mentors

### DIFF
--- a/app/javascript/mentor/DashboardMenu.vue
+++ b/app/javascript/mentor/DashboardMenu.vue
@@ -2,7 +2,7 @@
   <ul class="tabs__menu tabs-menu__parent-menu padding--none">
     <tab-link
       :class="registrationTabLinkClasses"
-      :to="{ name: 'basic-profile', meta: { active: registrationPagesActive } }"
+      :to="{ name: 'data-use', meta: { active: registrationPagesActive } }"
       :condition-to-enable="true"
       :condition-to-complete="true"
     >

--- a/app/javascript/registration/DashboardMenu.vue
+++ b/app/javascript/registration/DashboardMenu.vue
@@ -44,17 +44,6 @@
     </tab-link>
 
     <tab-link
-      :to="{ name: 'basic-profile' }"
-      css-classes="tabs__menu-link--has-subtitles"
-      :disabled-tooltip="basicProfileDisabledMessage"
-      :condition-to-enable="termsAgreed && isAgeSet && isProfileChosen"
-      :condition-to-complete="isBasicProfileSet"
-    >
-      Profile detail
-      <span>{{ profileLabel }}</span>
-    </tab-link>
-
-    <tab-link
       :to="{ name: 'login' }"
       :disabled-tooltip="Tooltips.MUST_FILL_OTHER_SECTIONS"
       :condition-to-enable="readyForAccount"
@@ -165,19 +154,6 @@ export default {
 
       if (!this.isAgeSet)
         return Tooltips.MUST_SET_AGE
-
-      return ''
-    },
-
-    basicProfileDisabledMessage () {
-      if (!this.termsAgreed)
-        return Tooltips.MUST_AGREE_TERMS
-
-      if (!this.isAgeSet)
-        return Tooltips.MUST_SET_AGE
-
-      if (!this.profileChoice)
-        return Tooltips.MUST_CHOOSE_PROFILE
 
       return ''
     },

--- a/app/javascript/registration/components/ChooseProfile.vue
+++ b/app/javascript/registration/components/ChooseProfile.vue
@@ -59,13 +59,7 @@
       >
         Back
       </a>
-      <button
-        class="button"
-        :disabled="!nextStepEnabled"
-        @click.prevent="handleSubmit"
-      >
-        Next
-      </button>
+      <br clear="all">
     </div>
   </form>
 </template>
@@ -103,10 +97,6 @@ export default {
     ...mapState(['months', 'birthMonth', 'genderIdentity', 'isLocked']),
 
     ...mapGetters(['getAge', 'getAgeByCutoff', 'isAgeSet', 'getBirthdate']),
-
-    nextStepEnabled () {
-      return this.isAgeSet && !!this.profileChoice
-    },
 
     profileChoice: {
       get () {
@@ -155,13 +145,6 @@ export default {
 
   methods: {
     ...mapActions(['updateProfileChoice']),
-
-    handleSubmit () {
-      if (!this.nextStepEnabled) return false
-      this.updateProfileChoice(this.profileChoice).then(() => {
-        this.$router.push({ name: 'basic-profile' })
-      })
-    },
 
     navigateBack () {
       this.$router.push({ name: 'age' })

--- a/spec/javascript/registration/components/ChooseProfile.spec.js
+++ b/spec/javascript/registration/components/ChooseProfile.spec.js
@@ -204,14 +204,4 @@ describe("Registration::Components::ChooseProfile.vue", () => {
       })
     })
   })
-
-  describe('markup', () => {
-    it('has one button element to prevent navigation issues when submitting', () => {
-      // Note: if this test is failing, you can change <button> to
-      // <a class="button"> for a similar effect
-      const buttons = defaultWrapper.findAll('button')
-
-      expect(buttons.length).toEqual(1)
-    })
-  })
 })


### PR DESCRIPTION
This will remove the "profile detail" link from the mentor dashboard. In order to make this change, I also had to update the "Complete your Profile" link (which I left a comment about), and remove the Next button on the "Choose your profile type" page (which I also left a comment about). 😄 