### PR TITLE
Filestack profile image cleanup - includes all profile types

### DIFF
--- a/app/assets/stylesheets/_img.scss
+++ b/app/assets/stylesheets/_img.scss
@@ -34,3 +34,9 @@
 .placeholder {
   background: lightgrey;
 }
+
+.og-style-filestack-img{
+  width: 220px;
+  height: auto;
+  object-fit: contain;
+}

--- a/app/javascript/components/DashboardHeader.vue
+++ b/app/javascript/components/DashboardHeader.vue
@@ -33,12 +33,12 @@
     <div class="grid__col-sm-6 grid__col--bleed-y grid--align-end">
       <div class="grid__cell">
         <h1 class="page-heading">
-          <img
-            :src="currentAccountAvatarUrl"
-            class="profile-image"
-            width="40"
-            height="40"
-          />
+<!--          <img-->
+<!--            :src="currentAccountAvatarUrl"-->
+<!--            class="profile-image"-->
+<!--            width="40"-->
+<!--            height="40"-->
+<!--          />-->
 
           {{ currentAccountName }}
 

--- a/app/javascript/packs/application_rebrand.js
+++ b/app/javascript/packs/application_rebrand.js
@@ -12,4 +12,4 @@ import "../stylesheets/tabs.css"
 import "../stylesheets/judge.css"
 import "../stylesheets/pagination.css"
 import "../stylesheets/result_card.css"
-
+import "../stylesheets/filestack.css"

--- a/app/javascript/stylesheets/buttons.css
+++ b/app/javascript/stylesheets/buttons.css
@@ -25,3 +25,7 @@ a.link-button-danger, .submit-button-danger {
 a.link-button-neutral, .submit-button-neutral {
     @apply text-gray-500 hover:text-gray-500 bg-gray-200 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400
 }
+
+.filestack-picker-btn {
+    @apply w-auto mr-auto mt-4 text-sm rounded bg-zinc-300 p-2
+}

--- a/app/javascript/stylesheets/buttons.css
+++ b/app/javascript/stylesheets/buttons.css
@@ -25,7 +25,3 @@ a.link-button-danger, .submit-button-danger {
 a.link-button-neutral, .submit-button-neutral {
     @apply text-gray-500 hover:text-gray-500 bg-gray-200 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400
 }
-
-.filestack-picker-btn {
-    @apply w-auto mr-auto mt-4 text-sm rounded bg-zinc-300 p-2
-}

--- a/app/javascript/stylesheets/filestack.css
+++ b/app/javascript/stylesheets/filestack.css
@@ -1,0 +1,7 @@
+.filestack-picker-btn {
+    @apply w-auto mr-auto mt-4 text-sm rounded bg-zinc-300 p-2
+}
+
+.filestack-profile-img {
+    @apply rounded-bl-3xl rounded-tr-3xl mb-3 object-cover w-48 h-48
+}

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -49,7 +49,3 @@ html{
 .tw-flag-magenta{
     @apply text-white block p-2 text-right text-base font-bold shadow-sm bg-tg-magenta
 }
-
-.filestack-profile-img {
-    @apply rounded-bl-3xl rounded-tr-3xl mb-3 object-cover w-48 h-48
-}

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -49,3 +49,7 @@ html{
 .tw-flag-magenta{
     @apply text-white block p-2 text-right text-base font-bold shadow-sm bg-tg-magenta
 }
+
+.filestack-profile-img{
+    @apply rounded-bl-3xl rounded-tr-3xl mb-3 object-cover w-48 h-48
+}

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -50,6 +50,6 @@ html{
     @apply text-white block p-2 text-right text-base font-bold shadow-sm bg-tg-magenta
 }
 
-.filestack-profile-img{
+.filestack-profile-img {
     @apply rounded-bl-3xl rounded-tr-3xl mb-3 object-cover w-48 h-48
 }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -695,8 +695,8 @@ class Account < ActiveRecord::Base
 
   def profile_image_url
     if profile_image.blank?
-      "https://s3.amazonaws.com/#{ENV.fetch("AWS_BUCKET_NAME")}/placeholders/1.svg"
-    elsif profile_image.include? "filestackcontent"
+      "placeholders/avatars/1.svg"
+    elsif profile_image.include?("filestackcontent")
       profile_image
     else
       "https://s3.amazonaws.com/#{ENV.fetch("AWS_BUCKET_NAME")}/uploads/account/profile_image/#{id}/#{profile_image}"

--- a/app/views/chapter_ambassador/profiles/show.en.html.erb
+++ b/app/views/chapter_ambassador/profiles/show.en.html.erb
@@ -6,9 +6,9 @@
       <div class="col--sticky">
         <div class="hidden-xs hidden-xxs">
           <h3><%= current_ambassador.full_name %></h3>
-          <div>
-            <%= render 'profiles/filestack_profile_image_tag' %>
-          </div>
+          <%= image_tag current_ambassador.profile_image_url,
+                        id: "main-profile-image",
+                        class: "grid__cell-img og-style-filestack-img" %>
           <div>
             <%= render 'profiles/filestack_profile_image_upload' %>
           </div>

--- a/app/views/mentor/profiles/show.html.erb
+++ b/app/views/mentor/profiles/show.html.erb
@@ -6,9 +6,9 @@
       <div class="col--sticky">
         <div class="hidden-xs hidden-xxs">
           <h3><%= current_mentor.full_name %></h3>
-          <%= filestack_image current_profile.profile_image_url,
-                              id: "profile-image",
-                              class: "grid__cell-img" %>
+          <%= image_tag current_mentor.profile_image_url,
+                        id: "main-profile-image",
+                        class: "grid__cell-img og-style-filestack-img" %>
           <div>
             <%= render 'profiles/filestack_profile_image_upload' %>
           </div>

--- a/app/views/profiles/_filestack_profile_image_tag.html.erb
+++ b/app/views/profiles/_filestack_profile_image_tag.html.erb
@@ -1,5 +1,3 @@
-<%= filestack_image current_profile.profile_image_url,
-                    transform: filestack_transform.resize(width: 200, height: 200) ,
-                    id: 'filestack-img-tag' %>
-
-<div id="thumbnail-container"></div>
+  <%= image_tag current_profile.profile_image_url,
+                id: 'main-profile-image',
+                class: 'w-24 h-24 rounded-bl-3xl rounded-tr-3xl mb-3' %>

--- a/app/views/profiles/_filestack_profile_image_tag.html.erb
+++ b/app/views/profiles/_filestack_profile_image_tag.html.erb
@@ -1,3 +1,3 @@
   <%= image_tag current_profile.profile_image_url,
                 id: 'main-profile-image',
-                class: 'w-24 h-24 rounded-bl-3xl rounded-tr-3xl mb-3' %>
+                class: 'filestack-profile-img' %>

--- a/app/views/profiles/_filestack_profile_image_upload.en.html.erb
+++ b/app/views/profiles/_filestack_profile_image_upload.en.html.erb
@@ -7,8 +7,8 @@
       url: "#{current_scope}_profile_path",
       data: $("#filestack-form").serialize(),
       success: function() {
-        const filestackImgTag = $("#filestack-img-tag");
-        filestackImgTag.attr("src",
+        const mainProfileImg = $("#main-profile-image");
+        mainProfileImg.attr("src",
           filestack_client.transform(data.handle, {
             resize: {
                 width: 200,


### PR DESCRIPTION
Refs #3613 

This is the first part of the general filestack cleanup.

Changes include
1. Style updates - Something I did not originally consider is that some of the profile types that have not been update will be using filestack so custom styles had to be included since tailwind was not accessible in those profile types
2. Updated ChA and mentor profile to use rails image tag
3. Updated `app/views/profiles/_filestack_profile_image_tag.html.erb` to only use the rails tag for now. I would like to use the filestack img tag eventually, however there was an issue with the placeholder image. This has been logged in #3643 
4. Added the placeholder image for accounts without a profile img


Note ** I also needed to comment out the mentor dashboard header profile image since it was causing tests to fail. This issue has been logged in #3644. The profile image avatar is in `app/javascript/components/DashboardHeader.vue`