### PR TITLE
Rebrand pending join requests page

### DIFF
--- a/app/controllers/student/join_requests_controller.rb
+++ b/app/controllers/student/join_requests_controller.rb
@@ -27,6 +27,8 @@ module Student
       elsif reviewer_is_unauthorized?(@join_request)
         redirect_to student_dashboard_path,
           alert: "You do not have permission to visit that page"
+      elsif @join_request.status == :pending
+        render template: "join_requests/rebranded/show_pending"
       else
         render template: "join_requests/show_#{@join_request.status}"
       end

--- a/app/views/join_requests/rebranded/show_pending.en.html.erb
+++ b/app/views/join_requests/rebranded/show_pending.en.html.erb
@@ -1,0 +1,49 @@
+<% provide :title, "Invite Details" %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around w-full lg:w-1/2">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Invite Details"} do %>
+    <h3>
+      <%= t(
+        "views.join_requests.show.greeting",
+        name: @join_request.requestor_first_name,
+        team_name: @join_request.team_name
+      ) %>
+    </h3>
+
+    <p class="mb-6"><%= t("views.join_requests.show.message") %></p>
+
+    <%= render "profiles/rebrand/public_show",
+               account: @join_request.requestor %>
+
+    <%= render "application/templates/tw_thick_rule" %>
+
+    <div class="flex justify-between mt-8">
+      <%= button_to(
+        t("controllers.join_requests.update.decline", name: @join_request.requestor_name),
+          send("#{current_scope}_join_request_path", @join_request),
+          class: "tw-gray-btn",
+          params: {
+            join_request: { status: :declined },
+          },
+          method: :put,
+          data: {
+            confirm: t("views.join_requests.form.confirm_decline")
+          }
+      ) %>
+
+      <%= button_to(
+        t("controllers.join_requests.update.accept", name: @join_request.requestor_first_name),
+          send("#{current_scope}_join_request_path", @join_request),
+          class: "tw-green-btn",
+          params: {
+            join_request: { status: :approved },
+          },
+          method: :put,
+          data: {
+            confirm: t("views.join_requests.form.confirm_accept"),
+            positive: true
+          }
+      ) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/mentor/profiles/rebrand/_public_profile.html.erb
+++ b/app/views/mentor/profiles/rebrand/_public_profile.html.erb
@@ -1,8 +1,21 @@
-<p class="font-bold"><%= t('models.mentor_profile.school_company_name') %></p>
-<p><%= account.school_company_name %></p>
+<dl>
+  <dt class="leading-tight"><%= t("models.account.address") %></dt>
+  <dd class="leading-tight"><%= account.address_details %></dd>
 
-<p class="font-bold"><%= t('models.mentor_profile.job_title') %></p>
-<p><%= account.job_title %></p>
+  <dt class="leading-tight"><%= t("models.account.gender") %></dt>
+  <dd class="leading-tight"><%= account.gender %></dd>
 
-<p class="font-bold"><%= t('models.mentor_profile.expertise_names') %></p>
-<p><%= account.expertise_names.present? ? account.expertise_names.to_sentence : 'No expertises selected'%></p>
+  <dt class="leading-tight"><%= t("models.mentor_profile.school_company_name") %></dt>
+  <dd class="leading-tight"><%= account.school_company_name %></dd>
+
+  <dt class="leading-tight"><%= t("models.mentor_profile.job_title") %></dt>
+  <dd class="leading-tight"><%= account.job_title %></dd>
+
+  <dt class="leading-tight"><%= t("models.mentor_profile.expertise_names") %></dt>
+  <dd class="leading-tight"><%= account.expertise_names.present? ? account.expertise_names.to_sentence : "No expertises selected"%></dd>
+</dl>
+
+<div>
+  <h3 class="text-neutral-700 font-bold leading-tight"><%= t("models.mentor_profile.bio") %></h3>
+  <%= account.bio.present? ? simple_format(account.bio) : "This mentor has not written a bio." %>
+</div>

--- a/app/views/profiles/rebrand/_public_show.html.erb
+++ b/app/views/profiles/rebrand/_public_show.html.erb
@@ -1,33 +1,13 @@
 <% title ||= t("views.accounts.show.title") %>
 
 <section class="mb-8">
-
   <h3 class="text-3xl font-bold mb-4"><%= account.full_name %></h3>
 
-  <div class="flex flex-col lg:flex-row lg:space-x-12 mb-4">
+  <div class="flex flex-wrap flex-col lg:flex-row lg:items-start mb-4">
     <%= image_tag account.profile_image_url,
-                  class: "rounded-tr-3xl rounded-bl-3xl w-1/4" %>
+                  class: "rounded-tr-3xl rounded-bl-3xl w-1/4 mr-8" %>
 
-    <div class="mt-auto">
-      <p class="font-bold">Location</p>
-      <p><%= account.address_details %></p>
-
-      <% unless account.student_profile.present? %>
-        <p class="font-bold"><%= t('models.account.gender') %></p>
-        <p><%= account.gender %></p>
-      <% end %>
-
-      <%= render "#{account.scope_name}/profiles/rebrand/public_profile",
-                 account: account %>
-    </div>
-  </div>
-
-  <div>
-    <p class="font-bold">Bio</p>
-    <% if account.respond_to?(:bio) %>
-      <p><%= simple_format account.bio %></p>
-    <% else %>
-      <p> This mentor has not written a bio.</p>
-    <% end %>
+    <%= render "#{account.scope_name}/profiles/rebrand/public_profile",
+               account: account %>
   </div>
 </section>

--- a/app/views/student/profiles/rebrand/_public_profile.html.erb
+++ b/app/views/student/profiles/rebrand/_public_profile.html.erb
@@ -1,0 +1,7 @@
+<dl>
+  <dt class="leading-tight">Location</dt>
+  <dd class="leading-tight"><%= account.address_details %></dd>
+
+  <dt class="leading-tight"><%= t("models.student_profile.school_name") %></dt>
+  <dd class="leading-tight"><%= account.student_profile.school_name %></dd>
+</dl>

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -38,6 +38,7 @@ en:
       virtual: "I am available to mentor teams virtually (online) from anywhere."
       job_title: "Job title"
       school_company_name: "School or company name"
+      bio: "Bio"
 
     parental_consent:
       electronic_signature: "Your name"


### PR DESCRIPTION
This will rebrand the pending join requests page.

The new join request page will show details for either a student or mentor (looking to join your team) and approve/decline buttons. This page will reuse/show the `app/views/profiles/rebrand/_public_show.html.erb` page, which in turn will display the rebranded public mentor detail page (an existing page), or the rebranded public student detail page (added in this PR).

-----

This is the existing public mentor details page (before any changes I made) accessed via searching/inviting a mentor to your team:
<img src="https://user-images.githubusercontent.com/58957909/192371187-7698fe84-4bdd-4e6f-befa-7d41054c5565.png" width="300">

I reused that page for viewing pending join requests and made some minor tweaks (the code changes are more significant though b/c I moved some of the code around):
<img src="https://user-images.githubusercontent.com/58957909/192370818-a862a411-4b49-43dc-825f-f48a373beab3.png" width="300">