### PR TITLE
Add output comments to season reset rake task

### DIFF
--- a/lib/tasks/reset_for_season.rake
+++ b/lib/tasks/reset_for_season.rake
@@ -6,16 +6,26 @@ end
 desc "Reset data for the new season on season start date every year"
 task :reset_for_season, [:force] => :environment do |t, args|
   if reset_day? || args[:force] == "force"
-    puts "Resetting for new season"
-
+    puts "Resetting consent waivers"
     ConsentWaiver.nonvoid.find_each(&:void!)
 
+    puts "Resetting data use terms"
     Account.update_all(terms_agreed_at: nil)
 
+    puts "Resetting onboarded flags"
     StudentProfile.update_all(onboarded: false)
     JudgeProfile.update_all(onboarded: false)
 
+    puts "Resetting mentor trainings"
     MentorProfile.update_all(training_completed_at: nil)
+
+    puts "Resetting judge trainings"
     JudgeProfile.update_all(completed_training_at: nil)
+
+    puts "Finished resetting"
+  else
+    season_start_date = "#{Date.today.year}-#{Season::START_MONTH.to_s.rjust(2, "0")}-#{Season::START_DAY.to_s.rjust(2, "0")}"
+
+    puts "The reset needs to happen on the season start date (#{season_start_date}) or you can run this rake task with the 'force' option (e.g. `bundle exec rake reset_for_season[force]`)"
   end
 end

--- a/spec/tasks/reset_for_season_spec.rb
+++ b/spec/tasks/reset_for_season_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Resetting for season" do
   let(:rollover_date) { Time.new(Time.now.year, Season::START_MONTH, Season::START_DAY) }
   let(:other_date) { rollover_date - 1.month }
-  let(:task) { Rake::Task['reset_for_season'] }
+  let(:task) { Rake::Task["reset_for_season"] }
   let(:output) { StringIO.new }
 
   before(:each) do
@@ -21,7 +21,13 @@ RSpec.describe "Resetting for season" do
 
     it "runs without being forced" do
       task.invoke
-      expect(output.string).to include("Resetting for new season")
+
+      expect(output.string).to include("Resetting consent waivers")
+      expect(output.string).to include("Resetting data use terms")
+      expect(output.string).to include("Resetting onboarded flags")
+      expect(output.string).to include("Resetting mentor trainings")
+      expect(output.string).to include("Resetting judge trainings")
+      expect(output.string).to include("Finished resetting")
     end
   end
 
@@ -31,12 +37,19 @@ RSpec.describe "Resetting for season" do
 
     it "runs if forced" do
       task.invoke("force")
-      expect(output.string).to include("Resetting for new season")
+
+      expect(output.string).to include("Resetting consent waivers")
+      expect(output.string).to include("Resetting data use terms")
+      expect(output.string).to include("Resetting onboarded flags")
+      expect(output.string).to include("Resetting mentor trainings")
+      expect(output.string).to include("Resetting judge trainings")
+      expect(output.string).to include("Finished resetting")
     end
 
     it "doesn't run if not forced" do
       task.invoke
-      expect(output.string).not_to include("Resetting for new season")
+
+      expect(output.string).to include("The reset needs to happen on the season start date")
     end
   end
 end


### PR DESCRIPTION
I didn't make any functional changes here, I just adding some output comments to make it clearer what is happening if the rake task is successful or providing some insights if it didn't run.

Example outputs:

```
Resetting consent waivers
Resetting data use terms
Resetting onboarded flags
Resetting mentor trainings
Resetting judge trainings
Finished resetting
```

```
The reset needs to happen on the season start date (2022-10-01) or you can run this rake task with the 'force' option (e.g. `bundle exec rake reset_for_season[force])`
```



