### PR TITLE
Added a conditional to only send judge welcome email when judge registration is open

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -89,7 +89,9 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
   def prepare_judge_for_current_season(record)
     subscribe_to_newsletter(record, :judge)
 
-    RegistrationMailer.welcome_judge(record.id).deliver_later
+    if SeasonToggles.judge_registration_open?
+      RegistrationMailer.welcome_judge(record.id).deliver_later
+    end
 
     record.judge_profile.update(completed_training_at: nil)
     record.judge_profile.save # fire commit hooks, if needed


### PR DESCRIPTION
Refs #3659 

This change was added to prevent the judge welcome email from being sent unless judge registration is open. 

We will need to revisit this in the future because any previous judges the login to their account before judge registration is open will be registered to the current season and we believe since that job will be completed, they will not receive the welcome email at all. 

