### PR TITLE
Added temporary text for team photo upload coming soon

### DIFF
--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -38,10 +38,9 @@
           </div>
 
           <div>
-            <%= render "image_upload",
-              modal_id: "team_photo_desktop",
-              heading: "Upload a team photo",
-              size: "450x300" %>
+            <button class="filestack-picker-btn cursor-not-allowed">
+              Team photo upload coming soon
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This is a temporary change to the "change image" button for team photo on the team summary page. This will be updated with the filestack change in #3658 
![CleanShot 2022-10-04 at 12 10 33@2x](https://user-images.githubusercontent.com/29210380/193883149-e8bc071b-3cd1-4be8-a72c-501de4db2a88.png)
