### PR TITLE
Integrate filestack for team photo upload

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -27,6 +27,7 @@ module Admin
       params.require(:team).permit(
         :name,
         :description,
+        :team_photo,
         :city,
         :state_province,
         :country

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -412,7 +412,7 @@ class Team < ActiveRecord::Base
   private
 
   def default_team_photo_url
-    if Season.current.year >= 2023
+    if Season.current.year >= 2023 && current?
       ActionController::Base.helpers.asset_path("placeholders/default-team-avatar.png")
     else
       ActionController::Base.helpers.asset_path("placeholders/team-missing.jpg")

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -155,8 +155,6 @@ class Team < ActiveRecord::Base
     team_photo
   end
 
-  mount_uploader :team_photo, TeamPhotoProcessor
-
   Division.names.keys.each do |division_name|
     scope division_name, -> {
       joins(:division).where(
@@ -261,7 +259,6 @@ class Team < ActiveRecord::Base
 
   validates :name, presence: true, team_name_uniqueness: true
   validates :division, presence: true
-  validates :team_photo, verify_cached_file: true
 
   delegate :name, to: :division, prefix: true
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -274,6 +274,16 @@ class Team < ActiveRecord::Base
     has_students? && all_students_onboarded?
   end
 
+  def team_photo_url
+    if team_photo.blank?
+      default_team_photo_url
+    elsif team_photo.include?("filestackcontent")
+      team_photo
+    else
+      "https://s3.amazonaws.com/#{ENV.fetch("AWS_BUCKET_NAME")}/uploads/team/team_photo/#{id}/#{team_photo}"
+    end
+  end
+
   def photo_url
     team_photo_url
   end
@@ -397,5 +407,15 @@ class Team < ActiveRecord::Base
 
   def assigned_judge_names
     assigned_judges.flat_map(&:full_name)
+  end
+
+  private
+
+  def default_team_photo_url
+    if Season.current.year >= 2023
+      ActionController::Base.helpers.asset_path("placeholders/default-team-avatar.png")
+    else
+      ActionController::Base.helpers.asset_path("placeholders/team-missing.jpg")
+    end
   end
 end

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -44,7 +44,7 @@
     </p>
 
     <p>
-      <%= f.label :profle_image %>
+      <%= f.label :profile_image %>
 
       <%= image_tag @account.profile_image_url,
                     id: "main-profile-image",

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -16,7 +16,7 @@
       <div class="grid">
         <div class="grid__col-6">
           <%= image_tag(
-            @team_submission.team_photo.url,
+            @team_submission.team_photo_url,
             class: "thumbnail--mdlg grid__cell-img"
           ) %>
         </div>

--- a/app/views/chapter_ambassador/team_submissions/show.html.erb
+++ b/app/views/chapter_ambassador/team_submissions/show.html.erb
@@ -9,7 +9,7 @@
       <div class="grid">
         <div class="grid__col-6">
           <%= image_tag(
-            @team_submission.team_photo.url,
+            @team_submission.team_photo_url,
             class: "thumbnail--mdlg grid__cell-img"
           ) %>
         </div>

--- a/app/views/completion_steps/_invitations.en.html.erb
+++ b/app/views/completion_steps/_invitations.en.html.erb
@@ -17,7 +17,7 @@
         <div class="grid grid--bleed margin--t-large">
           <div class="grid__col-4">
             <div class="grid__cell">
-              <%= image_tag invite.team.team_photo.url,
+              <%= image_tag invite.team.team_photo_url,
                             class: "thumbnail-md grid__cell-img" %>
             </div>
           </div>

--- a/app/views/completion_steps/rebrand/_invitations.en.html.erb
+++ b/app/views/completion_steps/rebrand/_invitations.en.html.erb
@@ -14,7 +14,7 @@
         <div class="lg:tw-flex-basis-33 mb-8">
           <%= content_tag :div, id: dom_id(invite), class:'h-full' do %>
             <div class="w-full md:w-64 h-full justify-center items-center bg-white shadow-lg rounded-lg flex flex-col">
-              <%= image_tag invite.team.team_photo.url, class: "w-full h-auto object-cover rounded-t-lg" %>
+              <%= image_tag invite.team.team_photo_url, class: "w-full h-auto object-cover rounded-t-lg" %>
               <div class="w-full p-4 justify-start flex flex-col">
                 <section class="h-4/5">
                   <p class="font-bold"><%= invite.team_name.titleize %></p>

--- a/app/views/dashboards/_invitations.en.html.erb
+++ b/app/views/dashboards/_invitations.en.html.erb
@@ -12,7 +12,7 @@
           <div class="grid grid--bleed">
             <div class="grid__col-4">
               <div class="grid__cell">
-                <%= image_tag invite.team.team_photo.url,
+                <%= image_tag invite.team.team_photo_url,
                   class: "thumbnail-md grid__cell-img" %>
               </div>
             </div>

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -1,0 +1,35 @@
+<%= javascript_tag do %>
+  function onFileUploadFinished(data) {
+    $("#team_team_photo").val(data.url);
+
+    $.ajax({
+      method: "PATCH",
+      url: "#{current_scope}_team_path",
+      data: $("#filestack-team-photo-form").serialize(),
+      success: function() {
+        const teamPhoto = $("#team-photo");
+        teamPhoto.attr("src", filestack_client.transform(data.handle))
+      }
+    });
+  }
+<% end %>
+
+<%= form_with model: current_team, id: "filestack-team-photo-form" do |form| %>
+  <%= form.filestack_field :team_photo,
+                        "Change Image",
+                        id: "team-photo-filepicker",
+                        class: "filestack-picker-btn",
+                        pickerOptions: {
+                          fromSources: ["local_file_system","webcam", "url"],
+                          uploadConfig: {
+                            intelligent: true,
+                          },
+                          onFileUploadFinished: "onFileUploadFinished",
+                          storeTo: {
+                            location: "s3",
+                            container: ENV.fetch("AWS_BUCKET_NAME"),
+                            path: "uploads/team/team_photo/#{current_team.id}/",
+                            region: "us-east-1"
+                          }
+                        } %>
+<% end %>

--- a/app/views/mentor/dashboards/_quick_links.html.erb
+++ b/app/views/mentor/dashboards/_quick_links.html.erb
@@ -45,7 +45,7 @@
               <%= link_to mentor_team_path(team),
                 class: "my-stuff__img my-stuff__img-team",
                 style: "left: #{30 * i}px;" do %>
-                <%= image_tag team.team_photo.url,
+                <%= image_tag team.team_photo_url,
                   title: team.name,
                   width: 100,
                   height: 100 %>

--- a/app/views/mentor/regional_pitch_event_selections/new.en.html.erb
+++ b/app/views/mentor/regional_pitch_event_selections/new.en.html.erb
@@ -30,7 +30,7 @@
 
         <div class="card__body">
           <div class="card-body__img">
-            <%= image_tag team.team_photo.url, width: 150, height: 100 %>
+            <%= image_tag team.team_photo_url, width: 150, height: 100 %>
           </div>
 
           <div class="card-body__details">

--- a/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
+++ b/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
@@ -11,7 +11,7 @@
         <div class="grid">
           <div class="grid__col-4">
             <%= link_to image_tag(
-              team.team_photo.url,
+              team.team_photo_url,
               class: "thumbnail--mdlg grid__cell-img"
             ), mentor_team_path(team) %>
 

--- a/app/views/mentor/teams/_team_list_item_content.html.erb
+++ b/app/views/mentor/teams/_team_list_item_content.html.erb
@@ -5,7 +5,7 @@
 <div class="grid grid--bleed">
   <div class="grid__col-6">
     <%= link_to image_tag(
-      team.team_photo.url,
+      team.team_photo_url,
       class: "thumbnail--mdlg grid__cell-img"
     ), mentor_team_path(team) %>
 

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -34,7 +34,7 @@
       <div class="w-1/4 self-end">
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
-            <%= image_tag team.photo_url,
+            <%= image_tag team.team_photo_url,
                           class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm",
                           id: "team-photo" %>
           </div>

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -35,7 +35,7 @@
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
             <%= image_tag team.team_photo_url,
-                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm",
+                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm filestack-profile-img",
                           id: "team-photo" %>
           </div>
 

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -34,13 +34,13 @@
       <div class="w-1/4 self-end">
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
-            <%= image_tag team.photo_url, class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm" %>
+            <%= image_tag team.photo_url,
+                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm",
+                          id: "team-photo" %>
           </div>
 
           <div>
-            <button class="filestack-picker-btn cursor-not-allowed">
-              Team photo upload coming soon
-            </button>
+            <%= render "filestack_uploads/team_photo_upload" %>
           </div>
         </div>
       </div>

--- a/app/views/teams/_intro.en.html.erb
+++ b/app/views/teams/_intro.en.html.erb
@@ -5,7 +5,11 @@
 %>
 
 <div class="<%= hidden_on.map { |size| "hidden-#{size}" }.join(" ") %>">
-  <%= image_tag team.team_photo_url, class: "grid__cell-img" %>
+  <%= image_tag team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
+
+  <% if @team.current? %>
+    <%= render "filestack_uploads/team_photo_upload", current_team: @team %>
+  <% end %>
 
   <% unless admin_chapter_ambassador %>
     <%= render 'image_upload',

--- a/app/views/teams/_public_show.html.erb
+++ b/app/views/teams/_public_show.html.erb
@@ -5,7 +5,7 @@
     <div class="grid__cell">
       <h3>Technovation team</h3>
 
-      <%= image_tag team.team_photo.url, class: "thumbnail-lg grid__cell-img" %>
+      <%= image_tag team.team_photo_url, class: "thumbnail-lg grid__cell-img" %>
 
       <h3><%= team.name %></h3>
 

--- a/app/views/teams/rebrand/_team_info.html.erb
+++ b/app/views/teams/rebrand/_team_info.html.erb
@@ -1,7 +1,7 @@
 <h3 class="text-3xl font-bold mb-4"><%= team.name %></h3>
 
 <div class="flex flex-col lg:flex-row lg:space-x-12 mb-4">
-  <%= image_tag team.team_photo.url,
+  <%= image_tag team.team_photo_url,
                 class: "rounded-tr-3xl rounded-bl-3xl w-1/4" %>
   <div class="mt-auto">
     <p class="font-bold"><%= team.division_name.humanize %> Division</p>

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -39,6 +39,13 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
+  scenario "Set the team photo" do
+    click_link "Team photo"
+    click_link "Summary"
+    expect(page).to have_selector("#filestack-team-photo-form", visible: false)
+    expect(page).to have_button "Change Image"
+  end
+
   scenario "Set the product description" do
     click_link "Ideation"
 


### PR DESCRIPTION
Refs #3658 

This change includes filestack integration for team photo upload. It would be great if you can test this one locally. I tried to login as different scenarios but there are so many places the team photo is integrated it would be helpful to have a second set of eyes 👀 ! 

With this change:
1. Students can upload a team photo using filestack
2. Admins can also now update team photos from the admin portal! This is a new feature. Admin can only update team photos for current season teams in order to preserve historical data for future seasonality updates. 

I added a beginning version of tests for this in `spec/features/student/submission_piece_spec.rb`. I spent some time researching, but it seems there is a known issue with rspec and filestack. I had difficulty getting the modal to actually open. I will continue to research this issue. 

Finally, the tests kept failing due to an undefined method `team_photo.url`. I think this was related to the old photo upload process/carrierwave/minimagick. I updated each of those references to `team_photo_url` which is an updated method in the team model that determines the correct team photo URL. This is similar to the approach with the account profile image.

Note: Team photos are stored on AWS S3 - `environment_bucket_here/uploads/team/team_photo/#{id}/#{team_photo}`