### PR TITLE
Consent Form Improvements

### DIFF
--- a/app/controllers/media_consents_controller.rb
+++ b/app/controllers/media_consents_controller.rb
@@ -31,7 +31,7 @@ class MediaConsentsController < ApplicationController
           action: :show,
           token: params.fetch(:token)
         },
-        success: t("controllers.media_consents.update.success")
+        success: t("controllers.media_consents.update.success_html")
       )
     else
       render :edit

--- a/app/javascript/stylesheets/base_forms.css
+++ b/app/javascript/stylesheets/base_forms.css
@@ -22,7 +22,7 @@
     input[type="checkbox"], input[type="radio"] {
         @apply inline-block focus:ring-transparent text-energetic-blue mr-2
     }
-    
+
     input[type="checkbox"], input[type="radio"] {
         color: #43b02a;
     }
@@ -38,5 +38,8 @@
     input[type="checkbox"]:disabled, input[type="radio"]:disabled {
         @apply text-gray-400
     }
-}
 
+    .radio label, .boolean label {
+      @apply cursor-pointer
+    }
+}

--- a/app/views/layouts/documents.html.erb
+++ b/app/views/layouts/documents.html.erb
@@ -36,7 +36,13 @@
     <div class="max-w-prose mx-auto px-8">
       <%= image_tag "new_registration/tg-girls-logo.png", alt:"Technovation Girls Logo", id:"tg-logo", class:"w-72 -ml-6"%>
 
-      <%= render "application/flash_messages" %>
+      <div id="flash">
+        <% flash.each do |type, message| %>
+          <div>
+            <%= message.html_safe %>
+          </div>
+        <% end %>
+      </div>
 
       <%= yield %>
     </div>

--- a/app/views/media_consents/edit.en.html.erb
+++ b/app/views/media_consents/edit.en.html.erb
@@ -46,9 +46,6 @@
 
   <div>
     <%= f.input :token, as: :hidden, input_html: { name: :token, value: params[:token] } %>
-    <%= f.button :submit,
-      t("views.media_consents.submit"),
-      class: "tw-green-btn"
-    %>
+    <%= f.submit t("views.media_consents.submit"), class: "tw-green-btn cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/media_consents/edit.en.html.erb
+++ b/app/views/media_consents/edit.en.html.erb
@@ -7,7 +7,10 @@
   }
 %>
 
-<%= simple_form_for @media_consent, html: {class: "consent-form"} do |f| %>
+<%= simple_form_for @media_consent,
+  html: {class: "consent-form"},
+  url:  media_consent_path(@media_consent, anchor: "media-consent-form") do |f| %>
+
   <%= render "errors", record: @media_consent %>
 
   <div class="prose consent-document prose-sm w-full max-w-full mt-8">
@@ -18,7 +21,7 @@
 
   <div class="w-full border-gray-400 my-8"></div>
 
-  <div style="my-4">
+  <div id="media-consent-form" style="my-4">
     <%= f.input :consent_provided,
       as: :radio_buttons,
       label: "",

--- a/app/views/media_consents/show.en.html.erb
+++ b/app/views/media_consents/show.en.html.erb
@@ -1,5 +1,7 @@
 <% provide :title, "Electronic Media Release Consent Form" %>
 
+<div class="mt-8"></div>
+
 <%= render partial: "parental_consents/consent_status",
   locals: {
     parental_consent: @parental_consent,

--- a/app/views/parental_consents/edit.en.html.erb
+++ b/app/views/parental_consents/edit.en.html.erb
@@ -13,7 +13,10 @@
   }
 %>
 
-<%= simple_form_for @parental_consent, html: {class: "consent-form"} do |f| %>
+<%= simple_form_for @parental_consent,
+  html: {class: "consent-form"},
+  url:  parental_consent_path(@parental_consent, anchor: "parental-consent-form") do |f| %>
+
   <%= render "errors", record: @parental_consent %>
 
   <div class="prose consent-document prose-sm w-full max-w-full mt-10">
@@ -24,7 +27,7 @@
 
   <div class="w-full border-gray-400 my-8"></div>
 
-  <div class="my-4">
+  <div id="parental-consent-form" class="my-4">
     <%= label_tag t("views.parental_consents.student_name.label") %>
     <%= text_field_tag nil, f.object.student_profile.full_name, disabled: "disabled" %>
   </div>

--- a/app/views/parental_consents/edit.en.html.erb
+++ b/app/views/parental_consents/edit.en.html.erb
@@ -49,9 +49,6 @@
 
   <div>
     <%= f.input :student_profile_consent_token, as: :hidden %>
-    <%= f.button :submit,
-      t("views.parental_consents.new.submit"),
-      class: "tw-green-btn"
-    %>
+    <%= f.submit t("views.parental_consents.new.submit"), class: "tw-green-btn cursor-pointer" %>
   </div>
 <% end %>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -88,7 +88,7 @@ en:
     media_consents:
       invalid: "You don't have permission to go there"
       update:
-        success: "Thank you for signing the media consent form"
+        success_html: "Thank you for signing the forms. Your child can now join a Technovation Girls team. Please find more information on supporting her participation in Technovation on our <a href='https://technovationchallenge.org/parent-resources/' class='underline'>Parent Resources</a> page."
 
     parental_consents:
       create:


### PR DESCRIPTION
From #3107, here are the things being addressed in this PR:

- Make the cursor be a hand and not an arrow on the buttons to submit the parental consent and media forms

-  If a user forgets to fill in a field, the form reloads at the top of the screen so the user can't see the error easily. Could it load at the bottom of the screen so the needed information is visible? The error text should also be a red color or have some other visual indication to draw attention.

- After guardians complete parental consent and media consent forms, they receive a "Thank you for signing the media consent form" banner at the top of the page. Let's change the text to say:

> "Thank you for signing the forms. Your child can now join a Technovation Girls team. Please find more information on supporting her participation in Technovation on our Parent Resources page."
