### PR TITLE
Update "available later" tooltips

### DIFF
--- a/app/javascript/mentor/DashboardMenu.vue
+++ b/app/javascript/mentor/DashboardMenu.vue
@@ -44,7 +44,7 @@
     <tab-link
       :class="eventsTabLinkClasses"
       :to="{ name: 'events', meta: { active: eventsPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.REGIONAL_PITCH_EVENTS_AVAILABLE_LATER"
       :condition-to-enable="regionalPitchEventsEnabled"
       :condition-to-complete="false"
     >
@@ -55,7 +55,7 @@
     <tab-link
       :class="scoresTabLinkClasses"
       :to="{ name: 'scores', meta: { active: scoresPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.SCORES_AND_CERTIFICATES_AVAILABLE_LATER"
       :condition-to-enable="scoresAndCertificatesEnabled"
       :condition-to-complete="false"
     >View Scores & Certificates</tab-link>

--- a/app/javascript/mixins/tooltips.js
+++ b/app/javascript/mixins/tooltips.js
@@ -15,7 +15,8 @@ const Tooltips = {
     }
   },
 
-  AVAILABLE_LATER: 'This feature will open later in the season if your local chapter is hosting an event.',
+  REGIONAL_PITCH_EVENTS_AVAILABLE_LATER: 'This feature will open later in the season if your local chapter is hosting an event.',
+  SCORES_AND_CERTIFICATES_AVAILABLE_LATER: 'This feature will open later in the season.'
 }
 
 export default {

--- a/app/javascript/student/DashboardMenu.vue
+++ b/app/javascript/student/DashboardMenu.vue
@@ -45,7 +45,7 @@
     <tab-link
       :class="eventsTabLinkClasses"
       :to="{ name: 'events', meta: { active: eventsPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.REGIONAL_PITCH_EVENTS_AVAILABLE_LATER"
       :condition-to-enable="regionalPitchEventsEnabled"
       :condition-to-complete="false"
     >
@@ -55,7 +55,7 @@
     <tab-link
       :class="scoresTabLinkClasses"
       :to="{ name: 'scores', meta: { active: scoresPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.SCORES_AND_CERTIFICATES_AVAILABLE_LATER"
       :condition-to-enable="scoresAndCertificatesEnabled"
       :condition-to-complete="false"
     >View Scores & Certificate</tab-link>

--- a/app/javascript/student/DashboardMenuRebrand.vue
+++ b/app/javascript/student/DashboardMenuRebrand.vue
@@ -52,7 +52,7 @@
     <tab-link
       :class="eventsTabLinkClasses"
       :to="{ name: 'events', meta: { active: eventsPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.REGIONAL_PITCH_EVENTS_AVAILABLE_LATER"
       :condition-to-enable="regionalPitchEventsEnabled"
       :condition-to-complete="false"
     >
@@ -65,7 +65,7 @@
     <tab-link
       :class="scoresTabLinkClasses"
       :to="{ name: 'scores', meta: { active: scoresPagesActive } }"
-      :disabled-tooltip="tooltips.AVAILABLE_LATER"
+      :disabled-tooltip="tooltips.SCORES_AND_CERTIFICATES_AVAILABLE_LATER"
       :condition-to-enable="scoresAndCertificatesEnabled"
       :condition-to-complete="false"
     >


### PR DESCRIPTION
We currently have one `AVAILABLE_LATER` tooltip that is being used by both RPEs and Scores and Certificates, this PR makes them separate:

- `REGIONAL_PITCH_EVENTS_AVAILABLE_LATER`
- `SCORES_AND_CERTIFICATES_AVAILABLE_LATER`

Refs: #3649


