### PR TITLE
Added accepted filetypes for filestack profile image upload - file types include jpeg, jpg, png

### DIFF
--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -55,6 +55,7 @@
                               "Change Image",
                               id: "profile-image-filepicker",
                               pickerOptions: {
+                                accept: ["image/jpeg", "image/jpg", "image/png"],
                                 uploadConfig: {
                                   intelligent: true,
                                 },

--- a/app/views/profiles/_filestack_profile_image_upload.en.html.erb
+++ b/app/views/profiles/_filestack_profile_image_upload.en.html.erb
@@ -31,6 +31,7 @@
                           id: "profile-image-filepicker",
                           class: "filestack-picker-btn",
                           pickerOptions: {
+                            accept: ["image/jpeg", "image/jpg", "image/png"],
                             fromSources: ["local_file_system","webcam", "url"],
                             uploadConfig: {
                               intelligent: true,


### PR DESCRIPTION
Refs #3685 

This change adds accepted file types for the filestack profile image upload process

