### PR TITLE
Added accepted filetypes for filestack team photo upload - filetypes include jpeg, jpg, png

### DIFF
--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -20,6 +20,7 @@
                         id: "team-photo-filepicker",
                         class: "filestack-picker-btn",
                         pickerOptions: {
+                          accept: ["image/jpeg", "image/jpg", "image/png"],
                           fromSources: ["local_file_system","webcam", "url"],
                           uploadConfig: {
                             intelligent: true,


### PR DESCRIPTION
Refs #3658 

This was a bug found on production with profile image upload, so adding in the accepted file types to the team photo upload before it is deployed to production. Code review not required! 

