### PR TITLE
Add/setup i18n-js NPM module

### DIFF
--- a/app/javascript/judge/scores/pieces/DemoVideoLink.vue
+++ b/app/javascript/judge/scores/pieces/DemoVideoLink.vue
@@ -9,7 +9,7 @@
         class="text-energetic-blue flex text-3xl"
       >
         <icon name="play-circle-o" color="0075cf"/>
-        Watch the demo video
+        Watch the {{ demo_video() }}
       </a>
     </p>
 
@@ -27,6 +27,7 @@
 import {mapState} from 'vuex'
 
 import Icon from '../../../components/Icon'
+import { i18n } from '../../../utilities/i18n.js'
 
 export default {
   computed: mapState(['score', 'submission']),
@@ -41,5 +42,11 @@ export default {
   components: {
     Icon
   },
+
+  methods: {
+    demo_video() {
+      return i18n.t("submissions.demo_video")
+    }
+  }
 }
 </script>

--- a/app/javascript/utilities/i18n.js
+++ b/app/javascript/utilities/i18n.js
@@ -1,0 +1,7 @@
+import { I18n } from "i18n-js";
+
+import translations from "../config/locales/en.json";
+
+const i18n = new I18n(translations);
+
+export {i18n}

--- a/app/views/team_submissions/pieces/demo_video_link.en.html.erb
+++ b/app/views/team_submissions/pieces/demo_video_link.en.html.erb
@@ -28,22 +28,22 @@
   <% end %>
 
   <p class="grid__cell--padding-sm-y">
-    Get some help making your demo video in the
+  Get some help making your <%= t("submissions.demo_video") %> in the
 
     <%= link_to(
       "Beginner",
       "https://beginner.technovationchallenge.org/path-player?courseid=beginners&unit=beginners_1630333562723_0Unit",
       target: "_blank"
     ) %>
-    
+
     or
-    
+
     <%= link_to(
       "Junior/Senior",
       "https://technovationchallenge.org/curriculum/pitch-3-outline-your-demo-video/",
       target: "_blank"
     ) %>
-    
+
     curriculum units.
   </p>
 </div>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "escape-string-regexp": "^4.0.0",
     "filestack-js": "^3.25.0",
     "flatpickr": "^4.2.4",
+    "i18n-js": "^4.1.1",
     "ini": "1.3.8",
     "lodash": "^4.17.19",
     "luxon": "^2.1.1",

--- a/spec/features/mentor/submission_piece_spec.rb
+++ b/spec/features/mentor/submission_piece_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  scenario "Uses the same video link for the demo video and pitch video" do
+  scenario "Doesn't allow the same video link for the demo/technical video and pitch video" do
     click_link "Pitch"
 
     within(".demo_video_link.incomplete") do

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -128,7 +128,7 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  scenario "Uses the same video link for the demo video and pitch video" do
+  scenario "Doesn't allow the same video link for the demo/technical video and pitch video" do
     click_link "Pitch"
 
     within(".demo_video_link.incomplete") do

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,6 +2652,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@*:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
+  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -5628,6 +5633,14 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+i18n-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.1.1.tgz#05ebd03c4d92f6dc26a00d7c5cfb90f9c326b67c"
+  integrity sha512-Uph8ghmfShexVhDcNtg5s40zprJZPrhW5iOEKsUwPiiBpIGN/0EJ9W7DTqhLFlWfAlpkFiaLxVxHsk8f+3KjIQ==
+  dependencies:
+    bignumber.js "*"
+    lodash "*"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -6952,7 +6965,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.21:
+lodash@*, lodash@^4.17.11, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This is the last piece that's needed to do i18n translations in Vue.js.

Basic overview of the changes:
- A new [i18n-js](https://github.com/fnando/i18n) NPM module was added to allow us to use the new i18n JSON files in Vue.js
- A basic utility wrapper around this module was created
- Using this new utility wrapper to do the translation for "demo video" that shows up in the judging flow
- Updated a couple of "demo video" stragglers in Rails land