### PR TITLE
Add rake task to reset judge trainings

### DIFF
--- a/lib/tasks/reset_judge_training.rake
+++ b/lib/tasks/reset_judge_training.rake
@@ -1,0 +1,14 @@
+desc "Reset judge trainings for judges in the current season"
+task reset_judge_training: :environment do
+  accounts = Account.current.joins(:judge_profile).where.not(judge_profile: {completed_training_at: nil})
+  judges_updated_count = 0
+
+  accounts.each do |account|
+    puts "Resetting judge training for account: #{account.id} - #{account.first_name} #{account.last_name}"
+
+    account.judge_profile.update(completed_training_at: nil)
+    judges_updated_count += 1
+  end
+
+  puts "Reset #{judges_updated_count} judges"
+end


### PR DESCRIPTION
This will add a rake task that will reset judge trainings for judges in the current season (2023) who completed the judge training for the 2022 season.

I tested this locally w/ production data and it reset 23 records (I removed production data from my machine already). I also wrote a dataclip and there were 23 records being returned, so it's lining up.

