### PR TITLE
Updated css for screenshots so they are the same size in judging experience in learning journey section

### DIFF
--- a/app/javascript/judge/scores/pieces/Screenshots.vue
+++ b/app/javascript/judge/scores/pieces/Screenshots.vue
@@ -1,17 +1,16 @@
 <template>
   <div
     id="screenshots-nav"
-    class="flex flex-row flex-nowrap max-w-full"
+    class="flex flex-row flex-wrap gap-4 justify-center"
     :data-modal-last="submission.screenshots.length - 1"
   >
-
     <div
       v-for="(screenshot, i) in submission.screenshots"
       :key="screenshot.id"
-      class="mx-2"
+      class="mx-2 w-1/2 lg:w-1/4"
     >
       <img
-        class="judge-screenshot-modal rounded"
+        class="judge-screenshot-modal rounded object-cover w-full h-full"
         :src="screenshot.thumb"
         :data-modal-url="screenshot.full"
         :data-modal-idx="i"


### PR DESCRIPTION
Refs #3699 

Basic CSS changes so screenshot images are the same size in the judging experience 

Also tagging this as "code review not needed" based on discussion and other similar tickets for this iteration! 