### PR TITLE
Rebrand technical additions upload confirmation and created rebranded version of job process vue template

### DIFF
--- a/app/controllers/student/team_submission_file_upload_confirmations_controller.rb
+++ b/app/controllers/student/team_submission_file_upload_confirmations_controller.rb
@@ -12,6 +12,9 @@ module Student
       flash.now[:success] = t("controllers.teams.show.file_processing")
       @unprocessed_file_url = "//s3.amazonaws.com/#{params[:bucket]}/#{params[:key]}"
       @job = Job.find_by!(job_id: job.job_id)
+
+      render 'student/team_submission_file_upload_confirmations/rebrand/show'
+
     end
   end
 end

--- a/app/javascript/components/job_process_rebrand/index.js
+++ b/app/javascript/components/job_process_rebrand/index.js
@@ -1,0 +1,16 @@
+import Vue from "vue";
+
+import JpTemplate from "./template";
+
+document.addEventListener("turbolinks:load", () => {
+  const el = document.querySelector("#job-process-app-rebrand");
+
+  if (el != undefined) {
+    new Vue({
+      el: el,
+      components: {
+        JpTemplate,
+      },
+    });
+  }
+});

--- a/app/javascript/components/job_process_rebrand/template.vue
+++ b/app/javascript/components/job_process_rebrand/template.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="flex flex-col items-center">
+    <div :class="['mb-4 p-4 text-2xl ', statusClass]">
+      <icon name="spinner" size="16" class="spin" v-if="showLoading" />
+      {{ statusMsg }}
+    </div>
+
+    <div v-if="statusCode === 'complete'">
+      <a class="tw-green-btn cursor-pointer" @click.stop.prevent="goBack">Back to submission</a>
+    </div>
+  </div>
+</template>
+
+<script>
+import { urlHelpers } from 'utilities/utilities'
+import Icon from '../Icon'
+
+export default {
+  components: {
+    Icon,
+  },
+
+  props: {
+    statusUrl: {
+      type: String,
+      required: true,
+    }
+  },
+
+  data () {
+    return {
+      interval: null,
+      statusCode: 'init',
+    }
+  },
+
+  mounted () {
+    this.interval = setInterval(() => {
+      window.axios.get(this.statusUrl).then(({ data }) => {
+        this.handleJSON(data)
+      })
+    }, 500)
+  },
+
+  destroyed () {
+    clearInterval(this.interval)
+  },
+
+  computed: {
+    showLoading () {
+      return this.statusCode !== 'complete' && this.statusCode !== 'error'
+    },
+
+    backUrl () {
+      return this.fetchGetParameterValue('back') || '/'
+    },
+
+    statusMsg () {
+      switch(this.statusCode) {
+        case 'init':
+          return 'Creating a job for your file...'
+        case 'queued':
+          return 'Your file is waiting in line...'
+        case 'busy':
+          return 'Your file is being processed...'
+        case 'error':
+          return 'There was an error processing your file, please try again'
+        case 'complete':
+          return 'Your file is ready!'
+      }
+    },
+
+    statusClass () {
+      switch(this.statusCode) {
+        case 'init':
+          return 'yellow'
+        case 'queued':
+          return 'green-waiting'
+        case 'busy':
+          return 'green-busy'
+        case 'error':
+          return 'red'
+        case 'complete':
+          return 'green-complete'
+      }
+    },
+  },
+
+  methods: {
+    fetchGetParameterValue: urlHelpers.fetchGetParameterValue,
+
+    handleJSON (json) {
+      this.statusCode = json.status
+
+      if (this.statusCode === 'complete' || this.statusCode === 'error') {
+        clearInterval(this.interval)
+      }
+    },
+
+    goBack () {
+      window.location.href = this.backUrl
+    }
+  },
+}
+</script>
+
+<style scoped>
+.yellow {
+  @apply font-bold bg-lime-50
+}
+.green-waiting {
+  @apply font-bold text-green-600
+}
+.green-busy {
+  @apply font-bold text-green-700
+}
+.green-complete {
+  @apply font-bold text-green-800
+}
+</style>

--- a/app/javascript/packs/job_process.js
+++ b/app/javascript/packs/job_process.js
@@ -1,18 +1,19 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 
-import Vue from 'vue'
+import Vue from "vue";
 
-import VueRouter from 'vue-router'
-import TurbolinksAdapter from 'vue-turbolinks'
-import VTooltip from 'v-tooltip'
-import Vue2Filters from 'vue2-filters'
+import VueRouter from "vue-router";
+import TurbolinksAdapter from "vue-turbolinks";
+import VTooltip from "v-tooltip";
+import Vue2Filters from "vue2-filters";
 
-import "../components/tooltip.scss"
+import "../components/tooltip.scss";
 
-Vue.use(VueRouter)
+Vue.use(VueRouter);
 Vue.use(TurbolinksAdapter);
-Vue.use(VTooltip)
-Vue.use(Vue2Filters)
+Vue.use(VTooltip);
+Vue.use(Vue2Filters);
 
-import '../components/job_process'
+import "../components/job_process";
+import "../components/job_process_rebrand";

--- a/app/views/student/team_submission_file_upload_confirmations/rebrand/show.en.html.erb
+++ b/app/views/student/team_submission_file_upload_confirmations/rebrand/show.en.html.erb
@@ -1,0 +1,25 @@
+<% provide :js, javascript_packs_with_chunks_tag('job_process') %>
+<% provide :css, stylesheet_packs_with_chunks_tag('job_process') %>
+
+<div class="container mx-auto flex flex-col w-full lg:w-1/2">
+  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Upload Confirmed'} do %>
+    <div class="flex flex-col gap-4">
+      <p class="text-2xl font-bold text-center text-tg-magenta">
+        Your file has been uploaded and will be linked soon!
+      </p>
+
+      <div class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-2">
+        <p class="font-bold">However, please note:</p>
+        <p>If you used any format besides .zip, .aia, .ppt, .pptx, or .pdf, your file will NOT be linked!</p>
+      </div>
+
+      <div class="flex justify-center">
+        <div id="job-process-app-rebrand">
+          <jp-template
+            status-url="<%= send("#{current_scope}_job_status_path", @job.job_id) %>"
+          ></jp-template>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/student/team_submission_file_upload_confirmations/rebrand/show.en.html.erb
+++ b/app/views/student/team_submission_file_upload_confirmations/rebrand/show.en.html.erb
@@ -16,7 +16,7 @@
       <div class="flex justify-center">
         <div id="job-process-app-rebrand">
           <jp-template
-            status-url="<%= send("#{current_scope}_job_status_path", @job.job_id) %>"
+            status-url="<%= send("student_job_status_path", @job.job_id) %>"
           ></jp-template>
         </div>
       </div>


### PR DESCRIPTION
Refs #3710 

This change updates/rebrands the technical additions upload confirmation view for students.

The biggest change was the addition of a duplicate job process vue app (mirroring `app/javascript/components/job_process/template.vue`) that is rebranded. I decided to follow this approach because the original vue app/component was shared between the mentor and student experience. Once the mentor experience is rebranded and is using tailwind we can update the mentor experience to use this new rebranded component. 

![CleanShot 2022-11-18 at 12 43 03@2x](https://user-images.githubusercontent.com/29210380/202779936-e28302ec-5378-410d-8e56-55d0b47ca09a.png)
