### PR TITLE
3722 mentor view completed submission

### DIFF
--- a/app/assets/stylesheets/_review_submission.scss
+++ b/app/assets/stylesheets/_review_submission.scss
@@ -36,3 +36,20 @@
     transform: scale(1.05, 1.05);
   }
 }
+
+.screenshot-container__flex {
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+
+  .screenshot-wrapper{
+    width: 12.5rem;
+    height: 12.5rem;
+
+    img {
+      height: 100%;
+      width: 100%;
+      object-fit: cover;
+    }
+  }
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,7 +8,7 @@ class ProjectsController < ApplicationController
     @team_submission = TeamSubmission.friendly.find(params.fetch(:id))
     @team = @team_submission.team
 
-    render "team_submissions/published"
+    render "team_submissions/rebrand/published"
   end
 
   private

--- a/app/controllers/student/published_team_submissions_controller.rb
+++ b/app/controllers/student/published_team_submissions_controller.rb
@@ -3,7 +3,7 @@ module Student
     def show
       @team_submission = current_team.submission
       @team = current_team
-      render "team_submissions/published"
+      render "team_submissions/rebrand/published"
     end
   end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -20,7 +20,7 @@ module SubmissionsHelper
       text = "Open this project in Thunkable"
       url = submission.thunkable_project_url
     else
-      text = "Download the source code"
+      text = "Download the technical work"
       url = submission.source_code_url
     end
 

--- a/app/views/team_submissions/published.en.html.erb
+++ b/app/views/team_submissions/published.en.html.erb
@@ -115,7 +115,7 @@
       <div class="grid__col-12 grid__col--bleed-y">
        <h3>Learning Journey</h3>
        <%= simple_format @team_submission.learning_journey %>
-       <div class="screenshot-container__flex">
+       <div class="screenshot-container__flex margin--t-xlarge">
          <% @team_submission.screenshots.each do |screenshot| %>
            <% if screenshot.image_url.present? %>
              <div class="screenshot-wrapper">

--- a/app/views/team_submissions/published.en.html.erb
+++ b/app/views/team_submissions/published.en.html.erb
@@ -89,6 +89,8 @@
                         ),
                       @team_submission.business_plan_url,
                       target: :_blank %>
+        <% else %>
+          Beginner teams do not upload a business plan
         <% end %>
       </div>
 

--- a/app/views/team_submissions/published.en.html.erb
+++ b/app/views/team_submissions/published.en.html.erb
@@ -1,60 +1,182 @@
 <% provide :title, "#{@team_submission.app_name} by #{@team.name}" %>
 
-<div class="w-full lg:w-3/4 mx-auto">
-  <%= render("student/dashboards/completion_steps/rebrand/view_completed_team_submission", submission: @team_submission) %>
-
-  <% if current_account.authenticated? && current_account.is_not_a_judge? %>
-    <div class="border-b-2 border-energetic-blue my-8 mb-6"></div>
-
-    <div class="mt-8">
-      <% @team_submission.awaiting_publish(current_scope) do %>
-        <p class="text-lg">
-          <%= link_to(
-            "Submit now",
-            send("#{current_scope}_honor_code_review_path", { team_id: current_team.id }),
-            class: "lg-link-button link-button-success"
-          ) %>
-
-          or
-
-          <%= link_to(
-            "continue editing",
-            send(
-              "#{current_scope}_team_submission_section_path",
-              @team_submission,
-              section: :ideation
-            ),
-            class: "text-energetic-blue hover:text-energetic-blue"
-          ) %>
-        </p>
-
-        <p class="mt-6 text-lg">
-          You can still make changes after you submit,
-          until <%= Season.deadline %>.
-        </p>
-      <% end %>
-
-      <% @team_submission.already_published(current_scope) do %>
-        <% if SeasonToggles.team_submissions_editable? %>
-          <p>
-            <%= link_to(
-              "Make changes",
-              send(
-                "#{current_scope}_team_submission_section_path",
-                @team_submission,
-                section: :ideation
-              ),
-              class: "lg-link-button link-button-success"
-            ) %>
-          </p>
-
-          <p class="mt-6 text-lg">
-            You can make changes until <%= Season.deadline %>.
-          </p>
-        <% else %>
-          <p class="text-lg">Submissions are not editable at this time.</p>
-        <% end %>
-      <% end %>
+<div class="grid">
+  <div class="grid__col-sm-3 col--sticky-parent">
+    <div class="col--sticky-spacer">
+      <div class="col--sticky">
+        <div class="submission-sidebar">
+          <%= render "team_submissions/team_info",
+                     submission: @team_submission,
+                     team: @team %>
+        </div>
+      </div>
     </div>
-  <% end %>
+  </div>
+
+  <div class="grid__col-sm-9">
+    <h3><%= @team_submission.app_name %></h3>
+    <%= simple_format @team_submission.app_description %>
+
+    <hr class="width--100-percent height--1-px border--none backgroundcolor--light-gray margin--b-xlarge">
+
+    <div class="grid" style="row-gap: 50px;">
+      <div class="grid__col-6 grid__col--bleed-y">
+        <h3>Videos</h3>
+
+        <p>
+          <%= link_to web_icon(
+                        "play-circle-o",
+                        text: "Watch the #{t("submissions.demo_video")}"
+                      ),
+                      "#",
+                      data: {
+                        opens_modal: "video-modal-" +
+                          @team_submission.video_id(:demo),
+                        modal_fetch: send(
+                          "#{current_scope}_embed_code_path",
+                          @team_submission,
+                          piece: :demo,
+                          ),
+                      } %>
+        </p>
+
+        <div
+          class="modal"
+          id="video-modal-<%= @team_submission.video_id(:demo) %>"
+        >
+          <div class="modal-content"></div>
+        </div>
+
+        <p>
+          <%= link_to web_icon(
+                        "play-circle-o",
+                        text: "Watch the pitch video"
+
+                      ),
+                      "#",
+                      data: {
+                        opens_modal: "video-modal-" +
+                          @team_submission.video_id(:pitch),
+                        modal_fetch: send(
+                          "#{current_scope}_embed_code_path",
+                          @team_submission,
+                          piece: :pitch,
+                          ),
+                      } %>
+        </p>
+
+        <div class="modal" id="video-modal-<%= @team_submission.video_id(:pitch) %>">
+          <div class="modal-content"></div>
+        </div>
+      </div>
+
+      <div class="grid__col-6 grid__col--bleed-y source-code">
+        <h3>Technical Elements</h3>
+
+        <%= link_to_submission_source_code(@team_submission) %>
+      </div>
+
+      <div class="grid__col-6 grid__col--bleed-y">
+        <h3>Entrepreneurship</h3>
+
+        <% if @team_submission.team.division.name != "beginner" %>
+          <%= link_to web_icon(
+                        "briefcase",
+                        text: "Read the #{@team_submission.senior_division? ? "business" : "user adoption"} plan",
+                        remote: true,
+                        size: 12,
+                        color: "5ABF94",
+                        ),
+                      @team_submission.business_plan_url,
+                      target: :_blank %>
+        <% end %>
+      </div>
+
+      <div class="grid__col-6 grid__col--bleed-y">
+        <h3>Regional Pitch Events</h3>
+
+        <% if @team.live_event? %>
+          <%= link_to web_icon(
+                        "area-chart",
+                        text: "See the presentation slides",
+                        remote: true,
+                        size: 12,
+                        color: "5ABF94",
+                        ),
+                      @team_submission.pitch_presentation_url,
+                      target: :_blank %>
+        <% else %>
+          Virtual judging teams do not upload presentation slides
+        <% end %>
+      </div>
+
+      <div class="grid__col-12 grid__col--bleed-y">
+       <h3>Learning Journey</h3>
+       <%= simple_format @team_submission.learning_journey %>
+       <div class="screenshot-container__flex">
+         <% @team_submission.screenshots.each do |screenshot| %>
+           <% if screenshot.image_url.present? %>
+             <div class="screenshot-wrapper">
+                 <%= image_tag screenshot.image_url,
+                               data: {
+                                 modal_url: screenshot.image_url,
+                               } %>
+             </div>
+          <% end %>
+        <% end %>
+       </div>
+     </div>
+    </div>
+
+    <hr class="width--100-percent height--1-px border--none backgroundcolor--light-gray margin--b-xlarge margin--t-xlarge">
+    <h3>Additional Information</h3>
+
+    <%= render "team_submissions/app_details", team_submission: @team_submission %>
+
+    <div class="grid">
+      <div class="grid__col-auto submission-footer">
+        <% @team_submission.awaiting_publish(current_scope) do %>
+          <p>
+            <%= link_to "Submit now",
+                        send("#{current_scope}_honor_code_review_path", { team_id: current_team.id }),
+                        class: "button" %>
+
+            or
+
+            <%= link_to "continue editing",
+                        send(
+                          "#{current_scope}_team_submission_section_path",
+                          @team_submission,
+                          section: :ideation
+                        ) %>
+          </p>
+
+          <p>
+            You can still make changes after you submit,
+            until <%= Season.deadline %>.
+          </p>
+        <% end %>
+
+        <% @team_submission.already_published(current_scope) do %>
+          <% if SeasonToggles.team_submissions_editable? %>
+            <p>
+              You can make changes until <%= Season.deadline %>.
+            </p>
+
+            <p>
+              <%= link_to "Make changes",
+                          send(
+                            "#{current_scope}_team_submission_section_path",
+                            @team_submission,
+                            section: :ideation
+                          ),
+                          class: "button button--small" %>
+            </p>
+          <% else %>
+            <p>Submissions are not editable at this time.</p>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/team_submissions/rebrand/published.en.html.erb
+++ b/app/views/team_submissions/rebrand/published.en.html.erb
@@ -1,0 +1,60 @@
+<% provide :title, "#{@team_submission.app_name} by #{@team.name}" %>
+
+<div class="w-full lg:w-3/4 mx-auto">
+  <%= render("student/dashboards/completion_steps/rebrand/view_completed_team_submission", submission: @team_submission) %>
+
+  <% if current_account.authenticated? && current_account.is_not_a_judge? %>
+    <div class="border-b-2 border-energetic-blue my-8 mb-6"></div>
+
+    <div class="mt-8">
+      <% @team_submission.awaiting_publish(current_scope) do %>
+        <p class="text-lg">
+          <%= link_to(
+            "Submit now",
+            send("#{current_scope}_honor_code_review_path", { team_id: current_team.id }),
+            class: "lg-link-button link-button-success"
+          ) %>
+
+          or
+
+          <%= link_to(
+            "continue editing",
+            send(
+              "#{current_scope}_team_submission_section_path",
+              @team_submission,
+              section: :ideation
+            ),
+            class: "text-energetic-blue hover:text-energetic-blue"
+          ) %>
+        </p>
+
+        <p class="mt-6 text-lg">
+          You can still make changes after you submit,
+          until <%= Season.deadline %>.
+        </p>
+      <% end %>
+
+      <% @team_submission.already_published(current_scope) do %>
+        <% if SeasonToggles.team_submissions_editable? %>
+          <p>
+            <%= link_to(
+              "Make changes",
+              send(
+                "#{current_scope}_team_submission_section_path",
+                @team_submission,
+                section: :ideation
+              ),
+              class: "lg-link-button link-button-success"
+            ) %>
+          </p>
+
+          <p class="mt-6 text-lg">
+            You can make changes until <%= Season.deadline %>.
+          </p>
+        <% else %>
+          <p class="text-lg">Submissions are not editable at this time.</p>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Refs #3722 

This issue ended up being a little more involved than initially anticipated. This was one of those shared views between student and mentor experiences. At some point, the view was updated to use new tailwind styling so for students the page looked great, but for mentors, everything was jumbled since the mentor dashboard is not yet rebranded. I suspect this was an issue last season but was missed. This view mirrors the student version as best as possible. New additions to this page include the screenshot section! 

There weren't any major changes here. I was able to pull the history of `app/views/team_submissions/published.en.html.erb` and use that as a starting point. We now have 2 versions of review published submissions 
- `app/views/team_submissions/published.en.html.erb`
-  `app/views/team_submissions/rebrand/published.en.html.erb` <--- updated tailwind for students and project page

I also used the new i18n name standard for the demo video text! yay! 


<img width="1792" alt="CleanShot 2022-11-22 at 10 20 18@2x" src="https://user-images.githubusercontent.com/29210380/203369043-a3b01fe3-721f-4ed4-8119-b701882fc5aa.png">
