### PR TITLE
Fixed screenshot responsive issue for old branding used in mentor, ChA, and admin views

### DIFF
--- a/app/assets/stylesheets/_screenshots.scss
+++ b/app/assets/stylesheets/_screenshots.scss
@@ -2,16 +2,16 @@
   margin-top: 30px;
   margin-bottom: 50px;
   max-width: 100%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-column-gap: 20px;
-  grid-row-gap: 50px;
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .screenshot-wrapper {
-  width: 200px;
-  height: 200px;
-  margin: auto;
+  width: 12rem;
+  height: 12rem;
 
   img {
       height: 100%;

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -221,6 +221,7 @@
 
       <p>
         <% if @team_submission.screenshots.any? %>
+          Total Uploaded Images: <%= @team_submission.screenshots.count %>
           <div class="submission-pieces__screenshots">
             <% @team_submission.screenshots.each do |screenshot| %>
               <% if screenshot.image_url.present? %>

--- a/app/views/chapter_ambassador/team_submissions/show.html.erb
+++ b/app/views/chapter_ambassador/team_submissions/show.html.erb
@@ -198,6 +198,7 @@
         <dt>Images</dt>
         <dd>
           <% if @team_submission.screenshots.any? %>
+            <p>Total Uploaded Images: <%= @team_submission.screenshots.count %></p>
             <div class="submission-pieces__screenshots">
               <% @team_submission.screenshots.each do |screenshot| %>
                 <% if screenshot.image_url.present? %>


### PR DESCRIPTION
Refs #3730 

Updated CSS to fix issue where screenshots were overflowing the container. These views will eventually be rebranded.