### PR TITLE
3681 change the word product to project

### DIFF
--- a/app/views/team_submissions/_finalize.en.html.erb
+++ b/app/views/team_submissions/_finalize.en.html.erb
@@ -5,7 +5,7 @@
 
     <p class="scent">
       <%= web_icon "check-circle", class: "icon--green" %>
-      Great job! Your product is qualified to be submitted for judging!
+      Great job! Your <%= t("submissions.app") %> is qualified to be submitted for judging!
     </p>
 
     <p class="scent">
@@ -25,7 +25,7 @@
   <% submission.already_published do %>
     <p class="scent">
       <%= web_icon "check-circle", class: "icon--green" %>
-      Your product has been entered for judging!
+      Your <%= t("submissions.app") %>  has been entered for judging!
     </p>
 
     <p class="scent">
@@ -47,7 +47,7 @@
 
   <p class="scent">
     Once your team is fully qualified, and you have finished all of the
-    deliverables, you will be able to submit your product for the judging
+    deliverables, you will be able to submit your <%= t("submissions.app") %>  for the judging
     rounds.
   </p>
 

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -50,7 +50,7 @@
           <%= link_to submission_progress_web_icon(
             submission,
             :app_name,
-            "Your product's name"
+            "Your #{t("submissions.app")}'s name"
           ),
             send(
               "#{current_scope}_team_submission_path",
@@ -64,7 +64,7 @@
           <%= link_to submission_progress_web_icon(
             submission,
             :app_description,
-            "A description of your product"
+            "A description of your #{t("submissions.app")}"
           ),
             send(
               "#{current_scope}_team_submission_path",

--- a/app/views/team_submissions/pieces/app_description.en.html.erb
+++ b/app/views/team_submissions/pieces/app_description.en.html.erb
@@ -10,7 +10,7 @@
 
     <div class="field">
       <%= f.label :app_description,
-        "Describe your product in a few sentences (100 words or less)",
+        "Describe your #{t("submissions.app")} in a few sentences (100 words or less)",
         for: :team_submission_app_description %>
 
       <%= f.text_area :app_description,

--- a/app/views/team_submissions/pieces/app_name.en.html.erb
+++ b/app/views/team_submissions/pieces/app_name.en.html.erb
@@ -11,7 +11,7 @@
     <%= hidden_field_tag :piece, piece_name %>
 
     <div class="field">
-      <%= f.label :app_name, "Your #{t("submissions.app")} name", for: :team_submission_app_name %>
+      <%= f.label :app_name, "Your #{t("submissions.app")}'s name", for: :team_submission_app_name %>
       <%= f.text_field :app_name, id: :team_submission_app_name %>
     </div>
 

--- a/app/views/team_submissions/pieces/app_name.en.html.erb
+++ b/app/views/team_submissions/pieces/app_name.en.html.erb
@@ -1,6 +1,6 @@
 <div class="panel">
   <h3 class="panel--heading">
-    Product name
+    <%= t("submissions.app").titlecase %>  name
   </h3>
 
   <%= form_with(
@@ -11,7 +11,7 @@
     <%= hidden_field_tag :piece, piece_name %>
 
     <div class="field">
-      <%= f.label :app_name, "Your product's name", for: :team_submission_app_name %>
+      <%= f.label :app_name, "Your #{t("submissions.app")} name", for: :team_submission_app_name %>
       <%= f.text_field :app_name, id: :team_submission_app_name %>
     </div>
 

--- a/app/views/team_submissions/sections/ideation.en.html.erb
+++ b/app/views/team_submissions/sections/ideation.en.html.erb
@@ -16,19 +16,19 @@
 
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
-  title: "Name Your Product",
+  title: "Name Your #{t("submissions.app").titlecase}",
   scope: current_scope,
   attribute: :app_name,
-  cta_when_empty: "Set your product's name",
-  cta_when_filled: "Change your product's name" %>
+  cta_when_empty: "Set your #{t("submissions.app")}'s name",
+  cta_when_filled: "Change your #{t("submissions.app")}'s name" %>
 
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
-  title: "Describe Your Product",
+  title: "Describe Your #{t("submissions.app").titlecase}",
   scope: current_scope,
   attribute: :app_description,
-  cta_when_empty: "Add your product's description",
-  cta_when_filled: "Change your product's description" do %>
+  cta_when_empty: "Add your #{t("submissions.app")}'s description",
+  cta_when_filled: "Change your #{t("submissions.app")}'s description" do %>
 
   <%= simple_format(@team_submission.app_description) %>
 <% end %>
@@ -50,7 +50,7 @@
   scope: current_scope,
   attribute: :screenshots,
   link_options: { data: { turbolinks: false } },
-  cta_when_empty: "Upload images of your product",
+  cta_when_empty: "Upload images of your #{t("submissions.app")}",
   cta_when_filled: "Make changes to your images" do %>
   <div class="submission-pieces__screenshots">
     <% @team_submission.screenshots.each do |screenshot| %>
@@ -66,8 +66,8 @@
   title: "Additional Information",
   scope: current_scope,
   attribute: :app_details,
-  cta_when_empty: "Add details about your product",
-  cta_when_filled: "Update details about your product" do %>
+  cta_when_empty: "Add details about your #{t("submissions.app")}",
+  cta_when_filled: "Update details about your #{t("submissions.app")}" do %>
 
   <%= render 'team_submissions/app_details',
     team_submission: @team_submission %>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -1,3 +1,4 @@
 en:
   submissions:
     demo_video: "technical video"
+    app: "project"

--- a/spec/features/admin/edit_team_submissions_spec.rb
+++ b/spec/features/admin/edit_team_submissions_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Toggling editable team submissions" do
         check "team_submission[integrity_affirmed]"
         click_button "Start now!"
 
-        expect(page).to have_css('.button', text: "Set your project'sname")
+        expect(page).to have_css('.button', text: "Set your project's name")
 
         visit mentor_dashboard_path
 
@@ -63,7 +63,7 @@ RSpec.feature "Toggling editable team submissions" do
         visit mentor_team_submission_path(team.reload.submission)
         expect(page).not_to have_css(
           ".button",
-          text: "Set your project'sname"
+          text: "Set your project's name"
         )
 
         visit mentor_team_path(team)

--- a/spec/features/admin/edit_team_submissions_spec.rb
+++ b/spec/features/admin/edit_team_submissions_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Toggling editable team submissions" do
         check "team_submission[integrity_affirmed]"
         click_button "Start now!"
 
-        expect(page).to have_css('.button', text: "Set your product's name")
+        expect(page).to have_css('.button', text: "Set your project'sname")
 
         visit mentor_dashboard_path
 
@@ -63,7 +63,7 @@ RSpec.feature "Toggling editable team submissions" do
         visit mentor_team_submission_path(team.reload.submission)
         expect(page).not_to have_css(
           ".button",
-          text: "Set your product's name"
+          text: "Set your project'sname"
         )
 
         visit mentor_team_path(team)

--- a/spec/features/mentor/submission_piece_spec.rb
+++ b/spec/features/mentor/submission_piece_spec.rb
@@ -16,22 +16,22 @@ RSpec.feature "Students edit submission pieces" do
     within("#find-team #team_#{student.team.id}") { click_link "Edit this team's submission" }
   end
 
-  scenario "Set the product name" do
+  scenario "Set the project name" do
     click_link "Ideation"
 
     within(".app_name.incomplete") do
-      click_link "Set your product's name"
+      click_link "Set your project's name"
     end
 
-    fill_in "Your product's name", with: "WonderApp2018"
+    fill_in "Your project's name", with: "WonderApp2018"
     click_button "Save this name"
 
     within(".app_name.complete") do
-      expect(page).not_to have_link("Set your product's name")
+      expect(page).not_to have_link("Set your project's name")
 
       expect(page).to have_content "WonderApp2018"
       expect(page).to have_link(
-        "Change your product's name",
+        "Change your project's name",
         href: edit_mentor_team_submission_path(
           submission.reload,
           piece: :app_name
@@ -40,11 +40,11 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  scenario "Set the product description" do
+  scenario "Set the project description" do
     click_link "Ideation"
 
     within(".app_description.incomplete") do
-      click_link "Add your product's description"
+      click_link "Add your project's description"
     end
 
     fill_in "Describe your product in a few sentences (100 words or less)",
@@ -53,11 +53,11 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save this description"
 
     within(".app_description.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_content "Only a few sentences"
       expect(page).to have_link(
-        "Change your product's description",
+        "Change your project's description",
         href: edit_mentor_team_submission_path(
           submission,
           piece: :app_description
@@ -81,7 +81,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".demo_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=demo']"
       expect(page).to have_link(
@@ -109,7 +109,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".pitch_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=pitch']"
       expect(page).to have_link(
@@ -140,7 +140,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".pitch_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=pitch']"
       expect(page).to have_link(
@@ -168,7 +168,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".demo_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=demo']"
       expect(page).to have_link(
@@ -196,7 +196,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".demo_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=demo']"
       expect(page).to have_link(

--- a/spec/features/mentor/submission_piece_spec.rb
+++ b/spec/features/mentor/submission_piece_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Students edit submission pieces" do
       click_link "Add your project's description"
     end
 
-    fill_in "Describe your product in a few sentences (100 words or less)",
+    fill_in "Describe your project in a few sentences (100 words or less)",
       with: "Only a few sentences"
 
     click_button "Save this description"

--- a/spec/features/mentor/submission_spec.rb
+++ b/spec/features/mentor/submission_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Student team submissions" do
     within("#find-team") { click_link "Edit this team's submission" }
 
     expect(page).to have_link(
-      "Set your product's name",
+      "Set your project's name",
       href: edit_mentor_team_submission_path(
         submission,
         piece: :app_name
@@ -63,7 +63,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_link(
-      "Add your product's description",
+      "Add your project's description",
       href: edit_mentor_team_submission_path(
         submission,
         piece: :app_description

--- a/spec/features/mentor/submission_spec.rb
+++ b/spec/features/mentor/submission_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_link(
-      "Upload images of your product",
+      "Upload images of your project",
       href: edit_mentor_team_submission_path(
         submission,
         piece: :screenshots

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -15,22 +15,22 @@ RSpec.feature "Students edit submission pieces" do
     click_link "My Submission"
   end
 
-  scenario "Set the product name" do
+  scenario "Set the project name" do
     click_link "Ideation"
 
     within(".app_name.incomplete") do
-      click_link "Set your product's name"
+      click_link "Set your project's name"
     end
 
-    fill_in "Your product's name", with: "WonderApp2018"
+    fill_in "Your project's name", with: "WonderApp2018"
     click_button "Save this name"
 
     within(".app_name.complete") do
-      expect(page).not_to have_link("Set your product's name")
+      expect(page).not_to have_link("Set your project's name")
 
       expect(page).to have_content "WonderApp2018"
       expect(page).to have_link(
-        "Change your product's name",
+        "Change your project's name",
         href: edit_student_team_submission_path(
           submission.reload,
           piece: :app_name
@@ -46,24 +46,24 @@ RSpec.feature "Students edit submission pieces" do
     expect(page).to have_button "Change Image"
   end
 
-  scenario "Set the product description" do
+  scenario "Set the project description" do
     click_link "Ideation"
 
     within(".app_description.incomplete") do
-      click_link "Add your product's description"
+      click_link "Add your project's description"
     end
 
-    fill_in "Describe your product in a few sentences (100 words or less)",
+    fill_in "Describe your project in a few sentences (100 words or less)",
       with: "Only a few sentences"
 
     click_button "Save this description"
 
     within(".app_description.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_content "Only a few sentences"
       expect(page).to have_link(
-        "Change your product's description",
+        "Change your project's description",
         href: edit_student_team_submission_path(
           submission,
           piece: :app_description
@@ -87,7 +87,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".demo_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=demo']"
       expect(page).to have_link(
@@ -115,7 +115,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".pitch_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=pitch']"
       expect(page).to have_link(
@@ -143,7 +143,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Save"
 
     within(".demo_video_link.complete") do
-      expect(page).not_to have_link("Add your product's description")
+      expect(page).not_to have_link("Add your project's description")
 
       expect(page).to have_css "[data-modal-fetch*='piece=demo']"
       expect(page).to have_link(

--- a/spec/features/student/submission_spec.rb
+++ b/spec/features/student/submission_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Student team submissions" do
     click_link "Ideation"
 
     expect(page).to have_link(
-      "Set your product's name",
+      "Set your project's name",
       href: edit_student_team_submission_path(
         submission,
         piece: :app_name
@@ -60,7 +60,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_link(
-      "Add your product's description",
+      "Add your project's description",
       href: edit_student_team_submission_path(
         submission,
         piece: :app_description
@@ -68,7 +68,7 @@ RSpec.feature "Student team submissions" do
     )
 
     expect(page).to have_link(
-      "Upload images of your product",
+      "Upload images of your project",
       href: edit_student_team_submission_path(
         submission,
         piece: :screenshots

--- a/spec/features/student/submit_a_project_spec.rb
+++ b/spec/features/student/submit_a_project_spec.rb
@@ -66,8 +66,8 @@ RSpec.feature "Student submits a project", :js do
   end
 
   def when_they_complete_their_submission
-    click_link "Your product's name"
-    fill_in "Your product's name", with: "Coolest app"
+    click_link "Your project's name"
+    fill_in "Your project's name", with: "Coolest app"
     click_button "Save this name"
   end
 

--- a/spec/system/admin/edit_team_submissions_spec.rb
+++ b/spec/system/admin/edit_team_submissions_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe "Toggling editable team submissions", :js do
         "Submitting your project is not available right now.\n" +
         "Technovation staff has disabled this feature for everyone."
       )
-      expect(page).not_to have_link("Your product's name")
+      expect(page).not_to have_link("Your project's name")
 
       visit student_team_submission_path(team.reload.submission)
       expect(page).not_to have_css(
         ".button",
-        text: "Set your product's name"
+        text: "Set your project's name"
       )
 
       visit student_team_path(team)
@@ -72,7 +72,7 @@ RSpec.describe "Toggling editable team submissions", :js do
       check "team_submission[integrity_affirmed]"
       click_button "Start now!"
 
-      expect(page).to have_css('.button', text: "Set your product's name")
+      expect(page).to have_css('.button', text: "Set your project's name")
 
       visit student_dashboard_path
       click_button "Submit your project"
@@ -83,7 +83,7 @@ RSpec.describe "Toggling editable team submissions", :js do
           "Technovation staff has disabled this feature for everyone."
         )
         expect(page).to have_link(
-          "Your product's name",
+          "Your project's name",
           href: student_team_submission_path(
             team.reload.submission,
             piece: :app_name


### PR DESCRIPTION
Refs #3681 

This change adds a i18n translation for "app" to "project". For historical context app was changed to product in the 2022 season and now "product" changed to "project" for the 2023 season. 


