### PR TITLE
Update submission deadline text

### DIFF
--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -52,7 +52,9 @@ module ImportantDates
     year = Integer(ENV.fetch("DATES_SUBMISSION_DEADLINE_YEAR"))
     month = Integer(ENV.fetch("DATES_SUBMISSION_DEADLINE_MONTH"))
     day = Integer(ENV.fetch("DATES_SUBMISSION_DEADLINE_DAY"))
-    Time.zone.local(year, month, day)
+    hour = Integer(ENV.fetch("DATES_SUBMISSION_DEADLINE_HOUR_IN_24_HOUR_FORMAT", 17))
+
+    Time.zone.local(year, month, day, hour)
   end
 
   def self.quarterfinals_judging_begins

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -8,17 +8,13 @@ class Season
     @year = year
   end
 
-  def self.deadline
+  def self.submission_deadline
     [
       submission_deadline_in_los_angeles_time_zone,
       submission_deadline_in_africa_time_zone,
       submission_deadline_in_madrid_time_zone,
       submission_deadline_in_india_time_zone
-    ].join(" / ")
-  end
-
-  def self.submission_deadline
-    "#{deadline}, #{ImportantDates.submission_deadline.year}"
+    ].join(" / ").squish
   end
 
   def self.years

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -9,8 +9,12 @@ class Season
   end
 
   def self.deadline
-    day = ImportantDates.submission_deadline.day
-    ImportantDates.submission_deadline.strftime("%B #{day}")
+    [
+      submission_deadline_in_los_angeles_time_zone,
+      submission_deadline_in_africa_time_zone,
+      submission_deadline_in_madrid_time_zone,
+      submission_deadline_in_india_time_zone
+    ].join(" / ")
   end
 
   def self.submission_deadline
@@ -53,4 +57,25 @@ class Season
 
     current_year
   end
+
+  def self.submission_deadline_in_los_angeles_time_zone
+    ImportantDates.submission_deadline.in_time_zone("America/Los_Angeles").strftime("%B %d, %l%p PDT")
+  end
+
+  def self.submission_deadline_in_africa_time_zone
+    ImportantDates.submission_deadline.in_time_zone("Africa/Algiers").strftime("%B %d at %l%p WAT")
+  end
+
+  def self.submission_deadline_in_madrid_time_zone
+    ImportantDates.submission_deadline.in_time_zone("Europe/Madrid").strftime("%l%p CEST")
+  end
+
+  def self.submission_deadline_in_india_time_zone
+    ImportantDates.submission_deadline.in_time_zone("Asia/Kolkata").strftime("%l%p IST")
+  end
+
+  private_class_method :submission_deadline_in_los_angeles_time_zone,
+    :submission_deadline_in_africa_time_zone,
+    :submission_deadline_in_madrid_time_zone,
+    :submission_deadline_in_india_time_zone
 end

--- a/app/views/team_mailer/submission_published.en.html.erb
+++ b/app/views/team_mailer/submission_published.en.html.erb
@@ -18,7 +18,7 @@
       <tr>
         <td class="content-block">
           Judging begins on <%= ImportantDates.quarterfinals_judging_begins.strftime("%B %-d") %>, and
-          <strong>your team can still make changes until <%= Season.deadline %>.</strong>
+          <strong>your team can still make changes until <%= Season.submission_deadline %>.</strong>
         </td>
       </tr>
       <tr>

--- a/app/views/team_submissions/_finalize.en.html.erb
+++ b/app/views/team_submissions/_finalize.en.html.erb
@@ -12,7 +12,7 @@
       <%= web_icon("exclamation-circle", class: "icon--green") %>
       Even after submitting,
       <strong>you will be able to make changes</strong>
-      until <%= Season.deadline %>.
+      until <%= Season.submission_deadline %>.
     </p>
 
     <p>
@@ -30,7 +30,7 @@
 
     <p class="scent">
       <%= web_icon("exclamation-circle", class: "icon--green") %>
-      <strong>You are allowed to make changes</strong> until <%= Season.deadline %>.
+      <strong>You are allowed to make changes</strong> until <%= Season.submission_deadline %>.
     </p>
 
     <p>
@@ -55,7 +55,7 @@
     <%= web_icon("exclamation-circle", class: "icon--green") %>
     Even after submitting,
     <strong>you will be able to make changes</strong>
-    until <%= Season.deadline %>.
+    until <%= Season.submission_deadline %>.
   </p>
 
   <p>

--- a/app/views/team_submissions/published.en.html.erb
+++ b/app/views/team_submissions/published.en.html.erb
@@ -155,14 +155,14 @@
 
           <p>
             You can still make changes after you submit,
-            until <%= Season.deadline %>.
+            until <%= Season.submission_deadline %>.
           </p>
         <% end %>
 
         <% @team_submission.already_published(current_scope) do %>
           <% if SeasonToggles.team_submissions_editable? %>
             <p>
-              You can make changes until <%= Season.deadline %>.
+              You can make changes until <%= Season.submission_deadline %>.
             </p>
 
             <p>

--- a/app/views/team_submissions/rebrand/published.en.html.erb
+++ b/app/views/team_submissions/rebrand/published.en.html.erb
@@ -30,7 +30,7 @@
 
         <p class="mt-6 text-lg">
           You can still make changes after you submit,
-          until <%= Season.deadline %>.
+          until <%= Season.submission_deadline %>.
         </p>
       <% end %>
 
@@ -49,7 +49,7 @@
           </p>
 
           <p class="mt-6 text-lg">
-            You can make changes until <%= Season.deadline %>.
+            You can make changes until <%= Season.submission_deadline %>.
           </p>
         <% else %>
           <p class="text-lg">Submissions are not editable at this time.</p>

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -48,19 +48,28 @@ RSpec.describe Season do
     end
   end
 
-  describe ".deadline" do
-    it "returns human-readable month and day" do
-      deadline = Date.new(2019, 4, 25)
-      expect(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
-      expect(Season.deadline).to include("April 25")
-    end
-  end
-
   describe ".submission_deadline" do
-    it "returns human-readable date" do
-      deadline = Date.new(2019, 4, 25)
-      expect(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
-      expect(Season.submission_deadline).to eq("April 25, 2019")
+    let(:deadline) { Time.zone.local(2019, 4, 25, 17) }
+
+    before do
+      allow(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
+    end
+
+    it "includes a human-readable date in the PDT time zone" do
+      expect(Season.submission_deadline).to include("April 25, 5PM PDT")
+    end
+
+    it "includes a human-readable date in the WAT time zone" do
+      expect(Season.submission_deadline).to include("April 26")
+      expect(Season.submission_deadline).to include("1AM WAT")
+    end
+
+    it "includes a human-readable date in the CEST time zone" do
+      expect(Season.submission_deadline).to include("2AM CEST")
+    end
+
+    it "includes a human-readable date in the IST time zone" do
+      expect(Season.submission_deadline).to include("5AM IST")
     end
   end
 end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Season do
     it "returns human-readable month and day" do
       deadline = Date.new(2019, 4, 25)
       expect(ImportantDates).to receive(:submission_deadline).at_least(:once).and_return(deadline)
-      expect(Season.deadline).to eq("April 25")
+      expect(Season.deadline).to include("April 25")
     end
   end
 


### PR DESCRIPTION
Before this PR we had two methods for displaying the submission deadline - `deadline` and `submission_deadline` - that would display the submission deadline in slightly different formats.

With this PR:
- `deadline` was removed
- `submission_deadline` was updated and will now be used to display the submission deadline everywhere
- New timezone formats (WAT, CEST, IST) were added for the submission deadline
- A new ENV (`DATES_SUBMISSION_DEADLINE_HOUR_IN_24_HOUR_FORMAT`) was added for the time of the submission deadline