### PR TITLE
Fix RPE polymorphic path on mentor dashboard

### DIFF
--- a/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
@@ -15,7 +15,7 @@
     <p class="hint">File types allowed: *.ppt, *.pptx, *.pdf</p>
 
     <%= form_with model: submission,
-      url: send("#{current_scope}_team_submission_path", multipart: true),
+      url: send("#{current_scope}_team_submission_path", submission, multipart: true),
       id: "team-submission-pitch-presentation-dropzone",
       class: "dropzone" do |f| %>
 


### PR DESCRIPTION
This path was updated as part of the Rails 6 upgrade, but it got updated incorrectly, the path used to take a `submission` and that was incorrectly removed.

See commit:
02a55fa3aadb0ae2baa74120b04c7e2db6cda9b5

`_pitch_presentation.en.html.erb`:
```
<%= form_with model: [current_scope, submission], multipart: true,
```

