### PR TITLE
Add `#rebranded?` to NullProfile

### DIFF
--- a/app/null_objects/null_profile.rb
+++ b/app/null_objects/null_profile.rb
@@ -13,6 +13,7 @@ class NullProfile < NullObject
   def completed_scores; NullCompletedScores.new; end
   def events; []; end
   def account; ::NullAccount.new; end
+  def rebranded?; false; end
 end
 
 class NullCompletedScores < NullObject


### PR DESCRIPTION
Sometimes we get this error message:

> ActionView::Template::Error: undefined method `rebranded?' for #<NullProfile:0x00007fa8cf3a1478>

I'm not sure how to reproduce this error, but this PR should address/fix it. 🤞 



