### PR TITLE
3733 screenshot filestack in admin portal

### DIFF
--- a/app/controllers/admin/screenshots_controller.rb
+++ b/app/controllers/admin/screenshots_controller.rb
@@ -1,0 +1,25 @@
+module Admin
+  class ScreenshotsController < AdminController
+    def new
+      @team_submission = TeamSubmission.friendly.find(params[:team_submission_id])
+      @screenshot = @team_submission.screenshots.build
+    end
+
+    def create
+      @team_submission = TeamSubmission.friendly.find(params[:team_submission_id])
+      if @team_submission.screenshots.create(screenshot_params)
+        redirect_to admin_team_submission_path(@team_submission),
+          success: "Screenshot has been added"
+      else
+        redirect_to admin_team_submission_path(@team_submission),
+          error: "There was an error processing your request. Please notify the dev team."
+      end
+    end
+
+    private
+
+    def screenshot_params
+      params.require(:screenshot).permit(:image)
+    end
+  end
+end

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -28,7 +28,7 @@
                                     intelligent: true,
                                   },
                                   fromSources: ["local_file_system"],
-                                  onFileUploadFinished: 'onFileUploadFinished',
+                                  onFileUploadFinished: "onFileUploadFinished",
                                   storeTo: {
                                     location: "s3",
                                     container: ENV.fetch("AWS_BUCKET_NAME"),

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -1,0 +1,45 @@
+<%= javascript_tag do %>
+  function onFileUploadFinished(data) {
+    const screenshot = document.getElementById("screenshot");
+    screenshot.src = filestack_client.transform(data.handle);
+  }
+<% end %>
+
+<div class="grid">
+  <div class="grid__col-10">
+    <div class="panel">
+
+      <h1>Add a screenshot</h1>
+      <% @team_submission.while_no_screenshots_remaining do %>
+        <p>Please delete a screenshot(s) in order to upload additional images</p>
+      <% end %>
+
+      <% @team_submission.while_screenshots_remaining do %>
+        <img src="" alt="" id="screenshot" class="og-style-filestack-img">
+
+        <%= form_with model:[@team_submission, @screenshot], url: admin_team_submission_screenshots_path(@team_submission), local: true do |f| %>
+          <%= f.label :image, "Screenshot" %>
+          <%= f.filestack_field :image,
+                                "Select image",
+                                id: 'admin-screenshot-picker',
+                                pickerOptions: {
+                                  accept: ["image/jpeg", "image/jpg", "image/png"],
+                                  uploadConfig: {
+                                    intelligent: true,
+                                  },
+                                  fromSources: ["local_file_system"],
+                                  onFileUploadFinished: 'onFileUploadFinished',
+                                  storeTo: {
+                                    location: "s3",
+                                    container: ENV.fetch("AWS_BUCKET_NAME"),
+                                    path: "uploads/screenshot/filestack/#{@team_submission.id}/",
+                                    region: "us-east-1"
+                                  }
+                                } %>
+          <br>
+          <%= f.submit "Save", class:"button" %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -11,7 +11,7 @@
 
       <h1>Add a screenshot</h1>
       <% @team_submission.while_no_screenshots_remaining do %>
-        <p>Please delete a screenshot(s) in order to upload additional images</p>
+        <p>Please delete a screenshot(s) in order to upload additional screenshots</p>
       <% end %>
 
       <% @team_submission.while_screenshots_remaining do %>

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -20,8 +20,8 @@
         <%= form_with model:[@team_submission, @screenshot], url: admin_team_submission_screenshots_path(@team_submission), local: true do |f| %>
           <%= f.label :image, "Screenshot" %>
           <%= f.filestack_field :image,
-                                "Select image",
-                                id: 'admin-screenshot-picker',
+                                "Select screenshot",
+                                id: "admin-screenshot-picker",
                                 pickerOptions: {
                                   accept: ["image/jpeg", "image/jpg", "image/png"],
                                   uploadConfig: {

--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -78,6 +78,27 @@
           <%= f.file_field :source_code %>
           <%= f.hidden_field :source_code_cache %>
         </div>
+
+        <div>
+          <h5>Screenshots</h5>
+
+          <% if @team_submission.screenshots.any? %>
+            Total Uploaded Images: <%= @team_submission.screenshots.count %>
+
+            <div class="submission-pieces__screenshots">
+              <% @team_submission.screenshots.each do |screenshot| %>
+                <% if screenshot.image_url.present? %>
+                  <%= render "screenshots/screenshot_grid", screenshot: screenshot %>
+                <% else %>
+                  <p> Issue displaying screenshots. Please notify the dev team.</p>
+                <% end %>
+              <% end %>
+            </div>
+
+          <% else %>
+            <p> No screenshots uploaded </p>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -219,6 +219,8 @@
         <i><%= @team_submission.game_description  %></i>
       <% end %>
 
+      <h5>Screenshots</h5>
+
       <p>
         <% if @team_submission.screenshots.any? %>
           Total Uploaded Images: <%= @team_submission.screenshots.count %>
@@ -233,6 +235,12 @@
           No screenshots uploaded
         <% end %>
       </p>
+
+      <% if @team_submission.max_screenshots_remaining > 0 %>
+        <%= link_to 'Add Screenshot', new_admin_team_submission_screenshot_path(@team_submission) %>
+      <% else %>
+        <p>Delete a screenshot(s) to upload additional images</p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,7 @@ Rails.application.routes.draw do
     resources :teams, except: :destroy
     resources :team_submissions, except: :destroy do
       resource :judge_assignments, only: :create
-      resources :screenshots
+      resources :screenshots, only: [:new, :create]
     end
     resources :team_memberships, only: [:destroy, :create]
     resources :team_locations, only: :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,6 +270,7 @@ Rails.application.routes.draw do
     resources :teams, except: :destroy
     resources :team_submissions, except: :destroy do
       resource :judge_assignments, only: :create
+      resources :screenshots
     end
     resources :team_memberships, only: [:destroy, :create]
     resources :team_locations, only: :edit

--- a/spec/features/admin/team_submissions_spec.rb
+++ b/spec/features/admin/team_submissions_spec.rb
@@ -65,4 +65,22 @@ RSpec.feature "admin team submissions" do
       href: submission.business_plan_url
     )
   end
+
+  scenario "Add a screenshot" do
+    click_link "some app name"
+    expect(page).to have_content("No screenshots uploaded")
+
+    click_link "Add Screenshot"
+    expect(page).to have_button("Select image")
+
+    # TODO: Groundwork for filestack specs
+    # expect(page).to have_selector("div#__filestack-picker")
+    # find("#fsp-fileUpload").set(Rails.root + "spec/support/fixtures/screenshot.jpg")
+
+    click_button "Save"
+
+    expect(current_path).to eq(
+      admin_team_submission_path(submission.reload)
+    )
+  end
 end

--- a/spec/features/admin/team_submissions_spec.rb
+++ b/spec/features/admin/team_submissions_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "admin team submissions" do
     expect(page).to have_content("No screenshots uploaded")
 
     click_link "Add Screenshot"
-    expect(page).to have_button("Select image")
+    expect(page).to have_button("Select screenshot")
 
     # TODO: Groundwork for filestack specs
     # expect(page).to have_selector("div#__filestack-picker")


### PR DESCRIPTION
Refs: #3733 

This change integrates filestack in the admin portal. Currently, as an admin you can only upload 1 screenshot at a time. I also added the groundwork for the filestack spec. Similar to the other filestack specs, I am running into issues actually trying to open the filestack picker with Capybara. After some research, it could be a driver issue since filestack requires JS.  I will be tackling this issue in #3703.

Next steps include the following: 
- Adding delete functionality
- Ability to upload more than 1 screenshot at a time

![CleanShot 2022-12-13 at 09 41 01](https://user-images.githubusercontent.com/29210380/207378161-92f8d94c-0ef0-429d-b7b9-db501041a274.gif)

