### PR TITLE
3739 update student layout for selecting rpe

### DIFF
--- a/app/views/regional_pitch_events/_event.en.html.erb
+++ b/app/views/regional_pitch_events/_event.en.html.erb
@@ -80,11 +80,9 @@
                   not event.at_team_capacity? %>
         <p>
           <%= link_to "Select this event",
-            [
-              current_scope,
-              :regional_pitch_event_selection,
-              { event_id: event.id, team_id: current_team.id },
-            ],
+            send("#{current_scope}_regional_pitch_event_selection_path",
+                 :regional_pitch_event_selection,
+                 { event_id: event.id, team_id: current_team.id }),
             class: "button small",
             data: {
               disable_with: "Selecting event...",

--- a/app/views/regional_pitch_events/index.en.html.erb
+++ b/app/views/regional_pitch_events/index.en.html.erb
@@ -18,6 +18,25 @@
     </div>
   </div>
 <% else %>
-  <%= render partial: 'regional_pitch_events/rebrand/event',
-             collection: @regional_events %>
+  <div class="container mx-auto flex w-full lg:w-3/4">
+    <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Available Events'} do %>
+      <section class="mb-8">
+        <p class="mb-4">
+          <%= link_to 'Go back!',
+                      back_from_event_path,
+                      class: "tw-gray-btn text-sm" %>
+        </p>
+        <p>These are the available events in your area. </p>
+        <p>
+          Events will be confirmed as either Regional Pitch Events or
+          Celebration Events after <%= ImportantDates.rpe_officiality_finalized.strftime("%B %-d") %>.
+          For more information, please check out the
+          <%= link_to 'Technovation FAQ', 'https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events' %>
+          or contact your chapter ambassador.
+        </p>
+      </section>
+      <%= render partial: 'regional_pitch_events/rebrand/available_event',
+                 collection: @regional_events, as: :event %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/regional_pitch_events/rebrand/_available_event.en.html.erb
+++ b/app/views/regional_pitch_events/rebrand/_available_event.en.html.erb
@@ -1,0 +1,99 @@
+<div class="border-solid rounded border-4 p-4 mb-4">
+    <% if current_scope != "judge" and
+        event.at_team_capacity? and
+          not current_team.attending_event?(event) %>
+            <div class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-2">
+              <p>This event is currently full</p>
+            </div>
+    <% end %>
+
+    <div class="mt-4 flex flex-col lg:flex-row lg:justify-between">
+      <section>
+        <p class="font-semibold text-2xl"><%= event.name %></p>
+        <p class="italic"><%= event.officiality.capitalize %> Event</p>
+      </section>
+
+      <section>
+        <p class="text-xl font-semibold">Event Details</p>
+
+        <div class="flex flex-col lg:flex-row mt-4">
+          <p class="font-medium w-24">Time:</p>
+          <p>
+            <%= event.starts_at
+                     .in_time_zone(event.timezone)
+                     .strftime("%A, %B %e") %>
+
+            <br />
+
+            <%= event.starts_at
+                     .in_time_zone(event.timezone)
+                     .strftime("%-I:%M%P") %>
+
+            &ndash;
+
+            <%= event.ends_at
+                     .in_time_zone(event.timezone)
+                     .strftime("%-I:%M%P %Z") %>
+          </p>
+        </div>
+
+        <div class="flex flex-col lg:flex-row mt-8">
+          <p class="font-medium w-24">Location:</p>
+          <p>
+            <%= event.venue_address %>
+            <br />
+            <%= event.city %>
+          </p>
+        </div>
+
+        <% unless event.event_link.blank? %>
+          <div class="flex flex-col lg:flex-row mt-8">
+            <p class="font-medium w-24">Event Link:</p>
+            <p>
+              <%= link_to "#{event.name}",
+                          event.event_link,
+                          target: :_blank,
+                          class: 'tw-link' %>
+            </p>
+          </div>
+        <% end %>
+      </section>
+
+      <section>
+        <p class="text-xl font-semibold">Hosted By</p>
+
+        <div class="flex flex-col lg:flex-row mt-4">
+          <p class="font-medium w-24">Name:</p>
+          <p><%= event.ambassador.name %></p>
+        </div>
+
+        <div class="flex flex-col lg:flex-row mt-8">
+          <p class="font-medium w-24">Email:</p>
+          <p class>
+            <%= event.ambassador.email %>
+          </p>
+        </div>
+
+        <% if current_scope != "judge" and
+            not current_team.attending_event?(event) and
+              SeasonToggles.select_regional_pitch_event? and
+                not event.at_team_capacity? %>
+                  <section class="mt-8 flex justify-center">
+                    <p>
+                      <%= link_to "Select this event",
+                                  send("#{current_scope}_regional_pitch_event_selection_path",
+                                       :regional_pitch_event_selection,
+                                       { event_id: event.id, team_id: current_team.id }),
+                                  class: "tw-green-btn mx-auto",
+                                  data: {
+                                    disable_with: "Selecting event...",
+                                    positive: true,
+                                    method: :post,
+                                    confirm: "Are you sure you want to attend #{event.name}? " + "<p><strong>You cannot change this.</strong></p>"
+                                  } %>
+                    </p>
+                  </section>
+        <% end %>
+      </section>
+    </div>
+</div>

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -105,10 +105,6 @@
                   </li>
                 </ol>
               </div>
-
-              <%= render 'regional_pitch_events/rebrand/event',
-                event: current_team.selected_regional_pitch_event %>
-
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
Refs #3739 

This change updates the layout for student RPE event selection. I mirrored the mentor view for selecting events. I created a partial called `avaialble_event` that is used by the view. The information is very similar to the `event` partial that displays when students want to view the full event details of their selected RPE. There is definitely room for improvement in the flow, but I thought this was a good starting point.

I also found 1 broken link on the mentor dashboard for selecting an RPE, which has been included in this PR. 

<img width="1459" alt="CleanShot 2022-12-15 at 21 15 54@2x" src="https://user-images.githubusercontent.com/29210380/208014157-0efe9129-3366-46b8-b9e0-230fb280625d.png">
