### PR TITLE
3739 v2 update layout for students selecting rpe

### DIFF
--- a/app/views/regional_pitch_events/_event.en.html.erb
+++ b/app/views/regional_pitch_events/_event.en.html.erb
@@ -80,17 +80,17 @@
                   not event.at_team_capacity? %>
         <p>
           <%= link_to "Select this event",
-            send("#{current_scope}_regional_pitch_event_selection_path",
-                 :regional_pitch_event_selection,
-                 { event_id: event.id, team_id: current_team.id }),
-            class: "button small",
-            data: {
-              disable_with: "Selecting event...",
-              positive: true,
-              method: :post,
-              confirm: "Are you sure you want to attend #{event.name}? " +
-              "<p><strong>You cannot change this.</strong></p>"
-            } %>
+                      send("#{current_scope}_regional_pitch_event_selection_path",
+                           :regional_pitch_event_selection,
+                           { event_id: event.id, team_id: current_team.id }),
+                      class: "button small",
+                      data: {
+                        disable_with: "Selecting event...",
+                        positive: true,
+                        method: :post,
+                        confirm: "Are you sure you want to attend #{event.name}? " +
+                        "<p><strong>You cannot change this.</strong></p>"
+                      } %>
         </p>
       <% end %>
     </div>

--- a/app/views/regional_pitch_events/_event.en.html.erb
+++ b/app/views/regional_pitch_events/_event.en.html.erb
@@ -80,11 +80,9 @@
                   not event.at_team_capacity? %>
         <p>
           <%= link_to "Select this event",
-            [
-              current_scope,
-              :regional_pitch_event_selection,
-              { event_id: event.id, team_id: current_team.id },
-            ],
+            send("#{current_scope}_regional_pitch_event_selection_path",
+                 :regional_pitch_event_selection,
+                 { event_id: event.id, team_id: current_team.id }),
             class: "button small",
             data: {
               disable_with: "Selecting event...",

--- a/app/views/regional_pitch_events/index.en.html.erb
+++ b/app/views/regional_pitch_events/index.en.html.erb
@@ -19,5 +19,6 @@
   </div>
 <% else %>
   <%= render partial: 'regional_pitch_events/rebrand/event',
+             locals: { multiple_events: true },
              collection: @regional_events %>
 <% end %>

--- a/app/views/regional_pitch_events/rebrand/_event.en.html.erb
+++ b/app/views/regional_pitch_events/rebrand/_event.en.html.erb
@@ -1,32 +1,26 @@
-<div class="container mx-auto flex w-full lg:w-1/2">
-  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Event Details'} do %>
+<% multiple_events ||= false %>
+
+<div class="<%= 'border-solid rounded border-4 p-4 mb-4' if multiple_events %>">
+  <% if current_scope != "judge" and
+          event.at_team_capacity? and
+            not current_team.attending_event?(event) %>
+              <div class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-2">
+                <p>This event is currently full</p>
+              </div>
+  <% end %>
+
+  <div class="mt-4 flex flex-col lg:flex-row lg:justify-between">
     <section>
-      <p>
-        <%= link_to 'Go back!',
-                    back_from_event_path,
-                    class: "tw-gray-btn text-sm" %>
-      </p>
-    </section>
-
-      <% if current_scope != "judge" and
-              event.at_team_capacity? and
-                not current_team.attending_event?(event) %>
-                  <div class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-2">
-                    <p>This event is currently full</p>
-                  </div>
-      <% end %>
-
-    <section class="mt-4">
       <p class="font-semibold text-2xl"><%= event.name %></p>
       <p class="italic"><%= event.officiality.capitalize %> Event</p>
     </section>
 
-    <section class="mt-8">
+    <section>
       <p class="text-xl font-semibold">Event Details</p>
 
       <div class="flex flex-col lg:flex-row mt-4">
         <p class="font-medium w-24">Time:</p>
-        <p class="">
+        <p>
           <%= event.starts_at
                    .in_time_zone(event.timezone)
                    .strftime("%A, %B %e") %>
@@ -42,12 +36,11 @@
           <%= event.ends_at
                    .in_time_zone(event.timezone)
                    .strftime("%-I:%M%P %Z") %></p>
-
       </div>
 
       <div class="flex flex-col lg:flex-row mt-8">
         <p class="font-medium w-24">Location:</p>
-        <p class>
+        <p>
           <%= event.venue_address %>
           <br />
           <%= event.city %>
@@ -61,61 +54,45 @@
             <%= link_to "#{event.name}",
                         event.event_link,
                         target: :_blank,
-                        class: 'tw-link'%>
+                        class: "tw-link" %>
           </p>
         </div>
       <% end %>
     </section>
 
-    <section class="mt-8">
+    <section>
       <p class="text-xl font-semibold">Hosted By</p>
 
       <div class="flex flex-col lg:flex-row mt-4">
         <p class="font-medium w-24">Name:</p>
-        <p class>
-          <%= event.ambassador.name  %>
-        </p>
+        <p><%= event.ambassador.name %></p>
       </div>
 
       <div class="flex flex-col lg:flex-row mt-8">
         <p class="font-medium w-24">Email:</p>
-        <p class>
-          <%= event.ambassador.email  %>
-        </p>
+        <p><%= event.ambassador.email %></p>
       </div>
 
-      <div class="flex flex-col lg:flex-row mt-8">
-        <p>
-          Events will be confirmed as either Regional Pitch Events or
-          Celebration Events after <%= ImportantDates.rpe_officiality_finalized.strftime("%B %-d") %>.
-          For more information, please check out the
-          <%= link_to 'Technovation FAQ',
-                      'https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events'
-          %> or contact your chapter ambassador.
-        </p>
-      </div>
-
-    </section>
-
-    <% if current_scope != "judge" and
-        not current_team.attending_event?(event) and
-          SeasonToggles.select_regional_pitch_event? and
-            not event.at_team_capacity? %>
-              <section class="mt-8 flex justify-center">
-                <p>
-                  <%= link_to "Select this event",
-                              send("#{current_scope}_regional_pitch_event_selection_path",
-                                   :regional_pitch_event_selection,
-                                   { event_id: event.id, team_id: current_team.id }),
-                              class: "tw-green-btn mx-auto",
-                              data: {
-                                disable_with: "Selecting event...",
-                                positive: true,
-                                method: :post,
-                                confirm: "Are you sure you want to attend #{event.name}? " + "<p><strong>You cannot change this.</strong></p>"
-                              } %>
-                </p>
-              </section>
+      <% if current_scope != "judge" and
+          not current_team.attending_event?(event) and
+            SeasonToggles.select_regional_pitch_event? and
+              not event.at_team_capacity? %>
+                <div class="mt-8 flex justify-center">
+                  <p>
+                    <%= link_to "Select this event",
+                                send("#{current_scope}_regional_pitch_event_selection_path",
+                                     :regional_pitch_event_selection,
+                                     { event_id: event.id, team_id: current_team.id }),
+                                class: "tw-green-btn mx-auto",
+                                data: {
+                                  disable_with: "Selecting event...",
+                                  positive: true,
+                                  method: :post,
+                                  confirm: "Are you sure you want to attend #{event.name}? " + "<p><strong>You cannot change this.</strong></p>"
+                                } %>
+                  </p>
+                </div>
       <% end %>
-  <% end %>
+    </section>
+  </div>
 </div>

--- a/app/views/regional_pitch_events/show.en.html.erb
+++ b/app/views/regional_pitch_events/show.en.html.erb
@@ -16,6 +16,18 @@
     </div>
   </div>
 <% else %>
-  <%= render 'regional_pitch_events/rebrand/event',
-             event: @regional_pitch_event %>
+
+  <div class="container mx-auto flex w-full lg:w-3/4">
+    <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Event Details'} do %>
+      <section class="mb-8">
+        <p class="mb-4">
+          <%= link_to 'Go back!',
+                      back_from_event_path,
+                      class: "tw-gray-btn text-sm" %>
+        </p>
+        <%= render 'regional_pitch_events/rebrand/event',
+                   event: @regional_pitch_event %>
+      </section>
+      <% end %>
+    </div>
 <% end %>

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -105,10 +105,6 @@
                   </li>
                 </ol>
               </div>
-
-              <%= render 'regional_pitch_events/rebrand/event',
-                event: current_team.selected_regional_pitch_event %>
-
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
Refs #3739 

This change updates the layout for student RPE event selection. I mirrored the mentor view for selecting events. This is version 2 for this ticket. I prefer this approach because it only uses the existing `event` partial with a bit of conditional styling. The 1st version of this ticket duplicated the `event` partial with an updated layout, but the content was pretty much the same. 

I also found 1 broken link on the mentor dashboard for selecting an RPE, which has been included in this PR. 

**Horizontal layout for available events**
![CleanShot 2022-12-16 at 12 36 34@2x](https://user-images.githubusercontent.com/29210380/208171420-2641f3ba-1a81-44b2-aaaa-56f2a410f531.png)

**Event details**
![CleanShot 2022-12-16 at 12 39 38@2x](https://user-images.githubusercontent.com/29210380/208171494-b835982a-511a-45fd-a09a-e2e4c5f6f034.png)

