### PR TITLE
"Additional Questions" improvements

### DIFF
--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -49,7 +49,7 @@
             collection: [['Yes', true], ['No', false]] %>
           <%= f.input :climate_change_description, label: false %>
 
-          <%= f.input :game, label: t('submissions.solve_hunger_or_food_waste_question'),
+          <%= f.input :game, label: t('submissions.solves_hunger_or_food_waste_question'),
             collection: [['Yes', true], ['No', false]] %>
           <%= f.input :game_description, label: false %>
         </div>

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -212,7 +212,7 @@
       <% end %>
 
       <p>
-        <%= t("submissions.solve_hunger_or_food_waste_question") %>
+        <%= t("submissions.solves_hunger_or_food_waste_question") %>
         <%= @team_submission.question_response("health_problem")  %>
       </p>
       <% if @team_submission.game? %>

--- a/app/views/chapter_ambassador/team_submissions/show.html.erb
+++ b/app/views/chapter_ambassador/team_submissions/show.html.erb
@@ -187,7 +187,7 @@
           <% end %>
 
           <p>
-            <%= t("submissions.solve_hunger_or_food_waste_question") %>
+            <%= t("submissions.solves_hunger_or_food_waste_question") %>
             <%= @team_submission.question_response("health_problem")  %>
           </p>
           <% if @team_submission.game? %>

--- a/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
@@ -202,7 +202,7 @@
 
   <div class="mt-6">
     <h3 class="mb-2 text-base font-semibold uppercase">
-      <%= t("submissions.solve_hunger_or_food_waste_question") %>
+      <%= t("submissions.solves_hunger_or_food_waste_question") %>
     </h3>
 
     <span class="inline-flex items-center px-2.5 py-0.5 rounded-md text-sm font-medium bg-gray-100 text-gray-800">

--- a/app/views/team_submissions/_app_details.en.html.erb
+++ b/app/views/team_submissions/_app_details.en.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </dd>
 
-  <dt><%= t("submissions.solve_hunger_or_food_waste_question") %></dt>
+  <dt><%= t("submissions.solves_hunger_or_food_waste_question") %></dt>
   <dd>
     <%= humanize_boolean(team_submission.game?) %>
 

--- a/app/views/team_submissions/_app_details.en.html.erb
+++ b/app/views/team_submissions/_app_details.en.html.erb
@@ -1,37 +1,28 @@
 <dl>
   <dt>Does your submission use artificial intelligence?</dt>
   <dd>
-    <% if team_submission.ai == true %>
-      Yes
+    <%= humanize_boolean(team_submission.ai?) %>
+
+    <% if team_submission.ai? %>
       <%= simple_format(team_submission.ai_description) %>
-    <% elsif team_submission.ai == false %>
-      No
-    <% elsif team_submission.ai == nil %>
-      -
     <% end %>
   </dd>
 
   <dt>Does your submission help solve climate change?</dt>
   <dd>
-    <% if team_submission.climate_change == true %>
-      Yes
+    <%= humanize_boolean(team_submission.game?) %>
+
+    <% if team_submission.climate_change? %>
       <%= simple_format(team_submission.climate_change_description) %>
-    <% elsif team_submission.climate_change == false %>
-      No
-    <% elsif team_submission.climate_change == nil %>
-      -
     <% end %>
   </dd>
 
   <dt><%= t("submissions.solve_hunger_or_food_waste_question") %></dt>
   <dd>
-    <% if team_submission.game == true %>
-      Yes
+    <%= humanize_boolean(team_submission.game?) %>
+
+    <% if team_submission.game? %>
       <%= simple_format(team_submission.game_description) %>
-    <% elsif team_submission.game == false %>
-      No
-    <% elsif team_submission.game == nil %>
-      -
     <% end %>
   </dd>
 

--- a/app/views/team_submissions/pieces/app_details.en.html.erb
+++ b/app/views/team_submissions/pieces/app_details.en.html.erb
@@ -101,7 +101,7 @@
 
     <div class="field margin--t-large">
       <%= f.label :game,
-        t("submissions.solve_hunger_or_food_waste_question"),
+        t("submissions.solves_hunger_or_food_waste_question"),
         for: :team_submission_game %>
 
       <%= f.select :game,

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -1,4 +1,4 @@
 en:
   submissions:
-    solve_hunger_or_food_waste_question: Does your submission help solve hunger or food waste in some way?
+    solves_hunger_or_food_waste_question: Does your submission help solve hunger or food waste in some way?
     uses_open_ai_question: "Did you use OpenAI/ChatGPT at any point when working on your project?"


### PR DESCRIPTION
A couple of minor things here:
- On the submission review page, the "AI", "climate change", "hunger" questions were just display a Yes/No response vs Yes/No/-, I updated it to Yes/No/-.
- I renamed `solve_hunger_or_food_waste_question` to `solves_hunger_or_food_waste_question` for the i18n translation key