### PR TITLE
Add OpenAI/ChatGPT question to admin

### DIFF
--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -280,6 +280,10 @@ class ScoredSubmissionsGrid
     end
   end
 
+  column :uses_open_ai, if: ->(grid) { grid.admin } do
+    ApplicationController.helpers.humanize_boolean(uses_open_ai?)
+  end
+
   filter :round,
   :enum,
   select: -> { [

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -106,6 +106,10 @@ class SubmissionsGrid
     end
   end
 
+  column :uses_open_ai, header: "Uses OpenAI/ChatGPT", if: ->(grid) { grid.admin } do
+    ApplicationController.helpers.humanize_boolean(uses_open_ai?)
+  end
+
   column :city, order: "teams.city" do
     team.city
   end

--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -52,6 +52,10 @@
           <%= f.input :game, label: t('submissions.solves_hunger_or_food_waste_question'),
             collection: [['Yes', true], ['No', false]] %>
           <%= f.input :game_description, label: false %>
+
+          <%= f.input :game, label: t('submissions.uses_open_ai_question'),
+            collection: [['Yes', true], ['No', false]] %>
+          <%= f.input :uses_open_ai_description, label: false %>
         </div>
 
         <div>

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -219,6 +219,15 @@
         <i><%= @team_submission.game_description  %></i>
       <% end %>
 
+      <p>
+        <%= t("submissions.uses_open_ai_question") %>
+        <%= humanize_boolean(@team_submission.uses_open_ai?) %>
+      </p>
+
+      <% if @team_submission.uses_open_ai? %>
+        <i><%= @team_submission.uses_open_ai_description %></i>
+      <% end %>
+
       <h5>Screenshots</h5>
 
       <p>

--- a/app/views/chapter_ambassador/team_submissions/show.html.erb
+++ b/app/views/chapter_ambassador/team_submissions/show.html.erb
@@ -193,6 +193,15 @@
           <% if @team_submission.game? %>
             <i><%= @team_submission.game_description  %></i>
           <% end %>
+
+          <p>
+            <%= t("submissions.uses_open_ai_question") %>
+            <%= humanize_boolean(@team_submission.uses_open_ai?) %>
+          </p>
+
+          <% if @team_submission.uses_open_ai? %>
+            <i><%= @team_submission.uses_open_ai_description %></i>
+          <% end %>
         </dd>
 
         <dt>Images</dt>


### PR DESCRIPTION
This PR will add the OpenAI/ChatGPT info to:
- the admin submisisons datagrid
- the admin submission scores datagrid
- the admin show/edit submission pages
- the ChA show submission page
