### PR TITLE
"Additional Questions" improvements

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -209,8 +209,8 @@ class TeamSubmission < ActiveRecord::Base
     if: ->(s) { s.development_platform == "App Inventor" }
 
   validates :thunkable_project_url,
-    absence: { 
-      message: 'Cannot add a Thunkable project URL when App Inventor selected as the development platform.' 
+    absence: {
+      message: 'Cannot add a Thunkable project URL when App Inventor selected as the development platform.'
     },
     if: ->(s) { s.development_platform == "App Inventor" }
 
@@ -219,8 +219,8 @@ class TeamSubmission < ActiveRecord::Base
     if: ->(s) { s.development_platform == "Thunkable" }
 
   validates :app_inventor_app_name,
-    absence: { 
-      message: 'Cannot add an App Inventor app name when Thunkable selected as the development platform.' 
+    absence: {
+      message: 'Cannot add an App Inventor app name when Thunkable selected as the development platform.'
     },
     if: ->(s) { s.development_platform == "Thunkable" }
 
@@ -610,17 +610,6 @@ class TeamSubmission < ActiveRecord::Base
 
   def video_url_root(video_type)
     VideoUrl.new(video_link_for(video_type)).root
-  end
-  
-  def question_response(question)
-    question_key = question == "health_problem" ? :game : question.to_sym 
-    if self[question_key].nil?
-      "-"
-    elsif self[question_key]
-      "Yes"
-    else
-      "No"
-    end
   end
 
   private

--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -41,11 +41,11 @@
 
         <div>
           <h6>Additional Questions</h6>
-          <%= f.input :ai, label: 'Does your submission use artificial intelligence?',
+          <%= f.input :ai, label: t('submissions.ai_question'),
             collection: [['Yes', true], ['No', false]]%>
           <%= f.input :ai_description, label: false %>
 
-          <%= f.input :climate_change, label: 'Does your submission help solve climate change?',
+          <%= f.input :climate_change, label: t('submissions.climate_change_question'),
             collection: [['Yes', true], ['No', false]] %>
           <%= f.input :climate_change_description, label: false %>
 

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -196,19 +196,19 @@
 
       <h5>Additional Questions</h5>
       <p>
-        Does your submission use artificial intelligence?
-        <%= @team_submission.question_response("ai")  %>
+        <%= t("submissions.ai_question") %>
+        <%= humanize_boolean(@team_submission.ai?) %>
       </p>
       <% if @team_submission.ai? %>
-        <i><%= @team_submission.ai_description  %></i>
+        <i><%= @team_submission.ai_description %></i>
       <% end %>
 
       <p>
-        Does your submission help solve climate change?
-        <%= @team_submission.question_response("climate_change")  %>
+        <%= t("submissions.climate_change_question") %>
+        <%= humanize_boolean(@team_submission.climate_change?) %>
       </p>
       <% if @team_submission.climate_change? %>
-        <i><%= @team_submission.climate_change_description  %></i>
+        <i><%= @team_submission.climate_change_description %></i>
       <% end %>
 
       <p>

--- a/app/views/chapter_ambassador/team_submissions/show.html.erb
+++ b/app/views/chapter_ambassador/team_submissions/show.html.erb
@@ -171,19 +171,19 @@
         <dt>Additional Questions</dt>
         <dd>
           <p>
-            Does your submission use artificial intelligence?
-            <%= @team_submission.question_response("ai")  %>
+            <%= t("submissions.ai_question") %>
+            <%= humanize_boolean(@team_submission.ai?) %>
           </p>
           <% if @team_submission.ai? %>
-            <i><%= @team_submission.ai_description  %></i>
+            <i><%= @team_submission.ai_description %></i>
           <% end %>
 
           <p>
-            Does your submission help solve climate change?
-            <%= @team_submission.question_response("climate_change")  %>
+            <%= t("submissions.climate_change_question") %>
+            <%= humanize_boolean(@team_submission.climate_change?) %>
           </p>
           <% if @team_submission.climate_change? %>
-            <i><%= @team_submission.climate_change_description  %></i>
+            <i><%= @team_submission.climate_change_description %></i>
           <% end %>
 
           <p>
@@ -198,7 +198,6 @@
             <%= t("submissions.uses_open_ai_question") %>
             <%= humanize_boolean(@team_submission.uses_open_ai?) %>
           </p>
-
           <% if @team_submission.uses_open_ai? %>
             <i><%= @team_submission.uses_open_ai_description %></i>
           <% end %>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -1,4 +1,8 @@
 en:
   submissions:
+    ai_question: Does your submission use artificial intelligence?
+    climate_change_question: Does your submission help solve climate change?
+    game_question: Is your app a game?
+    solves_health_problem_question: Does your submission help solve a health problem?
     solves_hunger_or_food_waste_question: Does your submission help solve hunger or food waste in some way?
     uses_open_ai_question: "Did you use OpenAI/ChatGPT at any point when working on your project?"


### PR DESCRIPTION
This PR has a few improvements for the "Additional Questions":
- Add missing i18n translations for the older questions
- Use the new `humanize_boolean` method instead of `team_submission.question_response`
- Remove `team_submission.question_response` since it's not being used any longer