### PR TITLE
Fixex broken view details rpe link on judge dashboard

### DIFF
--- a/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
@@ -89,7 +89,7 @@
         </p>
 
         <div class="step-actions margin--b-xlarge">
-          <%= link_to 'View details',
+          <%= link_to "View details",
                       send("judge_regional_pitch_event_path", event),
                       class: "tw-green-btn" %>
         </div>

--- a/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
@@ -90,7 +90,7 @@
 
         <div class="step-actions margin--b-xlarge">
           <%= link_to "View details",
-                      send("judge_regional_pitch_event_path", event),
+                      judge_regional_pitch_event_path(event),
                       class: "tw-green-btn" %>
         </div>
       <% end %>

--- a/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_events.en.html.erb
@@ -90,8 +90,8 @@
 
         <div class="step-actions margin--b-xlarge">
           <%= link_to 'View details',
-            send("#{current_scope}_consent_waiver_path", event),
-            class: "button" %>
+                      send("judge_regional_pitch_event_path", event),
+                      class: "tw-green-btn" %>
         </div>
       <% end %>
     <% else %>


### PR DESCRIPTION
Refs #3695 - Additional details on the issue

This change was needed to fix the broken "view details" button for RPEs on the judge dashboard. The path was incorrect and was linked to a random consent waiver view. We may still remove the button as part of the new RPE flow. 

