### PR TITLE
Default season to the current season for judge questions

### DIFF
--- a/app/services/judge_questions.rb
+++ b/app/services/judge_questions.rb
@@ -1,6 +1,8 @@
 class JudgeQuestions
+  attr_reader :season, :division
+
   def initialize(season:, division:)
-    @season = season
+    @season = season.presence || Season.current.year
     @division = division
   end
 
@@ -9,8 +11,6 @@ class JudgeQuestions
   end
 
   private
-
-  attr_reader :season, :division
 
   def season_module_name
     case season

--- a/spec/services/judge_questions_spec.rb
+++ b/spec/services/judge_questions_spec.rb
@@ -7,6 +7,26 @@ describe JudgeQuestions do
   let(:season) { 2021 }
   let(:division) { "senior" }
 
+  describe "#initialize" do
+    let(:judge_questions) { JudgeQuestions.new(season: season, division: division) }
+
+    context "when the season is not present" do
+      let(:season) { nil }
+
+      it "defaults the season to the current season" do
+        expect(judge_questions.season).to eq(Season.current.year)
+      end
+    end
+
+    context "when the season is an empty array" do
+      let(:season) { [] }
+
+      it "defaults the season to the current season" do
+        expect(judge_questions.season).to eq(Season.current.year)
+      end
+    end
+  end
+
   describe "#call" do
     let(:season) { 2022 }
     let(:division) { "beginner" }


### PR DESCRIPTION
A ChA can print out the scores for an RPE - this will loop over all the RPE submissions and their associated scores from each judge. But it is possible that a judge hasn't scored one of these submissions - in which case we create a new `SubmissionScore` for them but this won't have a season associated with it, and this missing season is what causes an error, when trying to get the judging questions for that season.

This PR will default the season to the current season if one wasn't provided when trying to fetch the judging questions.

