### PR TITLE
Update "parent/guardian email address can't match a student's email address" validations

### DIFF
--- a/app/controllers/concerns/profile_controller.rb
+++ b/app/controllers/concerns/profile_controller.rb
@@ -27,8 +27,6 @@ module ProfileController
             success: t('controllers.accounts.update.success')
         }
       end
-    elsif profile.errors["parent_guardian_email"].any?
-      render "student/parental_consent_notices/new"
     elsif profile.errors["account.password"].any? or
       profile.errors["account.existing_password"].any?
       if profile.account.email_changed?
@@ -38,6 +36,8 @@ module ProfileController
       end
     elsif profile.errors["account.email"].any?
       render 'email_addresses/edit'
+    elsif profile.errors["parent_guardian_email"].any?
+      render "student/parental_consent_notices/new"
     elsif profile.errors["account.city"].any? or
             profile.errors["account.state_province"].any? or
               profile.errors["account.country"].any?

--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -383,11 +383,11 @@ class StudentProfile < ActiveRecord::Base
 
   def validate_valid_parent_email
     return if parent_guardian_email.blank? ||
+      Division.for_account(account).name == "beginner" ||
       (
         !parent_guardian_email_changed? &&
         parent_guardian_email == ParentalConsent::PARENT_GUARDIAN_EMAIL_ADDDRESS_FOR_A_PAPER_CONSENT
-      ) ||
-      account&.division&.beginner?
+      )
 
     if Account.joins(:student_profile, :division)
         .where("lower(email) = ?", parent_guardian_email.downcase)

--- a/app/validators/student_email_validator.rb
+++ b/app/validators/student_email_validator.rb
@@ -6,6 +6,7 @@ class StudentEmailValidator < ActiveModel::Validator
         (record.email == record.student_profile.parent_guardian_email)
 
       record.errors.add(:email, :matches_parent_guardian_email)
+      record.student_profile.errors.add(:parent_guardian_email, :matches_student_email)
     end
   end
 end

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -40,9 +40,9 @@ en:
         student_profile:
           attributes:
             parent_guardian_email:
-              found_in_student_accounts: "cannot match your (or any other student's) email"
+              found_in_student_accounts: "cannot match your (or any other student's) email address"
               invalid: "does not appear to be an email address"
-              matches_student_email: "cannot match your (or any other student's) email"
+              matches_student_email: "cannot match your (or any other student's) email address"
 
         team_member_invite:
           attributes:

--- a/spec/models/student_profile_spec.rb
+++ b/spec/models/student_profile_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe StudentProfile do
 
       expect(another_student).to be_invalid
       expect(another_student.errors[:parent_guardian_email]).to include(
-        "cannot match your (or any other student's) email"
+        "cannot match your (or any other student's) email address"
       )
     end
 
@@ -174,7 +174,7 @@ RSpec.describe StudentProfile do
 
       expect(another_student).to be_invalid
       expect(another_student.errors[:parent_guardian_email]).to include(
-        "cannot match your (or any other student's) email"
+        "cannot match your (or any other student's) email address"
       )
     end
 
@@ -191,7 +191,7 @@ RSpec.describe StudentProfile do
 
       expect(another_student).to be_valid
       expect(another_student.errors[:parent_guardian_email]).not_to include(
-        "cannot match your (or any other student's) email"
+        "cannot match your (or any other student's) email address"
       )
     end
   end


### PR DESCRIPTION
There are two main fixes/changes here:
- The `StudentEmailValidator` will now add an error to `student_profile.parent_guardian_email` (it used to just add an error to `account.email`
- The division check in the `student_profile` validation will now match how it's done in `StudentEmailValidator`, meaning it will use `Division.for` to determine a student's division (that way both validations are consistent)
