### PR TITLE
Fix show/hide visibility of hunger/food waste description field

### DIFF
--- a/app/views/team_submissions/pieces/app_details.en.html.erb
+++ b/app/views/team_submissions/pieces/app_details.en.html.erb
@@ -115,7 +115,7 @@
         class: "width--20-percent",
         id: :team_submission_solves_hunger_or_food_waste %>
 
-      <div id="solves_hunger_or_food_waste_question">
+      <div id="solves_hunger_or_food_waste_description">
         <p class="hint margin--b-none">Please explain how:</p>
 
         <%= f.text_area :solves_hunger_or_food_waste_description,


### PR DESCRIPTION
The show/hide functionality (for the additional questions) works by having things properly named, which I didn't quite get right the first time for the hunger/food waste question! 😊 


Here's a snippet for what should be toggled for the hunger/food waste question:
```
data: {
  toggles: {
    "true": "#solves_hunger_or_food_waste_description"
  },
},
```

In this PR, I updated the `id` (of the `div` that should be shown/hidden) to match that corresponding field. ☝️ 😅 



