### PR TITLE
Update judge sections and questions for RPE printable page

### DIFF
--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -31,6 +31,7 @@ class Questions
       .call
       .uniq(&:section)
       .map(&:section)
+      .each_with_object({}) { |section, new_hash| new_hash[section] = section_display_name_for(section, division) }
   end
 
   def sections
@@ -153,5 +154,20 @@ class Questions
       text: score["#{section_name}_comment"],
       word_count: score["#{section_name}_comment_word_count"]
     }
+  end
+
+  def section_display_name_for(section, division)
+    case section
+    when "project_details"
+      "Project Description"
+    when "ideation"
+      "Learning Journey"
+    when "demo"
+      "Technical"
+    when "entrepreneurship"
+      division == "senior" ? "Business Plan" : "User Adoption Plan"
+    else
+      section.titlecase
+    end
   end
 end

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -15,6 +15,15 @@ class Questions
     new(score.judge_profile, score.team_submission, score: score)
   end
 
+  def self.sections_for(division:, season: Season.current.year)
+    JudgeQuestions
+      .new(division: division, season: season)
+      .call
+      .uniq(&:section)
+      .map(&:section)
+      .each_with_object({}) { |section, new_hash| new_hash[section] = section_display_name_for(section, division) }
+  end
+
   def each(&block)
     @questions.each { |q| block.call(q) }
   end
@@ -26,12 +35,7 @@ class Questions
   end
 
   def sections_for(division:, season: Season.current.year)
-    JudgeQuestions
-      .new(division: division, season: season)
-      .call
-      .uniq(&:section)
-      .map(&:section)
-      .each_with_object({}) { |section, new_hash| new_hash[section] = section_display_name_for(section, division) }
+    self.class.sections_for(division: division, season: season)
   end
 
   def sections
@@ -156,7 +160,7 @@ class Questions
     }
   end
 
-  def section_display_name_for(section, division)
+  def self.section_display_name_for(section, division)
     case section
     when "project_details"
       "Project Description"
@@ -170,4 +174,6 @@ class Questions
       section.titlecase
     end
   end
+
+  private_class_method :section_display_name_for
 end

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -74,7 +74,7 @@
   <% questions = Questions.for(@score) %>
 
   <div class="admin-score-sections">
-    <% questions.sections_for(division: @score.team.division_name).each do |section| %>
+    <% questions.sections_for(division: @score.team.division_name).each do |section, _| %>
       <% if section === "ideation" %>
         <% section_name = "Learning Journey" %>
       <% elsif section === "entrepreneurship" %>

--- a/app/views/chapter_ambassador/printable_scores/show.en.html.erb
+++ b/app/views/chapter_ambassador/printable_scores/show.en.html.erb
@@ -41,43 +41,22 @@
       <% unless score = @scores.find { |score| score.judge_profile_id == judge.id && score.team == team }
         score = SubmissionScore.new(judge_profile: judge, team_submission: team.submission)
       end %>
+
+      <% sections = Questions.sections_for(division: team.division_name) %>
+
       <div class="page <%= team.division_name %>">
         <header>
           <h3><%= judge.name %></h3>
           <h4><%= team.name %></h4>
 
           <table>
-            <tr>
-              <td>Ideation</td>
-              <td><%= score.ideation_total %></td>
-              <td></td>
-            </tr>
-
-            <tr>
-              <td>Technical</td>
-              <td><%= score.technical_total %></td>
-              <td></td>
-            </tr>
-
-            <tr>
-              <td>Pitch</td>
-              <td><%= score.pitch_total %></td>
-              <td></td>
-            </tr>
-
-            <% if team.senior? %>
+            <% sections.each do |section_lookup_key, section_display_name| %>
               <tr>
-                <td>Entrepreneurship</td>
-                <td><%= score.entrepreneurship_total %></td>
+                <td><%= section_display_name %></td>
+                <td><%= eval("score.#{section_lookup_key}_total") %></td>
                 <td></td>
               </tr>
             <% end %>
-
-            <tr>
-              <td>Overall</td>
-              <td><%= score.overall_impression_total %></td>
-              <td></td>
-            </tr>
 
             <tr>
               <th scope="row">Final:</th>
@@ -88,47 +67,11 @@
         </header>
 
         <div class="sections">
-          <h3>Ideation</h3>
-
-          <table>
-            <% Questions.for(score).in_section(:ideation).each do |question| %>
-              <tr>
-                <td><%= question.text %></td>
-                <td><%= question.score %></td>
-                <td></td>
-              </tr>
-            <% end %>
-          </table>
-
-          <h3>Technical</h3>
-
-          <table>
-            <% Questions.for(score).in_section(:technical).each do |question| %>
-              <tr>
-                <td><%= question.text %></td>
-                <td><%= question.score %></td>
-                <td></td>
-              </tr>
-            <% end %>
-          </table>
-
-          <h3>Pitch</h3>
-
-          <table>
-            <% Questions.for(score).in_section(:pitch).each do |question| %>
-              <tr>
-                <td><%= question.text %></td>
-                <td><%= question.score %></td>
-                <td></td>
-              </tr>
-            <% end %>
-          </table>
-
-          <% if team.senior? %>
-            <h3>Entrepreneurship</h3>
+          <% sections.each do |section_lookup_key, section_display_name| %>
+            <h3><%= section_display_name %></h3>
 
             <table>
-              <% Questions.for(score).in_section(:entrepreneurship).each do |question| %>
+              <% Questions.for(score).in_section(section_lookup_key).each do |question| %>
                 <tr>
                   <td><%= question.text %></td>
                   <td><%= question.score %></td>
@@ -137,18 +80,6 @@
               <% end %>
             </table>
           <% end %>
-
-          <h3>Overall Impression</h3>
-
-          <table>
-            <% Questions.for(score).in_section(:overall).each do |question| %>
-              <tr>
-                <td><%= question.text %></td>
-                <td><%= question.score %></td>
-                <td></td>
-              </tr>
-            <% end %>
-          </table>
         </div>
       </div>
 
@@ -156,22 +87,10 @@
         <h2>Comments given for <%= team.name %> by <%= judge.name %></h2>
         <h3>(they may be shortened to fit the page)</h3>
 
-        <h3>Ideation</h3>
-        <%= simple_format(truncate(score.ideation_comment, length: 500)) %>
-
-        <h3>Technical</h3>
-        <%= simple_format(truncate(score.technical_comment, length: 500)) %>
-
-        <h3>Pitch</h3>
-        <%= simple_format(truncate(score.pitch_comment, length: 500)) %>
-
-        <% if team.senior? %>
-          <h3>Entrepreneurship</h3>
-          <%= simple_format(truncate(score.entrepreneurship_comment, length: 500)) %>
+        <% sections.each do |section_lookup_key, section_display_name| %>
+          <h3><%= section_display_name %></h3>
+          <%= simple_format(truncate(eval("score.#{section_lookup_key}_comment"), length: 500)) %>
         <% end %>
-
-        <h3>Overall Impression</h3>
-        <%= simple_format(truncate(score.overall_comment, length: 500)) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/student/scores/score_details.en.html.erb
+++ b/app/views/student/scores/score_details.en.html.erb
@@ -16,7 +16,7 @@
 
     <% questions = Questions.for(@score) %>
     <section class="w-full px-0 lg:px-8 mx-auto">
-      <% questions.sections_for(division: @score.team.division_name).each do |section| %>
+      <% questions.sections_for(division: @score.team.division_name).each do |section, _| %>
         <%= render 'student/scores/section_score',
                     score: @score,
                     section: section,


### PR DESCRIPTION
This will update the judge sections and questions on the ChA RPE printable page.

One of the more noteworthy changes here is that I updated `sections_for` to be a class method, but also, instead of it returning an array, it will return a hash (with the contents of the array like it did before, but also it will return the display names for each section).

I think there will still be some work to do after this, but this will at least update the sections and questions to use what we currently have for the 2023 season.