### PR TITLE
Remove score section translation duplication

### DIFF
--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -93,7 +93,7 @@
 
         <tr>
           <td style="font-weight: 500;">
-            <%= section_display_name.titlecase %> Score
+            <%= section_display_name %> Score
           </td>
           <td nowrap>
             <span>

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -74,23 +74,15 @@
   <% questions = Questions.for(@score) %>
 
   <div class="admin-score-sections">
-    <% questions.sections_for(division: @score.team.division_name).each do |section, _| %>
-      <% if section === "ideation" %>
-        <% section_name = "Learning Journey" %>
-      <% elsif section === "entrepreneurship" %>
-        <% section_name = @score.team.senior? ? "Business Plan" : "User Adoption Plan" %>
-      <% else %>
-        <% section_name = section %>
-      <% end %>
-
+    <% questions.sections_for(division: @score.team.division_name).each do |section_lookup_key, section_display_name| %>
       <h3>
-        <%= section_name.titlecase %>
+        <%= section_display_name %>
       </h3>
 
       <table>
         <% section_total = 0 %>
 
-        <% questions.in_section(section).each do |question| %>
+        <% questions.in_section(section_lookup_key).each do |question| %>
           <% section_total += @score.total_for_question(question) %>
 
           <tr>
@@ -101,18 +93,18 @@
 
         <tr>
           <td style="font-weight: 500;">
-            <%= section_name.titlecase %> Score
+            <%= section_display_name.titlecase %> Score
           </td>
           <td nowrap>
             <span>
               <%= section_total %> /
-              <%= @score.total_points_for_section(@score.team.division_name, section) %>
+              <%= @score.total_points_for_section(@score.team.division_name, section_lookup_key) %>
             </span>
           </td>
         </tr>
       </table>
 
-      <%= simple_format @score.comment_for_section(section) %>
+      <%= simple_format @score.comment_for_section(section_lookup_key) %>
     <% end %>
   </div>
 

--- a/app/views/student/scores/_section_score.html.erb
+++ b/app/views/student/scores/_section_score.html.erb
@@ -1,18 +1,12 @@
 <div class="mb-10">
   <div class="flex justify-between items-center text-xl font-bold mb-8">
     <span>
-      <% if section === "ideation" %>
-        Learning Journey
-      <% elsif section === "entrepreneurship" %>
-        <%= score.team.senior? ? "Business Plan" : "User Adoption Plan" %>
-      <% else %>
-        <%= section.titlecase %>
-      <% end %>
+      <%= section_display_name %>
     </span>
   </div>
 
   <div class="flex-col mb-6 ml-8">
-    <% questions.in_section(section).each do |question| %>
+    <% questions.in_section(section_lookup_key).each do |question| %>
       <div class="flex justify-between my-2">
         <p><%= question.text.html_safe %></p>
         <p><%= score.total_for_question(question) %></p>
@@ -22,11 +16,11 @@
 
   <div class="flex justify-between items-center font-semibold border-t border-energetic-blue ml-8 mb-8">
     <span class="mt-2">Section Total</span>
-    <span><%= score.total_for_section(section)%></span>
+    <span><%= score.total_for_section(section_lookup_key)%></span>
   </div>
 
   <div class="ml-8">
     <p class="font-semibold">Judge Feedback</p>
-    <p><%= simple_format score.comment_for_section(section) %></p>
+    <p><%= simple_format score.comment_for_section(section_lookup_key) %></p>
   </div>
 </div>

--- a/app/views/student/scores/score_details.en.html.erb
+++ b/app/views/student/scores/score_details.en.html.erb
@@ -16,10 +16,11 @@
 
     <% questions = Questions.for(@score) %>
     <section class="w-full px-0 lg:px-8 mx-auto">
-      <% questions.sections_for(division: @score.team.division_name).each do |section, _| %>
+      <% questions.sections_for(division: @score.team.division_name).each do |section_lookup_key, section_display_name| %>
         <%= render 'student/scores/section_score',
                     score: @score,
-                    section: section,
+                    section_lookup_key: section_lookup_key,
+                    section_display_name: section_display_name,
                     questions: questions %>
       <% end %>
     </section>


### PR DESCRIPTION
In #3804, `sections_for` was updated to do the section name translations, and return the section display names.

The main changes in this PR will use this functionality (to display the section names), and remove the duplicate section name translations that were happening in the admin and student score views.
