### PR TITLE
Update student email link for pitch events

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -31,10 +31,17 @@ class EventMailer < ApplicationMailer
                admin_permission_token: @invite.admin_permission_token
              )
            when "registered", "past_season", "training", "ready"
-             send(
-               "#{@invite.scope_name}_dashboard_url",
-               mailer_token: @invite.mailer_token
-             )
+             if @invite.scope_name == "student"
+               student_dashboard_url(
+                 mailer_token: @invite.mailer_token,
+                 anchor: "/events"
+               )
+             else
+               send(
+                 "#{@invite.scope_name}_dashboard_url",
+                 mailer_token: @invite.mailer_token
+               )
+             end
            else
              raise ArgumentError,
                "#{@invite.status} is an unsupported @invite status"


### PR DESCRIPTION
This will update the link that is displayed in an email to the students about the pitch event - it will update the link so it goes to the events page/tab.

