### PR TITLE
3830 sizing issues for create team and team details bug

### DIFF
--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -10,10 +10,6 @@
     @apply bg-energetic-blue text-white p-2;
 }
 
-#show-container{
-    @apply w-full
-}
-
 @screen md{
     .tw-sm-hidden{
        @apply block

--- a/app/javascript/stylesheets/tabs.css
+++ b/app/javascript/stylesheets/tabs.css
@@ -15,7 +15,7 @@
 }
 
 @screen md{
-   #show-container div.tab-content{
+   .student-tab-container div.tab-content{
         width: 48rem;
     }
 

--- a/app/views/student/profiles/show.html.erb
+++ b/app/views/student/profiles/show.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% end %>
 
-<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6" id="show-container">
+<div class="container mx-auto flex flex-col lg:flex-row justify-center gap-6 student-tab-container">
   <%= render 'student/profiles/rebrand/menu' %>
 
   <div class="tab">

--- a/app/views/student/teams/new.html.erb
+++ b/app/views/student/teams/new.html.erb
@@ -1,8 +1,9 @@
 <% provide :title, t("views.teams.new.title") %>
 
-<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6">
-  <div class="tab-content tw-active">
-    <%= render 'teams/rebrand/form', view_type: "new" %>
-  </div>
+<div class="mx-auto w-full lg:w-1/2">
+  <%= render layout: "application/templates/dashboards/energetic_container",
+             locals: {heading: t("views.teams.new.title")} do %>
+    <%= render 'teams/rebrand/form'%>
+  <% end %>
 </div>
 

--- a/app/views/student/teams/show.html.erb
+++ b/app/views/student/teams/show.html.erb
@@ -1,7 +1,6 @@
 <% provide :title, "My team: #{current_team.name}" %>
 
-<div class="lg:flex lg:justify-around">
-  <div class="flex flex-col lg:flex-row gap-6">
+  <div class="container mx-auto flex flex-col lg:flex-row justify-center gap-6 student-tab-container">
     <%= render "student/teams/menu" %>
 
     <div class="tab">
@@ -26,4 +25,3 @@
       </div>
     </div>
   </div>
-</div>

--- a/app/views/teams/rebrand/_form.html.erb
+++ b/app/views/teams/rebrand/_form.html.erb
@@ -1,44 +1,33 @@
 <%= simple_form_for @team, 
-  url: (@team.id.present? ? send("#{current_scope}_team_path", @team) : 
-    send("#{current_scope}_teams_path")) do |f| %>
-    <div class="tw-blue-lg-container">
-        <div class="sm-header-wrapper bg-energetic-blue text-white p-2">
-            <p class="font-bold">
-                <%= t("views.teams.#{view_type}.title") %>
-            </p>
-        </div>
+  url: (@team.id.present? ? send("#{current_scope}_team_path", @team) : send("#{current_scope}_teams_path")) do |f| %>
+    <div class="p-2">
+      <%= f.input :name, label: "Team name" %>
 
-        <div class="p-6">
-            <%= f.input :name, label: "Team name" %>
+      <% if f.object.persisted? %>
+        <%= f.input :description, label: t("models.team.description") %>
+      <% end %>
 
-            <% if f.object.persisted? %>
-            <%= f.input :description, label: t("models.team.description") %>
-            <% end %>
+      <% action = f.object.persisted? ? :save : :create %>
 
-            <% action = f.object.persisted? ? :save : :create %>
+      <div class="pt-3 pb-7">
+        <p class="p-0 m-0">
+          <%= f.button :submit,
+             t("views.application.#{action}",
+             thing: t("models.team.class_name")),
+             class: "tw-green-btn float-right cursor-pointer" %>
+        </p>
 
-            <div class="pt-3 pb-7">
-                <p class="p-0 m-0">
-                    <%= f.button :submit,
-                        t("views.application.#{action}",
-                        thing: t("models.team.class_name")),
-                        class: "tw-green-btn float-right" %>
-                </p>
-
-                <p class="p-0 m-0">
-                    <%= 
-                        if @team.id.present?
-                            link_to t("views.application.cancel"),
-                            send("#{current_scope}_team_path", @team),
-                            class: "tw-green-btn float-left"
-                        else
-                            link_to t("views.application.cancel"),
-                            send("#{current_scope}_teams_path", @team),
-                            class: "tw-green-btn float-left"
-                        end      
-                    %>
-                </p>
-            </div>
-        </div>
-  </div>
+        <p class="p-0 m-0">
+          <% if @team.id.present? %>
+            <%= link_to t("views.application.cancel"),
+                        send("#{current_scope}_team_path", @team),
+                        class: "tw-green-btn float-left" %>
+          <% else %>
+            <%= link_to t("views.application.cancel"),
+                        send("#{current_scope}_teams_path", @team),
+                        class: "tw-green-btn float-left" %>
+          <% end %>
+        </p>
+      </div>
+    </div>
 <% end %>


### PR DESCRIPTION
Refs #3830 

This PR fixes the sizing issues on the create team form and the student team details. I did a little bit of cleanup with the create team form to incorporate the energetic container approach.

I also standardized the "profile" and "team" tabs so they are the same width/stay in the same place in the student experience.
![CleanShot 2023-02-06 at 16 31 28](https://user-images.githubusercontent.com/29210380/217102403-8c020293-7078-4300-8f3e-325dc93b49ef.gif)
