### PR TITLE
Adjust RPE judge assignment threshold

### DIFF
--- a/app/javascript/chapter_ambassador/events/Event.js
+++ b/app/javascript/chapter_ambassador/events/Event.js
@@ -173,7 +173,7 @@ export default function (event) {
   }
 
   this.teamListIsTooLong = () => {
-    return this.selectedTeams.length >= 10
+    return this.selectedTeams.length >= 8
   }
 
   this.resultReadyForList = (result, list) => {


### PR DESCRIPTION
For RPEs, in order to manually assign a judge to a submission, a certain number of teams needs to be participating in the event.

This PR will update that number to 8, so that if 8 or more teams are participating, judges can be manually assigned to submissions.


