### PR TITLE
ChA RPE admin updates

### DIFF
--- a/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
+++ b/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
@@ -16,6 +16,12 @@
         v-show="searching"
       >
         <div class="modal">
+          <div v-if="eventAtCapacity()" class="margin--b-xlarge">
+            <div class="flash flash--error margin--none">
+              This event is currently at capacity. No additional teams can be added.
+            </div>
+          </div>
+
           <input
             type="search"
             :placeholder="searchPlaceholder"

--- a/app/javascript/chapter_ambassador/events/EventForm.vue
+++ b/app/javascript/chapter_ambassador/events/EventForm.vue
@@ -88,6 +88,11 @@
         </div>
 
         <div class="grid__col-6">
+          <h6 class="margin--none">Event Time</h6>
+          <p class="hint">
+            Please select the time using a 24 hour clock. The time will display to students as the local time zone in your area.
+          </p>
+
           <label>
             From
             <datetime-input

--- a/app/javascript/chapter_ambassador/events/EventForm.vue
+++ b/app/javascript/chapter_ambassador/events/EventForm.vue
@@ -23,7 +23,7 @@
         </div>
 
         <div class="grid__col-sm-6">
-          <h6>Hosting divisions:</h6>
+          <h6>Hosting Divisions</h6>
 
           <label>
             <input

--- a/app/javascript/chapter_ambassador/events/EventsTable.vue
+++ b/app/javascript/chapter_ambassador/events/EventsTable.vue
@@ -87,6 +87,7 @@
                 className="events-list__action-item"
                 name="edit"
                 size="16"
+                v-tooltip.top-center="`Edit event`"
                 :handleClick="editEvent.bind(this, event)"
               />
 
@@ -96,6 +97,7 @@
                 name="remove"
                 size="16"
                 color="ff0000"
+                v-tooltip.top-center="`Delete event`"
                 :handleClick="removeEvent.bind(this, event)"
               />
             </div>


### PR DESCRIPTION
The changes listed below (from #3837) are in this PR:
- Add hover text to the edit icon (text: Edit event) and delete icon (text: Delete event).
- When creating or editing an event, can we add text near the time zone saying "Please select the time using a 24 hour clock. The time will display to students as the local time zone in your area."
- If an event is full, ChAs cannot add more teams from the events page as the button to select a team is greyed out. However, there is no message about why they cannot select a team. Add a message saying: This event is currently at capacity. No additional teams can be added. 