### PR TITLE
Reorder judge questions/sections

### DIFF
--- a/app/services/judging/twenty_twenty_three/beginner_questions.rb
+++ b/app/services/judging/twenty_twenty_three/beginner_questions.rb
@@ -15,27 +15,6 @@ module Judging
 
           Question.new(
             idx: 1,
-            section: "ideation",
-            field: :ideation_1,
-            worth: 3,
-            text: %(
-              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
-              Do we share any technical sources used/remixed and/or our favorite technical resource?
-            )
-          ),
-
-          Question.new(
-            idx: 2,
-            section: "ideation",
-            field: :ideation_2,
-            worth: 3,
-            text: %(
-              Do we describe how we overcame challenges?
-            )
-          ),
-
-          Question.new(
-            idx: 1,
             section: "pitch",
             field: :pitch_1,
             worth: 3,
@@ -170,6 +149,27 @@ module Judging
             worth: 3,
             text: %(
               Do we show what doesn’t work yet and/or share future prototype features?
+            )
+          ),
+
+          Question.new(
+            idx: 1,
+            section: "ideation",
+            field: :ideation_1,
+            worth: 3,
+            text: %(
+              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
+              Do we share any technical sources used/remixed and/or our favorite technical resource?
+            )
+          ),
+
+          Question.new(
+            idx: 2,
+            section: "ideation",
+            field: :ideation_2,
+            worth: 3,
+            text: %(
+              Do we describe how we overcame challenges?
             )
           )
         ]

--- a/app/services/judging/twenty_twenty_three/junior_questions.rb
+++ b/app/services/judging/twenty_twenty_three/junior_questions.rb
@@ -15,27 +15,6 @@ module Judging
 
           Question.new(
             idx: 1,
-            section: "ideation",
-            field: :ideation_1,
-            worth: 5,
-            text: %(
-              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
-              Do we share any technical sources used/remixed and/or our favorite technical resource?
-            )
-          ),
-
-          Question.new(
-            idx: 2,
-            section: "ideation",
-            field: :ideation_2,
-            worth: 5,
-            text: %(
-              Do we describe how we overcame challenges?
-            )
-          ),
-
-          Question.new(
-            idx: 1,
             section: "pitch",
             field: :pitch_1,
             worth: 5,
@@ -207,6 +186,27 @@ module Judging
             text: %(
               Do we explain how we will get new users to use our
               app or invention in its first year?
+            )
+          ),
+
+          Question.new(
+            idx: 1,
+            section: "ideation",
+            field: :ideation_1,
+            worth: 5,
+            text: %(
+              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
+              Do we share any technical sources used/remixed and/or our favorite technical resource?
+            )
+          ),
+
+          Question.new(
+            idx: 2,
+            section: "ideation",
+            field: :ideation_2,
+            worth: 5,
+            text: %(
+              Do we describe how we overcame challenges?
             )
           )
         ]

--- a/app/services/judging/twenty_twenty_three/senior_questions.rb
+++ b/app/services/judging/twenty_twenty_three/senior_questions.rb
@@ -15,27 +15,6 @@ module Judging
 
           Question.new(
             idx: 1,
-            section: "ideation",
-            field: :ideation_1,
-            worth: 5,
-            text: %(
-              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
-              Do we share any technical sources used/remixed and/or our favorite technical resource?
-            )
-          ),
-
-          Question.new(
-            idx: 2,
-            section: "ideation",
-            field: :ideation_2,
-            worth: 5,
-            text: %(
-              Do we describe how we overcame challenges?
-            )
-          ),
-
-          Question.new(
-            idx: 1,
             section: "pitch",
             field: :pitch_1,
             worth: 5,
@@ -228,6 +207,27 @@ module Judging
             text: %(
               Do we show realistic financial plans for starting and
               sustaining our business into the future?
+            )
+          ),
+
+          Question.new(
+            idx: 1,
+            section: "ideation",
+            field: :ideation_1,
+            worth: 5,
+            text: %(
+              Do we share what we learned through a combination of words and pictures (eg screenshots, prototypes)?
+              Do we share any technical sources used/remixed and/or our favorite technical resource?
+            )
+          ),
+
+          Question.new(
+            idx: 2,
+            section: "ideation",
+            field: :ideation_2,
+            worth: 5,
+            text: %(
+              Do we describe how we overcame challenges?
             )
           )
         ]


### PR DESCRIPTION
The order of the judge _sections_ (for the admin and students) is implicitly based on the ordering of the judging _questions_:
https://github.com/Iridescent-CM/technovation-app/blob/4be85d37ab8c747aac4be9e014e9fe97902ab1b8/app/models/questions.rb#L18-L25

The changes in this PR will reorder the Learning Journey (aka ideation) questions so the Learning Journey section/questions will display last.