### PR TITLE
Make pitch event details accessible for RPE teams on the student dashboard when judging is on or off

### DIFF
--- a/app/views/slots/student/rebrand/_events.en.html.erb
+++ b/app/views/slots/student/rebrand/_events.en.html.erb
@@ -4,9 +4,10 @@
   </div>
 
   <div class="tw-content=-wrapper p-8">
-    <% if current_student.onboarded? && SeasonToggles.select_regional_pitch_event? %>
+    <% if SeasonToggles.select_regional_pitch_event? || current_team.live_event? %>
       <%= render "student/dashboards/completion_steps/rebrand/regional_pitch_events" %>
-    <% else %>
-      <p>Due to COVID, there are no official pitch events this season.</p>
-    <% end %>  </div>
+    <% elsif SeasonToggles.events_disabled? %>
+      <%= render "explanations/feature_not_available", feature: :events %>
+    <% end %>
+  </div>
 </div>

--- a/spec/features/student/view_rpe_details_spec.rb
+++ b/spec/features/student/view_rpe_details_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.feature "Students view rpe details", js: true do
+
+  context "Student's team is registered for an RPE" do
+    before do
+      @rpe = FactoryBot.create(:rpe)
+      @submission = FactoryBot.create(:team_submission, :junior, :complete)
+      @student = @submission.team.students.sample
+      @submission.team.regional_pitch_events << @rpe
+    end
+
+    scenario "Judging is off" do
+      SeasonToggles.judging_round = :off
+
+      sign_in(@student)
+
+      find("span", text: "Pitch your project").click
+
+      expect(page).to have_content("You are attending #{@rpe.name}.")
+      expect(page).to have_link("View full details")
+    end
+
+    scenario "Judging is set to quarterfinals" do
+      SeasonToggles.judging_round = :qf
+
+      sign_in(@student)
+
+      find("span", text: "Pitch your project").click
+
+      expect(page).to have_content("You are attending #{@rpe.name}.")
+      expect(page).to have_link("View full details")
+    end
+  end
+
+  context "Student's team is not registered for an RPE" do
+    before do
+      @rpe = FactoryBot.create(:event, :chicago, :junior)
+      @submission = FactoryBot.create(:team_submission, :chicago, :junior)
+      @student = @submission.team.students.sample
+    end
+
+    scenario "Judging is off and selecting an event is disabled" do
+      SeasonToggles.judging_round = :off
+      SeasonToggles.select_regional_pitch_event_off!
+
+      sign_in(@student)
+
+      find("span", text: "Pitch your project").click
+
+      expect(page).to have_content("Selecting an event is not available right now.")
+    end
+
+    scenario "Judging is off and selecting an event is enabled" do
+      SeasonToggles.judging_round = :off
+      SeasonToggles.select_regional_pitch_event_on!
+
+      sign_in(@student)
+
+      find("span", text: "Pitch your project").click
+
+      expect(page).to have_content("Attend a pitching event in your area to pitch your submission to a live panel of judges!")
+      expect(page).to have_link("Select an Event")
+    end
+
+    scenario "Judging is on" do
+      # When judging is on, RPE selection is automatically disabled
+      SeasonToggles.judging_round = :off
+
+      sign_in(@student)
+
+      find("span", text: "Pitch your project").click
+
+      expect(page).to have_content("Selecting an event is not available right now.")
+    end
+  end
+end

--- a/spec/features/student/view_rpe_details_spec.rb
+++ b/spec/features/student/view_rpe_details_spec.rb
@@ -63,9 +63,9 @@ RSpec.feature "Students view rpe details", js: true do
       expect(page).to have_link("Select an Event")
     end
 
-    scenario "Judging is on" do
+    scenario "Judging is set to quarterfinals" do
       # When judging is on, RPE selection is automatically disabled
-      SeasonToggles.judging_round = :off
+      SeasonToggles.judging_round = :qf
 
       sign_in(@student)
 


### PR DESCRIPTION
Refs #3827 

This change allows for students that are registered for an RPE to view the event details when judging is on or off.

I also added some specs. 