### PR TITLE
Update v-html instances

### DIFF
--- a/app/javascript/judge/scores/sections/Ideation.vue
+++ b/app/javascript/judge/scores/sections/Ideation.vue
@@ -9,7 +9,7 @@
     >
       <template v-slot:main-content>
         <p class="font-bold text-lg">{{ submission.name }}</p>
-        <div class="mb-8" v-html="submission.learning_journey"></div>
+        <div class="mb-8" style="white-space: pre-line;">{{ submission.learning_journey }}</div>
 
         <p class="font-bold text-lg">Screenshots</p>
         <p class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-6 text-base">

--- a/app/javascript/judge/scores/sections/ProjectDetails.vue
+++ b/app/javascript/judge/scores/sections/ProjectDetails.vue
@@ -10,7 +10,7 @@
       >
         <template v-slot:main-content>
           <p class="font-bold text-lg">{{ submission.name }}</p>
-          <div v-html="submission.description"></div>
+          <div style="white-space: pre-line;">{{ submission.description }}</div>
         </template>
       </GenericJudgingContainer>
     </div>

--- a/app/models/questions.rb
+++ b/app/models/questions.rb
@@ -86,7 +86,7 @@ class Questions
         id: submission.id,
 
         name: submission.app_name,
-        description: simple_format(submission.app_description),
+        description: submission.app_description,
 
         learning_journey: submission.learning_journey,
 


### PR DESCRIPTION
This will remove `v-html` for the project description and learning journey when judging a submission.

For the project description, we were doing formatting on the Rails side, using `simple_format` which added `<p>` tags before it got to Vue.js. I removed this backend formatting and moved it to the Vue.js layer using `white-space: pre-line`. For some unknown reason, when I tried using the Tailwind class it wouldn't work, but adding it via `style` did. 🤷 

https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#pre-line
https://tailwindcss.com/docs/whitespace#pre-line
