### PR TITLE
Added rake task to update bishkek location data

### DIFF
--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -12,6 +12,8 @@ class State
       KenyaState.new(value)
     elsif countries.include?("PT")
       PortugalState.new(value)
+    elsif countries.include?("KG")
+      KyrgyzstanState.new(value)
     else
       new(value)
     end
@@ -83,6 +85,14 @@ class IndiaState < State
   def format_map
     {
       "TG" => "telangana",
+    }
+  end
+end
+
+class KyrgyzstanState < State
+  def format_map
+    {
+      "GB" => "gorod bishkek"
     }
   end
 end

--- a/lib/tasks/update_bishkek_location_data.rake
+++ b/lib/tasks/update_bishkek_location_data.rake
@@ -1,0 +1,36 @@
+desc "Update Bishkek state location data"
+task :update_bishkek_state_location_data, [:dry_run] => :environment do |t, args|
+  dry_run = args[:dry_run] != "run"
+  puts "DRY RUN: #{dry_run ? 'on' : 'off'}"
+
+  accounts = Account.current.where(country: "KG")
+    .where(city: "Bishkek")
+    .where("state_province is null or state_province = '' or state_province != 'Gorod Bishkek'")
+
+  puts "Accounts in the city Bishkek, KG that are not in Gorod Bishkek or have incorrect state/province data: #{accounts.count}"
+
+  if !dry_run
+    puts "Updating state province now..."
+    accounts.find_each do |account|
+      puts "===================================="
+      puts "Account##{account.id}"
+      puts "City: #{account.city}"
+      puts "Country: #{account.country}"
+
+      account.update_column(:state_province, "Gorod Bishkek")
+
+      puts "----------- ??? -------------"
+      puts "STATE CHANGED"
+      puts "State became: `#{account.state}`"
+
+    end
+
+    accounts = Account.current.where(country: "KG")
+      .where(city: "Bishkek")
+      .where("state_province is null or state_province = '' or state_province != 'Gorod Bishkek'")
+
+    puts "===================================="
+    puts "...done!"
+    puts "Accounts in the city Bishkek, KG that are in the state/province Gorod Bishkek: #{accounts.count}"
+  end
+end


### PR DESCRIPTION
Refs #3836 

This rake task will find all accounts located in the city Bishkek/ country Kyrgyzstan with incorrect state_province data.
The state_province is considered incorrect if it is EMPTY, NULL, or not "gorod bishkek". 

I went with a more general approach instead of by ID in case we need to rerun this in the future.

QA Steps
-----------
1. Pull prod data
2. Filter by Country: Kyrgyzstan, State: Gorod Bishkek  (there should be 0 results) 
3. Query the number of participants with incorrect state_province data in the city of Bishkek (Note as of 2/27/23 that value is 393)
4. Run the rake task dry to get the count or actually run it to update
 `bundle exec rake 'update_bishkek_state_location_data[dry]'` 
 or 
 `bundle exec rake 'update_bishkek_state_location_data[run]'` 
5. Check the number of participants from step 3 (should be 0 now)
6. Login as an admin
7. Filter by Country: Kyrgyzstan, State: Gorod Bishkek, City: Bishkek (there should be 393 results)
