### PR TITLE
Added format map for Kyrgyzstan to the state model 

### DIFF
--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -12,6 +12,8 @@ class State
       KenyaState.new(value)
     elsif countries.include?("PT")
       PortugalState.new(value)
+    elsif countries.include?("KG")
+      KyrgyzstanState.new(value)
     else
       new(value)
     end
@@ -83,6 +85,14 @@ class IndiaState < State
   def format_map
     {
       "TG" => "telangana",
+    }
+  end
+end
+
+class KyrgyzstanState < State
+  def format_map
+    {
+      "GB" => "gorod bishkek"
     }
   end
 end


### PR DESCRIPTION
Refs #3836 

This is similar to the translations needed for other countries (like MX and PT).

When filtering by country: Kyrgyzstan and state: Gorod Bishkek the value that is returned by the location filter is `GB`. This is causing issues when searching by `gorod bishkek`. This translation will map `GB` to `gorod bishkek` so the filtering works as expected. 