### PR TITLE
Update Checkr API

### DIFF
--- a/app/models/background_check.rb
+++ b/app/models/background_check.rb
@@ -1,6 +1,6 @@
 class BackgroundCheck < ActiveRecord::Base
   # If these change, you will need to update dataclips
-  enum status: %i{ pending clear consider suspended }
+  enum status: %i[pending clear consider suspended canceled]
 
   belongs_to :account
 

--- a/app/technovation/background_check/report.rb
+++ b/app/technovation/background_check/report.rb
@@ -29,6 +29,10 @@ class BackgroundCheck::Report
   end
 
   class NoReport
+    def result
+      nil
+    end
+
     def status
       "Not submitted"
     end

--- a/app/technovation/background_check/report.rb
+++ b/app/technovation/background_check/report.rb
@@ -1,5 +1,5 @@
 class BackgroundCheck::Report
-  attr_accessor :id, :status, :candidate_id, :adjudication
+  attr_accessor :id, :status, :candidate_id, :adjudication, :result
 
   def initialize(attributes = {})
     required_keys.each do |key|
@@ -43,7 +43,8 @@ class BackgroundCheck::Report
   end
 
   private
+
   def required_keys
-    [:id, :status, :candidate_id, :adjudication]
+    [:id, :status, :candidate_id, :adjudication, :result]
   end
 end

--- a/app/technovation/background_checking.rb
+++ b/app/technovation/background_checking.rb
@@ -9,26 +9,34 @@ class BackgroundChecking
 
   def execute
     if @report.present?
-      new_status = "engaged" == @report.adjudication ? "clear" : @report.status
+      case @report.result
+      when "clear"
+        @bg_check.clear!
+        do_clear
+      when "consider"
+        @bg_check.consider!
+      else
+        new_status = "engaged" == @report.adjudication ? "clear" : @report.status
 
-      if new_status != @bg_check.status
-        if @bg_check.respond_to?("#{new_status}!")
-          @bg_check.send("#{new_status}!")
-          @logger.info(
-            "Report UPDATED TO #{@bg_check.status.upcase} for #{@bg_check.account.email}"
-          )
+        if new_status != @bg_check.status
+          if @bg_check.respond_to?("#{new_status}!")
+            @bg_check.send("#{new_status}!")
+            @logger.info(
+              "Report UPDATED TO #{@bg_check.status.upcase} for #{@bg_check.account.email}"
+            )
+          else
+            @logger.info(
+              "Could not call ##{new_status}! for #{@bg_check.account.email}"
+            )
+          end
+          if respond_to?("do_#{new_status}", :include_private)
+            send("do_#{new_status}")
+          end
         else
           @logger.info(
-            "Could not call ##{new_status}! for #{@bg_check.account.email}"
+            "Report STILL #{@bg_check.status} for #{@bg_check.account.email}"
           )
         end
-        if respond_to?("do_#{new_status}", :include_private)
-          send("do_#{new_status}")
-        end
-      else
-        @logger.info(
-          "Report STILL #{@bg_check.status} for #{@bg_check.account.email}"
-        )
       end
     else
       @logger.info("Report NOT FOUND for #{@bg_check.account.email}")

--- a/config/initializers/checkr.rb
+++ b/config/initializers/checkr.rb
@@ -1,3 +1,4 @@
-require 'checkr'
+require "checkr"
 
+Checkr.api_base = ENV.fetch("CHECKR_API_BASE", "https://api.checkr.com")
 Checkr.api_key = ENV.fetch("CHECKR_API_KEY")

--- a/spec/support/checkr.rb
+++ b/spec/support/checkr.rb
@@ -1,4 +1,5 @@
 class FakeReport
-  def status; 'clear'; end
-  def adjudication; ''; end
+  def result; "clear"; end
+  def status; "clear"; end
+  def adjudication; ""; end
 end


### PR DESCRIPTION
There are two main changes we had to make to incorporate the Checkr changes:
- Add support for the `result` parameter in the Reports payload
- Add support for the `canceled` value for status


From their documentation:
> If you have any automation tied to a report `status` of `clear` or `consider`, it should be adjusted to tie to the new report `result` value of `clear` or ` consider` instead.

> If any automation is built based on the report’s status, the new `canceled` status should be taken into account.

If you want to test locally, you'll have point your local environment to our Checkr staging environment:
```
CHECKR_API_BASE=https://api.checkr-staging.com 
CHECKR_API_KEY=[[in the password safe]]
```

And then you need to use one of the test candidates here:
https://docs.google.com/spreadsheets/d/11ZeECuXArp7x3DoBXW-pz-Lgbe5uHvpCGGK1ZrdOMkU/edit#gid=0

Any existing mentor (in the US) will work, their details don't need to match the test candidates in that^ spreadsheet, but on the Background Check form, that's where the test candidate details needs to match what's on the spreadsheet.