### PR TITLE
Add REDIS_URL to Sidekiq configuration

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,7 +4,13 @@ Sidekiq.default_worker_options = {
 }
 
 Sidekiq.configure_server do |config|
-  config.redis = {ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}}
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: {
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    }
+  }
+
 
   if database_url = ENV['DATABASE_URL']
     pool = ENV.fetch("SIDEKIQ_DB_POOL_SIZE") { 25 }
@@ -13,5 +19,10 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}}
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: {
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    }
+  }
 end


### PR DESCRIPTION
This is totally a "throw it against the wall and see if it will stick" PR.

Reviewing our SSL errors, it looks like we already incorporated some fixes, but I noticed that we're not including the `REDIS_URL` which is mentioned in the Heroku documentation and the following blog post:
- https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-from-sidekiq
- https://www.sandipmane.dev/openssl-connection-error-with-redis6-on-heroku
