### PR TITLE
Updated layout for uploading RPE presentation slides

### DIFF
--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -5,7 +5,32 @@
     <p class="font-bold">My Submission</p>
   </div>
 
-  <div class="tw-content=-wrapper p-8">
-    <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+  <div class="tw-content-wrapper p-8">
+    <% if SeasonToggles.submissions_disabled? and SeasonToggles.quarterfinals_or_earlier? and current_team.live_event? %>
+      <div class="flex flex-col lg:flex-row gap-8">
+        <div class="w-full lg:w-2/3">
+          <p>Your team is attending a Regional Pitch Event. Please upload the slides your team will use to pitch your project at the event.</p>
+          <p class="mt-4">Contact your mentor or Chapter Ambassador for more information about the presentation slides.</p>
+        </div>
+        <div class="w-full lg:w-1/3 flex justify-center items-center">
+            <%= link_to "Edit presentation slides",
+                        send("#{current_scope}_team_submission_section_path",
+                             current_submission,
+                             section: :pitch_presentation),
+                        class: "tw-green-btn mx-auto" %>
+        </div>
+      </div>
+    <% else %>
+      <div class="flex flex-col lg:flex-row gap-8">
+        <div class="w-full lg:w-1/2">
+          <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+        </div>
+        <div class="w-full lg:w-1/2 flex justify-center items-center">
+          <%= render "student/dashboards/view_submission_link",
+                     current_team: current_team,
+                     current_student: current_student %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="tw-content-wrapper p-8">
-    <% if SeasonToggles.submissions_disabled? and SeasonToggles.quarterfinals_or_earlier? and current_team.live_event? %>
+    <% if SeasonToggles.submissions_disabled? && SeasonToggles.quarterfinals_or_earlier? && current_team.live_event? %>
       <div class="flex flex-col lg:flex-row gap-8">
         <div class="w-full lg:w-2/3">
           <p>Your team is attending a Regional Pitch Event. Please upload the slides your team will use to pitch your project at the event.</p>
@@ -23,7 +23,7 @@
     <% else %>
       <div class="flex flex-col lg:flex-row gap-8">
         <div class="w-full lg:w-1/2">
-          <%= render partial: feature.partial_path, locals: feature.partial_locals  %>
+          <%= render partial: feature.partial_path, locals: feature.partial_locals %>
         </div>
         <div class="w-full lg:w-1/2 flex justify-center items-center">
           <%= render "student/dashboards/view_submission_link",

--- a/app/views/student/dashboards/_view_submission_link.html.erb
+++ b/app/views/student/dashboards/_view_submission_link.html.erb
@@ -1,9 +1,6 @@
 <% if StudentSubmissionLinkGuard.new(team: current_team, student: current_student).
   display_link_to_published? %>
-
-  <div class="margin--t-xlarge">
-    <%= link_to t("views.application.dashboards.buttons.team_submission_html"),
-      student_published_team_submission_path(current_team.submission),
-      class: "button" %>
-  </div>
+  <%= link_to t("views.application.dashboards.buttons.team_submission_html"),
+    student_published_team_submission_path(current_team.submission),
+    class: "tw-green-btn mx-auto" %>
 <% end %>

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -66,48 +66,6 @@
 
       <div slot="submission">
         <%= render "slots/student/submissions" %>
-        <%= render "student/dashboards/view_submission_link",
-          current_team: current_team,
-          current_student: current_student %>
-
-        <% if SeasonToggles.submissions_disabled? and
-                SeasonToggles.quarterfinals_or_earlier? and
-                  current_team.live_event? %>
-          <div class="progress">
-            <div class="progress__section">
-              <h1>
-                <%= link_to "Regional events",
-                  send(
-                    "#{current_scope}_team_submission_section_path",
-                    current_submission,
-                    section: :pitch_presentation
-                  )
-                %>
-              </h1>
-
-              <div class="margin--b-large">
-                <ol class="list--reset">
-                  <li>
-                    <small>
-                      Your team is attending a live, regional event:
-                    </small>
-
-                    <%= link_to submission_progress_web_icon(
-                      current_submission,
-                      :pitch_presentation,
-                      "Edit presentation slides"
-                    ),
-                    send(
-                      "#{current_scope}_team_submission_section_path",
-                      current_submission,
-                      section: :pitch_presentation
-                    ) %>
-                  </li>
-                </ol>
-              </div>
-            </div>
-          </div>
-        <% end %>
       </div>
 
       <div slot="events">


### PR DESCRIPTION
Refs #3743 

This change updates the layout of the student submissions tab for uploading RPE presentation slides 

<img width="1513" alt="CleanShot 2023-03-17 at 15 16 15@2x" src="https://user-images.githubusercontent.com/29210380/226033796-4e231112-1484-4c20-9827-cc651d22533d.png">
<img width="1377" alt="CleanShot 2023-03-17 at 15 16 46@2x" src="https://user-images.githubusercontent.com/29210380/226033816-7dd8b40e-2a45-43b4-a41e-4784eec2f172.png">
