### PR TITLE
Extract filestack picker options (in rails) + add 2mb image size maximum for submissions 

### DIFF
--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -1,0 +1,27 @@
+module FilestackPickerHelper
+  def filestack_picker_options(object)
+    {
+      accept: ["image/jpeg", "image/jpg", "image/png"],
+      uploadConfig: {
+        intelligent: true
+      },
+      maxSize: 2 * 1024 * 1024, # 2 MB LIMIT
+      fromSources: ["local_file_system"],
+      onFileSelected: "onFileSelected",
+      onFileUploadFinished: "onFileUploadFinished",
+      storeTo: {
+        location: "s3",
+        container: ENV.fetch("AWS_BUCKET_NAME"),
+        path: aws_path(object),
+        region: "us-east-1"
+      }
+    }
+  end
+
+  def aws_path(object)
+    case object
+    when TeamSubmission
+      "uploads/screenshot/filestack/#{object.id}/"
+    end
+  end
+end

--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -1,5 +1,5 @@
 module FilestackPickerHelper
-  def filestack_picker_options(object)
+  def filestack_picker_options(klass, record)
     {
       accept: ["image/jpeg", "image/jpg", "image/png"],
       uploadConfig: {
@@ -12,16 +12,15 @@ module FilestackPickerHelper
       storeTo: {
         location: "s3",
         container: ENV.fetch("AWS_BUCKET_NAME"),
-        path: aws_path(object),
+        path: aws_path(klass, record),
         region: "us-east-1"
       }
     }
   end
 
-  def aws_path(object)
-    case object
-    when TeamSubmission
-      "uploads/screenshot/filestack/#{object.id}/"
+  def aws_path(klass, record)
+    if klass.safe_constantize == TeamSubmission
+      "uploads/screenshot/filestack/#{record.id}/"
     end
   end
 end

--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -1,5 +1,5 @@
 module FilestackPickerHelper
-  def filestack_picker_options(klass, record)
+  def filestack_picker_options(record)
     {
       accept: ["image/jpeg", "image/jpg", "image/png"],
       uploadConfig: {
@@ -12,14 +12,16 @@ module FilestackPickerHelper
       storeTo: {
         location: "s3",
         container: ENV.fetch("AWS_BUCKET_NAME"),
-        path: aws_path(klass, record),
+        path: aws_path(record),
         region: "us-east-1"
       }
     }
   end
 
-  def aws_path(klass, record)
-    if klass.safe_constantize == TeamSubmission
+  private
+
+  def aws_path(record)
+    if record.is_a?(TeamSubmission)
       "uploads/screenshot/filestack/#{record.id}/"
     end
   end

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -29,7 +29,7 @@
           <%= f.filestack_field :image,
                                 "Select image",
                                 id: "admin-image-picker",
-                                pickerOptions: filestack_picker_options(@team_submission) %>
+                                pickerOptions: filestack_picker_options("TeamSubmission", @team_submission) %>
           <br>
           <%= f.submit "Save", class:"button" %>
         <% end %>

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -29,7 +29,7 @@
           <%= f.filestack_field :image,
                                 "Select image",
                                 id: "admin-image-picker",
-                                pickerOptions: filestack_picker_options("TeamSubmission", @team_submission) %>
+                                pickerOptions: filestack_picker_options(@team_submission) %>
           <br>
           <%= f.submit "Save", class:"button" %>
         <% end %>

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -3,6 +3,13 @@
     const screenshot = document.getElementById("screenshot");
     screenshot.src = filestack_client.transform(data.handle);
   }
+
+  function onFileSelected(file) {
+  // https://www.filestack.com/docs/uploads/pickers/web/#callbacks
+    if (file.size >  2 * 1024 * 1024) {
+        throw new Error("Image is too large. Please select a photo under 2MB.");
+    }
+  }
 <% end %>
 
 <div class="grid">
@@ -20,22 +27,9 @@
         <%= form_with model:[@team_submission, @screenshot], url: admin_team_submission_screenshots_path(@team_submission), local: true do |f| %>
           <%= f.label :image, "Image" %>
           <%= f.filestack_field :image,
-                                "Select screenshot",
-                                id: "admin-screenshot-picker",
-                                pickerOptions: {
-                                  accept: ["image/jpeg", "image/jpg", "image/png"],
-                                  uploadConfig: {
-                                    intelligent: true,
-                                  },
-                                  fromSources: ["local_file_system"],
-                                  onFileUploadFinished: "onFileUploadFinished",
-                                  storeTo: {
-                                    location: "s3",
-                                    container: ENV.fetch("AWS_BUCKET_NAME"),
-                                    path: "uploads/screenshot/filestack/#{@team_submission.id}/",
-                                    region: "us-east-1"
-                                  }
-                                } %>
+                                "Select image",
+                                id: "admin-image-picker",
+                                pickerOptions: filestack_picker_options(@team_submission) %>
           <br>
           <%= f.submit "Save", class:"button" %>
         <% end %>

--- a/app/views/admin/screenshots/new.html.erb
+++ b/app/views/admin/screenshots/new.html.erb
@@ -9,16 +9,16 @@
   <div class="grid__col-10">
     <div class="panel">
 
-      <h1>Add a screenshot</h1>
+      <h1>Add an image</h1>
       <% @team_submission.while_no_screenshots_remaining do %>
-        <p>Please delete a screenshot(s) in order to upload additional screenshots</p>
+        <p>Please delete an image in order to upload additional images.</p>
       <% end %>
 
       <% @team_submission.while_screenshots_remaining do %>
         <img src="" alt="" id="screenshot" class="og-style-filestack-img">
 
         <%= form_with model:[@team_submission, @screenshot], url: admin_team_submission_screenshots_path(@team_submission), local: true do |f| %>
-          <%= f.label :image, "Screenshot" %>
+          <%= f.label :image, "Image" %>
           <%= f.filestack_field :image,
                                 "Select screenshot",
                                 id: "admin-screenshot-picker",

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -204,7 +204,9 @@
           <div class="submission-pieces__screenshots">
             <% @team_submission.screenshots.each do |screenshot| %>
               <% if screenshot.image_url.present? %>
-                <%= render "screenshots/screenshot_grid", screenshot: screenshot %>
+                <div class="screenshot-wrapper">
+                  <%= render "screenshots/filestack_image", screenshot: screenshot %>
+                </div>
               <% end %>
             <% end %>
           </div>

--- a/app/views/admin/team_submissions/show.html.erb
+++ b/app/views/admin/team_submissions/show.html.erb
@@ -196,7 +196,7 @@
 
       <%= render "additional_questions", team_submission: @team_submission %>
 
-      <h5>Screenshots</h5>
+      <h5>Images</h5>
 
       <p>
         <% if @team_submission.screenshots.any? %>
@@ -209,14 +209,14 @@
             <% end %>
           </div>
         <% else %>
-          No screenshots uploaded
+          No images uploaded
         <% end %>
       </p>
 
       <% if @team_submission.max_screenshots_remaining > 0 %>
-        <%= link_to 'Add Screenshot', new_admin_team_submission_screenshot_path(@team_submission) %>
+        <%= link_to 'Add image', new_admin_team_submission_screenshot_path(@team_submission) %>
       <% else %>
-        <p>Delete a screenshot(s) to upload additional images</p>
+        <p>Delete an image to upload additional images</p>
       <% end %>
     </div>
   </div>

--- a/app/views/screenshots/_filestack_image.html.erb
+++ b/app/views/screenshots/_filestack_image.html.erb
@@ -1,0 +1,3 @@
+<%= filestack_image screenshot.image_url,
+                    class: "submission-pieces__screenshot",
+                    transform: filestack_transform.auto_image %>

--- a/spec/features/admin/team_submissions_spec.rb
+++ b/spec/features/admin/team_submissions_spec.rb
@@ -66,12 +66,12 @@ RSpec.feature "admin team submissions" do
     )
   end
 
-  scenario "Add a screenshot" do
+  scenario "Add an image" do
     click_link "some app name"
-    expect(page).to have_content("No screenshots uploaded")
+    expect(page).to have_content("No images uploaded")
 
-    click_link "Add Screenshot"
-    expect(page).to have_button("Select screenshot")
+    click_link "Add image"
+    expect(page).to have_button("Select image")
 
     # TODO: Groundwork for filestack specs
     # expect(page).to have_selector("div#__filestack-picker")


### PR DESCRIPTION
Refs #3885 

2 main changes here:
- Extracted filestack picker options to a helper method
- Added a 2mb file size limit for uploading submission images

I also updated the language from "screenshots" to "images" to align with the student experience. There will be a 2nd PR to add the file size limit on the student submission image upload.  

I could use some feedback on the "aws_path" method! 