### PR TITLE
Confirmation dialog and info text for saving production system settings 

### DIFF
--- a/app/javascript/admin/content-settings/components/AdminContentSettings.vue
+++ b/app/javascript/admin/content-settings/components/AdminContentSettings.vue
@@ -135,7 +135,7 @@
         ref="submitButton"
         type="submit"
         class="button primary"
-        @click.prevent="saveSettings"
+        @click.prevent="isProduction() ? confirmSaveSettings() : saveSettings()"
       >Save these settings</button>
       or
       <a
@@ -149,9 +149,11 @@
 </template>
 
 <script>
+import Swal from 'sweetalert2'
 import { mapGetters, mapMutations } from 'vuex'
 
 import Icon from 'components/Icon'
+import { isProduction } from '../../../utilities/utilities'
 
 export default {
   name: 'admin-content-settings',
@@ -196,9 +198,26 @@ export default {
   },
 
   methods: {
+    isProduction,
+
     saveSettings () {
       this.$refs.formData.innerHTML = this.buildFormInputsMarkup(this.formData)
       document.getElementById('season_schedule').submit()
+    },
+
+    confirmSaveSettings () {
+      Swal.fire({
+        title: 'PRODUCTION SETTINGS',
+        html: 'You are about to update settings on Production!<br>Are you sure you want to continue?',
+        confirmButtonText: 'Yes, save settings',
+        confirmButtonColor: '#28A880',
+        showCancelButton: true,
+        focusCancel: true,
+      }).then((result) => {
+        if (result.isConfirmed) {
+         this.saveSettings();
+        }
+      })
     },
 
     buildFormInputsMarkup (formData, prefix = 'season_toggles') {

--- a/app/javascript/admin/content-settings/components/AdminContentSettings.vue
+++ b/app/javascript/admin/content-settings/components/AdminContentSettings.vue
@@ -209,6 +209,7 @@ export default {
       Swal.fire({
         title: 'PRODUCTION SETTINGS',
         html: 'You are about to update settings on Production!<br>Are you sure you want to continue?',
+        background: '#fecaca',
         confirmButtonText: 'Yes, save settings',
         confirmButtonColor: '#28A880',
         showCancelButton: true,

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -172,14 +172,19 @@
     </div>
 
     <div class="notice warning">
-      The changes you make here affect the end-user experience.<br>
-      Please double check everything before saving.
+      The changes you are about to make are for {{ environmentName() }}.
+
+      <p v-if="isProduction()">
+        Please double check everything before saving.
+      </p>
     </div>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+
+import { isProduction, isQa } from '../../../utilities/utilities'
 
 export default {
   name: 'review-and-save-settings-section',
@@ -204,6 +209,20 @@ export default {
         finished: 'Finished',
       }
     }
+  },
+
+  methods: {
+    isProduction,
+
+    environmentName() {
+      if (isProduction()) {
+        return "PRODUCTION"
+      } else if (isQa()) {
+        return "QA"
+      } else {
+        return "your local environment"
+      }
+    },
   },
 
   computed: {

--- a/app/javascript/utilities/utilities.js
+++ b/app/javascript/utilities/utilities.js
@@ -6,6 +6,14 @@ export const airbrake = new AirbrakeClient({
   environment: process.env.AIRBRAKE_RAILS_ENV,
 });
 
+export const isProduction = () => {
+  return process.env.HOST_DOMAIN == "my.technovationchallenge.org"
+}
+
+export const isQa = () => {
+  return process.env.HOST_DOMAIN == "technovation-qa.herokuapp.com"
+}
+
 export const isEmptyObject = (object) => {
   return Object.keys(object).length === 0 && object.constructor === Object
 }


### PR DESCRIPTION
A couple of changes to help us distinguish between QA and Prod (and our local env):
- Dynamic info text (above the save button) depending on the environment:
  - For our local environment: "The changes you are about to make are for your local environment."
  - For QA: "The changes you are about to make are for QA."
  - For Prod: "The changes you are about to make are for PRODUCTION. Please double check everything before saving."
- A confirmation dialog that will only display for Prod

<img src="https://user-images.githubusercontent.com/58957909/228385868-232f37d3-a280-4877-b5b2-991478f2aecb.png" width="600">