### PR TITLE
Added filestack image url transformation method for submission images on judging portal

### DIFF
--- a/app/javascript/judge/scores/pieces/Screenshots.vue
+++ b/app/javascript/judge/scores/pieces/Screenshots.vue
@@ -11,7 +11,7 @@
     >
       <img
         class="judge-screenshot-modal object-cover h-full w-full rounded"
-        :src="screenshot.thumb"
+        :src="filestackTransformationUrl(screenshot)"
         :data-modal-url="screenshot.full"
         :data-modal-idx="i"
       />
@@ -24,5 +24,10 @@ import { mapState } from 'vuex'
 
 export default {
   computed: mapState(['submission']),
+  methods: {
+    filestackTransformationUrl(screenshot) {
+      return (screenshot.full).replace("https://cdn.filestackcontent.com/", "https://cdn.filestackcontent.com/resize=w:300/")
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Refs #3890 

This change was needed to compress submission images to reduce bandwidth on the judging portal. Initially there were 3 main filestack transformations to reduce file size: resize, auto_image, and compress. Since we have limited transformations per month, I could only go with one. I chose the "resize" transformation because it reduced the file size the most compared to auto_image and compress. For example, on one sample submission the image sizes were reduced from 7.2mb to 131kb and 2.7mb to 93.9kb. Also noting there shouldn't be too many additional images in the future over 2mb with the updated file size limit.