### PR TITLE
Updated logic/text that displays for virtual judges on the judge submissions tab

### DIFF
--- a/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="mb-4">
-    <p class="mb-4">
-      Begin scoring your assigned submissions. You will be able to edit
-      your scores until round one of judging closes. For more information
-      about your events, please view your dashboard.
-    </p>
-    <h2 class="text-base text-energetic-blue font-semibold tracking-wide uppercase">
-      {{ this.title }}
-    </h2>
-
     <div v-if="notStartedSubmissions.length">
+      <p class="mb-4">
+        Begin scoring your submissions. You will be able to edit
+        your scores until the current round of judging closes.
+        <span v-if="isLiveJudge">For more information about your
+          events, please view your dashboard.
+        </span>
+      </p>
+
+      <h2 class="text-base text-energetic-blue font-semibold tracking-wide uppercase">
+        {{ this.title }}
+      </h2>
+
       <div class="mt-2 mb-8 flex flex-col">
         <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
           <div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
@@ -67,9 +70,12 @@
       </div>
     </div>
     <div v-else>
-      <p>
+      <p v-if="isLiveJudge">
         You currently do not have any new submissions to score.
         Please contact your chapter ambassador if this is a mistake.
+      </p>
+      <p v-else>
+        To start a new score, complete any scores in progress.
       </p>
     </div>
   </div>
@@ -91,7 +97,11 @@ export default {
     scoresEditable: {
       type: Boolean,
       default: true,
-    }
+    },
+    isLiveJudge: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   methods: {

--- a/app/views/judge/dashboards/onboarded/_scores.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_scores.en.html.erb
@@ -1,13 +1,19 @@
 <% if current_judge.onboarded? and SeasonToggles.judging_enabled? %>
   <div id="judge-dashboard-scores-app">
-      <not-started-scores-list></not-started-scores-list>
-
     <% if CanStartNewScore.(current_judge) %>
+      <p class="mb-4">Click on the button below to open a submission and start scoring.</p>
       <%= link_to "Start a new score",
-        new_judge_score_path,
-        class: "md-link-button link-button-success",
-        data: { turbolinks: false } %>
-    <% elsif @scores_in_progress.present? %>
+                  new_judge_score_path,
+                  class: "md-link-button link-button-success",
+                  data: { turbolinks: false } %>
+    <% else %>
+      <not-started-scores-list
+        :is-live-judge="<%= current_judge.live_event? %>"
+      >
+      </not-started-scores-list>
+    <% end %>
+
+    <% if @scores_in_progress.present? %>
       <h2 class="text-base text-energetic-blue font-semibold tracking-wide uppercase">
         <% if @scores_in_progress.one? %>
           Your Score in Progress

--- a/spec/features/judge/starting_rpe_scores_spec.rb
+++ b/spec/features/judge/starting_rpe_scores_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "starting RPE scores", js: true do
       sign_in(judge)
       click_link "Judge Submissions"
 
-      expect(page).to have_content("Begin scoring your assigned submissions.")
+      expect(page).to have_content("Begin scoring your submissions.")
       expect(page).to have_content("SUBMISSIONS TO SCORE")
       expect(page).to have_link "Start"
 
@@ -63,7 +63,7 @@ RSpec.feature "starting RPE scores", js: true do
       sign_in(judge)
       click_link "Judge Submissions"
 
-      expect(page).to have_content("Begin scoring your assigned submissions.")
+      expect(page).to have_content("Begin scoring your submissions.")
       expect(page).to have_content("SUBMISSIONS TO SCORE")
       expect(page).to have_link "Start", count: @submissions.count
     end
@@ -79,7 +79,7 @@ RSpec.feature "starting RPE scores", js: true do
       sign_in(judge)
       click_link "Judge Submissions"
 
-      expect(page).to have_content("Begin scoring your assigned submissions.")
+      expect(page).to have_content("Begin scoring your submissions.")
       expect(page).to have_content("YOUR SCORE IN PROGRESS")
       expect(page).to have_link "Resume", count: 1
     end


### PR DESCRIPTION
Refs #3907 

Slight update to the logic that displays the "start score" button and the "Submissions to Score" table. This change was needed because information for live event judges was displayed even for virtual judges. 