### PR TITLE
Add additional columns to admin datagrid pages

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -9,6 +9,8 @@ class AccountsGrid
     Account.not_admin
   end
 
+  column :id, header: "Participant ID", if: ->(g) { g.admin }
+
   column :profile_type do
     scope_name
   end

--- a/app/data_grids/judges_grid.rb
+++ b/app/data_grids/judges_grid.rb
@@ -17,6 +17,8 @@ class JudgesGrid
       .where("judge_profiles.id IS NOT NULL")
   end
 
+  column :id, header: "Participant ID", if: ->(g) { g.admin }
+
   column :mentor, header: "Mentor?", mandatory: true do
     mentor_profile.present? ? "yes" : "no"
   end

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -9,6 +9,8 @@ class TeamsGrid
     Team
   end
 
+  column :id, header: "Team ID", if: ->(g) { g.admin }
+
   column :name, mandatory: true
 
   column :division, mandatory: true do

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -37,23 +37,23 @@ class TeamsGrid
     students.collect(&:name).join(",")
   end
 
-  column :student_1_name, if: ->(grid) { grid.admin }  do
+  column :student_1_name, if: ->(grid) { grid.admin } do
     students.first&.name
   end
 
-  column :student_2_name, if: ->(grid) { grid.admin }  do
+  column :student_2_name, if: ->(grid) { grid.admin } do
     students.second&.name
   end
 
-  column :student_3_name, if: ->(grid) { grid.admin }  do
+  column :student_3_name, if: ->(grid) { grid.admin } do
     students.third&.name
   end
 
-  column :student_4_name, if: ->(grid) { grid.admin }  do
+  column :student_4_name, if: ->(grid) { grid.admin } do
     students.fourth&.name
   end
 
-  column :student_5_name, if: ->(grid) { grid.admin }  do
+  column :student_5_name, if: ->(grid) { grid.admin } do
     students.fifth&.name
   end
 
@@ -61,23 +61,23 @@ class TeamsGrid
     students.collect(&:email).join(",")
   end
 
-  column :student_1_email, if: ->(grid) { grid.admin }  do
+  column :student_1_email, if: ->(grid) { grid.admin } do
     students.first&.email
   end
 
-  column :student_2_email, if: ->(grid) { grid.admin }  do
+  column :student_2_email, if: ->(grid) { grid.admin } do
     students.second&.email
   end
 
-  column :student_3_email, if: ->(grid) { grid.admin }  do
+  column :student_3_email, if: ->(grid) { grid.admin } do
     students.third&.email
   end
 
-  column :student_4_email, if: ->(grid) { grid.admin }  do
+  column :student_4_email, if: ->(grid) { grid.admin } do
     students.fourth&.email
   end
 
-  column :student_5_email, if: ->(grid) { grid.admin }  do
+  column :student_5_email, if: ->(grid) { grid.admin } do
     students.fifth&.email
   end
 
@@ -85,23 +85,23 @@ class TeamsGrid
     students.collect(&:parent_guardian_name).join(",")
   end
 
-  column :student_1_parent, if: ->(grid) { grid.admin }  do
+  column :student_1_parent, if: ->(grid) { grid.admin } do
     students.first&.parent_guardian_name
   end
 
-  column :student_2_parent, if: ->(grid) { grid.admin }  do
+  column :student_2_parent, if: ->(grid) { grid.admin } do
     students.second&.parent_guardian_name
   end
 
-  column :student_3_parent, if: ->(grid) { grid.admin }  do
+  column :student_3_parent, if: ->(grid) { grid.admin } do
     students.third&.parent_guardian_name
   end
 
-  column :student_4_parent, if: ->(grid) { grid.admin }  do
+  column :student_4_parent, if: ->(grid) { grid.admin } do
     students.fourth&.parent_guardian_name
   end
 
-  column :student_5_parent, if: ->(grid) { grid.admin }  do
+  column :student_5_parent, if: ->(grid) { grid.admin } do
     students.fifth&.parent_guardian_name
   end
 
@@ -109,23 +109,23 @@ class TeamsGrid
     students.collect(&:parent_guardian_email).join(",")
   end
 
-  column :student_1_parent_email, if: ->(grid) { grid.admin }  do
+  column :student_1_parent_email, if: ->(grid) { grid.admin } do
     students.first&.parent_guardian_email
   end
 
-  column :student_2_parent_email, if: ->(grid) { grid.admin }  do
+  column :student_2_parent_email, if: ->(grid) { grid.admin } do
     students.second&.parent_guardian_email
   end
 
-  column :student_3_parent_email, if: ->(grid) { grid.admin }  do
+  column :student_3_parent_email, if: ->(grid) { grid.admin } do
     students.third&.parent_guardian_email
   end
 
-  column :student_4_parent_email, if: ->(grid) { grid.admin }  do
+  column :student_4_parent_email, if: ->(grid) { grid.admin } do
     students.fourth&.parent_guardian_email
   end
 
-  column :student_5_parent_email, if: ->(grid) { grid.admin }  do
+  column :student_5_parent_email, if: ->(grid) { grid.admin } do
     students.fifth&.parent_guardian_email
   end
 

--- a/spec/features/survey_links_spec.rb
+++ b/spec/features/survey_links_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
-RSpec.xfeature "Survey links" do
-  %i{student mentor}.each do |scope|
+RSpec.feature "Survey links" do
+  %i[student mentor].each do |scope|
     before do
       SeasonToggles.set_survey_link(scope, "survey", "http")
+
+      allow(ImportantDates).to receive(:new_season_switch).and_return(Date.new(2020, 1, 1))
     end
 
     scenario "a new #{scope} waits 2 days from profile creation" do
@@ -24,12 +26,12 @@ RSpec.xfeature "Survey links" do
       user.account.update_columns(
         seasons: [Season.current.year - 1],
         created_at: 1.year.ago,
-        updated_at: 1.year.ago,
+        updated_at: 1.year.ago
       )
 
       user.update_columns(
         created_at: 1.year.ago,
-        updated_at: 1.year.ago,
+        updated_at: 1.year.ago
       )
 
       sign_in(user) # Signing in registers to the season
@@ -40,7 +42,6 @@ RSpec.xfeature "Survey links" do
         expect(page).to have_css("#survey-modal")
       end
     end
-
 
     scenario "all #{scope}s get reminded in 2 more days" do
       user = FactoryBot.create(scope)


### PR DESCRIPTION
This will allow admins to select/view these additional columns:
- the account ID on the participants page
- the account ID on the judges page
- the team ID on the teams page