### PR TITLE
Update survey specs

### DIFF
--- a/spec/features/survey_links_spec.rb
+++ b/spec/features/survey_links_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
-RSpec.xfeature "Survey links" do
-  %i{student mentor}.each do |scope|
+RSpec.feature "Survey links" do
+  %i[student mentor].each do |scope|
     before do
       SeasonToggles.set_survey_link(scope, "survey", "http")
+
+      allow(ImportantDates).to receive(:new_season_switch).and_return(Date.new(2020, 1, 1))
     end
 
     scenario "a new #{scope} waits 2 days from profile creation" do
@@ -24,12 +26,12 @@ RSpec.xfeature "Survey links" do
       user.account.update_columns(
         seasons: [Season.current.year - 1],
         created_at: 1.year.ago,
-        updated_at: 1.year.ago,
+        updated_at: 1.year.ago
       )
 
       user.update_columns(
         created_at: 1.year.ago,
-        updated_at: 1.year.ago,
+        updated_at: 1.year.ago
       )
 
       sign_in(user) # Signing in registers to the season
@@ -40,7 +42,6 @@ RSpec.xfeature "Survey links" do
         expect(page).to have_css("#survey-modal")
       end
     end
-
 
     scenario "all #{scope}s get reminded in 2 more days" do
       user = FactoryBot.create(scope)


### PR DESCRIPTION
These was a very tricky set of specs to fix!

Here's a little history on these specs:
d0ea25e41cfb54543d8cb40515cd4062a5c749e7

The fix was to basically hard code `ImportantDates.new_season_switch` to a date in the past. The reason why is little complicated... if it's not hard coded it will use the ENVS (`DATES_NEW_SEASON_START_MONTH` and `DATES_NEW_SEASON_START_DAY`). In the specs we're advancing time (`2.days.from_now`), if these specs are run within two days of the `new_season_switch` date, a survey will get created in one season, time will advance (`2.days.from_now`) and it will be the next season, and there won't be a survey reminder for a survey from the previous season (which is what the specs are testing for). 😅 

If you want to see this strange behavior, on the QA branch, you can set `DATES_NEW_SEASON_START_MONTH` to this month and `DATES_NEW_SEASON_START_DAY` to one day in the future, and then run these specs and some of them should fail. They should also pass if the date is not within two days of now. 🤯 🥺 


