### PR TITLE
Created filestack helper method to return dynamic transformation filestack resize url in vue.js

### DIFF
--- a/app/javascript/judge/scores/SubmissionOverview.vue
+++ b/app/javascript/judge/scores/SubmissionOverview.vue
@@ -4,7 +4,6 @@
 
     <div class="flex flex-col lg:flex-row gap-x-8 mt-4">
       <div class="w-full lg:w-1/4">
-        <p>overview!</p>
         <img class="h-full object-cover rounded-tr-2xl rounded-bl-2xl"
              :src="filestackResizeUrl"
              alt="Team Photo"

--- a/app/javascript/judge/scores/SubmissionOverview.vue
+++ b/app/javascript/judge/scores/SubmissionOverview.vue
@@ -4,7 +4,11 @@
 
     <div class="flex flex-col lg:flex-row gap-x-8 mt-4">
       <div class="w-full lg:w-1/4">
-        <img class="h-full object-cover rounded-tr-2xl rounded-bl-2xl" :src="team.photo" alt="Team Photo"/>
+        <p>overview!</p>
+        <img class="h-full object-cover rounded-tr-2xl rounded-bl-2xl"
+             :src="filestackResizeUrl"
+             alt="Team Photo"
+        />
       </div>
 
       <div class="mt-6">
@@ -59,6 +63,7 @@ import JudgeRecusalPopup from './JudgeRecusalPopup'
 import Icon from '../../components/Icon'
 import ThickRule from "../components/ThickRule";
 import {getJudgingRubricLink} from "../../utilities/judge-helpers";
+import {getFilestackResizeUrl} from "../../utilities/filestack-helpers";
 
 export default {
   data() {
@@ -87,6 +92,10 @@ export default {
 
     rubricLink () {
       return getJudgingRubricLink(this.team.division)
+    },
+
+    filestackResizeUrl() {
+      return getFilestackResizeUrl(this.team.photo, 300)
     }
   },
   components: {

--- a/app/javascript/judge/scores/TeamInfo.vue
+++ b/app/javascript/judge/scores/TeamInfo.vue
@@ -3,7 +3,10 @@
     <p class="font-bold text-3xl">{{ team.name | capitalize}}</p>
     <div class="flex flex-col lg:flex-row gap-x-8 mt-4">
       <div class="w-full lg:w-1/4">
-        <img class="h-full object-cover rounded-tr-2xl rounded-bl-2xl" :src="team.photo" alt="Team Photo"/>
+        <img class="h-full object-cover rounded-tr-2xl rounded-bl-2xl"
+             :src="filestackResizeUrl"
+             alt="Team Photo"
+        />
       </div>
 
       <div class="mt-6">
@@ -38,6 +41,7 @@
 <script>
 import { mapState } from 'vuex'
 import {getJudgingRubricLink} from "../../utilities/judge-helpers"
+import {getFilestackResizeUrl} from "../../utilities/filestack-helpers";
 
 import JudgeRecusalPopup from './JudgeRecusalPopup'
 import Icon from '../../components/Icon'
@@ -59,6 +63,10 @@ export default {
 
     rubricLink () {
       return getJudgingRubricLink(this.team.division)
+    },
+
+    filestackResizeUrl() {
+      return getFilestackResizeUrl(this.team.photo, 300)
     }
   },
 

--- a/app/javascript/judge/scores/pieces/Screenshots.vue
+++ b/app/javascript/judge/scores/pieces/Screenshots.vue
@@ -11,7 +11,7 @@
     >
       <img
         class="judge-screenshot-modal object-cover h-full w-full rounded"
-        :src="filestackTransformationUrl(screenshot)"
+        :src="filestackResizeUrl(screenshot.full)"
         :data-modal-url="screenshot.full"
         :data-modal-idx="i"
       />
@@ -21,12 +21,13 @@
 
 <script>
 import { mapState } from 'vuex'
+import {getFilestackResizeUrl} from "../../../utilities/filestack-helpers";
 
 export default {
   computed: mapState(['submission']),
   methods: {
-    filestackTransformationUrl(screenshot) {
-      return (screenshot.full).replace("https://cdn.filestackcontent.com/", "https://cdn.filestackcontent.com/resize=w:300/")
+    filestackResizeUrl(screenshotUrl) {
+      return getFilestackResizeUrl(screenshotUrl, 300)
     }
   }
 }

--- a/app/javascript/utilities/filestack-helpers.js
+++ b/app/javascript/utilities/filestack-helpers.js
@@ -1,0 +1,8 @@
+function getFilestackResizeUrl(screenshotUrl, width) {
+  return screenshotUrl.replace(
+    "https://cdn.filestackcontent.com/",
+    `https://cdn.filestackcontent.com/resize=w:${width}/`
+  );
+}
+
+export { getFilestackResizeUrl };


### PR DESCRIPTION
Refs #3923 

This PR has 2 main changes
1. Creates a helper method that returns the filestack transformation resize URL. The resize width is dynamic and can be adjusted.
2. Adds this method to the judging portal for the learning journey images (the resize already existed here, just updated to use new helper method) & added resize method for team photo in the submission overview and team info