### PR TITLE
Fixed bug on "submissions to score" table where incorrect submission was being loaded

### DIFF
--- a/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
@@ -107,7 +107,7 @@ export default {
   methods: {
     newScoreUrl(submission) {
       if (submission.score_id) {
-        return `/judge/scores/new?score=${submission.score_id}`
+        return `/judge/scores/new?score_id=${submission.score_id}`
       } else if (submission.submission_id) {
         return `/judge/scores/new?team_submission_id=${submission.submission_id}`
       }


### PR DESCRIPTION
Refs #3932 
In `app/javascript/judge/scores/index.js` a url was crafted using the URL params. `score_id` was found by searching for `score_id` in the URL. The URL had `score` instead of `score_id`. Since `score_id` was null, once the request was made there was a piece of logic in `app/technovation/find_eligible_submission_id.rb` that would find the first available submission for that judge, which happened to be the one in progress. That is why the one in progress would always load. 

This PR updates the new score url to `score_id` from `score`