### PR TITLE
Add export option to ChA activities datagrid

### DIFF
--- a/app/controllers/chapter_ambassador/activities_controller.rb
+++ b/app/controllers/chapter_ambassador/activities_controller.rb
@@ -33,9 +33,5 @@ module ChapterAmbassador
     def grid_params
       params[:activities_grid] ||= {}
     end
-
-    def csv_export_supported?(grid)
-      false
-    end
   end
 end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -616,6 +616,10 @@ class TeamSubmission < ActiveRecord::Base
     VideoUrl.new(video_link_for(video_type)).root
   end
 
+  def scope_name
+    "submission"
+  end
+
   private
 
   def standardize_url(url)


### PR DESCRIPTION
This will enable the CSV export option for the ChA activities datagrid.