### PR TITLE
Add additional columns to admin data grids

### DIFF
--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -47,6 +47,10 @@ class SubmissionsGrid
 
   column :pitch_presentation_url
 
+  column :team_id, header: "Team Id", if: ->(grid) { grid.admin } do
+    team.id
+  end
+
   column :team_name,
     mandatory: true,
     order: "teams.name",

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -33,6 +33,10 @@ class TeamsGrid
     students.length
   end
 
+  column :student_ids, header: "Student Ids", if: ->(grid) { grid.admin } do
+    students.collect { |s| s.account.id }.join(",")
+  end
+
   column :student_names do
     students.collect(&:name).join(",")
   end

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -137,6 +137,10 @@ class TeamsGrid
     mentors.length
   end
 
+  column :mentor_ids, header: "Mentor Ids", if: ->(grid) { grid.admin } do
+    mentors.collect { |m| m.account.id }.join(",")
+  end
+
   column :mentor_names do
     mentors.collect(&:name).join(",")
   end


### PR DESCRIPTION
Adding some additional columns for admins:

For the admin "Teams" page:
- Student Ids
- Mentor Ids

For the admin "Submissions" page:
- Team Id