### PR TITLE
Temporarily remove activities export functionality

### DIFF
--- a/app/controllers/chapter_ambassador/activities_controller.rb
+++ b/app/controllers/chapter_ambassador/activities_controller.rb
@@ -33,5 +33,9 @@ module ChapterAmbassador
     def grid_params
       params[:activities_grid] ||= {}
     end
+
+    def csv_export_supported?(grid)
+      false
+    end
   end
 end


### PR DESCRIPTION
The export functionality isn't working as expected, we're planning to do a deployment tomorrow so I'm removing this functionality for now.


