### PR TITLE
Added rake task to force fail job by id

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -16,4 +16,19 @@ namespace :jobs do
       end
     end
   end
+
+  desc "Force fail job by id"
+  task :force_fail_job_by_id, [:id, :dry_run] => :environment do |t, args|
+
+    id = args[:id]
+    dry_run = args[:dry_run] != "run"
+    puts "DRY RUN: #{dry_run ? "on" : "off"}"
+
+    job = Job.find(id)
+    puts "Updating job #{job.id} - job_id: #{job.job_id} - created_at: #{job.created_at.strftime("%B %d, %Y")}"
+    if !dry_run
+      job.update_column(:status, "failed")
+      puts "Job #{job.id} updated - Status: #{job.status}"
+    end
+  end
 end


### PR DESCRIPTION
Refs #3952 

We had a request to force fail a specific export job. Our current rake to force fail queued jobs cannot do that. This rake task takes the job id and will force fail that job. There is also a dry mode. One thing to be aware of, the jobs table has an "id" field and a "job_id" field. This rake task uses the "id" field. 

QA Steps
1. Identify the job you want to force fail. Get the id
2. Run rake task locally - ` bundle exec rake 'jobs:force_fail_job_by_id[id_here, dry]' `
3. Verify the output
4. Run rake task in `run` mode
5. Verify the status of that job. It should be "failed"