### PR TITLE
potential fix for rpe score duplication bug on the frontend

### DIFF
--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -146,7 +146,7 @@ module Judge
     end
 
     def not_started_scores
-      current_judge.scores.not_started
+      current_judge.scores.not_started.virtual
         .map do |score|
         {
           id: score.id,


### PR DESCRIPTION
Refs #3958 

Weird bug where an RPE submission score would display twice if the judge clicked "start", then the submission loads, and then the judge returns to the dashboard without actually starting the score. The score would display as a pitch event score and also an online score in the submissions to score table. The submissions to score table scores come from the not started  list which includes not started RPEs and virtual not started scores. 

`not_started`  is returned from `judge/scores_controller.rb` The overall list is created using `not_started_rpe_assigned_submissions + not_started_scores` . Once an RPE judge clicks on "start", a new record is created in the submission_scores table. If they don't actually start anything the updated_at and created_at timestamp stay the same. So then if you reload the page, when the `not_started` list is created and the submission_score is now in 2 categories (RPE and online). This change will remove any "live" (RPE) scores from the `not_started` list which removes the duplication on the front end. There was never an issue with a duplicated `submission_score` record