### PR TITLE
Added missing column name configuration for judge recusal counter cache

### DIFF
--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -161,6 +161,14 @@ class SubmissionScore < ActiveRecord::Base
     if score.current_season? && score.incomplete? && score.judge_recusal?
       "recusal_scores_count"
     end
+  },
+  column_names: {
+    [
+      "? = ANY (submission_scores.seasons) AND " +
+        "submission_scores.completed_at IS NULL AND " +
+        "submission_scores.judge_recusal = TRUE",
+      Season.current.year.to_s
+    ] => "recusal_scores_count"
   }
 
   scope :complete, -> { where("submission_scores.completed_at IS NOT NULL") }


### PR DESCRIPTION
Refs #3690 

The judge recusal count was incorrect. It appears that all judge recusals per judge were displayed in the count column regardless of the season. This seems to have been an issue since 2021 (actually one of the first things I added! 👀  😢 ). The judge `recusal_scores_count` column was missing the [column_name configuration](recusal_scores_count), which is needed. This change adds the needed configuration. 

QA Steps
1. Pull prod data
2. Check the recusal count on the judges tab for season 2023 - sort by descending 
3. The top few counts are the following
```
83 
82 
74 
18 
* note values may be a little off depending on when you pull prod data
```
4. Run the `fix_counts` rake task
5. Check the judge recusal count for season 2023 - sort by descending 
```
4
3
3
3
```
I also manually checked a few of these judge profiles to verify the number of recusals and it seems to be correct.

