### PR TITLE
Added approved at column to scores grid

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -131,6 +131,10 @@ class ScoresGrid
     updated_at.strftime("%Y-%m-%d %H:%M")
   end
 
+  column :approved_at do
+    approved? ? approved_at.strftime("%Y-%m-%d %H:%M") : "-"
+  end
+
   column :view, html: true do |submission_score|
     link_to(
       web_icon("list-ul", size: 16, remote: true),


### PR DESCRIPTION
Refs #3967 

Adds `approved_at` column to the scores grid. Would score monitoring peeps find this helpful? I did when investigating the suspicious scores bug! 