### PR TITLE
Update/fix clicked video tracking

### DIFF
--- a/app/controllers/judge/embed_codes_controller.rb
+++ b/app/controllers/judge/embed_codes_controller.rb
@@ -1,5 +1,20 @@
 module Judge
   class EmbedCodesController < JudgeController
     include EmbedCodeController
+
+    after_action :update_clicked_video_tracking, only: :show
+
+    private
+
+    def update_clicked_video_tracking
+      submission_score = current_judge.submission_scores.find_by(team_submission_id: @team_submission.id)
+
+      case params[:piece]
+      when "pitch"
+        submission_score.update(clicked_pitch_video: true)
+      when "demo"
+        submission_score.update(clicked_demo_video: true)
+      end
+    end
   end
 end

--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -202,8 +202,6 @@ module Judge
         :overall_2,
         :overall_comment,
         :overall_comment_word_count,
-        :clicked_pitch_video,
-        :clicked_demo_video,
         :downloaded_source_code,
         :downloaded_business_plan,
         :judge_recusal_reason,

--- a/app/javascript/judge/scores/pieces/DemoVideoLink.vue
+++ b/app/javascript/judge/scores/pieces/DemoVideoLink.vue
@@ -5,7 +5,6 @@
         :href="`${submission.demo_video_url}`"
         :data-opens-modal="`video-modal-${submission.demo_video_id}`"
         :data-modal-fetch="submission.demo_video_url"
-        @click="trackDemoVideoClick"
         class="text-energetic-blue flex text-3xl"
       >
         <icon name="play-circle-o" color="0075cf"/>
@@ -31,13 +30,6 @@ import { i18n } from '../../../utilities/i18n.js'
 
 export default {
   computed: mapState(['score', 'submission']),
-
-  methods: {
-    async trackDemoVideoClick (event) {
-      event.preventDefault()
-      await window.axios.patch(`/judge/scores/${this.score.id}`, {submission_score: {'clicked_demo_video': true}})
-    },
-  },
 
   components: {
     Icon

--- a/app/javascript/judge/scores/pieces/PitchVideoLink.vue
+++ b/app/javascript/judge/scores/pieces/PitchVideoLink.vue
@@ -5,7 +5,6 @@
         :href="`${submission.pitch_video_url}`"
         :data-opens-modal="`video-modal-${submission.pitch_video_id}`"
         :data-modal-fetch="submission.pitch_video_url"
-        @click="trackPitchVideoClick"
         class="text-energetic-blue flex text-3xl"
       >
         <Icon name="play-circle-o" color="0075cf"/>
@@ -30,13 +29,6 @@ import Icon from '../../../components/Icon'
 
 export default {
   computed: mapState(['score', 'submission']),
-
-  methods: {
-    async trackPitchVideoClick (event) {
-      event.preventDefault()
-      await window.axios.patch(`/judge/scores/${this.score.id}`, {submission_score: {'clicked_pitch_video': true}})
-    },
-  },
 
   components: {
     Icon


### PR DESCRIPTION
For some reason our existing video tracking isn't working, I have a hunch it's b/c the pop-up modal is intercepting/blocking the click that makes the HTTP request to the back-end to update the video tracking fields in the database.

Anywho, I added some new functionality that doesn't require an extra HTTP request but instead hooks into the "embeds" controller, and looks at what is being embedded (either the pitch or demo/technical video) and updates the tracking field (for the specific submission score) in the database accordingly. I also removed the old video tracking functionality.
