### PR TITLE
Only display highest awarded certificates for students for previous seasons

### DIFF
--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -15,7 +15,7 @@ module Student
       end
 
       @certificate = Certificate.none
-      @previous_certificates = current_account.certificates.past
+      @previous_certificates = current_account.certificates.highest_awarded_student_certs_for_previous_seasons
 
       if SeasonToggles.display_scores?
         @certificate = current_account.certificates.highest_awarded_student_cert_for_current_season

--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -14,11 +14,11 @@ module Student
         end
       end
 
-      @certificates = Certificate.none
+      @certificate = Certificate.none
       @previous_certificates = current_account.certificates.past
 
       if SeasonToggles.display_scores?
-        @certificates = current_account.certificates.current
+        @certificate = current_account.certificates.highest_awarded_student_cert_for_current_season
       end
 
       render template: "student/scores/index"

--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -14,11 +14,11 @@ module Student
         end
       end
 
-      @certificate = Certificate.none
+      @certificates = Certificate.none
       @previous_certificates = current_account.certificates.highest_awarded_student_certs_for_previous_seasons
 
       if SeasonToggles.display_scores?
-        @certificate = current_account.certificates.highest_awarded_student_cert_for_current_season
+        @certificates = current_account.certificates.current
       end
 
       render template: "student/scores/index"

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -28,6 +28,13 @@ class Certificate < ApplicationRecord
     current.student_certs_ordered_by_highest_awarded.first
   end
 
+  def self.highest_awarded_student_certs_for_previous_seasons
+    past
+      .student_certs_ordered_by_highest_awarded
+      .group_by { |cert| cert.season }
+      .map { |_, certs| certs.first }
+  end
+
   def self.student_certs_ordered_by_highest_awarded
     all.sort do |cert_a, cert_b|
       if cert_a.cert_type == "semifinalist" && (cert_b.cert_type == "quarterfinalist" || cert_b.cert_type == "participation") ||

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -24,6 +24,24 @@ class Certificate < ApplicationRecord
     where(team: team)
   }
 
+  def self.highest_awarded_student_cert_for_current_season
+    current.student_certs_ordered_by_highest_awarded.first
+  end
+
+  def self.student_certs_ordered_by_highest_awarded
+    all.sort do |cert_a, cert_b|
+      if cert_a.cert_type == "semifinalist" && (cert_b.cert_type == "quarterfinalist" || cert_b.cert_type == "participation") ||
+          cert_a.cert_type == "quarterfinalist" && cert_b.cert_type == "participation"
+        -1
+      elsif cert_a.cert_type == "participation" && (cert_b.cert_type == "quarterfinalist" || cert_b.cert_type == "semifinalist") ||
+          cert_a.cert_type == "quarterfinalist" && cert_b.cert_type == "semifinalist"
+        1
+      else
+        0
+      end
+    end
+  end
+
   def description
     title = cert_type.humanize.titleize
 

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -24,10 +24,6 @@ class Certificate < ApplicationRecord
     where(team: team)
   }
 
-  def self.highest_awarded_student_cert_for_current_season
-    current.student_certs_ordered_by_highest_awarded.first
-  end
-
   def self.highest_awarded_student_certs_for_previous_seasons
     past
       .student_certs_ordered_by_highest_awarded

--- a/app/views/student/scores/_certificates.html.erb
+++ b/app/views/student/scores/_certificates.html.erb
@@ -23,9 +23,11 @@
   <%= image_tag "certificates-congrats.svg", width: 500, class: 'mx-auto my-8' %>
 
   <div class="certificates-btn-wrapper">
-      <%= link_to "Open your #{@certificate.cert_type == 'completion' ? 'quarterfinalist' : @certificate.cert_type} certificate",
-                  @certificate.file_url,
+    <% @certificates.each do |certificate| %>
+      <%= link_to "Open your #{certificate.cert_type == 'completion' ? 'quarterfinalist' : certificate.cert_type} certificate",
+                  certificate.file_url,
                   target: "_blank",
                   class: "tw-green-btn" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/student/scores/_certificates.html.erb
+++ b/app/views/student/scores/_certificates.html.erb
@@ -23,11 +23,9 @@
   <%= image_tag "certificates-congrats.svg", width: 500, class: 'mx-auto my-8' %>
 
   <div class="certificates-btn-wrapper">
-    <% @certificates.each do |certificate| %>
-      <%= link_to "Open your #{certificate.cert_type == 'completion' ? 'quarterfinalist' : certificate.cert_type} certificate",
-                  certificate.file_url,
+      <%= link_to "Open your #{@certificate.cert_type == 'completion' ? 'quarterfinalist' : @certificate.cert_type} certificate",
+                  @certificate.file_url,
                   target: "_blank",
                   class: "tw-green-btn" %>
-    <% end %>
   </div>
 </div>

--- a/app/views/student/scores/_previous_certificates.html.erb
+++ b/app/views/student/scores/_previous_certificates.html.erb
@@ -9,6 +9,9 @@
           Team
         </th>
         <th scope="col" class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+          Certificate Type
+        </th>
+        <th scope="col" class="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
           Certificate
         </th>
       </tr>
@@ -22,6 +25,9 @@
           </td>
           <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
             <%= certificate.team.name %>
+          </td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+            <%= certificate.cert_type.capitalize %>
           </td>
           <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
             <%= link_to "Download your certificate",


### PR DESCRIPTION
This PR should limit the previous season's certs (for students) to the highest awarded one.

Notes:
On QA (or for using QA data), account `729` has two certs:
```
[#<Certificate:0x0000000112141de8                                                                                                                                                   
  id: 647,                                                                                                                                                                          
  account_id: 729,                                                                                                                                                                  
  file: "2022-completion-729-378.pdf",                                                                                                                                              
  created_at: Mon, 27 Jun 2022 16:14:15.833820000 PDT -07:00,          
  updated_at: Mon, 27 Jun 2022 16:14:15.833820000 PDT -07:00,          
  season: 2022,                                                         
  cert_type: "quarterfinalist",                                         
  team_id: 378>,                                                        
 #<Certificate:0x0000000112141cd0                                       
  id: 648,                                                              
  account_id: 729,                                                      
  file: "2022-semifinalist-729-378.pdf",                                
  created_at: Tue, 28 Jun 2022 15:20:32.715660000 PDT -07:00,
  updated_at: Tue, 28 Jun 2022 15:20:32.715660000 PDT -07:00,
  season: 2022,
  cert_type: "semifinalist",
  team_id: 378>]
```