### PR TITLE
Fixed width of text and button for student "view my submission"

### DIFF
--- a/app/views/slots/student/_submissions.en.html.erb
+++ b/app/views/slots/student/_submissions.en.html.erb
@@ -21,11 +21,11 @@
         </div>
       </div>
     <% else %>
-      <div class="flex flex-col lg:flex-row gap-8">
-        <div class="w-full lg:w-1/2">
+      <div class="flex flex-col">
+        <div class="w-full">
           <%= render partial: feature.partial_path, locals: feature.partial_locals %>
         </div>
-        <div class="w-full lg:w-1/2 flex justify-center items-center">
+        <div class="flex justify-center items-center pt-8">
           <%= render "student/dashboards/view_submission_link",
                      current_team: current_team,
                      current_student: current_student %>


### PR DESCRIPTION
Refs #3947 

Fixed the width of the text when submissions are closed for students in the "my submission" container on the dashboard
<img width="1670" alt="Screen Shot 2023-05-11 at 12 13 03 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/e88597e4-f1b5-4c47-a0ac-752e8135e117">
