### PR TITLE
Created rebrand version of change email error page for student and judges

### DIFF
--- a/app/views/email_addresses/edit.en.html.erb
+++ b/app/views/email_addresses/edit.en.html.erb
@@ -1,2 +1,6 @@
 <% provide :title, "Change your email" %>
-<%= render 'profiles/email', standalone: true %>
+<% if profile.rebranded? %>
+  <%= render 'profiles/rebrand/email'%>
+<% else %>
+  <%= render 'profiles/email', standalone: true %>
+<% end %>

--- a/app/views/profiles/rebrand/_email.en.html.erb
+++ b/app/views/profiles/rebrand/_email.en.html.erb
@@ -1,0 +1,30 @@
+<div class="container mx-auto flex flex-col w-full lg:w-1/2">
+  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Change your email'} do %>
+    <%= render 'errors', record: current_profile %>
+
+    <p class="text-sm italic mb-4">
+      If you change your email address, we will send a message
+      to your inbox to confirm that you own the address.
+    </p>
+
+    <p class="text-sm italic mb-4">
+      You <span class="font-semibold">must</span> use the link in that message
+      to confirm your new email address and restore full access to this site.
+    </p>
+
+    <%= simple_form_for current_profile, url: send("#{current_scope}_profile_path", local: true) do |f| %>
+      <%= f.simple_fields_for :account, include_id: false do |a| %>
+        <%= a.input :existing_password,
+                    label: "Current password",
+                    id: "existing_password_field_email",
+                    placeholder: "Enter your password first" %>
+
+        <%= a.input :email %>
+      <% end %>
+
+      <p>
+        <%= f.submit "Change email", class: "tw-green-btn mx-auto" %>
+      </p>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
Refs #3978 

This change adds a rebranded version of the error page for students and judges when they try to reset their email and have an error in the form. I also verified that the mentor reset error page uses the old branding. 

![CleanShot 2023-05-12 at 17 13 24](https://github.com/Iridescent-CM/technovation-app/assets/29210380/931b0a0a-72ec-4e5c-beb4-844dc2d3417c)


