### PR TITLE
Adds logic to display current season highest certificate for students 

### DIFF
--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -18,7 +18,7 @@ module Student
       @previous_certificates = current_account.certificates.highest_awarded_student_certs_for_previous_seasons
 
       if SeasonToggles.display_scores?
-        @certificates = current_account.certificates.current
+        @highest_current_certificate = current_account.certificates.highest_awarded_student_cert_for_current_season
       end
 
       render template: "student/scores/index"

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -31,6 +31,10 @@ class Certificate < ApplicationRecord
       .map { |_, certs| certs.first }
   end
 
+  def self.highest_awarded_student_cert_for_current_season
+    current.student_certs_ordered_by_highest_awarded.first
+  end
+
   def self.student_certs_ordered_by_highest_awarded
     all.sort do |cert_a, cert_b|
       if cert_a.cert_type == "semifinalist" && (cert_b.cert_type == "quarterfinalist" || cert_b.cert_type == "participation") ||

--- a/app/views/student/scores/_certificates.html.erb
+++ b/app/views/student/scores/_certificates.html.erb
@@ -23,11 +23,16 @@
   <%= image_tag "certificates-congrats.svg", width: 500, class: 'mx-auto my-8' %>
 
   <div class="certificates-btn-wrapper">
-    <% @certificates.each do |certificate| %>
-      <%= link_to "Open your #{certificate.cert_type == 'completion' ? 'quarterfinalist' : certificate.cert_type} certificate",
-                  certificate.file_url,
+    <% if @highest_current_certificate %>
+      <%= link_to "Open your #{@highest_current_certificate.cert_type == 'completion' ? 'quarterfinalist' : @highest_current_certificate.cert_type} certificate",
+                  @highest_current_certificate.file_url,
                   target: "_blank",
                   class: "tw-green-btn" %>
+    <% else %>
+      <p>
+        You don't have a certificate for this season.
+        Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> if you believe this is an error.
+      </p>
     <% end %>
   </div>
 </div>

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -135,4 +135,39 @@ RSpec.feature "Student certificates" do
       expect(page).not_to have_link("View your scores and certificate")
     end
   end
+
+  context "when the student has received two certificates" do
+    let(:student) { FactoryBot.create(:student, :virtual, :on_team, :semifinalist) }
+
+    before {
+      FactoryBot.create(:certificate,
+        account: student.account,
+        team: student.team,
+        cert_type: :quarterfinalist)
+
+      FactoryBot.create(:certificate,
+        account: student.account,
+        team: student.team,
+        cert_type: :semifinalist)
+    }
+
+    scenario "the highest certificate is displayed" do
+      expect(student.certificates.current.quarterfinalist.count).to eq(1)
+      expect(student.certificates.current.semifinalist.count).to eq(1)
+
+      student.account.took_program_survey!
+      sign_in(student)
+
+      expect(page).to have_content("Congratulations, your team was a semifinalist!")
+
+      click_link("View your scores and certificate")
+      expect(page).to have_content("Congratulations, your team was a semifinalist!")
+
+      click_link("Certificates")
+
+      expect(page).to have_link(
+        "Open your semifinalist certificate"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Refs #3976 

If a student is awarded more than 1 certificate, all certificates are displayed. This change adds the logic to only display the highest certificate available in the current season. The logic builds on previous functionality that displays the highest certificate for past seasons.