### PR TITLE
Remove nowrap on judge score table cells

### DIFF
--- a/app/javascript/judge/dashboards/scores/FinishedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/FinishedScoresList.vue
@@ -37,10 +37,10 @@
                     v-for="score in scores"
                     :key="score.id">
 
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                    <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                       {{ score.submission_name }}
                     </td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <td class="px-3 py-4 text-sm text-gray-500">
                       {{ score.team_name }}
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
@@ -41,10 +41,10 @@
                   <tr
                     v-for="submission in notStartedSubmissions"
                     :key="submission.id">
-                    <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                    <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                       {{ submission.app_name }}
                     </td>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <td class="px-3 py-4 text-sm text-gray-500">
                       {{ submission.team_name }}
                     </td>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 capitalize">

--- a/app/views/judge/dashboards/onboarded/_scores.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/_scores.en.html.erb
@@ -53,10 +53,10 @@
                 <tbody class="divide-y divide-gray-200 bg-white">
                   <% @scores_in_progress.each do |score| %>
                     <tr>
-                      <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                      <td class="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
                         <%= score.team_submission.name %>
                       </td>
-                      <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                      <td class="px-3 py-4 text-sm text-gray-500">
                         <%= score.team_submission.team.name %>
                       </td>
                       <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">

--- a/app/views/judge/dashboards/rebrand/_side_nav_content.html.erb
+++ b/app/views/judge/dashboards/rebrand/_side_nav_content.html.erb
@@ -1,6 +1,6 @@
 <div class="tw-tab-content">
   <a id="dashboard-tab" href="#dashboard-tab-content" data-heading="Judge Dashboard">Dashboard</a>
-  <div>
+  <div class="whitespace-nowrap">
     <% if current_judge.consent_signed? %>
       <%= web_icon(
             "check-circle",
@@ -19,7 +19,7 @@
     <% end %>
   </div>
 
-  <div>
+  <div class="whitespace-nowrap">
     <% if current_judge.training_completed? %>
       <%= web_icon(
             "check-circle",
@@ -49,14 +49,14 @@
   <% if SeasonToggles.judging_enabled? %>
     <%= render 'application/templates/tw_thick_rule' %>
 
-    <div class="tw-tab-content">
+    <div class="tw-tab-content whitespace-nowrap">
       <a id="judge-submissions-tab" href="#judge-submissions-tab-content" data-heading="Online Judging">Judge Submissions</a>
     </div>
   <%end %>
 
   <%= render 'application/templates/tw_thick_rule' %>
 
-  <div class="tw-tab-content">
+  <div class="tw-tab-content whitespace-nowrap">
     <a id="scores-tab" href="#scores-tab-content" data-heading="Your Judge Certificate">Your judge certificate</a>
   </div>
 <% end %>


### PR DESCRIPTION
This will remove the "nowrap" option for submission and team name table cells, allowing the content to wrap to the next line instead of pushing the content and table row potentially off the screen.

I tested it by using the browser dev tools to make a submission name longer.
<img src="https://github.com/Iridescent-CM/technovation-app/assets/58957909/6cf68a50-d5a1-4a6b-81a2-2ed13542eb97" width="600">

I also updated the judge side nav items so they won't wrap to the next line (like the screenshot in https://github.com/Iridescent-CM/technovation-app/issues/3996#issue-1715943733).

#3996 
