### PR TITLE
Adds admin_type to admin_profiles table to implement "super admin" permissions

### DIFF
--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -7,6 +7,11 @@ class AdminProfile < ActiveRecord::Base
 
   has_many :exports, as: :owner, dependent: :destroy
 
+  enum admin_type: %w{
+    admin
+    super_admin
+  }
+
   def authenticated?
     true
   end

--- a/db/migrate/20230525160029_add_admin_type_to_admin_profiles.rb
+++ b/db/migrate/20230525160029_add_admin_type_to_admin_profiles.rb
@@ -1,0 +1,5 @@
+class AddAdminTypeToAdminProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :admin_profiles, :admin_type, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -191,7 +191,8 @@ CREATE TABLE public.admin_profiles (
     id integer NOT NULL,
     account_id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    admin_type integer DEFAULT 0 NOT NULL
 );
 
 
@@ -3178,6 +3179,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230104212325'),
 ('20230112172357'),
 ('20230118232040'),
-('20230119163655');
+('20230119163655'),
+('20230525160029');
 
 


### PR DESCRIPTION
This is a potential solution for adding super_admin permissions (#3986)

When I first started working on this, I discovered 3 paths:

1. Add a super_admin_profiles table similar to the admin_profiles table. As I started proving out some of the other pieces of functionality (locking down features, logic to display/hide, etc) some other questions popped up. For example, could a super admin also be a regular admin, if not, then would we need to share some of the logic/functionality that already exists for admin with super_admin.... would we need to pull admin data from 2 separate tables... etc. It seems like a possible route, but I'm not sure if it is the best route.

2. As I worked through the first approach, I discovered a lot of logic for the admin portal that references the `admin_status` which is a field on the accounts table. An admin can have 1 of 3 different statuses (not_admin, temporary_password, full_admin). I tried the idea of adding a 4th status of `super_admin`. It seemed to sort of work, but did not feel right. As I continued to investigate this approach, it seems like `admin_status` is really describing the state of an admin profile, like if they have updated their password. So this led me to the current approach

3. I thought we keep the admin_profiles table and everyone is admin, but we add an `admin_type` (open to naming suggestions here). Admin_type represents the level of permissions. Right now there is just admin and super_admin. So far this seems to be working as expected. I also think that in the future if there were other types of admin, they could be added to the enum. This could also prevent us from having to make additional admin profile tables. 

I could totally be off base, so let me know what you think! I will have this PR and a 2nd PR as a demonstration of locking down the "add a new admin" feature to just super_admins (#3996)