### PR TITLE
Display pending email confirmation page on judge dashboard

### DIFF
--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -1,29 +1,33 @@
-<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
-  <%= render layout: 'application/templates/dashboards/side_nav', locals: { heading: 'Welcome'} do%>
-    <%= SeasonToggles.dashboard_text(:judge) %>
-    <div class="p-6" id="tab-wrapper">
-      <%= render 'judge/dashboards/rebrand/side_nav_content' %>
-    </div>
-  <% end %>
-  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Judge Dashboard'} do %>
-    <div class="tab">
-      <div id="dashboard-tab-content" class="tab-content tw-active" >
-         <% if current_judge.onboarded? %>
-          <%= render 'judge/dashboards/onboarded/dashboard' %>
-        <% else %>
-          <div class="mb-4">
-            <p>To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training.</p>
+<% if !current_judge.email_confirmed? %>
+  <%= render 'completion_steps/rebrand/confirm_changed_email', profile: current_judge %>
+<% else %>
+  <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+    <%= render layout: 'application/templates/dashboards/side_nav', locals: { heading: 'Welcome'} do%>
+      <%= SeasonToggles.dashboard_text(:judge) %>
+      <div class="p-6" id="tab-wrapper">
+        <%= render 'judge/dashboards/rebrand/side_nav_content' %>
+      </div>
+    <% end %>
+    <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Judge Dashboard'} do %>
+      <div class="tab">
+        <div id="dashboard-tab-content" class="tab-content tw-active" >
+           <% if current_judge.onboarded? %>
+            <%= render 'judge/dashboards/onboarded/dashboard' %>
+          <% else %>
+            <div class="mb-4">
+              <p>To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training.</p>
+            </div>
+          <% end %>
+        </div>
+        <% if current_judge.onboarded? %>
+          <div id="judge-submissions-tab-content" class="tab-content">
+            <%= render 'judge/dashboards/onboarded/scores' %>
+          </div>
+          <div id="scores-tab-content" class="tab-content">
+            <%= render 'judge/dashboards/onboarded/certificates' %>
           </div>
         <% end %>
       </div>
-      <% if current_judge.onboarded? %>
-        <div id="judge-submissions-tab-content" class="tab-content">
-          <%= render 'judge/dashboards/onboarded/scores' %>
-        </div>
-        <div id="scores-tab-content" class="tab-content">
-          <%= render 'judge/dashboards/onboarded/certificates' %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
This will display the "Confirm your email" page on the judge dashboard when their email address hasn't been confirmed yet, which is the same behavior as for students.


