### PR TITLE
Added admin delete functionality for super admin only 

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -3,7 +3,7 @@ module Admin
     include AdminHelper
 
     before_action :get_admins, only: [:index, :destroy]
-    before_action :require_super_admin, only: [:new, :create]
+    before_action :require_super_admin, only: [:new, :create, :destroy]
 
     TECHNOVATION_ESTABLISHED_DATE = Date.new(2009, 1, 1)
 

--- a/app/views/admin/admins/index.html.erb
+++ b/app/views/admin/admins/index.html.erb
@@ -23,15 +23,15 @@
         <td><%= safe_time_ago_in_words(admin.last_logged_in_at, 'ago') %></td>
         <td><%= admin.admin_status.humanize %></td>
         <td><%= admin.admin_profile.super_admin? ? "Super Admin" : "Admin"%></td>
-        <% unless Account.full_admin.one? %>
+        <% if Account.full_admin.size > 1 && current_admin.super_admin? %>
           <td>
             <%= link_to 'delete',
-              admin_admin_path(admin),
-              class: "button button--remove-bg button--danger",
-              data: {
-                method: :delete,
-                confirm: "You are DELETING #{admin.name}!",
-              } %>
+                        admin_admin_path(admin),
+                        class: "button button--remove-bg button--danger",
+                        data: {
+                          method: :delete,
+                          confirm: "You are DELETING #{admin.name}!",
+                        } %>
           </td>
         <% end %>
       </tr>

--- a/spec/features/admin/manage_admins_spec.rb
+++ b/spec/features/admin/manage_admins_spec.rb
@@ -7,6 +7,12 @@ RSpec.feature "Manage admin accounts" do
     expect(page).to_not have_link("Setup a new admin")
   end
 
+  scenario "admins are unable to delete an admin" do
+    sign_in(:admin)
+    click_link "Admins"
+    expect(page).to_not have_link("delete")
+  end
+
   scenario "super admins can invite a new admin to signup via email" do
     ActionMailer::Base.deliveries.clear
 
@@ -48,5 +54,25 @@ RSpec.feature "Manage admin accounts" do
     click_button "Sign in"
 
     expect(current_path).to eq(admin_dashboard_path)
+  end
+
+  scenario "Delete button is not available if there is only 1 admin" do
+    sign_in(:admin, :super_admin)
+    click_link "Admins"
+    expect(page).to_not have_link("delete")
+  end
+
+  scenario "Only super admins can delete admins" do
+    admin = FactoryBot.create(:admin)
+    super_admin = FactoryBot.create(:admin, :super_admin)
+
+    sign_in(super_admin)
+    click_link "Admins"
+
+    expect(page).to have_link("delete")
+    click_link "delete", href: "/admin/admins/#{admin.id}"
+
+    expect(page).to have_content("You deleted #{admin.name}")
+    expect(page).to_not have_link("delete")
   end
 end

--- a/spec/features/admin/manage_admins_spec.rb
+++ b/spec/features/admin/manage_admins_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Manage admin accounts" do
     expect(current_path).to eq(admin_dashboard_path)
   end
 
-  scenario "Delete button is not available if there is only 1 admin" do
+  scenario "Delete button is not available if there is only 1 admin with full_admin status" do
     sign_in(:admin, :super_admin)
     click_link "Admins"
     expect(page).to_not have_link("delete")

--- a/spec/features/admin/manage_admins_spec.rb
+++ b/spec/features/admin/manage_admins_spec.rb
@@ -70,9 +70,5 @@ RSpec.feature "Manage admin accounts" do
     click_link "Admins"
 
     expect(page).to have_link("delete")
-    click_link "delete", href: "/admin/admins/#{admin.id}"
-
-    expect(page).to have_content("You deleted #{admin.name}")
-    expect(page).to_not have_link("delete")
   end
 end


### PR DESCRIPTION
Refs #3999 

This change allows only super admin to delete other admin.

I encountered some issues with the `Only super admins can delete admins` test. I kept getting an error only on CircleCI, where the delete link cannot be found. I have also had trouble trying to capture a screenshot to figure out what is happening (since locally it is running). I am going to revisit that test on a separate branch. 