### PR TITLE
Update mentor types

### DIFF
--- a/app/constants/mentor_type_options.rb
+++ b/app/constants/mentor_type_options.rb
@@ -1,9 +1,9 @@
 # If these change, you will need to update various TC dataclips on Heroku.
 # Alternatively, these could be moved to a table in the database and the
 # the dataclips could just be updated once to relfect the new table.
-MENTOR_TYPE_OPTIONS = %w{
-  Industry\ professional
-  Educator
-  Parent
-  Past\ Technovation\ student
+MENTOR_TYPE_OPTIONS = {
+  "Industry professional" => 0,
+  "Educator" => 1,
+  "Parent" => 2,
+  "Past Technovation student" => 3
 }

--- a/app/constants/mentor_type_options.rb
+++ b/app/constants/mentor_type_options.rb
@@ -5,5 +5,6 @@ MENTOR_TYPE_OPTIONS = {
   "Industry professional" => 0,
   "Educator" => 1,
   "Parent" => 2,
-  "Past Technovation student" => 3
+  "Technovation alumnae" => 3,
+  "Postsecondary student" => 4
 }

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -59,7 +59,7 @@ class NewRegistrationController < ApplicationController
 
   def mentor_params
     {
-      mentor_type: registration_params[:mentorType],
+      mentor_type: registration_params[:mentorType].to_i,
       school_company_name: registration_params[:mentorSchoolCompanyName],
       job_title: registration_params[:mentorJobTitle],
       bio: registration_params[:mentorBio],

--- a/app/controllers/registration/mentor_types_controller.rb
+++ b/app/controllers/registration/mentor_types_controller.rb
@@ -1,0 +1,11 @@
+module Registration
+  class MentorTypesController < RegistrationController
+    def index
+      mentor_types = MENTOR_TYPE_OPTIONS.map do |mentor_type, index|
+        {name: mentor_type, id: index}
+      end
+
+      render json: mentor_types
+    end
+  end
+end

--- a/app/javascript/new_registration/components/MentorStepTwo.vue
+++ b/app/javascript/new_registration/components/MentorStepTwo.vue
@@ -169,12 +169,7 @@ export default {
         'Non-binary',
         'Prefer not to say'
       ],
-      mentorTypeOptions: [
-        'Industry professional',
-        'Educator',
-        'Parent',
-        'Past Technovation student'
-      ],
+      mentorTypeOptions: [],
       mentorProfileExpertiseOptions: [],
       hasValidationErrors: true
     }
@@ -221,9 +216,27 @@ export default {
         })
       }
     },
+    async getMentorTypeOptions () {
+      try {
+        const response = await axios.get('/registration/mentor_types')
+
+        response.data.forEach((mentor_type) => {
+          this.mentorTypeOptions.push({
+            label: mentor_type.name,
+            value: mentor_type.id
+          })
+        })
+      }
+      catch(error) {
+        airbrake.notify({
+          error: `[REGISTRATION] Error getting mentor types - ${error.response.data}`
+        })
+      }
+    },
   },
   created() {
     this.getMentorExpertiseOptions();
+    this.getMentorTypeOptions();
   },
   props: {
     formValues: {

--- a/app/services/student_to_mentor_converter.rb
+++ b/app/services/student_to_mentor_converter.rb
@@ -27,7 +27,7 @@ class StudentToMentorConverter
     account.create_mentor_profile!({
       school_company_name: account.student_profile.school_name,
       job_title: "Technovation Alumnus",
-      mentor_type: "Past Technovation student",
+      mentor_type: "Technovation alumnae",
       former_student: true
     })
 

--- a/app/technovation/create_mentor_profile.rb
+++ b/app/technovation/create_mentor_profile.rb
@@ -27,7 +27,7 @@ module CreateMentorProfile
       {
         school_company_name: account.student_profile.school_name,
         job_title: "Technovation Alumnus",
-        mentor_type: "Past Technovation student",
+        mentor_type: "Technovation alumnae",
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,7 @@ Rails.application.routes.draw do
     resource :account, only: :create
     resources :top_companies, only: :index
     resources :expertises, only: :index
+    resources :mentor_types, only: :index
   end
 
   namespace :api do

--- a/spec/services/student_to_mentor_converter_spec.rb
+++ b/spec/services/student_to_mentor_converter_spec.rb
@@ -19,7 +19,7 @@ describe StudentToMentorConverter do
     expect(account).to receive(:create_mentor_profile!)
       .with({
         former_student: true,
-        mentor_type: "Past Technovation student",
+        mentor_type: "Technovation alumnae",
         job_title: "Technovation Alumnus",
         school_company_name: student_profile.school_name
       })


### PR DESCRIPTION
This PR will:
- Update mentor type "Past Technovation student" to "Technovation alumnae"
- Add mentor type "Postsecondary student"
- Add a new route/endpoint to get mentor types
- Refactor the mentor registration flow to use this endpoint to make the mentor types list, instead of hard coding it