### PR TITLE
Makes content and settings only editable by super admin

### DIFF
--- a/app/javascript/admin/content-settings/components/AdminContentSettings.vue
+++ b/app/javascript/admin/content-settings/components/AdminContentSettings.vue
@@ -131,17 +131,17 @@
         :to="{ name: 'review' }"
       >Review</router-link>
       <button
-        v-else
+        v-else-if="isSuperAdmin"
         ref="submitButton"
         type="submit"
         class="button primary"
         @click.prevent="isProduction() ? confirmSaveSettings() : saveSettings()"
       >Save these settings</button>
-      or
       <a
         ref="cancelButton"
+        class="button secondary"
         :href="cancelButtonUrl"
-      >cancel</a>
+      >Cancel</a>
     </div>
 
     <div ref="formData"></div>
@@ -190,6 +190,7 @@ export default {
     ...mapGetters([
       'judgingEnabled',
       'formData',
+      'isSuperAdmin'
     ]),
 
     currentRoute() {

--- a/app/javascript/admin/content-settings/components/Events.vue
+++ b/app/javascript/admin/content-settings/components/Events.vue
@@ -15,6 +15,7 @@
         id="season_toggles_select_regional_pitch_event"
         type="checkbox"
         v-model="$store.state.select_regional_pitch_event"
+        :disabled="!isSuperAdmin"
       >
       <label
         for="season_toggles_select_regional_pitch_event"
@@ -44,8 +45,9 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
+      'isSuperAdmin'
     ])
-  },
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/Judging.vue
+++ b/app/javascript/admin/content-settings/components/Judging.vue
@@ -7,6 +7,7 @@
         type="radio"
         value="off"
         v-model="$store.state.judging_round"
+        :disabled="!isSuperAdmin"
       >
       <label for="season_toggles_judging_round_off">Off</label>
       <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Before judging: Judges cannot judge'" />
@@ -17,6 +18,7 @@
         type="radio"
         value="qf"
         v-model="$store.state.judging_round"
+        :disabled="!isSuperAdmin"
       >
       <label for="season_toggles_judging_round_qf">Quarterfinals</label>
       <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges can now judge either virtually or their assigned submissions'" />
@@ -27,6 +29,7 @@
         type="radio"
         value="between"
         v-model="$store.state.judging_round"
+        :disabled="!isSuperAdmin"
       >
       <label for="season_toggles_judging_round_between">Between rounds</label>
       <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges now see the &quot;between rounds&quot; screen'" />
@@ -37,6 +40,7 @@
         type="radio"
         value="sf"
         v-model="$store.state.judging_round"
+        :disabled="!isSuperAdmin"
       >
       <label for="season_toggles_judging_round_sf">Semifinals</label>
       <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'Judges can now judge semifinals submissions'" />
@@ -47,6 +51,7 @@
         type="radio"
         value="finished"
         v-model="$store.state.judging_round"
+        :disabled="!isSuperAdmin"
       >
       <label for="season_toggles_judging_round_finished">Finished</label>
       <icon name="question-circle" :size="16" color="00529B" v-tooltip.right="'After judging: judges cannot judge'" />
@@ -80,8 +85,9 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
+      'isSuperAdmin'
     ])
-  },
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/Notices.vue
+++ b/app/javascript/admin/content-settings/components/Notices.vue
@@ -13,6 +13,7 @@
         id="season_toggles_student_dashboard_text"
         type="text"
         v-model="$store.state.student_dashboard_text"
+        :disabled="!isSuperAdmin"
       >
     </p>
 
@@ -22,6 +23,7 @@
         id="season_toggles_mentor_dashboard_text"
         type="text"
         v-model="$store.state.mentor_dashboard_text"
+        :disabled="!isSuperAdmin"
       >
     </p>
 
@@ -31,6 +33,7 @@
         id="season_toggles_judge_dashboard_text"
         type="text"
         v-model="$store.state.judge_dashboard_text"
+        :disabled="!isSuperAdmin"
       >
     </p>
 
@@ -40,14 +43,21 @@
         id="season_toggles_chapter_ambassador_dashboard_text"
         type="text"
         v-model="$store.state.chapter_ambassador_dashboard_text"
+        :disabled="!isSuperAdmin"
       >
     </p>
   </div>
 </template>
 
 <script>
+import {mapGetters} from "vuex";
+
 export default {
   name: 'notices-section',
+
+  computed: {
+    ...mapGetters(['isSuperAdmin'])
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/Registration.vue
+++ b/app/javascript/admin/content-settings/components/Registration.vue
@@ -15,6 +15,7 @@
           :id="`season_toggles_${scope}_signup`"
           type="checkbox"
           v-model="$store.state[`${scope}_signup`]"
+          :disabled="!isSuperAdmin"
         >
         <label
           :for="`season_toggles_${scope}_signup`"
@@ -54,6 +55,7 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
+      'isSuperAdmin'
     ])
   },
 

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -171,7 +171,10 @@
       </div>
     </div>
 
-    <div class="notice warning">
+    <div
+      v-if="isSuperAdmin"
+      class="notice warning"
+    >
       The changes you are about to make are for {{ environmentName() }}.
 
       <p v-if="isProduction()">
@@ -228,8 +231,9 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
-      'formData'
+      'formData',
+      'isSuperAdmin'
     ]),
-  },
+  }
 }
 </script>

--- a/app/javascript/admin/content-settings/components/ScoresAndCertificates.vue
+++ b/app/javascript/admin/content-settings/components/ScoresAndCertificates.vue
@@ -15,6 +15,7 @@
         id="season_toggles_display_scores"
         type="checkbox"
         v-model="$store.state.display_scores"
+        :disabled="!isSuperAdmin"
       >
       <label
         for="season_toggles_display_scores"
@@ -44,8 +45,9 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
+      'isSuperAdmin'
     ])
-  },
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/Surveys.vue
+++ b/app/javascript/admin/content-settings/components/Surveys.vue
@@ -15,12 +15,14 @@
           type="text"
           id="season_toggles_student_survey_link_text"
           v-model="$store.state.student_survey_link.text"
+          :disabled="!isSuperAdmin"
         >
         <input
           placeholder="URL"
           type="text"
           id="season_toggles_student_survey_link_url"
           v-model="$store.state.student_survey_link.url"
+          :disabled="!isSuperAdmin"
         >
       </p>
       <p class="margin--t-none">
@@ -29,6 +31,7 @@
           placeholder="Add more text that appears only in the popup modal"
           id="season_toggles_student_survey_link_long_desc"
           v-model="$store.state.student_survey_link.long_desc"
+          :disabled="!isSuperAdmin"
         />
       </p>
       <div class="notice info hint">
@@ -44,12 +47,14 @@
           type="text"
           id="season_toggles_mentor_survey_link_text"
           v-model="$store.state.mentor_survey_link.text"
+          :disabled="!isSuperAdmin"
         >
         <input
           placeholder="URL"
           type="text"
           id="season_toggles_mentor_survey_link_url"
           v-model="$store.state.mentor_survey_link.url"
+          :disabled="!isSuperAdmin"
         >
       </p>
       <p class="margin--t-none">
@@ -58,6 +63,7 @@
           placeholder="Add more text that appears only in the popup modal"
           id="season_toggles_mentor_survey_link_long_desc"
           v-model="$store.state.mentor_survey_link.long_desc"
+          :disabled="!isSuperAdmin"
         />
       </p>
       <div class="notice info hint">
@@ -68,8 +74,13 @@
 </template>
 
 <script>
+import {mapGetters} from "vuex";
+
 export default {
   name: 'surveys-section',
+  computed: {
+    ...mapGetters(['isSuperAdmin'])
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
+++ b/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
@@ -15,6 +15,7 @@
         id="season_toggles_team_building_enabled"
         type="checkbox"
         v-model="$store.state.team_building_enabled"
+        :disabled="!isSuperAdmin"
       >
       <label
         for="season_toggles_team_building_enabled"
@@ -40,6 +41,7 @@
         id="season_toggles_team_submissions_editable"
         type="checkbox"
         v-model="$store.state.team_submissions_editable"
+        :disabled="!isSuperAdmin"
       >
       <label
         for="season_toggles_team_submissions_editable"
@@ -69,8 +71,9 @@ export default {
   computed: {
     ...mapGetters([
       'judgingEnabled',
+      'isSuperAdmin'
     ])
-  },
+  }
 }
 </script>
 

--- a/app/javascript/admin/content-settings/index.js
+++ b/app/javascript/admin/content-settings/index.js
@@ -1,15 +1,17 @@
-import Vue from 'vue'
-import VueRouter from 'vue-router'
+import Vue from "vue";
+import VueRouter from "vue-router";
 
-import AdminContentSettings from './components/AdminContentSettings'
+import AdminContentSettings from "./components/AdminContentSettings";
 
-Vue.use(VueRouter)
+Vue.use(VueRouter);
 
-import store from './store'
-import { router } from './routes'
+import store from "./store";
+import { router } from "./routes";
 
-document.addEventListener('turbolinks:load', () => {
-  const adminContentSettingsElement = document.getElementById('admin-content-settings')
+document.addEventListener("turbolinks:load", () => {
+  const adminContentSettingsElement = document.getElementById(
+    "admin-content-settings"
+  );
 
   if (adminContentSettingsElement) {
     new Vue({
@@ -19,6 +21,15 @@ document.addEventListener('turbolinks:load', () => {
       components: {
         AdminContentSettings,
       },
-    })
+
+      mounted() {
+        if (this.$refs.isSuperAdmin) {
+          this.$store.commit(
+            "setIsSuperAdmin",
+            this.$refs.isSuperAdmin.dataset.superAdmin
+          );
+        }
+      },
+    });
   }
-})
+});

--- a/app/javascript/admin/content-settings/store/getters.js
+++ b/app/javascript/admin/content-settings/store/getters.js
@@ -1,12 +1,17 @@
 const judgingEnabled = (state) => {
-  return state.judging_round !== 'off' && state.judging_round !== 'finished'
-}
+  return state.judging_round !== "off" && state.judging_round !== "finished";
+};
+
+const isSuperAdmin = (state) => {
+  return state.is_super_admin;
+};
 
 export default {
   judgingEnabled,
+  isSuperAdmin,
 
-  formData (state) {
-    const judgingRoundEnabled = judgingEnabled(state)
+  formData(state) {
+    const judgingRoundEnabled = judgingEnabled(state);
 
     return {
       // Registration
@@ -21,8 +26,8 @@ export default {
       student_dashboard_text: state.student_dashboard_text,
       mentor_dashboard_text: state.mentor_dashboard_text,
       judge_dashboard_text: state.judge_dashboard_text,
-      chapter_ambassador_dashboard_text: state
-        .chapter_ambassador_dashboard_text,
+      chapter_ambassador_dashboard_text:
+        state.chapter_ambassador_dashboard_text,
 
       // Surveys
       student_survey_link: {
@@ -54,6 +59,6 @@ export default {
 
       // Scores & Certificates
       display_scores: Boolean(!judgingRoundEnabled && state.display_scores),
-    }
+    };
   },
-}
+};

--- a/app/javascript/admin/content-settings/store/mutations.js
+++ b/app/javascript/admin/content-settings/store/mutations.js
@@ -1,15 +1,18 @@
-import mergeWith from 'lodash/mergeWith'
+import mergeWith from "lodash/mergeWith";
 
 function mergeWithCustomizer(objValue, srcValue) {
   if (srcValue === false) {
-    return 0
+    return 0;
   } else if (srcValue === true) {
-    return 1
+    return 1;
   }
 }
 
 export default {
-  setFormData (state, formData) {
-    mergeWith(state, formData, mergeWithCustomizer)
+  setFormData(state, formData) {
+    mergeWith(state, formData, mergeWithCustomizer);
   },
-}
+  setIsSuperAdmin(state, isSuperAdmin) {
+    state.is_super_admin = JSON.parse(isSuperAdmin);
+  },
+};

--- a/app/javascript/admin/content-settings/store/state.js
+++ b/app/javascript/admin/content-settings/store/state.js
@@ -1,4 +1,5 @@
 export default {
+  is_super_admin: false,
   // Registration
   student_signup: 0,
   mentor_signup: 0,
@@ -6,20 +7,20 @@ export default {
   chapter_ambassador_signup: 0,
 
   // Notices
-  student_dashboard_text: '',
-  mentor_dashboard_text: '',
-  judge_dashboard_text: '',
-  chapter_ambassador_dashboard_text: '',
+  student_dashboard_text: "",
+  mentor_dashboard_text: "",
+  judge_dashboard_text: "",
+  chapter_ambassador_dashboard_text: "",
   // Surveys
   student_survey_link: {
-    text: '',
-    url: '',
-    long_desc: '',
+    text: "",
+    url: "",
+    long_desc: "",
   },
   mentor_survey_link: {
-    text: '',
-    url: '',
-    long_desc: '',
+    text: "",
+    url: "",
+    long_desc: "",
   },
   // Teams & Submissions
   team_building_enabled: 0,
@@ -27,7 +28,7 @@ export default {
   // Events
   select_regional_pitch_event: 0,
   // Judging
-  judging_round: 'off',
+  judging_round: "off",
   // Scores & Certificates
   display_scores: 0,
-}
+};

--- a/app/views/admin/season_schedule_settings/edit.html.erb
+++ b/app/views/admin/season_schedule_settings/edit.html.erb
@@ -2,8 +2,15 @@
 <h3>
   Toggle user features and content throughout the season
 </h3>
+<h5>Note: Only available to super admin</h5>
 
 <div id="admin-content-settings">
+  <div
+    ref="isSuperAdmin"
+    data-super-admin="<%= current_admin.super_admin? %>"
+  >
+  </div>
+
   <%= form_with(
         id: "season_schedule",
         scope: :season_toggles,

--- a/spec/features/admin/content_and_settings_spec.rb
+++ b/spec/features/admin/content_and_settings_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "Season controls exposed through Content & Settings tab", js: true do
-  let(:admin) { FactoryBot.create(:admin) }
+  let(:super_admin) { FactoryBot.create(:super_admin) }
 
   before do
-    sign_in(admin)
+    sign_in(super_admin)
     expect(page).to have_content("Welcome back!")
 
     visit edit_admin_season_schedule_settings_path

--- a/spec/javascript/admin/content-settings/components/AdminContentSettings.spec.js
+++ b/spec/javascript/admin/content-settings/components/AdminContentSettings.spec.js
@@ -1,514 +1,511 @@
-import Vuex from 'vuex'
-import { shallowMount, createLocalVue, RouterLinkStub } from '@vue/test-utils'
+import Vuex from "vuex";
+import { shallowMount, createLocalVue, RouterLinkStub } from "@vue/test-utils";
 
-import mockStore from 'admin/content-settings/store/__mocks__'
-import AdminContentSettings from 'admin/content-settings/components/AdminContentSettings'
-import Icon from 'components/Icon'
+import mockStore from "admin/content-settings/store/__mocks__";
+import AdminContentSettings from "admin/content-settings/components/AdminContentSettings";
+import Icon from "components/Icon";
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
-describe('Admin Content & Settings - AdminContentSettings component', () => {
-
-  let wrapper
+describe("Admin Content & Settings - AdminContentSettings component", () => {
+  let wrapper;
 
   function assertIconProps(icon) {
     expect(icon.props()).toEqual(
       expect.objectContaining({
-        name: 'exclamation-circle',
+        name: "exclamation-circle",
         size: 16,
-        color: 'D8000C',
+        color: "D8000C",
       })
-    )
+    );
   }
 
   beforeAll(() => {
-    console.error = jest.fn(() => {})
-  })
+    console.error = jest.fn(() => {});
+  });
 
   beforeEach(() => {
-    axios.mockResponseOnce("get", { data: { attributes: {} } })
+    axios.mockResponseOnce("get", { data: { attributes: {} } });
 
-    wrapper = shallowMount(
-      AdminContentSettings,
-      {
-        localVue,
-        store: mockStore.createMocks().store,
-        stubs: {
-          RouterLink: RouterLinkStub,
-          'router-view': true,
-        },
-        propsData: {
-          cancelButtonUrl: '/admin/dashboard',
-        },
-        computed: {
-          currentRoute: jest.fn(() => { return 'not-review' })
-        },
-      }
-    )
-  })
+    wrapper = shallowMount(AdminContentSettings, {
+      localVue,
+      store: mockStore.createMocks().store,
+      stubs: {
+        RouterLink: RouterLinkStub,
+        "router-view": true,
+      },
+      propsData: {
+        cancelButtonUrl: "/admin/dashboard",
+      },
+      computed: {
+        currentRoute: jest.fn(() => {
+          return "not-review";
+        }),
+      },
+    });
+  });
 
-  it('has a name attribute', () => {
-    expect(AdminContentSettings.name).toEqual('admin-content-settings')
-  })
+  it("has a name attribute", () => {
+    expect(AdminContentSettings.name).toEqual("admin-content-settings");
+  });
 
-  it('starts out loading', () => {
-    const myUncreatedWrapper = shallowMount(
-      AdminContentSettings, {
-        store: mockStore.createMocks().store,
-        localVue,
-        created () {
-          // no op 'stub' for this test
-        },
-      }
-    )
+  it("starts out loading", () => {
+    const myUncreatedWrapper = shallowMount(AdminContentSettings, {
+      store: mockStore.createMocks().store,
+      localVue,
+      created() {
+        // no op 'stub' for this test
+      },
+    });
 
-    expect(myUncreatedWrapper.find('.loading').text()).toEqual('Loading...')
-  })
+    expect(myUncreatedWrapper.find(".loading").text()).toEqual("Loading...");
+  });
 
-  describe('props', () => {
-
-    it('contains the correct props', () => {
+  describe("props", () => {
+    it("contains the correct props", () => {
       expect(AdminContentSettings.props).toEqual({
         cancelButtonUrl: {
           type: String,
           required: true,
         },
-      })
-    })
+      });
+    });
+  });
 
-  })
-
-  describe('created hook', () => {
-
-    it('initializes settings state from remote data', (done) => {
+  describe("created hook", () => {
+    it("initializes settings state from remote data", (done) => {
       axios.mockResponseOnce("get", {
         data: {
           attributes: {
             student_signup: 1,
-            student_dashboard_text: 'Student dashboard text',
-            mentor_dashboard_text: 'Mentor dashboard text',
-            judge_dashboard_text: 'Judge dashboard text',
-            chapter_ambassador_dashboard_text: 'Chapter ambassador dashboard text',
+            student_dashboard_text: "Student dashboard text",
+            mentor_dashboard_text: "Mentor dashboard text",
+            judge_dashboard_text: "Judge dashboard text",
+            chapter_ambassador_dashboard_text:
+              "Chapter ambassador dashboard text",
             student_survey_link: {
-              text: 'Student Link',
-              url: 'http://google.com',
-              long_desc: 'This is a long description for student link',
+              text: "Student Link",
+              url: "http://google.com",
+              long_desc: "This is a long description for student link",
             },
             mentor_survey_link: {
-              text: 'Mentor Link',
-              url: 'http://bing.com',
-              long_desc: 'This is a long description for mentor link',
+              text: "Mentor Link",
+              url: "http://bing.com",
+              long_desc: "This is a long description for mentor link",
             },
             team_building_enabled: 1,
             select_regional_pitch_event: 0,
-            judging_round: 'qf',
+            judging_round: "qf",
             display_scores: 1,
-          }
-        }
-      })
+          },
+        },
+      });
 
-      wrapper = shallowMount(
-        AdminContentSettings,
-        {
-          localVue,
-          store: mockStore.createMocks().store,
-          stubs: {
-            RouterLink: RouterLinkStub,
-            'router-view': true,
-          },
-          propsData: {
-            cancelButtonUrl: '/admin/dashboard',
-          },
-          computed: {
-            currentRoute: jest.fn(() => { return 'not-review' })
-          },
-        }
-      )
+      wrapper = shallowMount(AdminContentSettings, {
+        localVue,
+        store: mockStore.createMocks().store,
+        stubs: {
+          RouterLink: RouterLinkStub,
+          "router-view": true,
+        },
+        propsData: {
+          cancelButtonUrl: "/admin/dashboard",
+        },
+        computed: {
+          currentRoute: jest.fn(() => {
+            return "not-review";
+          }),
+        },
+      });
 
       setImmediate(() => {
-        expect(wrapper.vm.isLoading).toBe(false)
+        expect(wrapper.vm.isLoading).toBe(false);
         expect(wrapper.vm.$store.state).toEqual({
+          is_super_admin: false,
           student_signup: 1,
           mentor_signup: 0,
           judge_signup: 0,
           chapter_ambassador_signup: 0,
-          student_dashboard_text: 'Student dashboard text',
-          mentor_dashboard_text: 'Mentor dashboard text',
-          judge_dashboard_text: 'Judge dashboard text',
-          chapter_ambassador_dashboard_text: 'Chapter ambassador dashboard text',
+          student_dashboard_text: "Student dashboard text",
+          mentor_dashboard_text: "Mentor dashboard text",
+          judge_dashboard_text: "Judge dashboard text",
+          chapter_ambassador_dashboard_text:
+            "Chapter ambassador dashboard text",
           student_survey_link: {
-            text: 'Student Link',
-            url: 'http://google.com',
-            long_desc: 'This is a long description for student link',
+            text: "Student Link",
+            url: "http://google.com",
+            long_desc: "This is a long description for student link",
           },
           mentor_survey_link: {
-            text: 'Mentor Link',
-            url: 'http://bing.com',
-            long_desc: 'This is a long description for mentor link',
+            text: "Mentor Link",
+            url: "http://bing.com",
+            long_desc: "This is a long description for mentor link",
           },
           team_building_enabled: 1,
           team_submissions_editable: 0,
           select_regional_pitch_event: 0,
-          judging_round: 'qf',
+          judging_round: "qf",
           display_scores: 1,
-        })
-        done()
-      })
-    })
+        });
+        done();
+      });
+    });
+  });
 
-  })
-
-  describe('methods', () => {
-
-    describe('buildFormInputsMarkup', () => {
-
-      it('builds input markup to submit form', () => {
+  describe("methods", () => {
+    describe("buildFormInputsMarkup", () => {
+      it("builds input markup to submit form", () => {
         const formData = {
           student_signup: 1,
           mentor_signup: false,
-          student_dashboard_text: 'Student',
-          mentor_dashboard_text: 'Mentor',
-          judge_dashboard_text: 'Judge',
-          chapter_ambassador_dashboard_text: 'Chapter Ambassador',
+          student_dashboard_text: "Student",
+          mentor_dashboard_text: "Mentor",
+          judge_dashboard_text: "Judge",
+          chapter_ambassador_dashboard_text: "Chapter Ambassador",
           student_survey_link: {
-            text: 'Student Link',
-            url: 'http://google.com',
-            long_desc: 'This is a long student description',
+            text: "Student Link",
+            url: "http://google.com",
+            long_desc: "This is a long student description",
           },
           mentor_survey_link: {
-            text: 'Mentor Link',
-            url: 'http://bing.com',
-            long_desc: 'This is a long mentor description',
+            text: "Mentor Link",
+            url: "http://bing.com",
+            long_desc: "This is a long mentor description",
           },
-        }
+        };
 
-        const testElement = document.createElement('div')
-        testElement.innerHTML = wrapper.vm.buildFormInputsMarkup(formData)
+        const testElement = document.createElement("div");
+        testElement.innerHTML = wrapper.vm.buildFormInputsMarkup(formData);
 
-        const inputs = testElement.querySelectorAll('input')
+        const inputs = testElement.querySelectorAll("input");
 
-        expect(inputs[0].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[student_signup]" value="1">')
-        expect(inputs[1].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[mentor_signup]" value="0">')
-        expect(inputs[2].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[student_dashboard_text]" value="Student">')
-        expect(inputs[3].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[mentor_dashboard_text]" value="Mentor">')
-        expect(inputs[4].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[judge_dashboard_text]" value="Judge">')
-        expect(inputs[5].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[chapter_ambassador_dashboard_text]" value="Chapter Ambassador">')
-        expect(inputs[6].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[student_survey_link][text]" value="Student Link">')
-        expect(inputs[7].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[student_survey_link][url]" value="http://google.com">')
-        expect(inputs[8].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[student_survey_link][long_desc]" value="This is a long student description">')
-        expect(inputs[9].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[mentor_survey_link][text]" value="Mentor Link">')
-        expect(inputs[10].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[mentor_survey_link][url]" value="http://bing.com">')
-        expect(inputs[11].outerHTML)
-          .toEqual('<input type="hidden" name="season_toggles[mentor_survey_link][long_desc]" value="This is a long mentor description">')
-      })
+        expect(inputs[0].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[student_signup]" value="1">'
+        );
+        expect(inputs[1].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[mentor_signup]" value="0">'
+        );
+        expect(inputs[2].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[student_dashboard_text]" value="Student">'
+        );
+        expect(inputs[3].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[mentor_dashboard_text]" value="Mentor">'
+        );
+        expect(inputs[4].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[judge_dashboard_text]" value="Judge">'
+        );
+        expect(inputs[5].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[chapter_ambassador_dashboard_text]" value="Chapter Ambassador">'
+        );
+        expect(inputs[6].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[student_survey_link][text]" value="Student Link">'
+        );
+        expect(inputs[7].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[student_survey_link][url]" value="http://google.com">'
+        );
+        expect(inputs[8].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[student_survey_link][long_desc]" value="This is a long student description">'
+        );
+        expect(inputs[9].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[mentor_survey_link][text]" value="Mentor Link">'
+        );
+        expect(inputs[10].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[mentor_survey_link][url]" value="http://bing.com">'
+        );
+        expect(inputs[11].outerHTML).toEqual(
+          '<input type="hidden" name="season_toggles[mentor_survey_link][long_desc]" value="This is a long mentor description">'
+        );
+      });
+    });
+  });
 
-    })
-
-  })
-
-  describe('computed properties', () => {
-
-    describe('formData', () => {
-
-      it('returns an object used for populating form inputs based on dynamic data', () => {
-        wrapper = shallowMount(
-          AdminContentSettings,
-          {
-            localVue,
-            store: mockStore.createMocks({
-              state: {
-                student_signup: 1,
-                mentor_signup: 0,
-                judge_signup: 0,
-                chapter_ambassador_signup: 0,
-                student_dashboard_text: 'Student',
-                mentor_dashboard_text: 'Mentor',
-                judge_dashboard_text: 'Judge',
-                chapter_ambassador_dashboard_text: 'Chapter Ambassador',
-                student_survey_link: {
-                  text: 'Student Link',
-                  url: 'http://google.com',
-                  long_desc: 'Student link long description',
-                },
-                mentor_survey_link: {
-                  text: 'Mentor Link',
-                  url: 'http://bing.com',
-                  long_desc: 'Mentor link long description',
-                },
-                team_building_enabled: 1,
-                team_submissions_editable: 0,
-                select_regional_pitch_event: 1,
-                judging_round: 'off',
-                display_scores: 0,
+  describe("computed properties", () => {
+    describe("formData", () => {
+      it("returns an object used for populating form inputs based on dynamic data", () => {
+        wrapper = shallowMount(AdminContentSettings, {
+          localVue,
+          store: mockStore.createMocks({
+            state: {
+              student_signup: 1,
+              mentor_signup: 0,
+              judge_signup: 0,
+              chapter_ambassador_signup: 0,
+              student_dashboard_text: "Student",
+              mentor_dashboard_text: "Mentor",
+              judge_dashboard_text: "Judge",
+              chapter_ambassador_dashboard_text: "Chapter Ambassador",
+              student_survey_link: {
+                text: "Student Link",
+                url: "http://google.com",
+                long_desc: "Student link long description",
               },
-            }).store,
-            stubs: {
-              RouterLink: RouterLinkStub,
-              'router-view': true,
+              mentor_survey_link: {
+                text: "Mentor Link",
+                url: "http://bing.com",
+                long_desc: "Mentor link long description",
+              },
+              team_building_enabled: 1,
+              team_submissions_editable: 0,
+              select_regional_pitch_event: 1,
+              judging_round: "off",
+              display_scores: 0,
             },
-            propsData: {
-              cancelButtonUrl: '/admin/dashboard',
-            },
-            computed: {
-              currentRoute: jest.fn(() => { return 'not-review' })
-            },
-          }
-        )
+          }).store,
+          stubs: {
+            RouterLink: RouterLinkStub,
+            "router-view": true,
+          },
+          propsData: {
+            cancelButtonUrl: "/admin/dashboard",
+          },
+          computed: {
+            currentRoute: jest.fn(() => {
+              return "not-review";
+            }),
+          },
+        });
 
         expect(wrapper.vm.formData).toEqual({
           student_signup: true,
           mentor_signup: false,
           judge_signup: false,
           chapter_ambassador_signup: false,
-          student_dashboard_text: 'Student',
-          mentor_dashboard_text: 'Mentor',
-          judge_dashboard_text: 'Judge',
-          chapter_ambassador_dashboard_text: 'Chapter Ambassador',
+          student_dashboard_text: "Student",
+          mentor_dashboard_text: "Mentor",
+          judge_dashboard_text: "Judge",
+          chapter_ambassador_dashboard_text: "Chapter Ambassador",
           student_survey_link: {
-            text: 'Student Link',
-            url: 'http://google.com',
-            long_desc: 'Student link long description',
+            text: "Student Link",
+            url: "http://google.com",
+            long_desc: "Student link long description",
           },
           mentor_survey_link: {
-            text: 'Mentor Link',
-            url: 'http://bing.com',
-            long_desc: 'Mentor link long description',
+            text: "Mentor Link",
+            url: "http://bing.com",
+            long_desc: "Mentor link long description",
           },
           team_building_enabled: true,
           team_submissions_editable: false,
           select_regional_pitch_event: true,
-          judging_round: 'off',
+          judging_round: "off",
           display_scores: false,
-        })
-      })
+        });
+      });
+    });
+  });
 
-    })
+  describe("HTML layout", () => {
+    it("contains the tab grid layout", () => {
+      expect(wrapper.find("#admin-content-settings").classes()).toEqual([
+        "tabs",
+        "tabs--vertical",
+        "grid",
+      ]);
 
-  })
+      expect(wrapper.find("#admin-content-settings ul").classes()).toEqual([
+        "tabs__menu",
+        "grid__col-md-3",
+      ]);
 
-  describe('HTML layout', () => {
-
-    it('contains the tab grid layout', () => {
-      expect(wrapper.find('#admin-content-settings').classes()).toEqual([
-        'tabs',
-        'tabs--vertical',
-        'grid',
-      ])
-
-      expect(wrapper.find('#admin-content-settings ul').classes()).toEqual([
-        'tabs__menu',
-        'grid__col-md-3',
-      ])
-
-      expect(wrapper.find('router-view-stub').classes()).toEqual([
-        'tabs__content',
-        'grid__col-md-9',
-      ])
+      expect(wrapper.find("router-view-stub").classes()).toEqual([
+        "tabs__content",
+        "grid__col-md-9",
+      ]);
 
       const routerLinks = [
-        'registrationLink',
-        'noticesLink',
-        'surveysLink',
-        'teamsAndSubmissionsLink',
-        'eventsLink',
-        'judgingLink',
-        'scoresAndCertificatesLink',
-      ]
+        "registrationLink",
+        "noticesLink",
+        "surveysLink",
+        "teamsAndSubmissionsLink",
+        "eventsLink",
+        "judgingLink",
+        "scoresAndCertificatesLink",
+      ];
 
       routerLinks.forEach((ref) => {
-        const link = wrapper.find({ ref })
-        const props = link.props()
-        const attributes = link.attributes()
+        const link = wrapper.find({ ref });
+        const props = link.props();
+        const attributes = link.attributes();
 
-        expect(props.tag).toBe('li')
-        expect(props.activeClass).toBe('tabs__menu-link--active')
-        expect(attributes.class).toBe('tabs__menu-link')
+        expect(props.tag).toBe("li");
+        expect(props.activeClass).toBe("tabs__menu-link--active");
+        expect(attributes.class).toBe("tabs__menu-link");
 
         expect(link.find('button[role="button"]').classes()).toEqual([
-          'tabs__menu-button',
-        ])
-      })
+          "tabs__menu-button",
+        ]);
+      });
 
-      const reviewLink = wrapper.find({ ref: 'reviewLink' })
-      const reviewLinkProps = reviewLink.props()
+      const reviewLink = wrapper.find({ ref: "reviewLink" });
+      const reviewLinkProps = reviewLink.props();
 
-      expect(reviewLinkProps.tag).toBe('button')
-      expect(reviewLinkProps.to).toEqual({ name: 'review' })
-      expect(reviewLink.attributes().class).toBe('button primary')
+      expect(reviewLinkProps.tag).toBe("button");
+      expect(reviewLinkProps.to).toEqual({ name: "review" });
+      expect(reviewLink.attributes().class).toBe("button primary");
 
-      const cancelButton = wrapper.find({ ref: 'cancelButton' })
-      const cancelButtonAttributes= cancelButton.attributes()
+      const cancelButton = wrapper.find({ ref: "cancelButton" });
+      const cancelButtonAttributes = cancelButton.attributes();
 
-      expect(cancelButtonAttributes.href).toBe('/admin/dashboard')
-    })
+      expect(cancelButtonAttributes.href).toBe("/admin/dashboard");
+    });
 
-    it('displays warning icons on router links if judging is enabled', (done) => {
-      wrapper = shallowMount(
-        AdminContentSettings,
-        {
-          localVue,
-          store: mockStore
-            .createMocks({
-              getters: {
-                judgingEnabled: () => {
-                  return true
-                },
-              },
-              actions: {
-                init: () => {
-                  return Promise.resolve({})
-                }
-              }
-            })
-            .store,
-          stubs: {
-            RouterLink: RouterLinkStub,
-            'router-view': true,
-          },
-          propsData: {
-            cancelButtonUrl: '/admin/dashboard',
-          },
-          computed: {
-            currentRoute: jest.fn(() => { return 'not-review' })
-          },
-        }
-      )
-
-      setImmediate(() => {
-        expect(wrapper.vm.judgingEnabled).toBe(true)
-        expect(wrapper.vm.isLoading).toBe(false)
-        expect(wrapper.vm.hasError).toBe(false)
-
-        const registrationLink = wrapper.find({ ref: 'registrationLink' })
-        assertIconProps(registrationLink.find(Icon))
-
-        const noticesLink = wrapper.find({ ref: 'noticesLink' })
-        expect(noticesLink.find(Icon).exists()).toBe(false)
-
-        const surveysLink = wrapper.find({ ref: 'surveysLink' })
-        expect(surveysLink.find(Icon).exists()).toBe(false)
-
-        const teamsAndSubmissionsLink = wrapper
-          .find({ ref: 'teamsAndSubmissionsLink' })
-        assertIconProps(teamsAndSubmissionsLink.find(Icon))
-
-        const eventsLink = wrapper.find({ ref: 'eventsLink' })
-        assertIconProps(eventsLink.find(Icon))
-
-        const judgingLink = wrapper.find({ ref: 'judgingLink' })
-        expect(judgingLink.find(Icon).exists()).toBe(false)
-
-        const scoresAndCertificatesLink = wrapper
-          .find({ ref: 'scoresAndCertificatesLink' })
-        assertIconProps(scoresAndCertificatesLink.find(Icon))
-
-        done()
-      })
-    })
-
-    it('displays save button if on review page', (done) => {
-      const properties = {
+    it("displays warning icons on router links if judging is enabled", (done) => {
+      wrapper = shallowMount(AdminContentSettings, {
         localVue,
-        store: mockStore
-          .createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-            actions: {
-              init: () => {
-                return Promise.resolve({})
-              }
-            }
-          })
-          .store,
+          },
+          actions: {
+            init: () => {
+              return Promise.resolve({});
+            },
+          },
+        }).store,
         stubs: {
           RouterLink: RouterLinkStub,
-          'router-view': true,
+          "router-view": true,
         },
         propsData: {
-          cancelButtonUrl: '/admin/dashboard',
+          cancelButtonUrl: "/admin/dashboard",
         },
-      }
+        computed: {
+          currentRoute: jest.fn(() => {
+            return "not-review";
+          }),
+        },
+      });
+
+      setImmediate(() => {
+        expect(wrapper.vm.judgingEnabled).toBe(true);
+        expect(wrapper.vm.isLoading).toBe(false);
+        expect(wrapper.vm.hasError).toBe(false);
+
+        const registrationLink = wrapper.find({ ref: "registrationLink" });
+        assertIconProps(registrationLink.find(Icon));
+
+        const noticesLink = wrapper.find({ ref: "noticesLink" });
+        expect(noticesLink.find(Icon).exists()).toBe(false);
+
+        const surveysLink = wrapper.find({ ref: "surveysLink" });
+        expect(surveysLink.find(Icon).exists()).toBe(false);
+
+        const teamsAndSubmissionsLink = wrapper.find({
+          ref: "teamsAndSubmissionsLink",
+        });
+        assertIconProps(teamsAndSubmissionsLink.find(Icon));
+
+        const eventsLink = wrapper.find({ ref: "eventsLink" });
+        assertIconProps(eventsLink.find(Icon));
+
+        const judgingLink = wrapper.find({ ref: "judgingLink" });
+        expect(judgingLink.find(Icon).exists()).toBe(false);
+
+        const scoresAndCertificatesLink = wrapper.find({
+          ref: "scoresAndCertificatesLink",
+        });
+        assertIconProps(scoresAndCertificatesLink.find(Icon));
+
+        done();
+      });
+    });
+
+    it("displays save button if on review page", (done) => {
+      const properties = {
+        localVue,
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
+            },
+          },
+          actions: {
+            init: () => {
+              return Promise.resolve({});
+            },
+          },
+        }).store,
+        stubs: {
+          RouterLink: RouterLinkStub,
+          "router-view": true,
+        },
+        propsData: {
+          cancelButtonUrl: "/admin/dashboard",
+        },
+      };
 
       wrapper = shallowMount(
         AdminContentSettings,
         Object.assign({}, properties, {
           computed: {
-            currentRoute: jest.fn(() => { return 'not-review' })
-          }
+            currentRoute: jest.fn(() => {
+              return "not-review";
+            }),
+          },
         })
-      )
+      );
 
       setImmediate(() => {
-        let reviewLink = wrapper.find({ ref: 'reviewLink' })
-        let submitButton = wrapper.find({ ref: 'submitButton' })
+        let reviewLink = wrapper.find({ ref: "reviewLink" });
+        let submitButton = wrapper.find({ ref: "submitButton" });
 
-        expect(reviewLink.exists()).toBe(true)
-        expect(submitButton.exists()).toBe(false)
+        expect(reviewLink.exists()).toBe(true);
+        expect(submitButton.exists()).toBe(false);
 
-        done()
-      })
-    })
+        done();
+      });
+    });
 
-    it('displays review router link otherwise', (done) => {
+    it("displays review router link otherwise", (done) => {
       const properties = {
         localVue,
-        store: mockStore
-          .createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-            actions: {
-              init: () => {
-                return Promise.resolve({})
-              }
-            }
-          })
-          .store,
+            isSuperAdmin: () => {
+              return true;
+            },
+          },
+          actions: {
+            init: () => {
+              return Promise.resolve({});
+            },
+          },
+        }).store,
         stubs: {
           RouterLink: RouterLinkStub,
-          'router-view': true,
+          "router-view": true,
         },
         propsData: {
-          cancelButtonUrl: '/admin/dashboard',
+          cancelButtonUrl: "/admin/dashboard",
         },
-      }
+      };
 
       wrapper = shallowMount(
         AdminContentSettings,
         Object.assign({}, properties, {
           computed: {
-            currentRoute: jest.fn(() => { return 'review' })
-          }
+            currentRoute: jest.fn(() => {
+              return "review";
+            }),
+          },
         })
-      )
+      );
 
       setImmediate(() => {
-        let reviewLink = wrapper.find({ ref: 'reviewLink' })
-        let submitButton = wrapper.find({ ref: 'submitButton' })
+        let reviewLink = wrapper.find({ ref: "reviewLink" });
+        let submitButton = wrapper.find({ ref: "submitButton" });
 
-        expect(reviewLink.exists()).toBe(false)
-        expect(submitButton.exists()).toBe(true)
+        expect(reviewLink.exists()).toBe(false);
+        expect(submitButton.exists()).toBe(true);
 
-        done()
-      })
-    })
-  })
-
-})
+        done();
+      });
+    });
+  });
+});

--- a/spec/javascript/admin/content-settings/components/Registration.spec.js
+++ b/spec/javascript/admin/content-settings/components/Registration.spec.js
@@ -1,198 +1,189 @@
-import Vuex from 'vuex'
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from "vuex";
+import { shallowMount, createLocalVue } from "@vue/test-utils";
 
-import mockStore from 'admin/content-settings/store/__mocks__'
-import Registration from 'admin/content-settings/components/Registration'
-import Icon from 'components/Icon'
+import mockStore from "admin/content-settings/store/__mocks__";
+import Registration from "admin/content-settings/components/Registration";
+import Icon from "components/Icon";
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
-describe('Admin Content & Settings - Registration component', () => {
-
-  let wrapper
+describe("Admin Content & Settings - Registration component", () => {
+  let wrapper;
 
   beforeEach(() => {
-    wrapper = shallowMount(
-      Registration,
-      {
-        localVue,
-        store: mockStore.createMocks().store,
-      }
-    )
-  })
+    wrapper = shallowMount(Registration, {
+      localVue,
+      store: mockStore.createMocks().store,
+    });
+  });
 
-  it('has a name attribute', () => {
-    expect(Registration.name).toEqual('registration-section')
-  })
+  it("has a name attribute", () => {
+    expect(Registration.name).toEqual("registration-section");
+  });
 
-  describe('data', () => {
-
-    it('contains the correct default data', () => {
+  describe("data", () => {
+    it("contains the correct default data", () => {
       expect(Registration.data()).toEqual({
         checkboxes: {
-          student: 'Students',
-          mentor: 'Mentors',
-          judge: 'Judges',
+          student: "Students",
+          mentor: "Mentors",
+          judge: "Judges",
         },
-      })
-    })
+      });
+    });
+  });
 
-  })
+  describe("markup", () => {
+    it("contains the proper HTML based on data", () => {
+      const studentCheckbox = wrapper.find("#season_toggles_student_signup");
+      const studentCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_student_signup"]'
+      );
+      const mentorCheckbox = wrapper.find("#season_toggles_mentor_signup");
+      const mentorCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_mentor_signup"]'
+      );
+      const judgeCheckbox = wrapper.find("#season_toggles_judge_signup");
+      const judgeCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_judge_signup"]'
+      );
 
-  describe('markup', () => {
+      expect(wrapper.vm.judgingEnabled).toBe(false);
 
-    it('contains the proper HTML based on data', () => {
-      const studentCheckbox = wrapper.find('#season_toggles_student_signup')
-      const studentCheckboxLabel = wrapper
-        .find('label[for="season_toggles_student_signup"]')
-      const mentorCheckbox = wrapper.find('#season_toggles_mentor_signup')
-      const mentorCheckboxLabel = wrapper
-        .find('label[for="season_toggles_mentor_signup"]')
-      const judgeCheckbox = wrapper.find('#season_toggles_judge_signup')
-      const judgeCheckboxLabel = wrapper
-        .find('label[for="season_toggles_judge_signup"]')
+      expect(studentCheckbox.exists()).toBe(true);
+      expect(studentCheckboxLabel.exists()).toBe(true);
+      expect(mentorCheckbox.exists()).toBe(true);
+      expect(mentorCheckboxLabel.exists()).toBe(true);
+      expect(judgeCheckbox.exists()).toBe(true);
+      expect(judgeCheckboxLabel.exists()).toBe(true);
+    });
 
-      expect(wrapper.vm.judgingEnabled).toBe(false)
-
-      expect(studentCheckbox.exists()).toBe(true)
-      expect(studentCheckboxLabel.exists()).toBe(true)
-      expect(mentorCheckbox.exists()).toBe(true)
-      expect(mentorCheckboxLabel.exists()).toBe(true)
-      expect(judgeCheckbox.exists()).toBe(true)
-      expect(judgeCheckboxLabel.exists()).toBe(true)
-    })
-
-    it('disables checkboxes and sets values to 0 is judging is enabled', () => {
-      wrapper = shallowMount(
-        Registration,
-        {
-          localVue,
-          store: mockStore.createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+    it("disables checkboxes and sets values to 0 is judging is enabled", () => {
+      wrapper = shallowMount(Registration, {
+        localVue,
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-          }).store,
-        }
-      )
+          },
+        }).store,
+      });
 
-      const studentCheckbox = wrapper.find('#season_toggles_student_signup')
-      const studentCheckboxLabel = wrapper
-        .find('label[for="season_toggles_student_signup"]')
-      const mentorCheckbox = wrapper.find('#season_toggles_mentor_signup')
-      const mentorCheckboxLabel = wrapper
-        .find('label[for="season_toggles_mentor_signup"]')
+      const studentCheckbox = wrapper.find("#season_toggles_student_signup");
+      const studentCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_student_signup"]'
+      );
+      const mentorCheckbox = wrapper.find("#season_toggles_mentor_signup");
+      const mentorCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_mentor_signup"]'
+      );
 
-      expect(wrapper.vm.judgingEnabled).toBe(true)
+      expect(wrapper.vm.judgingEnabled).toBe(true);
 
       expect(studentCheckbox.attributes()).toEqual(
         expect.objectContaining({
-          id: 'season_toggles_student_signup',
-          type: 'checkbox',
-          disabled: 'disabled',
-          value: '0',
+          id: "season_toggles_student_signup",
+          type: "checkbox",
+          disabled: "disabled",
+          value: "0",
         })
-      )
+      );
 
       expect(studentCheckboxLabel.attributes()).toEqual(
         expect.objectContaining({
-          class: 'label--disabled',
+          class: "label--disabled",
         })
-      )
+      );
 
       expect(mentorCheckbox.attributes()).toEqual(
         expect.objectContaining({
-          id: 'season_toggles_mentor_signup',
-          type: 'checkbox',
-          disabled: 'disabled',
-          value: '0',
+          id: "season_toggles_mentor_signup",
+          type: "checkbox",
+          disabled: "disabled",
+          value: "0",
         })
-      )
+      );
 
       expect(mentorCheckboxLabel.attributes()).toEqual(
         expect.objectContaining({
-          class: 'label--disabled',
+          class: "label--disabled",
         })
-      )
-    })
+      );
+    });
 
-    it('allows judge registraitons when juding is enabled', () => {
-      wrapper = shallowMount(
-        Registration,
-        {
-          localVue,
-          store: mockStore.createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+    it("allows judge registraitons when juding is enabled", () => {
+      wrapper = shallowMount(Registration, {
+        localVue,
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-          }).store,
-        }
-      )
+            isSuperAdmin: () => {
+              return true;
+            },
+          },
+        }).store,
+      });
 
-      const judgeCheckbox = wrapper.find('#season_toggles_judge_signup')
-      const judgeCheckboxLabel = wrapper
-        .find('label[for="season_toggles_judge_signup"]')
+      const judgeCheckbox = wrapper.find("#season_toggles_judge_signup");
+      const judgeCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_judge_signup"]'
+      );
 
-      expect(wrapper.vm.judgingEnabled).toBe(true)
+      expect(wrapper.vm.judgingEnabled).toBe(true);
 
       expect(judgeCheckbox.attributes()).toEqual(
         expect.objectContaining({
-          id: 'season_toggles_judge_signup',
-          type: 'checkbox',
+          id: "season_toggles_judge_signup",
+          type: "checkbox",
         })
-      )
+      );
 
       expect(judgeCheckbox.attributes()).not.toEqual(
         expect.objectContaining({
-          id: 'season_toggles_judge_signup',
-          type: 'checkbox',
-          disabled: 'disabled',
+          id: "season_toggles_judge_signup",
+          type: "checkbox",
+          disabled: "disabled",
         })
-      )
+      );
 
       expect(judgeCheckboxLabel.attributes()).not.toEqual(
         expect.objectContaining({
-          class: 'label--disabled',
+          class: "label--disabled",
         })
-      )
-    })
+      );
+    });
 
-    it('displays warning notices if judging is enabled', () => {
-      wrapper = shallowMount(
-        Registration,
-        {
-          localVue,
-          store: mockStore.createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+    it("displays warning notices if judging is enabled", () => {
+      wrapper = shallowMount(Registration, {
+        localVue,
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-          }).store,
-        }
-      )
+          },
+        }).store,
+      });
 
-      const notices = wrapper.findAll('.notice')
+      const notices = wrapper.findAll(".notice");
 
-      expect(wrapper.vm.judgingEnabled).toBe(true)
-      expect(notices.length).toEqual(2)
+      expect(wrapper.vm.judgingEnabled).toBe(true);
+      expect(notices.length).toEqual(2);
       notices.wrappers.forEach((notice) => {
-        const props = notice.find(Icon).props()
+        const props = notice.find(Icon).props();
 
         expect(props).toEqual(
           expect.objectContaining({
-            name: 'exclamation-circle',
+            name: "exclamation-circle",
             size: 16,
-            color: '00529B',
+            color: "00529B",
           })
-        )
-      })
-    })
-
-  })
-
-})
+        );
+      });
+    });
+  });
+});

--- a/spec/javascript/admin/content-settings/store/index.spec.js
+++ b/spec/javascript/admin/content-settings/store/index.spec.js
@@ -1,16 +1,15 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import Vue from "vue";
+import Vuex from "vuex";
 
-import state from 'admin/content-settings/store/state'
-import getters from 'admin/content-settings/store/getters'
-import mutations from 'admin/content-settings/store/mutations'
-import actions from 'admin/content-settings/store/actions'
+import state from "admin/content-settings/store/state";
+import getters from "admin/content-settings/store/getters";
+import mutations from "admin/content-settings/store/mutations";
+import actions from "admin/content-settings/store/actions";
 
-Vue.use(Vuex)
+Vue.use(Vuex);
 
-describe('Admin Content & Settings - Vuex store', () => {
-
-  let store
+describe("Admin Content & Settings - Vuex store", () => {
+  let store;
 
   beforeEach(() => {
     store = new Vuex.Store({
@@ -18,53 +17,55 @@ describe('Admin Content & Settings - Vuex store', () => {
       getters,
       mutations,
       actions,
-    })
-  })
+    });
+  });
 
-  it('returns the initial state used by the AdminDashboard component', () => {
+  it("returns the initial state used by the AdminDashboard component", () => {
     expect(state).toEqual({
+      is_super_admin: false,
       student_signup: 0,
       mentor_signup: 0,
       judge_signup: 0,
       chapter_ambassador_signup: 0,
-      student_dashboard_text: '',
-      mentor_dashboard_text: '',
-      judge_dashboard_text: '',
-      chapter_ambassador_dashboard_text: '',
+      student_dashboard_text: "",
+      mentor_dashboard_text: "",
+      judge_dashboard_text: "",
+      chapter_ambassador_dashboard_text: "",
       student_survey_link: {
-        text: '',
-        url: '',
-        long_desc: '',
+        text: "",
+        url: "",
+        long_desc: "",
       },
       mentor_survey_link: {
-        text: '',
-        url: '',
-        long_desc: '',
+        text: "",
+        url: "",
+        long_desc: "",
       },
       team_building_enabled: 0,
       team_submissions_editable: 0,
       select_regional_pitch_event: 0,
-      judging_round: 'off',
+      judging_round: "off",
       display_scores: 0,
-    })
-  })
+    });
+  });
 
-  describe('getters', () => {
+  describe("getters", () => {
+    describe("judgingEnabled", () => {
+      it("returns false if judging is not enabled", () => {
+        expect(store.state.judging_round).toEqual("off");
+        expect(store.getters.judgingEnabled).toBe(false);
+      });
 
-    describe('judgingEnabled', () => {
-
-      it('returns false if judging is not enabled', () => {
-        expect(store.state.judging_round).toEqual('off')
-        expect(store.getters.judgingEnabled).toBe(false)
-      })
-
-      it('returns true if judging is enabled', () => {
-        store.state.judging_round = 'qf'
-        expect(store.state.judging_round).toEqual('qf')
-        expect(store.getters.judgingEnabled).toBe(true)
-      })
-
-    })
-
-  })
-})
+      it("returns true if judging is enabled", () => {
+        store.state.judging_round = "qf";
+        expect(store.state.judging_round).toEqual("qf");
+        expect(store.getters.judgingEnabled).toBe(true);
+      });
+    });
+    describe("isSuperAdmin", () => {
+      it("returns false if admin is not a super admin", () => {
+        expect(store.state.is_super_admin).toBe(false);
+      });
+    });
+  });
+});

--- a/spec/system/admin/toggle_ui_spec.rb
+++ b/spec/system/admin/toggle_ui_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Admin UI for season toggles:", :js do
-  before { sign_in(FactoryBot.create(:admin)) }
+  before { sign_in(FactoryBot.create(:super_admin)) }
 
   scenario "toggle user signups" do
     %w{student mentor}.each do |scope|
-      
+
       SeasonToggles.disable_signup(scope)
 
       visit edit_admin_season_schedule_settings_path


### PR DESCRIPTION
Refs #4001 

This change will make the content and setting toggles only editable by super admin. Regular admin can click through all of the tabs, but the form inputs are disabled.

It was a little challenging to pass the super admin boolean from rails to the vue.js but found a similar pattern in the judge scores app. I passed the value as a data attribute and then committed it to the vue store so it was accessible in all of the child components. 

Note - the linter auto-updated a lot of the code style in the js tests 