### PR TITLE
Rebrand initial submission honor code for mentors and students

### DIFF
--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -178,7 +178,7 @@ module TeamSubmissionController
   def determine_layout
     if action_name == "new" ||
         action_name == "create"
-      "application"
+      "application_rebrand"
     else
       "submissions"
     end

--- a/app/views/team_submissions/_honor_code.en.html.erb
+++ b/app/views/team_submissions/_honor_code.en.html.erb
@@ -1,4 +1,4 @@
-<p>
+<p class="margin--b-large">
   Technovation Girls’ mission is to educate and empower 
   <%= link_to "young women", "https://www.technovation.org/diversity-equity-inclusion-statement/" %>
   to make a difference in their community using technology. In order to
@@ -7,7 +7,7 @@
   realizing this mission.
 </p>
 
-<p>
+<p class="margin--b-large">
   You promise that all elements of your team’s <%= Season.current.year %>
   Technovation Girls submission were created solely by the students
   on your <%= Season.current.year %> Technovation team. Exceptions: 
@@ -16,14 +16,14 @@
   made updates and improvements to the project during the current season.
 </p>
 
-<p>
+<p class="margin--b-large">
   Students and mentors promise that they may have received assistance 
   from mentors in learning new skills and finding resources, but that 
   mentors did not create, design, develop or write any aspect of the 
   team’s submission deliverables.
 </p>
 
-<p>
+<p class="margin--b-large">
   Finally, you or your team members agree to cite any sources you use, 
   such as tutorials, code libraries, code templates, datasets, and more 
   in the Learning Journey section of your submission.

--- a/app/views/team_submissions/new.en.html.erb
+++ b/app/views/team_submissions/new.en.html.erb
@@ -1,37 +1,37 @@
-<div class="grid grid--justify-space-around">
-  <div class="grid__col-sm-8">
-    <div class="panel panel--left">
-      <h1><%= Season.current.year %> Technovation Honor Code</h1>
+<div class="w-full lg:w-1/2 lg:mx-auto">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: {heading: "#{Season.current.year} Technovation Honor Code"} do %>
+    <%= form_with(
+          model: @team_submission,
+          url: send("#{current_scope}_team_submissions_path", @team_submission),
+          local: true
+        ) do |f| %>
 
-      <%= form_with(
-        model: @team_submission,
-        url: send("#{current_scope}_team_submissions_path", @team_submission),
-        local: true
-      ) do |f| %>
-        <%= hidden_field_tag :team_id, params[:team_id] %>
+      <%= hidden_field_tag :team_id, params[:team_id] %>
 
-        <div class="field">
+      <div class="mx-auto">
+        <div id="honor-code">
           <%= render "team_submissions/honor_code" %>
+        </div>
 
-          <p class="scent--strong">
-            By checking the box below, you confirm that each team member
-            has read and agreed to the statements above.
+        <div class="mb-4 border-l-2 border-energetic-blue bg-blue-50 p-2">
+          <p class="text-base">
+            By checking the box below, you confirm that each team member has read and agreed to the statements above.
           </p>
+        </div>
 
+        <div class="mb-4">
           <%= f.check_box :integrity_affirmed,
-            id: :team_submission_integrity_affirmed %>
+                          id: :team_submission_integrity_affirmed %>
 
           <%= f.label :integrity_affirmed,
-            "OUR TEAM AGREES TO ABIDE BY THIS HONOR CODE",
-            for: :team_submission_integrity_affirmed %>
+                      "OUR TEAM AGREES TO ABIDE BY THIS HONOR CODE",
+                      for: :team_submission_integrity_affirmed %>
         </div>
 
-        <div class="actions">
-          <p>
-            <%= f.submit "Start now!", class: "button" %>
-          </p>
+        <div class="flex justify-center">
+          <p><%= f.submit "Start now!", class: "tw-green-btn cursor-pointer" %></p>
         </div>
-      <% end %>
-    </div>
-  </div>
+      </div>
+    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
Refs #4022 

This change rebrands the initial student submission honor code. The rebranded honor code will also display for mentors if they are the participant that starts the submission.

![CleanShot 2023-06-13 at 14 54 42](https://github.com/Iridescent-CM/technovation-app/assets/29210380/65866344-ac8c-40ef-bf6a-8a9fb9425e7f)
