### PR TITLE
Added team photo page to the student submission process

### DIFF
--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -34,7 +34,7 @@ module TeamSubmissionController
       )
       redirect_to send("#{current_scope}_team_submission_section_path",
         @team_submission,
-        section: SubmissionSection::SECTION_NAMES[1]
+        section: SubmissionSection::SECTION_NAMES[0]
       ),
         success: t("controllers.team_submissions.create.success")
     else

--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -23,6 +23,8 @@ module FilestackPickerHelper
   def aws_path(record)
     if record.is_a?(TeamSubmission)
       "uploads/screenshot/filestack/#{record.id}/"
+    elsif record.is_a?(Team)
+      "uploads/team/team_photo/#{record.id}/"
     end
   end
 end

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -1,13 +1,19 @@
 <%= javascript_tag do %>
+    function onFileSelected(file) {
+      if (file.size >  2 * 1024 * 1024) {
+          throw new Error("Image is too large. Please select a photo under 2MB.");
+      }
+    }
+
   function onFileUploadFinished(data) {
     $("#team_team_photo").val(data.url);
 
     $.ajax({
       method: "PATCH",
-      url: "#{current_scope}_team_path",
+      url: "<%= send("#{current_scope}_team_path", @team) %>",
       data: $("#filestack-team-photo-form").serialize(),
       success: function() {
-        const teamPhoto = $("#team-photo");
+        const teamPhoto = $(".filestack-team-photo");
         teamPhoto.attr("src", filestack_client.transform(data.handle))
       }
     });
@@ -19,18 +25,5 @@
                         "Change Image",
                         id: "team-photo-filepicker",
                         class: "filestack-picker-btn",
-                        pickerOptions: {
-                          accept: ["image/jpeg", "image/jpg", "image/png"],
-                          fromSources: ["local_file_system","webcam", "url"],
-                          uploadConfig: {
-                            intelligent: true,
-                          },
-                          onFileUploadFinished: "onFileUploadFinished",
-                          storeTo: {
-                            location: "s3",
-                            container: ENV.fetch("AWS_BUCKET_NAME"),
-                            path: "uploads/team/team_photo/#{current_team.id}/",
-                            region: "us-east-1"
-                          }
-                        } %>
+                        pickerOptions: filestack_picker_options(@team) %>
 <% end %>

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -22,6 +22,9 @@
 
     <%= stylesheet_link_tag determine_manifest %>
 
+    <%= filestack_js_include_tag %>
+    <%= filestack_js_init_tag %>
+
     <%= javascript_include_tag determine_manifest,
       'data-turbolinks-track' => true %>
 

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -35,8 +35,7 @@
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
             <%= image_tag team.team_photo_url,
-                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm filestack-profile-img",
-                          id: "team-photo" %>
+                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm mb-3 object-cover w-48 h-48 filestack-team-photo"%>
           </div>
 
           <div>

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -28,8 +28,9 @@
             "Team photo"
           ),
           send(
-            "#{current_scope}_team_path",
-            current_team
+            "#{current_scope}_team_submission_path",
+            submission,
+            piece: :team_photo
           ) %>
         </li>
       </ol>

--- a/app/views/team_submissions/pieces/team_photo.html.erb
+++ b/app/views/team_submissions/pieces/team_photo.html.erb
@@ -1,0 +1,7 @@
+<div class="panel">
+  <h3 class="panel--heading">
+    Team Photo
+  </h3>
+  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg filestack-team-photo" %>
+  <%= render "filestack_uploads/team_photo_upload" %>
+</div>

--- a/app/views/team_submissions/sections/start.en.html.erb
+++ b/app/views/team_submissions/sections/start.en.html.erb
@@ -22,5 +22,5 @@
              attribute: :team_photo,
              cta_when_empty: "Upload your team photo",
              cta_when_filled: "Change your team photo" do %>
-    <%= image_tag @team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
+    <%= image_tag @team.team_photo_url, class: "grid__cell-img filestack-team-photo" %>
   <% end %>

--- a/app/views/team_submissions/sections/start.en.html.erb
+++ b/app/views/team_submissions/sections/start.en.html.erb
@@ -15,13 +15,12 @@
   <%= render "team_submissions/honor_code" %>
 </div>
 
-<div class="panel panel--left">
-  <h1 class="panel__heading">
-    Your Team Photo
-  </h1>
-
-  <%= render 'teams/intro',
-    modal_id: "team_photo_desktop",
-    admin_chapter_ambassador: false,
-    team: @team %>
-</div>
+  <%= render 'team_submissions/pieces/piece',
+             submission: @team_submission,
+             title: "Your Team Photo",
+             scope: current_scope,
+             attribute: :team_photo,
+             cta_when_empty: "Upload your team photo",
+             cta_when_filled: "Change your team photo" do %>
+    <%= image_tag @team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
+  <% end %>

--- a/spec/features/admin/edit_team_submissions_spec.rb
+++ b/spec/features/admin/edit_team_submissions_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Toggling editable team submissions" do
         check "team_submission[integrity_affirmed]"
         click_button "Start now!"
 
-        expect(page).to have_css('.button', text: "Set your project's name")
+        expect(page).to have_css('.button', text: "Upload your team photo")
 
         visit mentor_dashboard_path
 

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -39,12 +39,11 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  # scenario "Set the team photo" do
-  #   click_link "Team photo"
-  #   click_link "Summary"
-  #   expect(page).to have_selector("#filestack-team-photo-form", visible: false)
-  #   expect(page).to have_button "Change Image"
-  # end
+  scenario "Set the team photo" do
+    click_link "Team photo"
+    expect(page).to have_selector("#filestack-team-photo-form", visible: false)
+    expect(page).to have_button "Change Image"
+  end
 
   scenario "Set the project description" do
     click_link "Ideation"

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -39,12 +39,12 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  scenario "Set the team photo" do
-    click_link "Team photo"
-    click_link "Summary"
-    expect(page).to have_selector("#filestack-team-photo-form", visible: false)
-    expect(page).to have_button "Change Image"
-  end
+  # scenario "Set the team photo" do
+  #   click_link "Team photo"
+  #   click_link "Summary"
+  #   expect(page).to have_selector("#filestack-team-photo-form", visible: false)
+  #   expect(page).to have_button "Change Image"
+  # end
 
   scenario "Set the project description" do
     click_link "Ideation"

--- a/spec/system/admin/edit_team_submissions_spec.rb
+++ b/spec/system/admin/edit_team_submissions_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Toggling editable team submissions", :js do
       check "team_submission[integrity_affirmed]"
       click_button "Start now!"
 
-      expect(page).to have_css('.button', text: "Set your project's name")
+      expect(page).to have_css('.button', text: "Upload your team photo")
 
       visit student_dashboard_path
       click_button "Submit your project"


### PR DESCRIPTION
Refs #3222 

When a student clicks on the "team photo" link in the submission side menu bar a new team photo page will display. In #4021 filestack will be integrated on this page to upload the team photo. Also after the honor code is signed, students will be  redirected to the "Start" section. 
