### PR TITLE
Add missing migration for mentor types work

### DIFF
--- a/db/migrate/20230613163115_remove_mentor_type_from_signup_attempts.rb
+++ b/db/migrate/20230613163115_remove_mentor_type_from_signup_attempts.rb
@@ -1,0 +1,5 @@
+class RemoveMentorTypeFromSignupAttempts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :signup_attempts, :mentor_type
+  end
+end


### PR DESCRIPTION
I forgot to add this migration which is to remove `mentor_type` from the `signup_attempts` table.



