### PR TITLE
Update team submission friendly id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "country_state_select", "~> 3.0"
 
 gem "nokogiri", "~> 1.11.0"
 
-gem "friendly_id", "~> 5.4"
+gem "friendly_id", "~> 5.5"
 
 gem "bcrypt", "~> 3.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.3.0)
-    friendly_id (5.4.2)
+    friendly_id (5.5.0)
       activerecord (>= 4.0.0)
     geocoder (1.4.9)
     gibbon (3.4.4)
@@ -576,7 +576,7 @@ DEPENDENCIES
   filestack-rails
   flag_shih_tzu (~> 0.3)
   fog-aws (~> 1.4)
-  friendly_id (~> 5.4)
+  friendly_id (~> 5.5)
   geocoder (~> 1.4.9)
   gibbon (~> 3.4.4)
   hiredis (~> 0.6)

--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -18,7 +18,7 @@ module Admin
       @team_submission = TeamSubmission.friendly.find(params[:id])
 
       if @team_submission.update(team_submission_params)
-        redirect_to admin_team_submission_path,
+        redirect_to admin_team_submission_path(@team_submission),
         success: "Submission has been updated"
       else
         flash.now[:alert] = if @team_submission.errors.full_messages

--- a/app/models/submissions/required_fields.rb
+++ b/app/models/submissions/required_fields.rb
@@ -82,7 +82,7 @@ end
 
 class RequiredAppNameField < RequiredField
   def blank?
-    value.blank? || value == "(no name yet)"
+    value.blank? || value == TeamSubmission::DEFAULT_APP_NAME
   end
 end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,6 +10,8 @@ class Team < ActiveRecord::Base
 
   include PublicActivity::Common
 
+  after_commit :regenerate_team_submission_friendly_id
+
   after_commit -> {
     return false if destroyed?
 
@@ -410,6 +412,12 @@ class Team < ActiveRecord::Base
   end
 
   private
+
+  def regenerate_team_submission_friendly_id
+    if saved_change_to_name? && !submission.is_a?(NullTeamSubmission)
+      submission.update(slug: nil)
+    end
+  end
 
   def default_team_photo_url
     if Season.current.year >= 2023 && current?

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -44,7 +44,7 @@ class TeamSubmission < ActiveRecord::Base
   acts_as_paranoid
 
   extend FriendlyId
-  friendly_id :team_name_and_app_name,
+  friendly_id :project_name_by_team_name,
     use: :scoped,
     scope: :deleted_at
 
@@ -641,7 +641,7 @@ class TeamSubmission < ActiveRecord::Base
     return url
   end
 
-  def team_name_and_app_name
+  def project_name_by_team_name
     "#{app_name} by #{team_name}"
   end
 

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -642,9 +642,11 @@ class TeamSubmission < ActiveRecord::Base
   end
 
   def team_name_and_app_name
-    [
-      [:app_name, :team_name, :slug]
-    ]
+    "#{app_name} by #{team_name}"
+  end
+
+  def should_generate_new_friendly_id?
+    app_name_changed? || team.name_changed? || super
   end
 
   def copy_possible_thunkable_url

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -4,6 +4,7 @@ class TeamSubmission < ActiveRecord::Base
   MAX_SCREENSHOTS_ALLOWED = 6
   PARTICIPATION_MINIMUM_PERCENT = 50
 
+  DEFAULT_APP_NAME = "(no name yet)"
   MOBILE_APP_SUBMISSION_TYPE = "Mobile App"
   AI_PROJECT_SUBMISSION_TYPE = "AI Project"
 
@@ -472,7 +473,7 @@ class TeamSubmission < ActiveRecord::Base
 
   def app_name
     if (self[:app_name] || "").strip.blank?
-      "(no name yet)"
+      TeamSubmission::DEFAULT_APP_NAME
     else
       self[:app_name].strip
     end

--- a/app/null_objects/null_team_submission.rb
+++ b/app/null_objects/null_team_submission.rb
@@ -14,7 +14,7 @@ class NullTeamSubmission < NullObject
   end
 
   def app_name
-    "not started"
+    TeamSubmission::DEFAULT_APP_NAME
   end
   alias :name :app_name
 

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     trait :live_event_eligible do
-      team_submissions { build_list :submission, 1 }
+      team_submissions { create_list :submission, 1 }
     end
 
     trait :not_live_event_eligible do

--- a/spec/tasks/import_scores_spec.rb
+++ b/spec/tasks/import_scores_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Tasks: rails import_scores" do
                                     team: team)
 
     headers = %w{team_submission_id ideation_1}
-    rows = [%w{hello-world 4}]
+    rows = [%w{hello-by-world 4}]
 
     CSV.open("./tmp/test.csv", "wb") do |csv|
       csv << headers


### PR DESCRIPTION
Brief overview of the changes in this PR:
- Making it so that if the submission name or team name changes, it will regenerate the slug
- Restoring the default slug name, so it will be "app-name-by-team-name"
- Updating the FriendlyId gem
  - [Changelog](https://github.com/norman/friendly_id/blob/master/Changelog.md)