### PR TITLE
Update migration for mentor type conversion

### DIFF
--- a/db/migrate/20230609190316_convert_mentor_type_to_mentor_types.rb
+++ b/db/migrate/20230609190316_convert_mentor_type_to_mentor_types.rb
@@ -4,9 +4,10 @@ class ConvertMentorTypeToMentorTypes < ActiveRecord::Migration[6.1]
 
     MentorProfile.find_each do |mentor_profile|
       if mentor_profile.mentor_type.present?
-        mentor_profile.mentor_types << mentor_types[mentor_profile.mentor_type]
-
-        mentor_profile.save
+        MentorProfileMentorType.create!(
+          mentor_profile_id: mentor_profile.id,
+          mentor_type_id: mentor_types[mentor_profile.mentor_type].id
+        )
       end
     end
 


### PR DESCRIPTION
This a slight tweak to how `mentor_type` will get converted to "mentor types", I tried the migration locally w/ production data and it was taking too long, I let it run for 15mins and then I stopped it, realizing this wasn't going to be ideal. So, this change, instead of going through `MentorProfile`, we'll now add the new mentor types by using `MentorProfileMentorTypes` directly. This new way should take less than a minute to run.

if you wan to test this locally, here's what I did:
- `git checkout 044e2fc53` (a commit before this work was introduced)
- Reset database `bundle exec rails db:drop db:setup`
- Import production data
- `git checkout 4013-update-migration-for-mentor-type-conversion`
- Run migrations `bundle exec rails db:migrate`
