### PR TITLE
4021 add filestack to team photo submissions

### DIFF
--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -23,6 +23,8 @@ module FilestackPickerHelper
   def aws_path(record)
     if record.is_a?(TeamSubmission)
       "uploads/screenshot/filestack/#{record.id}/"
+    elsif record.is_a?(Team)
+      "uploads/team/team_photo/#{record.id}/"
     end
   end
 end

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -25,18 +25,5 @@
                         "Change Image",
                         id: "team-photo-filepicker",
                         class: "filestack-picker-btn",
-                        pickerOptions: {
-                          accept: ["image/jpeg", "image/jpg", "image/png"],
-                          fromSources: ["local_file_system","webcam", "url"],
-                          uploadConfig: {
-                            intelligent: true,
-                          },
-                          onFileUploadFinished: "onFileUploadFinished",
-                          storeTo: {
-                            location: "s3",
-                            container: ENV.fetch("AWS_BUCKET_NAME"),
-                            path: "uploads/team/team_photo/#{current_team.id}/",
-                            region: "us-east-1"
-                          }
-                        } %>
+                        pickerOptions: filestack_picker_options(@team) %>
 <% end %>

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -1,4 +1,10 @@
 <%= javascript_tag do %>
+    function onFileSelected(file) {
+      if (file.size >  2 * 1024 * 1024) {
+          throw new Error("Image is too large. Please select a photo under 2MB.");
+      }
+    }
+
   function onFileUploadFinished(data) {
     $("#team_team_photo").val(data.url);
 

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -13,7 +13,7 @@
       url: "<%= send("#{current_scope}_team_path", @team) %>",
       data: $("#filestack-team-photo-form").serialize(),
       success: function() {
-        const teamPhoto = $("#team-photo");
+        const teamPhoto = $(".filestack-team-photo");
         teamPhoto.attr("src", filestack_client.transform(data.handle))
       }
     });

--- a/app/views/filestack_uploads/_team_photo_upload.en.html.erb
+++ b/app/views/filestack_uploads/_team_photo_upload.en.html.erb
@@ -10,7 +10,7 @@
 
     $.ajax({
       method: "PATCH",
-      url: "#{current_scope}_team_path",
+      url: "<%= send("#{current_scope}_team_path", @team) %>",
       data: $("#filestack-team-photo-form").serialize(),
       success: function() {
         const teamPhoto = $("#team-photo");

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -22,6 +22,9 @@
 
     <%= stylesheet_link_tag determine_manifest %>
 
+    <%= filestack_js_include_tag %>
+    <%= filestack_js_init_tag %>
+
     <%= javascript_include_tag determine_manifest,
       'data-turbolinks-track' => true %>
 

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -35,8 +35,7 @@
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
             <%= image_tag team.team_photo_url,
-                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm filestack-profile-img",
-                          id: "team-photo" %>
+                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm filestack-profile-img filestack-team-photo"%>
           </div>
 
           <div>

--- a/app/views/student/teams/_summary.en.html.erb
+++ b/app/views/student/teams/_summary.en.html.erb
@@ -35,7 +35,7 @@
         <div class="ml-4 flex flex-col items-center content-start">
           <div>
             <%= image_tag team.team_photo_url,
-                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm filestack-profile-img filestack-team-photo"%>
+                          class: "max-w-full h-auto mb-4 rounded-tl-sm rounded-tr-3xl rounded-bl-3xl rounded-br-sm mb-3 object-cover w-48 h-48 filestack-team-photo"%>
           </div>
 
           <div>

--- a/app/views/team_submissions/pieces/team_photo.erb
+++ b/app/views/team_submissions/pieces/team_photo.erb
@@ -1,0 +1,6 @@
+<div class="panel">
+  <h3 class="panel--heading">
+    Team Photo
+  </h3>
+  <%= image_tag @team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
+</div>

--- a/app/views/team_submissions/pieces/team_photo.erb
+++ b/app/views/team_submissions/pieces/team_photo.erb
@@ -1,6 +1,0 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    Team Photo
-  </h3>
-  <%= image_tag @team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
-</div>

--- a/app/views/team_submissions/pieces/team_photo.html.erb
+++ b/app/views/team_submissions/pieces/team_photo.html.erb
@@ -1,0 +1,7 @@
+<div class="panel">
+  <h3 class="panel--heading">
+    Team Photo
+  </h3>
+  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg", id: "team-photo" %>
+  <%= render "filestack_uploads/team_photo_upload" %>
+</div>

--- a/app/views/team_submissions/pieces/team_photo.html.erb
+++ b/app/views/team_submissions/pieces/team_photo.html.erb
@@ -2,6 +2,6 @@
   <h3 class="panel--heading">
     Team Photo
   </h3>
-  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg", id: "team-photo" %>
+  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg filestack-team-photo" %>
   <%= render "filestack_uploads/team_photo_upload" %>
 </div>

--- a/app/views/team_submissions/sections/start.en.html.erb
+++ b/app/views/team_submissions/sections/start.en.html.erb
@@ -22,5 +22,5 @@
              attribute: :team_photo,
              cta_when_empty: "Upload your team photo",
              cta_when_filled: "Change your team photo" do %>
-    <%= image_tag @team.team_photo_url, class: "grid__cell-img", id: "team-photo" %>
+    <%= image_tag @team.team_photo_url, class: "grid__cell-img filestack-team-photo" %>
   <% end %>

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -39,12 +39,11 @@ RSpec.feature "Students edit submission pieces" do
     end
   end
 
-  # scenario "Set the team photo" do
-  #   click_link "Team photo"
-  #   click_link "Summary"
-  #   expect(page).to have_selector("#filestack-team-photo-form", visible: false)
-  #   expect(page).to have_button "Change Image"
-  # end
+  scenario "Set the team photo" do
+    click_link "Team photo"
+    expect(page).to have_selector("#filestack-team-photo-form", visible: false)
+    expect(page).to have_button "Change Image"
+  end
 
   scenario "Set the project description" do
     click_link "Ideation"


### PR DESCRIPTION
Refs #4021 

This is the 2nd part of #3222. This PR adds the filestack file picker to the team photo page. The team photo image size will be standardized when we complete the submission rebrand as part of #4025. 
<img width="1393" alt="CleanShot 2023-06-21 at 20 36 43@2x" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/4c6c6b8a-3d88-470a-b686-89afb35f5968">
