### PR TITLE
4054 text changes for certs 2023

### DIFF
--- a/app/views/judge/dashboards/not_onboarded/_dashboard.en.html.erb
+++ b/app/views/judge/dashboards/not_onboarded/_dashboard.en.html.erb
@@ -1,0 +1,9 @@
+<div class="relative">
+  <% if SeasonToggles.judging_finished? %>
+      <%= render 'judge/dashboards/not_onboarded/judging_finished' %>
+  <% else %>
+    <div class="mb-4">
+      <p>To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training.</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/judge/dashboards/not_onboarded/_judging_finished.html.erb
+++ b/app/views/judge/dashboards/not_onboarded/_judging_finished.html.erb
@@ -1,0 +1,15 @@
+<div class="absolute -top-2 -right-6">
+  <span class="block mb-2 px-2 py-1 text-right text-sm font-bold tw-flag-magenta">Season close</span>
+</div>
+
+<h2 class="text-2xl text-energetic-blue font-semibold tracking-wide mb-2">
+  Thank you!
+</h2>
+
+<p class="mb-3">
+  Thank you for your interest in judging this season. The season is currently finished.
+</p>
+
+<p>
+  We hope to see you next season!
+</p>

--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -14,9 +14,7 @@
            <% if current_judge.onboarded? %>
             <%= render 'judge/dashboards/onboarded/dashboard' %>
           <% else %>
-            <div class="mb-4">
-              <p>To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training.</p>
-            </div>
+            <%= render 'judge/dashboards/not_onboarded/dashboard' %>
           <% end %>
         </div>
         <% if current_judge.onboarded? %>

--- a/app/views/student/scores/_certificates.html.erb
+++ b/app/views/student/scores/_certificates.html.erb
@@ -13,7 +13,7 @@
     <a class="tw-link" target="_blank" href="https://www.facebook.com/technovationglobal">Facebook</a>,
     <a class="tw-link" target="_blank" href="https://www.instagram.com/technovationglobal">Instagram</a>, or
     <a class="tw-link" target="_blank" href="https://www.linkedin.com/company/technovation">LinkedIn</a>
-    with #Technovation2022Alumna and tag Technovation!
+    with <%= "#Technovation#{Season.current.year}Alumna" %> and tag Technovation!
   </p>
 
   <p class="my-4">

--- a/lib/fill_pdfs/quarterfinalist.rb
+++ b/lib/fill_pdfs/quarterfinalist.rb
@@ -5,7 +5,7 @@ module FillPdfs
     include FillPdfs
 
     def full_text
-      "For their outstanding work as a member of Technovation #{recipient.region}, #{recipient.team_name}, to develop the project #{recipient.mobile_app_name} in the #{recipient.season} season."
+      "For their outstanding work as a member of Technovation #{recipient.region},team #{recipient.team_name}, to develop the project #{recipient.mobile_app_name} in the #{recipient.season} season."
     end
   end
 end

--- a/lib/fill_pdfs/quarterfinalist.rb
+++ b/lib/fill_pdfs/quarterfinalist.rb
@@ -5,7 +5,7 @@ module FillPdfs
     include FillPdfs
 
     def full_text
-      "For their outstanding work as a member of Technovation #{recipient.region},team #{recipient.team_name}, to develop the project #{recipient.mobile_app_name} in the #{recipient.season} season."
+      "For their outstanding work as a member of Technovation #{recipient.region}, team #{recipient.team_name}, to develop the project #{recipient.mobile_app_name} in the #{recipient.season} season."
     end
   end
 end

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -72,15 +72,14 @@ RSpec.feature "Judge certificates" do
     expect(page).to have_content("Certificates are currently unavailable.")
   end
 
-  scenario "non-onboarded judges see no certificates or badge" do
+  scenario "non-onboarded judges see no certificates when judging is set to finished" do
+    SeasonToggles.set_judging_round(:finished)
     SeasonToggles.display_scores_on!
 
     judge = FactoryBot.create(:judge)
-
-    FillPdfs.(judge.account)
     sign_in(judge)
 
-    expect(page).to have_content("To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training.")
+    expect(page).to have_content("Thank you for your interest in judging this season. The season is currently finished.")
     expect(page).not_to have_link("Your judge certificate")
   end
 

--- a/spec/features/student/certificates_spec.rb
+++ b/spec/features/student/certificates_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature "Student certificates" do
 
       click_link("View your scores and certificate")
       expect(page).to have_content("Congratulations, your team was a quarterfinalist!")
+      expect(page).to have_content("#Technovation#{Season.current.year}Alumna")
 
       click_link("Certificates")
       expect(page).to have_link(


### PR DESCRIPTION
Refs #4054 

- I updated the student certificate page social media hashtag to be dynamic and use the current season year so we will not have to update it manually (unless the entire hashtag changes).
- I did a basic refactor for the not_onboarded judges. When the season is set to finished they will see the following screen (text can be edited if needed)
![CleanShot 2023-06-26 at 11 05 02@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/4924c840-998b-40f3-9112-44560515f3dd)

- During other parts of the season if they have not completed onboarding they will still see the "To be able to judge submissions online this season, make sure to complete the items on the left: Consent Waiver and Judge Training." text

