### PR TITLE
Added custom message in filestack picker

### DIFF
--- a/app/helpers/filestack_picker_helper.rb
+++ b/app/helpers/filestack_picker_helper.rb
@@ -5,6 +5,9 @@ module FilestackPickerHelper
       uploadConfig: {
         intelligent: true
       },
+      customText: {
+        "Select Files to Upload": "Select Files to Upload (Max 2MB)"
+      },
       maxSize: 2 * 1024 * 1024, # 2 MB LIMIT
       fromSources: ["local_file_system"],
       onFileSelected: "onFileSelected",


### PR DESCRIPTION
Refs #4056 

This PR adds custom text to the filestack picker. I was unable to recreate the bug. The error message is always displayed when uploading an image larger than 2MB. If you scroll to the bottom of the page and then upload an image through the picker, you cannot see the error message since it is at the top of the page. Since this is filestack default styling, I don't think there is a way to lower the error message. 

![CleanShot 2023-06-27 at 16 06 07@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/bc3ea2fd-fba5-4451-a439-884a22c89cc0)
