### PR TITLE
Update rake task that generates certs in batches

### DIFF
--- a/lib/tasks/award_certificates.rake
+++ b/lib/tasks/award_certificates.rake
@@ -35,7 +35,7 @@ namespace :certificates do
   task :award_batch_direct, [:starting_id, :batch_size] => :environment do |t, args|
     accounts = Account.current
       .where("id > ?", args[:starting_id])
-      .first(args[:batch_size])
+      .first(args[:batch_size].to_i)
 
     accounts.each do |account|
       award_to(account)


### PR DESCRIPTION
I ran into an error running this rake task:
```
ArgumentError: comparison of String with 0 failed
```

I found that `batch_size` needs to be converted to an integer for it to work.



