### PR TITLE
Remove lingering student/parent email validation

### DIFF
--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -269,7 +269,7 @@ class StudentProfile < ActiveRecord::Base
 
   def media_consent_signed?
     !!media_consent && media_consent.signed?
-  end  
+  end
 
   def can_search_teams?
     SeasonToggles.team_building_enabled? and
@@ -382,14 +382,6 @@ class StudentProfile < ActiveRecord::Base
         !parent_guardian_email_changed? &&
         parent_guardian_email == ParentalConsent::PARENT_GUARDIAN_EMAIL_ADDDRESS_FOR_A_PAPER_CONSENT
       )
-
-    if Account.joins(:student_profile, :division)
-        .where("lower(email) = ?", parent_guardian_email.downcase)
-        .where.not(division: {name: "beginner"})
-        .any?
-
-      errors.add(:parent_guardian_email, :found_in_student_accounts)
-    end
 
     if not parent_guardian_email.match(
       /^[^@\.][\w\.\-]+(?:\+?[\w\.\-]+)?@[\w\.\-]+\w+$/

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -40,7 +40,6 @@ en:
         student_profile:
           attributes:
             parent_guardian_email:
-              found_in_student_accounts: "cannot match any other student's email address"
               invalid: "does not appear to be an email address"
               matches_student_email: "cannot match any other student's email address"
 

--- a/config/locales/activerecord.es-MX.yml
+++ b/config/locales/activerecord.es-MX.yml
@@ -42,7 +42,6 @@ es-MX:
         student_profile:
           attributes:
             parent_guardian_email:
-              found_in_student_accounts: "no puede ser igual al correo electrónico de otro estudiante"
               invalid: "parece no ser una dirección de correo válida"
               matches_student_email: "no puede ser el mismo que tu correo electrónico"
 

--- a/spec/models/student_profile_spec.rb
+++ b/spec/models/student_profile_spec.rb
@@ -143,57 +143,6 @@ RSpec.describe StudentProfile do
         "does not appear to be an email address"
       )
     end
-
-    it "doesn't allow a senior student's email address to be used as another student's parent/guardian email address" do
-      FactoryBot.create(
-        :student,
-        :senior,
-        account: FactoryBot.create(:account, email: "senior_student@test.com")
-      )
-      another_student = FactoryBot.build(
-        :student_profile,
-        parent_guardian_email: "senior_student@test.com"
-      )
-
-      expect(another_student).to be_invalid
-      expect(another_student.errors[:parent_guardian_email]).to include(
-        "cannot match any other student's email address"
-      )
-    end
-
-    it "doesn't allow a junior student's email address to be used as another student's parent/guardian email address" do
-      FactoryBot.create(
-        :student,
-        :junior,
-        account: FactoryBot.create(:account, email: "junior_student@test.com")
-      )
-      another_student = FactoryBot.build(
-        :student_profile,
-        parent_guardian_email: "junior_student@test.com"
-      )
-
-      expect(another_student).to be_invalid
-      expect(another_student.errors[:parent_guardian_email]).to include(
-        "cannot match any other student's email address"
-      )
-    end
-
-    it "allows a beginner parent's email address to be used as another student's parent/guardian email address" do
-      FactoryBot.create(
-        :student,
-        :beginner,
-        account: FactoryBot.create(:account, email: "parent_of_beginner@test.com")
-      )
-      another_student = FactoryBot.build(
-        :student_profile,
-        parent_guardian_email: "parent_of_beginner@test.com"
-      )
-
-      expect(another_student).to be_valid
-      expect(another_student.errors[:parent_guardian_email]).not_to include(
-        "cannot match your (or any other student's) email address"
-      )
-    end
   end
 
   it "allows ON FILE as the email ONLY by admin action" do

--- a/spec/requests/student/profile_requests_spec.rb
+++ b/spec/requests/student/profile_requests_spec.rb
@@ -68,16 +68,6 @@ RSpec.describe "Student Profile Requests", type: :request do
       end
     end
 
-    context "when a student already has an email address that's the same as their parent's email address, and they try to update their profile" do
-      it "renders the parental consent form" do
-        student_account.update_column(:email, parent_guardian_email_address)
-
-        patch student_profile_path, params: params, headers: headers
-
-        expect(response).to render_template("student/parental_consent_notices/new")
-      end
-    end
-
     context "when a student is trying to change their email address without providing their existing password" do
       let(:params) do
         {


### PR DESCRIPTION
This validation was causing the issue w/ junior and senior students not being able to create a new team.