### PR TITLE
Update Thunkable URL format validation

### DIFF
--- a/app/validators/thunkable_share_url_validator.rb
+++ b/app/validators/thunkable_share_url_validator.rb
@@ -1,6 +1,6 @@
 class ThunkableShareUrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if !value.match(/^https?:\/\/x.thunkable.com\/projects\/.+$/)
+    if !value.match(/^https?:\/\/x.thunkable.com\/projectPage\/.+$/)
       record.errors.add(attribute, :invalid)
     end
   end

--- a/spec/features/mentor/submission_dev_platform_spec.rb
+++ b/spec/features/mentor/submission_dev_platform_spec.rb
@@ -51,20 +51,20 @@ RSpec.feature "Mentors edit submission development platform" do
     click_button "Save"
 
     expect(page).to have_css(
-      ".field_with_errors #team_submission_thunkable_project_url",
+      ".field_with_errors #team_submission_thunkable_project_url"
     )
 
     fill_in "What is the email address of your team's Thunkable account (optional)?",
       with: "our-team@thunkable.com"
 
     fill_in "What is the URL to your Thunkable project?",
-      with: "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+      with: "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
 
     click_button "Save"
 
     within(".development_platform.complete") do
       expect(page).to have_content "Thunkable"
-      expect(page).to have_link "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+      expect(page).to have_link "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
     end
   end
 end

--- a/spec/features/student/submission_dev_platform_spec.rb
+++ b/spec/features/student/submission_dev_platform_spec.rb
@@ -53,20 +53,20 @@ RSpec.feature "Students edit submission development platform" do
     click_button "Save"
 
     expect(page).to have_css(
-      ".field_with_errors #team_submission_thunkable_project_url",
+      ".field_with_errors #team_submission_thunkable_project_url"
     )
 
     fill_in "What is the email address of your team's Thunkable account (optional)?",
       with: "our-team@thunkable.com"
 
     fill_in "What is the URL to your Thunkable project?",
-      with: "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+      with: "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
 
     click_button "Save"
 
     within(".development_platform.complete") do
       expect(page).to have_content "Thunkable"
-      expect(page).to have_link "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+      expect(page).to have_link "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
     end
   end
 end

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -34,20 +34,20 @@ RSpec.describe TeamSubmission do
     submission.thunkable_project_url = "https://x.thunkable.com/not-projects/something"
     expect(submission).not_to be_valid
 
-    submission.thunkable_project_url = "https://not-an-x.thunkable.com/projects/abc123"
+    submission.thunkable_project_url = "https://not-an-x.thunkable.com/projectPage/abc123"
     expect(submission).not_to be_valid
 
-    submission.thunkable_project_url = "http://x.thunkable.com/projects/abc123"
+    submission.thunkable_project_url = "http://x.thunkable.com/projectPage/abc123"
     expect(submission).to be_valid
-    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projects/abc123")
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/abc123")
 
-    submission.thunkable_project_url = "x.thunkable.com/projects/abc123"
+    submission.thunkable_project_url = "x.thunkable.com/projectPage/abc123"
     expect(submission).to be_valid
-    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projects/abc123")
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/abc123")
 
-    submission.thunkable_project_url = "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+    submission.thunkable_project_url = "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
     expect(submission).to be_valid
-    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4")
+    expect(submission.thunkable_project_url).to eq("https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4")
   end
 
   describe "ACTIVE_DEVELOPMENT_PLATFORMS_ENUM" do

--- a/spec/system/submissions/upload_source_code_spec.rb
+++ b/spec/system/submissions/upload_source_code_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Uploading technical work to submissions", :js do
       end
 
       context "and development platform is Thunkable" do
-        let(:url) { "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4" }
+        let(:url) { "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4" }
 
         before do
           TeamSubmission.last.update!({
@@ -97,7 +97,7 @@ RSpec.describe "Uploading technical work to submissions", :js do
           with: "our-team@thunkable.com"
 
         fill_in "What is the URL to your Thunkable project?",
-          with: "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+          with: "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
 
         sleep 1
 
@@ -105,13 +105,13 @@ RSpec.describe "Uploading technical work to submissions", :js do
 
         within(".development_platform.complete") do
           expect(page).to have_content "Thunkable"
-          expect(page).to have_link "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+          expect(page).to have_link "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
         end
 
         click_link "Technical Elements"
 
         within(".source_code_url.complete") do
-          expect(page).to have_link "https://x.thunkable.com/projects/47d800b3aa47590210ad662249e63dd4"
+          expect(page).to have_link "https://x.thunkable.com/projectPage/47d800b3aa47590210ad662249e63dd4"
         end
       end
     end


### PR DESCRIPTION
Pretty simple change here, just changing `products` to `projectPage` in the Thunkable URLs.