### PR TITLE
Update Rack gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 ruby "3.1.2"
 
 gem "rails", "~> 6.1.0"
+gem "rack", "~> 2.2.0"
 
 gem "puma", "~> 4.3.12"
 gem "pg", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.7.1)
-    rack (2.2.4)
+    rack (2.2.7)
     rack-proxy (0.7.0)
       rack
     rack-rewrite (1.5.1)
@@ -607,6 +607,7 @@ DEPENDENCIES
   premailer-rails (~> 1.10)
   public_activity (~> 1.6)
   puma (~> 4.3.12)
+  rack (~> 2.2.0)
   rack-rewrite (~> 1.5)
   rack-timeout (~> 0.5)
   rails (~> 6.1.0)


### PR DESCRIPTION
This will update the Rack gem from 2.2.4 to 2.2.7 to address the security vulnerabilities listed in #4087.