### PR TITLE
Updated mentor type logic to display all of mentor's mentor types not just the types that are filtered

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -21,7 +21,7 @@ class AccountsGrid
 
   column :mentor_types do
     if mentor_profile.present?
-      mentor_profile.mentor_types.pluck(:name).join(",")
+      mentor_profile.mentor_profile_mentor_types.joins(:mentor_type).pluck(:name).join(", ")
     else
       "-"
     end


### PR DESCRIPTION
Refs #4030 

Updated mentor type logic to display all of the mentor's mentor types, not just the types that are filtered. This is based on feedback from VET 