### PR TITLE
Update PDFKit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem "loofah", "~> 2.2"
 
 gem "dotenv-rails", "~> 2.7"
 
-gem "pdfkit", "0.8.4.3.2"
+gem "pdfkit", "~> 0.8.7.0"
 
 gem "gibbon", "~> 3.4.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pdfkit (0.8.4.3.2)
+    pdfkit (0.8.7.3)
     pg (1.2.3)
     pp_sql (0.2.10)
       anbt-sql-formatter (~> 0.0.6)
@@ -598,7 +598,7 @@ DEPENDENCIES
   paranoia (~> 2.4)
   pdf-forms (~> 1.2)
   pdf-reader (~> 2.4)
-  pdfkit (= 0.8.4.3.2)
+  pdfkit (~> 0.8.7.0)
   pg (~> 1.2)
   pp_sql (~> 0.2)
   premailer-rails (~> 1.10)


### PR DESCRIPTION
PDFKit is used for the parental consent form that students can download in PDF format.

Should be a pretty safe upgrade, nothing really popping out to me in the changelog:
- https://github.com/pdfkit/pdfkit/releases

This will resolve the following (critical) security vulnerability:
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/96