### PR TITLE
Update loader-utils module

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6858,18 +6858,18 @@ loader-runner@^2.4.0:
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
 loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
 loader-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
This will update `loader-utils`, which has six security vulnerabilities (two that are critical), this **should** address:
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/98
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/97
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/103
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/102
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/100
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/99

I say **should** update, because... we have two version of `loader-utils` a `1.x.x` version and a `2.x.x` version, Dependabot says to update to `2.0.4` which I did, and I also updated our `1.x.x` version to `1.4.2` because Dependabot **also** says that this vulnerability is fixed in `1.4.2` (despite it saying to update to version `2.0.4`), this can be seen in one of the Dependabot issues:
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/98

To address this, first, I tried removing `yarn.lock` and the `node_modules` directory, and reinstalling the modules and rebuilding `yarn.lock` in order to update `loader-utils`, but kept running into issues because most of our modules haven't been updated in years, which means a lot of breaking changes.

I ended up updating `loader-utils` manually by updating `yarn.lock`, probably not ideal, but in this case it seems simple enough and I ran across a couple of posts suggesting it:
https://stackoverflow.com/a/58142690
https://dev.to/ayc0/yarn-lock-how-to-update-it-1fa2