### PR TITLE
Update Chrome web drivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ group :test do
 
   gem "capybara", "~> 3.37"
   gem "capybara-email", "~> 3.0"
-  gem "webdrivers"
+  gem "selenium-webdriver"
   gem "rspec-rails", "~> 5.0"
   gem "rspec-retry"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,10 +515,6 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (4.6.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.17.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -614,6 +610,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0)
   rspec-retry
   sass-rails (~> 6.0)
+  selenium-webdriver
   sidekiq (~> 6.2)
   simple_form (~> 5.0)
   spring (~> 2.0)
@@ -627,7 +624,6 @@ DEPENDENCIES
   uglifier (~> 3.2)
   vcr (~> 6.1)
   web-console (~> 3.7)
-  webdrivers
   webmock (~> 3.17)
   webpacker (~> 5.x)
   will_paginate (~> 3.1)

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.3
 
 jobs:
   build:


### PR DESCRIPTION
Two fixes here related to Chrome web drivers:

1. Our CircleCI builds are failing when trying to install `ChromeDriver`:
```
Installed version of Google Chrome is 115.0.5790.98
curl: (22) The requested URL returned error: 404
```

This was fixed in version 1.4.3 of `browser-tools-orbs`:
`fix: ChromeDriver path and install location`

Related issue and fix:
https://github.com/CircleCI-Public/browser-tools-orb/issues/75

2. Our tests are failing with:
```
     Webdrivers::VersionError:
       Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html
```

Related issue with the fix I used (replacing `webdrivers` with `selenium-webdriver`):
https://github.com/titusfortner/webdrivers/issues/247