### PR TITLE
Changed order of pitch and demo video link on admin edit and project page so they are consistent

### DIFF
--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -22,8 +22,8 @@
       <div class="panel">
         <div>
           <h6>Pitch</h6>
-          <%= f.input :demo_video_link %>
           <%= f.input :pitch_video_link %>
+          <%= f.input :demo_video_link %>
         </div>
 
         <div class="grid__cell--padding-md-y">

--- a/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
@@ -55,7 +55,7 @@
 
       <ul>
         <li>
-          <%= link_to submission.demo_video_link, class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :_blank do %>
+          <%= link_to submission.pitch_video_link, class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :_blank do %>
             <div class="flex items-center">
               <svg class="mr-2 h-6 w-6 flex-shrink" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -63,7 +63,7 @@
               </svg>
 
               <div>
-                Watch the <%= t("submissions.demo_video") %>
+                Watch the pitch video
               </div>
 
               <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -74,7 +74,7 @@
         </li>
 
         <li>
-          <%= link_to submission.pitch_video_link, class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :_blank do %>
+          <%= link_to submission.demo_video_link, class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :_blank do %>
             <div class="flex items-center">
               <svg class="mr-2 h-6 w-6 flex-shrink" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -82,7 +82,7 @@
               </svg>
 
               <div>
-                Watch the pitch video
+                Watch the <%= t("submissions.demo_video") %>
               </div>
 
               <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
Refs #4105 

This PR changes the order of pitch and demo(technical) video link on admin edit and project page so they are consistent. Pitch video first, demo(technical) video 2nd. 