### PR TITLE
Update resend parent consent email link as a button

### DIFF
--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -16,6 +16,10 @@
     }
 }
 
+.tw-gold-btn{
+    @apply w-auto max-w-fit px-4 py-2 rounded bg-tg-gold text-white font-medium hover:bg-tg-dark-gold hover:text-gray-50
+}
+
 .tw-green-btn{
     @apply w-auto mr-auto px-4 py-2 rounded bg-tg-green text-white font-medium
 }

--- a/app/javascript/tailwind.config.js
+++ b/app/javascript/tailwind.config.js
@@ -1,45 +1,43 @@
 module.exports = {
   content: [
-    './app/helpers/**/*.rb',
-    './app/javascript/**/*.{js,vue}',
-    './app/views/**/*',
+    "./app/helpers/**/*.rb",
+    "./app/javascript/**/*.{js,vue}",
+    "./app/views/**/*",
   ],
   theme: {
     extend: {
       borderRadius: {
-        '4xl': '2.5rem;'
+        "4xl": "2.5rem;",
       },
       colors: {
-        'energetic-blue': "#0075cf",
-        'energetic-blue-600': { 600: '#0075cf' },
-        'energetic-blue-light': '#539aef',
-        'tg-green': '#43b02a',
-        'tg-dark-green': '#3fa428',
-        'tg-dark-blue': '#041E42',
-        'tg-bright-blue': '#5bc2e7',
-        'tg-gold': '#ffb81c',
-        'tg-magenta': '#d0006f',
-        'tg-orange': '#ff7500',
+        "energetic-blue": "#0075cf",
+        "energetic-blue-600": { 600: "#0075cf" },
+        "energetic-blue-light": "#539aef",
+        "tg-green": "#43b02a",
+        "tg-dark-green": "#3fa428",
+        "tg-dark-blue": "#041E42",
+        "tg-bright-blue": "#5bc2e7",
+        "tg-gold": "#ffb81c",
+        "tg-dark-gold": "#e5a51b",
+        "tg-magenta": "#d0006f",
+        "tg-orange": "#ff7500",
       },
       height: {
-        'fit-content': 'fit-content'
+        "fit-content": "fit-content",
       },
       typography: {
         DEFAULT: {
           css: {
             a: {
-              'text-decoration': 'none',
-              '&:hover': {
-                'text-decoration': 'underline'
-              }
-            }
-          }
-        }
-      }
-    }
+              "text-decoration": "none",
+              "&:hover": {
+                "text-decoration": "underline",
+              },
+            },
+          },
+        },
+      },
+    },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-    require('@tailwindcss/forms')
-  ],
-}
+  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],
+};

--- a/app/views/student/profiles/rebrand/_parent_info_troubleshoot.en.html.erb
+++ b/app/views/student/profiles/rebrand/_parent_info_troubleshoot.en.html.erb
@@ -8,18 +8,19 @@
 
   <div>
     <p>Ask the parent/guardian listed above to check their email inbox and spam folder.</p>
+  </div>
 
+  <div class="flex flex-col md:flex-row md:justify-center md:items-center md:space-x-4">
     <%= link_to "Resend consent email",
                 student_parental_consent_notice_path,
                 data: { method: :post },
-                class:"tw-link"
+                class:"tw-gold-btn"
+    %>
+    <%= link_to "Edit parent email",
+                new_student_parental_consent_notice_path,
+                class:"tw-green-btn"
     %>
   </div>
-
-  <%= link_to "Edit parent email",
-              new_student_parental_consent_notice_path,
-              class:"tw-green-btn"
-  %>
 </section>
 
 <div class="bg-energetic-blue h-1 mb-8"></div>


### PR DESCRIPTION
Refs #4118 

This PR updates the "resent parent consent link." It will now be displayed as a button. I added a new button style called `.tw-gold-btn` that follows the same pattern as the `tw-green-btn`

![CleanShot 2023-07-24 at 14 11 09@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/a444d44d-b24a-4f48-a0a6-90039748dc38)
