### PR TITLE
Allow admins to reject uploaded parental consents

### DIFF
--- a/app/controllers/admin/paper_parental_consents_controller.rb
+++ b/app/controllers/admin/paper_parental_consents_controller.rb
@@ -31,6 +31,18 @@ module Admin
         success: "You approved the parental consent for #{parental_consent.student_profile_full_name}."
     end
 
+    def reject
+      parental_consent = ParentalConsent.find(params[:paper_parental_consent_id])
+
+      parental_consent.update(
+        upload_rejected_at: Time.now,
+        upload_approval_status: ParentalConsent::PAPER_CONSENT_UPLOAD_STATUSES[:rejected]
+      )
+
+      redirect_to admin_paper_parental_consents_path,
+        success: "You rejected the parental consent for #{parental_consent.student_profile_full_name}."
+    end
+
     private
 
     def grid_params

--- a/app/data_grids/parental_consents_grid.rb
+++ b/app/data_grids/parental_consents_grid.rb
@@ -45,8 +45,18 @@ class ParentalConsentsGrid
       }
     )
 
+    reject_button = link_to(
+      "Reject",
+      admin_paper_parental_consent_reject_path(parental_consent),
+      class: "button danger small",
+      data: {
+        method: :patch,
+        confirm: "You are about to reject this parental consent"
+      }
+    )
+
     if parental_consent.upload_approval_status_pending?
-      view_button + " " + approve_button
+      view_button + " " + approve_button + " " + reject_button
     else
       view_button
     end

--- a/app/mailers/student_mailer.rb
+++ b/app/mailers/student_mailer.rb
@@ -1,0 +1,9 @@
+class StudentMailer < ApplicationMailer
+  def parental_consent_rejected(account)
+    @name = account.first_name
+
+    I18n.with_locale(account.locale) do
+      mail to: account.email
+    end
+  end
+end

--- a/app/views/student_mailer/parental_consent_rejected.en.html.erb
+++ b/app/views/student_mailer/parental_consent_rejected.en.html.erb
@@ -1,0 +1,29 @@
+<tr>
+  <td class="content-wrap">
+    <meta itemprop="name" content="Student notification that parent signed consent"/>
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td class="content-block">
+          Hey <%= @name %>,
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          Thank you for uploading the parent/guardian permission form.
+          We have identified an issue with the form and need some
+          additional information in order to confirm you have parental
+          consent to participate in the Technovation Girls program.
+          Please contact us at
+          <%= mail_to ENV.fetch("HELP_EMAIL"), ENV.fetch("HELP_EMAIL") %>
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          — The Technovation Team
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -39,6 +39,10 @@ en:
     welcome_returning_judge:
       subject: "Welcome to Technovation %{season_year}!"
 
+  student_mailer:
+    parental_consent_rejected:
+      subject: Issue with parent/guardian consent form
+
   team_mailer:
     invite_member:
       greeting:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,6 +312,7 @@ Rails.application.routes.draw do
     resource :paper_parental_consent, only: :create
     resources :paper_parental_consents, only: [:index] do
       patch :approve
+      patch :reject
     end
 
     resource :paper_media_consent, only: :create


### PR DESCRIPTION
This will add basic functionality for an admin to reject an uploaded parental consent form.

Basic overview of changes:
- New route/controller action
- New reject button/action on the datagrid
- New student mailer (to notify them about rejected parental consent)