### PR TITLE
Add "additional questions" for 2024 season

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -52,6 +52,8 @@ module SubmissionsHelper
       [:ai, :climate_change, :solves_health_problem]
     when 2023
       [:ai, :climate_change, :solves_hunger_or_food_waste, :uses_open_ai]
+    when 2024
+      [:ai, :climate_change, :solves_hunger_or_food_waste, :uses_open_ai]
     end
   end
 end


### PR DESCRIPTION
This will use the same questions for the 2024 season as 2023 one; this will fix the bug, we can update the questions later if necessary.
