### PR TITLE
Allow students to upload media consents

### DIFF
--- a/app/constants/consent_forms.rb
+++ b/app/constants/consent_forms.rb
@@ -1,0 +1,7 @@
+module ConsentForms
+  PAPER_CONSENT_UPLOAD_STATUSES = {
+    pending: 0,
+    approved: 1,
+    rejected: 2
+  }
+end

--- a/app/controllers/admin/paper_parental_consents_controller.rb
+++ b/app/controllers/admin/paper_parental_consents_controller.rb
@@ -22,9 +22,9 @@ module Admin
 
       parental_consent.update(
         status: ParentalConsent.statuses[:signed],
-        electronic_signature: ParentalConsent::PARENT_GUARDIAN_NAME_FOR_A_PAPER_CONSENT,
+        electronic_signature: ConsentForms::PARENT_GUARDIAN_NAME_FOR_A_PAPER_CONSENT,
         upload_approved_at: Time.now,
-        upload_approval_status: ParentalConsent::PAPER_CONSENT_UPLOAD_STATUSES[:approved]
+        upload_approval_status: ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES[:approved]
       )
 
       redirect_to admin_paper_parental_consents_path,
@@ -36,7 +36,7 @@ module Admin
 
       parental_consent.update(
         upload_rejected_at: Time.now,
-        upload_approval_status: ParentalConsent::PAPER_CONSENT_UPLOAD_STATUSES[:rejected]
+        upload_approval_status: ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES[:rejected]
       )
 
       redirect_to admin_paper_parental_consents_path,
@@ -47,7 +47,7 @@ module Admin
 
     def grid_params
       grid = (params[:parental_consents_grid] ||= {}).merge(
-        upload_approval_status: params[:parental_consents_grid][:upload_approval_status] || ParentalConsent::PAPER_CONSENT_UPLOAD_STATUSES[:pending],
+        upload_approval_status: params[:parental_consents_grid][:upload_approval_status] || ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES[:pending],
         season: params[:parental_consents_grid][:season] || Season.current.year
       )
 

--- a/app/controllers/student/paper_consent_uploads_controller.rb
+++ b/app/controllers/student/paper_consent_uploads_controller.rb
@@ -2,20 +2,29 @@ module Student
   class PaperConsentUploadsController < StudentController
     def update
       @parental_consent = current_student.parental_consent
+      @media_consent = current_student.media_consent
 
-      if @parental_consent.update(parental_consent_upload_params.merge(uploaded_at: Time.now))
+      if @parental_consent.update(parental_consent_params) && @media_consent.update(media_consent_params)
         redirect_to student_dashboard_path, success: "Thank you for uploading your consent form, we will review it as soon as we can."
       else
-        redirect_to student_dashboard_path, error: "The consent form needs to be an image or in PDF format and less than #{PaperParentalConsentUploader::MAXIMUM_UPLOAD_FILE_SIZE_IN_MEGABYTES} MB. Please try again."
+        redirect_to student_dashboard_path, error: "The consent forms need to be an image or in PDF format, and less than #{PaperParentalConsentUploader::MAXIMUM_UPLOAD_FILE_SIZE_IN_MEGABYTES} MB. Please try again."
       end
     end
 
     private
 
-    def parental_consent_upload_params
+    def parental_consent_params
       params.require(:parental_consent).permit(
-        :uploaded_consent_form
-      )
+        :uploaded_consent_form,
+        media_consent: [:uploaded_consent_form]
+      ).except(:media_consent).merge(uploaded_at: Time.now)
+    end
+
+    def media_consent_params
+      params.require(:parental_consent).permit(
+        :uploaded_consent_form,
+        media_consent: [:uploaded_consent_form]
+      ).except(:uploaded_consent_form)[:media_consent].merge(uploaded_at: Time.now)
     end
   end
 end

--- a/app/controllers/student/profiles_controller.rb
+++ b/app/controllers/student/profiles_controller.rb
@@ -4,6 +4,7 @@ module Student
 
     def show
       @parental_consent = current_student.parental_consent
+      @media_consent = current_student.media_consent
     end
 
     def profile_params

--- a/app/data_grids/parental_consents_grid.rb
+++ b/app/data_grids/parental_consents_grid.rb
@@ -77,7 +77,7 @@ class ParentalConsentsGrid
   filter :upload_approval_status,
     :enum,
     header: "Status",
-    select: ParentalConsent::PAPER_CONSENT_UPLOAD_STATUSES.transform_keys(&:capitalize)
+    select: ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES.transform_keys(&:capitalize)
 
   filter :season,
     :enum,

--- a/app/models/media_consent.rb
+++ b/app/models/media_consent.rb
@@ -11,6 +11,14 @@ class MediaConsent < ActiveRecord::Base
   validates :electronic_signature, presence: true, on: :update, unless: :uploaded?
   validates :consent_provided, inclusion: [false, true], on: :update, if: :signed?
 
+  before_save -> {
+    if uploaded_at_changed?
+      self.upload_approval_status = ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES[:pending]
+      self.upload_approved_at = nil
+      self.upload_rejected_at = nil
+    end
+  }
+
   after_commit :send_media_conent_confirmation_email_to_parent,
     if: proc { |media_consent| media_consent.signed? }
 

--- a/app/models/media_consent.rb
+++ b/app/models/media_consent.rb
@@ -1,11 +1,15 @@
 class MediaConsent < ActiveRecord::Base
   ELECTRONIC_SIGNATURE_FOR_A_PAPER_MEDIA_CONSENT = "ON FILE"
 
+  enum upload_approval_status: ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES, _prefix: true
+
   belongs_to :student_profile
 
+  mount_uploader :uploaded_consent_form, PaperParentalConsentUploader
+
   validates :season, presence: true
-  validates :electronic_signature, presence: true, on: :update
-  validates :consent_provided, inclusion: [false, true], on: :update
+  validates :electronic_signature, presence: true, on: :update, unless: :uploaded?
+  validates :consent_provided, inclusion: [false, true], on: :update, if: :signed?
 
   after_commit :send_media_conent_confirmation_email_to_parent,
     if: proc { |media_consent| media_consent.signed? }
@@ -20,6 +24,10 @@ class MediaConsent < ActiveRecord::Base
 
   def on_file?
     electronic_signature === ELECTRONIC_SIGNATURE_FOR_A_PAPER_MEDIA_CONSENT
+  end
+
+  def uploaded?
+    uploaded_at.present?
   end
 
   private

--- a/app/models/parental_consent.rb
+++ b/app/models/parental_consent.rb
@@ -4,11 +4,6 @@ class ParentalConsent < ActiveRecord::Base
   FIRST_SEASON_FOR_UPLOADABLE_PARENTAL_CONSENT_FORMS = 2024
   PARENT_GUARDIAN_NAME_FOR_A_PAPER_CONSENT = "ON FILE"
   PARENT_GUARDIAN_EMAIL_ADDDRESS_FOR_A_PAPER_CONSENT = "ON FILE"
-  PAPER_CONSENT_UPLOAD_STATUSES = {
-    pending: 0,
-    approved: 1,
-    rejected: 2
-  }
 
   # If these change, you will need to update dataclips
   enum status: %i{
@@ -17,7 +12,7 @@ class ParentalConsent < ActiveRecord::Base
     voided
   }
 
-  enum upload_approval_status: PAPER_CONSENT_UPLOAD_STATUSES, _prefix: true
+  enum upload_approval_status: ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES, _prefix: true
 
   belongs_to :student_profile
 
@@ -45,7 +40,7 @@ class ParentalConsent < ActiveRecord::Base
 
   before_save -> {
     if uploaded_at_changed?
-      self.upload_approval_status = PAPER_CONSENT_UPLOAD_STATUSES[:pending]
+      self.upload_approval_status = ConsentForms::PAPER_CONSENT_UPLOAD_STATUSES[:pending]
       self.upload_approved_at = nil
       self.upload_rejected_at = nil
     end

--- a/app/views/student/paper_consent_uploads/_form.html.erb
+++ b/app/views/student/paper_consent_uploads/_form.html.erb
@@ -54,5 +54,10 @@
   <%= f.label :uploaded_consent_form, "Upload parental consent form" %>
   <%= f.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
 
+  <%= f.fields_for @media_consent do |media_consent_fields| %>
+    <%= media_consent_fields.label :uploaded_consent_form, "Upload media consent form", class: "mt-8" %>
+    <%= media_consent_fields.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
+  <% end %>
+
   <%= f.submit "Upload", class: "mt-4 tw-green-btn" %>
 <% end %>

--- a/db/migrate/20230810134239_add_paper_consents_to_media_consents.rb
+++ b/db/migrate/20230810134239_add_paper_consents_to_media_consents.rb
@@ -1,0 +1,9 @@
+class AddPaperConsentsToMediaConsents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :media_consents, :uploaded_consent_form, :string
+    add_column :media_consents, :uploaded_at, :datetime
+    add_column :media_consents, :upload_approval_status, :integer, default: 0
+    add_column :media_consents, :upload_approved_at, :datetime
+    add_column :media_consents, :upload_rejected_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -761,7 +761,12 @@ CREATE TABLE public.media_consents (
     electronic_signature character varying,
     signed_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    uploaded_consent_form character varying,
+    uploaded_at timestamp without time zone,
+    upload_approval_status integer DEFAULT 0,
+    upload_approved_at timestamp without time zone,
+    upload_rejected_at timestamp without time zone
 );
 
 
@@ -3322,6 +3327,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230613163115'),
 ('20230626193226'),
 ('20230727123214'),
-('20230809190653');
+('20230809190653'),
+('20230810134239');
 
 

--- a/spec/models/media_consent_spec.rb
+++ b/spec/models/media_consent_spec.rb
@@ -116,4 +116,22 @@ describe MediaConsent do
       end
     end
   end
+
+  describe "#uploaded?" do
+    context "when the media consent has an `uploaded_at` date" do
+      let(:media_consent) { MediaConsent.new(uploaded_at: 1.day.ago) }
+
+      it "returns true" do
+        expect(media_consent.uploaded?).to eq(true)
+      end
+    end
+
+    context "when the media consent does not have an `uploaded_at` date" do
+      let(:media_consent) { MediaConsent.new(uploaded_at: nil) }
+
+      it "returns false" do
+        expect(media_consent.uploaded?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/media_consent_spec.rb
+++ b/spec/models/media_consent_spec.rb
@@ -134,4 +134,17 @@ describe MediaConsent do
       end
     end
   end
+
+  context "when the media consent has been rejected" do
+    it "resets the media consent to 'pending' when a student uploads another one" do
+      student = FactoryBot.create(:onboarding_student)
+      student.parental_consent.update(upload_rejected_at: 1.day.ago)
+
+      student.media_consent.update(uploaded_at: Time.now)
+
+      expect(student.media_consent.upload_approval_status).to eq("pending")
+      expect(student.media_consent.upload_rejected_at).to be_nil
+      expect(student.media_consent.upload_approved_at).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This will add new functionality allowing students to upload a media consent form.

Overview of the changes:
- a database migration to add the necessary fields to the `media_consents` table
- an updated form to upload a media consent
- an updated controller action to save the uploaded media consent
- extracting out the `PAPER_CONSENT_UPLOAD_STATUSES` so it could be reused for media consents
- resetting the media consent status to pending when a new one is uploaded