### PR TITLE
4151 add note to review submission page

### DIFF
--- a/app/controllers/student/published_team_submissions_controller.rb
+++ b/app/controllers/student/published_team_submissions_controller.rb
@@ -3,6 +3,10 @@ module Student
     def show
       @team_submission = current_team.submission
       @team = current_team
+
+      if SeasonToggles.team_submissions_editable? && @team_submission.incomplete?
+        flash.now[:notice] = "Please review your submission for accuracy. Then click the Submit button at the bottom of the page to submit your project."
+      end
       render "team_submissions/rebrand/published"
     end
   end

--- a/app/views/student/dashboards/completion_steps/_team_submission_progress.html.erb
+++ b/app/views/student/dashboards/completion_steps/_team_submission_progress.html.erb
@@ -10,12 +10,12 @@
   </p>
 <% elsif SeasonToggles.team_submissions_editable? &&
         current_team.submission.only_needs_to_submit? %>
-  <p>You've done everything and you're ready to publish for the judges!</p>
+  <p class="mb-4">You've done everything and you're ready to publish for the judges!</p>
 
   <p>
     <%= link_to "Review and submit now!",
       student_published_team_submission_path(current_team.submission),
-      class: "button" %>
+      class: "tw-green-btn" %>
   </p>
 <% elsif SeasonToggles.team_submissions_editable? %>
   <%= render 'team_submissions/menu',


### PR DESCRIPTION
Refs #4151 

This change includes the following
- Updated button style to new rebranding for the `Review and submit now!` button on student dashboard
- Added a flash message to the top of the published submission page. I included logic only to display this message when submissions are editable and when they have not yet submitted their project 

<img width="1552" alt="Screen Shot 2023-08-22 at 4 05 03 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/dc07e956-7fdf-44ff-8297-b9370313420b">