### PR TITLE
Verify returning students age

### DIFF
--- a/app/controllers/concerns/verify_student_age_concern.rb
+++ b/app/controllers/concerns/verify_student_age_concern.rb
@@ -1,0 +1,24 @@
+module VerifyStudentAgeConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :verify_student_age
+  end
+
+  private
+
+  def verify_student_age
+    if current_account.authenticated? && current_account.age_by_cutoff > 18 && !currently_on_student_mentor_conversion_page?
+      redirect_to student_mentor_conversion_path(id: current_student)
+    end
+  end
+
+  def currently_on_student_mentor_conversion_page?
+    current_request_path = Rails.application.routes.recognize_path(
+      request.fullpath,
+      method: request.method
+    )
+
+    current_request_path == Rails.application.routes.recognize_path(student_mentor_conversion_path)
+  end
+end

--- a/app/controllers/student/mentor_conversions_controller.rb
+++ b/app/controllers/student/mentor_conversions_controller.rb
@@ -1,0 +1,18 @@
+module Student
+  class MentorConversionsController < ApplicationController
+    layout "application_rebrand"
+
+    def create
+      account = Account.find(params[:account_id])
+      student_converter_result = StudentToMentorConverter.new(account: account).call
+
+      if student_converter_result.success?
+        redirect_to mentor_dashboard_path,
+          success: "You are now a mentor!"
+      else
+        redirect_to student_dashboard_path,
+          error: "Something went wrong, please try again or contact us if you need assistance."
+      end
+    end
+  end
+end

--- a/app/controllers/student_controller.rb
+++ b/app/controllers/student_controller.rb
@@ -1,5 +1,6 @@
 class StudentController < ApplicationController
   include Authenticated
+  include VerifyStudentAgeConcern
 
   layout "student"
   helper_method :current_student,

--- a/app/views/student/mentor_conversions/show.html.erb
+++ b/app/views/student/mentor_conversions/show.html.erb
@@ -1,0 +1,33 @@
+<div class="w-full lg:w-3/4 mx-auto">
+  <div class="inline-block mb-auto rounded-md border-solid border-4 border-energetic-blue">
+    <div class="sm-header-wrapper">
+      <p class="font-bold">Do you want to become a mentor?</p>
+    </div>
+
+    <div class="p-6">
+      <p class="prose">
+        Thank you for participating in Technovation Girls. Since you will be
+        older than 18 on August 1, you are no longer eligible to participate as
+        a student. Choose from the options below to access our alumnae resources
+        or learn more about being a mentor for a team of students.
+      </p>
+
+      <div class="flex justify-center mt-8">
+        <div>
+          <%= link_to "View Alumnae Resources",
+            "https://www.technovation.org/alumnae-community-resources/",
+            class: "tw-gray-btn mr-4"
+          %>
+        </div>
+
+        <div>
+          <%= link_to "Become a Mentor",
+            student_mentor_conversion_path(account_id: current_account),
+            data: {method: :post},
+            class: "tw-green-btn"
+          %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/student/mentor_conversions/show.html.erb
+++ b/app/views/student/mentor_conversions/show.html.erb
@@ -6,9 +6,11 @@
 
     <div class="p-6">
       <p class="prose">
-        Thank you for participating in Technovation Girls. Since you will be
-        older than 18 on August 1, you are no longer eligible to participate as
-        a student. Choose from the options below to access our alumnae resources
+        Thank you for participating in Technovation Girls.
+        Since you will be older than 18 on
+        <%= ImportantDates.division_cutoff.strftime("%B %e") %>,
+        you are no longer eligible to participate as a student.
+        Choose from the options below to access our alumnae resources
         or learn more about being a mentor for a team of students.
       </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
 
     resources :mentors, only: :show
     resources :students, only: :show
+    resource :mentor_conversion, only: [:show, :create]
 
     resources :team_member_invites, except: [:edit]
     resources :mentor_invites, only: [:create, :destroy]

--- a/spec/features/student/convert_to_mentor_spec.rb
+++ b/spec/features/student/convert_to_mentor_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature "Students converting to a mentor" do
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_YEAR", any_args).and_return(Time.current.year)
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_MONTH", any_args).and_return(8)
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_DAY", any_args).and_return(1)
+  end
+
+  let(:student) { FactoryBot.create(:student, :returning, date_of_birth: 20.years.ago) }
+
+  before do
+    sign_in(student)
+  end
+
+  scenario "A student successfully converting to be a mentor" do
+    click_link "Become a Mentor"
+
+    expect(current_path).to eq(mentor_dashboard_path)
+    expect(page).to have_content "You are now a mentor!"
+  end
+end

--- a/spec/system/student/verifying_students_age_spec.rb
+++ b/spec/system/student/verifying_students_age_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Verifying a student's age" do
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_YEAR", any_args).and_return(Time.current.year)
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_MONTH", any_args).and_return(8)
+    allow(ENV).to receive(:fetch).with("DATES_DIVISION_CUTOFF_DAY", any_args).and_return(1)
+  end
+
+  context "when a returning student is older than 18 years old by the cut-off date" do
+    let(:student) { FactoryBot.create(:student, :returning, date_of_birth: 20.years.ago) }
+
+    before do
+      sign_in(student)
+    end
+
+    it "redirects to the `student_mentor_conversion_path`" do
+      expect(current_path).to eq(student_mentor_conversion_path)
+    end
+
+    it "displays a 'Become a Mentor' link" do
+      expect(page).to have_link "Become a Mentor"
+    end
+  end
+
+  context "when a student is younger than 18 years old by the cut-off date" do
+    let(:student) { FactoryBot.create(:student, date_of_birth: 15.years.ago) }
+
+    before do
+      sign_in(student)
+    end
+
+    it "redirects to the student dashboard" do
+      expect(current_path).to eq(student_dashboard_path)
+    end
+  end
+end


### PR DESCRIPTION
This will add a `before_action` hook for students to verify that they will be 18 or younger by the division cut-off date. If they're going to be older, we'll display the new mentor conversion page with the option to become a mentor.