### PR TITLE
Added chrome driver version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -116,7 +116,8 @@ jobs:
 
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
 
       - restore_cache:
           name: Restore cached gems


### PR DESCRIPTION
Earlier today the install chrome driver step failed during the QA build.
This is the error
<img width="1386" alt="Screen Shot 2023-08-29 at 3 27 26 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/75fc1601-7086-43e7-8233-15cc5dd40298">

There seems to be an issue with chrome driver [v116.0.5845.140](https://googlechromelabs.github.io/chrome-for-testing/)
<img width="1004" alt="Screen Shot 2023-08-29 at 3 28 32 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/d1e98d25-2f39-42d9-ad44-b4bda839e80d">

This fix is a temporary workaround while the chromedriver versions are being sorted. 
[CircleCI Support thread here](https://github.com/CircleCI-Public/browser-tools-orb/issues/75)
[Additional Issue here](https://github.com/CircleCI-Public/browser-tools-orb/issues/90)