### PR TITLE
Integrate admin invite codes with new registration flow

### DIFF
--- a/app/javascript/new_registration/components/FormWrapper.vue
+++ b/app/javascript/new_registration/components/FormWrapper.vue
@@ -97,6 +97,7 @@ export default {
     },
     async submitHandler (data) {
       const csrfTokenMetaTag = document.querySelector('meta[name="csrf-token"]')
+      const inviteCode = new URLSearchParams(document.location.search).get('admin_permission_token')
 
       let config = {
         headers: {
@@ -106,7 +107,7 @@ export default {
       }
 
       try {
-        await axios.post('/new-registration', data, config)
+        await axios.post('/new-registration', Object.assign(data, {inviteCode}), config)
 
         switch(data.profileType) {
           case 'student':


### PR DESCRIPTION
This will make it so that after someone registers with an admin invite code (aka `admin_permission_token`), the associated invitation will get updated with their newly created account and be marked as "registered", this will also be reflected in the invitations area in the admin.


