### PR TITLE
Various consent form upload improvements

### DIFF
--- a/app/controllers/student/paper_consent_uploads_controller.rb
+++ b/app/controllers/student/paper_consent_uploads_controller.rb
@@ -4,9 +4,13 @@ module Student
       @parental_consent = current_student.parental_consent
       @media_consent = current_student.media_consent
 
-      if params[:parental_consent].blank?
-        redirect_to student_dashboard_path, error: "You forgot to upload a consent form. Please try again."
-      elsif @parental_consent.update(parental_consent_params) && @media_consent.update(media_consent_params)
+      if parental_consent_params[:uploaded_consent_form].blank?
+        redirect_to student_dashboard_path, error: "You forgot to upload your parental consent form. Please try again."
+      elsif @parental_consent.update(parental_consent_params)
+        if media_consent_params[:uploaded_consent_form].present?
+          @media_consent.update(media_consent_params)
+        end
+
         redirect_to student_dashboard_path, success: "Thank you for uploading your consent form, we will review it as soon as we can."
       else
         redirect_to student_dashboard_path, error: "The consent forms need to be an image or in PDF format, and less than #{PaperParentalConsentUploader::MAXIMUM_UPLOAD_FILE_SIZE_IN_MEGABYTES} MB. Please try again."

--- a/app/controllers/student/profiles_controller.rb
+++ b/app/controllers/student/profiles_controller.rb
@@ -3,8 +3,8 @@ module Student
     include ProfileController
 
     def show
-      @parental_consent = current_student.parental_consent
-      @media_consent = current_student.media_consent
+      @parental_consent = current_student.parental_consents.find_or_create_by(seasons: [Season.current.year])
+      @media_consent = current_student.media_consents.find_or_create_by(season: Season.current.year)
     end
 
     def profile_params

--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -59,16 +59,13 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
       RegistrationMailer.welcome_parent(record).deliver_later
     end
 
-    if student_profile.reload.parental_consent.nil?
-      student_profile.parental_consents.create!
-    end
+    student_profile.parental_consents.find_or_create_by(seasons: [Season.current.year])
+    student_profile.media_consents.find_or_create_by(season: Season.current.year)
 
     if student_profile.reload.parental_consent.pending? &&
         !student_profile.parent_guardian_email.blank?
       ParentMailer.consent_notice(student_profile.id).deliver_later
     end
-
-    student_profile.media_consents.create(season: Season.current.year)
 
     if record.seasons.many?
       record.update(division: Division.for_account(record))

--- a/app/views/admin/participants/_student_media_consent.html.erb
+++ b/app/views/admin/participants/_student_media_consent.html.erb
@@ -4,7 +4,7 @@
     <% if media_consent&.consent_provided.nil? %>
       <h5>Has not completed media consent form</h5>
       <% if admin  %>
-        <%= link_to "GRANT permission",
+        <%= link_to "Create paper media consent WITH CONSENT",
           admin_paper_media_consent_path(
             id: profile.id,
             consent: true
@@ -12,12 +12,11 @@
           class: "button button--secondary",
           data: {
             method: :post,
-            confirm: "You are granting to #{full_name} " +
-            "media consent on file.",
-          } 
+            confirm: "You are creating a paper media consent WITH CONSENT for #{full_name}."
+          }
         %>
 
-        <%= link_to "Do NOT GRANT permission",
+        <%= link_to "Create paper media consent WITHOUT CONSENT",
           admin_paper_media_consent_path(
             id: profile.id,
             consent: false
@@ -25,20 +24,19 @@
           class: "button button--secondary",
           data: {
             method: :post,
-            confirm: "You are denying to #{full_name} " +
-            "media consent on file.",
-          } 
+            confirm: "You are creating a paper media consent WITHOUT CONSENT for #{full_name}."
+          }
         %>
       <% end %>
     <% else %>
       <% if media_consent&.consent_provided? %>
         <h5>
-          AGREED to media content  via 
+          AGREED to media content via
           <%= media_consent.on_file? ? "paper form" : "online form" %>
         </h5>
       <% else %>
         <h5>
-          Did NOT AGREE to media consent via 
+          Did NOT AGREE to media consent via
           <%= media_consent.on_file? ? "paper form" : "online form" %>
         </h5>
       <% end %>

--- a/app/views/student/paper_consent_uploads/_form.html.erb
+++ b/app/views/student/paper_consent_uploads/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% if @parental_consent.uploaded_at.present? && @parental_consent.upload_approval_status_pending? %>
   <div class="container px-4 py-4 mb-8 bg-blue-100 border-l-4 border-energetic-blue">
-    <h4 class="mb-3 text-base text-gray-600">Thank you for uploading your consent form!</h2>
+    <h4 class="mb-3 text-base text-gray-600">Thank you for uploading your consent form!</h4>
 
     <p class="mb-3 text-base text-gray-500">
       We will review it as soon as possible, and you will receive
@@ -45,8 +45,8 @@
     Please contact
     <%= mail_to ENV.fetch("HELP_EMAIL"),
       "support@technovation.org",
-      subject: "Parental consent signed form",
-      class:"tw-link"
+      subject: "Parental consent form",
+      class: "tw-link"
     %>
     with any questions.
   </p>

--- a/app/views/student/paper_consent_uploads/_form.html.erb
+++ b/app/views/student/paper_consent_uploads/_form.html.erb
@@ -1,18 +1,30 @@
 <h3 class="mb-4">Uploading Consent Forms</h3>
 
-<% if @parental_consent.uploaded_at.present? && @parental_consent.upload_approval_status_pending? %>
+<% if @parental_consent.uploaded_at.present? && @parental_consent.upload_approval_status_pending? ||
+  @media_consent.uploaded_at.present? && @media_consent.upload_approval_status_pending? %>
+
+  <% if @parental_consent.uploaded_at.present? && @media_consent.uploaded_at.blank? %>
+    <% consent_form_type = "parental consent form" %>
+  <% elsif @media_consent.uploaded_at.present? && @parental_consent.uploaded_at.blank? %>
+    <% consent_form_type = "media consent form" %>
+  <% else %>
+    <% consent_form_type = "consent forms" %>
+  <% end %>
+
   <div class="container px-4 py-4 mb-8 bg-blue-100 border-l-4 border-energetic-blue">
-    <h4 class="mb-3 text-base text-gray-600">Thank you for uploading your consent form!</h4>
+    <h4 class="mb-3 text-base text-gray-600">Thank you for uploading your <%= consent_form_type %>!</h4>
 
     <p class="mb-3 text-base text-gray-500">
-      We will review it as soon as possible, and you will receive
-      an email when the form is accepted or if we need additional
-      information.
+      We will review <%= (@parental_consent.uploaded_at.present? && @media_consent.uploaded_at.present?) ? "them" : "it" %>
+      as soon as possible, and you will receive an email when the form
+      is accepted or if we need additional information.
     </p>
   </div>
 <% end %>
 
-<% if @parental_consent.uploaded_at.blank? || @parental_consent.upload_approval_status_rejected? %>
+<% if @parental_consent.uploaded_at.blank? || @parental_consent.upload_approval_status_rejected? ||
+  @media_consent.uploaded_at.blank? || @media_consent.upload_approval_status_rejected? %>
+
   <p>
     If your parent or guardian does not have an email address to sign the
     permission and media consent forms online, you can upload the signed
@@ -52,12 +64,16 @@
   </p>
 
   <%= form_for @parental_consent, url: student_paper_consent_upload_path, html: { multipart: true } do |f| %>
-    <%= f.label :uploaded_consent_form, "Upload parental consent form" %>
-    <%= f.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
+    <% if @parental_consent.uploaded_at.blank? || @parental_consent.upload_approval_status_rejected? %>
+      <%= f.label :uploaded_consent_form, "Upload parental consent form" %>
+      <%= f.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
+    <% end %>
 
-    <%= f.fields_for @media_consent do |media_consent_fields| %>
-      <%= media_consent_fields.label :uploaded_consent_form, "Upload media consent form", class: "mt-8" %>
-      <%= media_consent_fields.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
+    <% if @media_consent.uploaded_at.blank? || @media_consent.upload_approval_status_rejected? %>
+      <%= f.fields_for @media_consent do |media_consent_fields| %>
+        <%= media_consent_fields.label :uploaded_consent_form, "Upload media consent form", class: "mt-8" %>
+        <%= media_consent_fields.file_field :uploaded_consent_form, label: "Upload your", class: "tw-file-upload" %>
+      <% end %>
     <% end %>
 
     <%= f.submit "Upload", class: "mt-4 tw-green-btn" %>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -96,6 +96,19 @@ en:
       new:
         unauthorized: "Sorry, that consent token was invalid."
 
+    paper_consent_uploads:
+      update:
+        upload_missing: You forgot to upload a consent form. Please try again.
+        parental_consent:
+          success: "Thank you for uploading your parental consent form, we will review it as soon as we can."
+          error: "The parental consent form needs to be an image or in PDF format, and less than %{max_file_size}. Please try again."
+        media_consent:
+          success: "Thank you for uploading your media consent form, we will review it as soon as we can."
+          error: "The media consent form needs to be an image or in PDF format, and less than %{max_file_size}. Please try again."
+        parental_and_media_consent:
+          success: "Thank you for uploading your consent forms, we will review them as soon as we can."
+          error: "The consent forms needs to be an image or in PDF format, and less than %{max_file_size}. Please try again."
+
     passwords:
       create:
         success: "You successfully reset your password and you've been logged in"


### PR DESCRIPTION
Bundling together a few improvements/fixes related to consent form uploads:
- Ensuring a consent forms exist when impersonating a student
- Only allowing a media consent to be uploaded if a parental consent is also being uploaded
- Text changes for paper media consents (related to the comment here: https://github.com/Iridescent-CM/technovation-app/pull/4164#pullrequestreview-1585073082)
- A couple HTML tweaks, mismatched header tags, etc. (good catch on those)