### PR TITLE
Make admin invites use new registration system

### DIFF
--- a/app/controllers/api/registration_invites_controller.rb
+++ b/app/controllers/api/registration_invites_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  class RegistrationInvitesController < ApplicationController
+    def show
+      invite = RegistrationInviteValidator.new(invite_code: params[:id]).call
+
+      render json: {
+        isValid: invite.valid?,
+        profileType: invite.profile_type,
+        friendlyProfileType: invite.friendly_profile_type
+      }
+    end
+  end
+end

--- a/app/javascript/new_registration/components/FormWrapper.vue
+++ b/app/javascript/new_registration/components/FormWrapper.vue
@@ -97,7 +97,7 @@ export default {
     },
     async submitHandler (data) {
       const csrfTokenMetaTag = document.querySelector('meta[name="csrf-token"]')
-      const inviteCode = new URLSearchParams(document.location.search).get('admin_permission_token')
+      const inviteCode = new URLSearchParams(document.location.search).get('invite_code')
 
       let config = {
         headers: {

--- a/app/javascript/new_registration/components/StepOne.vue
+++ b/app/javascript/new_registration/components/StepOne.vue
@@ -53,7 +53,7 @@
         @input="hasValidationErrors = false"
       />
 
-      <p v-if="this.isStudentRegistrationOpen" class="italic text-sm">
+      <p v-if="displayDivisionCutoffDescription()" class="italic text-sm">
         *As of <strong>{{ divisionCutoffDate }}</strong>.
         For example, if you turn 13 on {{ exampleStudentBirthday }}, you will need to select
         “I am registering myself and am 13-18 years old.”
@@ -209,6 +209,9 @@ export default {
         id: 'judge'
       }
     },
+    displayDivisionCutoffDescription() {
+      return (this.isStudentRegistrationOpen && typeof this.registrationInvite =='undefined') || (this.registrationInvite.isValid == true && this.registrationInvite.profileType == 'student' || this.registrationInvite.isValid == false)
+    }
   },
   computed: {
     divisionCutoffDate: divisionCutoffDateFormatted,

--- a/app/javascript/stylesheets/new_registration.css
+++ b/app/javascript/stylesheets/new_registration.css
@@ -53,6 +53,9 @@
     .formulate-input-group-item {
         @apply flex;
     }
+    .profile-type input[type="radio"] {
+        @apply scale-150
+    }
     .profile-type input[type="radio"].disabled {
         @apply opacity-40
     }

--- a/app/javascript/stylesheets/new_registration.css
+++ b/app/javascript/stylesheets/new_registration.css
@@ -53,8 +53,17 @@
     .formulate-input-group-item {
         @apply flex;
     }
+    .profile-type input[type="radio"].disabled {
+        @apply opacity-40
+    }
     .profile-type img {
         @apply w-28 ml-4 mr-6
+    }
+    .profile-type img.disabled {
+        @apply opacity-40
+    }
+    .profile-type span.disabled {
+        @apply text-gray-400
     }
 
     [data-classification="box"] .formulate-input-wrapper, .input-label-text {

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -13,16 +13,17 @@ class RegistrationMailer < ApplicationMailer
 
   def admin_permission(user_invitation_id)
     invitation = UserInvitation.find(user_invitation_id)
+    invite_code = invitation.admin_permission_token
 
-    if token = invitation.admin_permission_token
-      @url = send(
-        "#{invitation.profile_type}_signup_url",
-        admin_permission_token: token
-      )
+    if invite_code.present?
+      if invitation.profile_type == "chapter_ambassador"
+        @url = chapter_ambassador_signup_url(admin_permission_token: invite_code)
+      else
+        @url = signup_url(invite_code: invite_code)
+      end
 
       mail to: invitation.email,
-           subject: t("registration_mailer.admin_permission.subject",
-                      season_year: Season.current.year) do |f|
+        subject: t("registration_mailer.admin_permission.subject", season_year: Season.current.year) do |f|
         f.html { render :confirm_email }
       end
     else

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -102,6 +102,10 @@ class UserInvitation < ApplicationRecord
     false
   end
 
+  def pending?
+    !registered?
+  end
+
   def human_status
     case status
     when "sent", "opened"; "must sign up"

--- a/app/services/registration_invite_validator.rb
+++ b/app/services/registration_invite_validator.rb
@@ -1,0 +1,29 @@
+class RegistrationInviteValidator
+  def initialize(invite_code:)
+    @invite_code = invite_code
+  end
+
+  def call
+    invite = UserInvitation.find_by(admin_permission_token: invite_code)
+
+    if invite.present? && invite.pending?
+      if invite.student? && SeasonToggles.student_registration_open?
+        return Result.new(valid?: true, profile_type: "student", friendly_profile_type: "student")
+      elsif invite.mentor? && SeasonToggles.mentor_registration_open?
+        return Result.new(valid?: true, profile_type: "mentor", friendly_profile_type: "mentor")
+      elsif invite.judge? && SeasonToggles.judge_registration_open?
+        return Result.new(valid?: true, profile_type: "judge", friendly_profile_type: "judge")
+      elsif invite.chapter_ambassador?
+        return Result.new(valid?: true, profile_type: "chapter_ambassador", friendly_profile_type: "chapter ambassador")
+      end
+    end
+
+    Result.new(valid?: false, profile_type: "", friendly_profile_type: "")
+  end
+
+  private
+
+  Result = Struct.new(:valid?, :profile_type, :friendly_profile_type, keyword_init: true)
+
+  attr_reader :invite_code
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,6 +354,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :registration_settings, only: :index
+    resources :registration_invites, only: :show
   end
 
   resource :terms_agreement, only: [:edit, :update]

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -92,4 +92,37 @@ RSpec.describe UserInvitation do
     expect(invite.account).to eq(judge.account)
     expect(event.reload.judge_list).to eq([judge])
   end
+
+  describe "#pending?" do
+    let(:invite) do
+      UserInvitation.new(
+        profile_type: :student,
+        status: invite_status
+      )
+    end
+
+    context "when the invite has a status of 'sent'" do
+      let(:invite_status) { "sent" }
+
+      it "is pending" do
+        expect(invite.pending?).to eq(true)
+      end
+    end
+
+    context "when the invite has a status of 'opened'" do
+      let(:invite_status) { "opened" }
+
+      it "is pending" do
+        expect(invite.pending?).to eq(true)
+      end
+    end
+
+    context "when the invite has a status of 'registered'" do
+      let(:invite_status) { "registered" }
+
+      it "is is not pending" do
+        expect(invite.pending?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/registration_invite_validator_spec.rb
+++ b/spec/services/registration_invite_validator_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+describe RegistrationInviteValidator do
+  let(:registration_invite_validator) {
+    RegistrationInviteValidator.new(invite_code: invite_code)
+  }
+  let(:invite_code) { "12345abcde9876zyxw" }
+
+  before do
+    allow(UserInvitation).to receive(:find_by)
+      .with(admin_permission_token: invite_code)
+      .and_return(invitation)
+
+    allow(SeasonToggles).to receive(:student_registration_open?).and_return(student_registration_open)
+    allow(SeasonToggles).to receive(:mentor_registration_open?).and_return(mentor_registration_open)
+    allow(SeasonToggles).to receive(:judge_registration_open?).and_return(judge_registration_open)
+  end
+
+  let(:student_registration_open) { false }
+  let(:mentor_registration_open) { false }
+  let(:judge_registration_open) { false }
+
+  let(:invitation) do
+    instance_double(UserInvitation,
+      pending?: pending_invite,
+      student?: student_invite,
+      mentor?: mentor_invite,
+      judge?: judge_invite,
+      chapter_ambassador?: chapter_ambassador_invite)
+  end
+
+  let(:pending_invite) { false }
+  let(:student_invite) { false }
+  let(:mentor_invite) { false }
+  let(:judge_invite) { false }
+  let(:chapter_ambassador_invite) { false }
+
+  context "when an invite is pending" do
+    let(:pending_invite) { true }
+
+    context "when the invite is for a student" do
+      let(:student_invite) { true }
+
+      context "when student registration is open" do
+        let(:student_registration_open) { true }
+
+        it "is valid" do
+          expect(registration_invite_validator.call.valid?).to eq(true)
+        end
+
+        it "sets the profile type to 'student'" do
+          expect(registration_invite_validator.call.profile_type).to eq("student")
+        end
+
+        it "sets the friendly profile type to 'student'" do
+          expect(registration_invite_validator.call.friendly_profile_type).to eq("student")
+        end
+      end
+
+      context "when student registration is closed" do
+        let(:student_registration_open) { false }
+
+        it "is not valid" do
+          expect(registration_invite_validator.call.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "when the invite is for a mentor" do
+      let(:mentor_invite) { true }
+
+      context "when mentor registration is open" do
+        let(:mentor_registration_open) { true }
+
+        it "is valid" do
+          expect(registration_invite_validator.call.valid?).to eq(true)
+        end
+
+        it "sets the profile type to 'mentor'" do
+          expect(registration_invite_validator.call.profile_type).to eq("mentor")
+        end
+
+        it "sets the friendly profile type to 'mentor'" do
+          expect(registration_invite_validator.call.friendly_profile_type).to eq("mentor")
+        end
+      end
+
+      context "when mentor registration is closed" do
+        let(:mentor_registration_open) { false }
+
+        it "is not valid" do
+          expect(registration_invite_validator.call.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "when the invite is for a judge" do
+      let(:judge_invite) { true }
+
+      context "when judge registration is open" do
+        let(:judge_registration_open) { true }
+
+        it "is valid" do
+          expect(registration_invite_validator.call.valid?).to eq(true)
+        end
+
+        it "sets the profile type to 'judge'" do
+          expect(registration_invite_validator.call.profile_type).to eq("judge")
+        end
+
+        it "sets the friendly profile type to 'judge'" do
+          expect(registration_invite_validator.call.friendly_profile_type).to eq("judge")
+        end
+      end
+
+      context "when judge registration is closed" do
+        let(:judge_registration_open) { false }
+
+        it "is not valid" do
+          expect(registration_invite_validator.call.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "when the invite is for a chapter ambassador" do
+      let(:chapter_ambassador_invite) { true }
+
+      it "is valid" do
+        expect(registration_invite_validator.call.valid?).to eq(true)
+      end
+
+      it "sets the profile type to 'chapter_ambassador'" do
+        expect(registration_invite_validator.call.profile_type).to eq("chapter_ambassador")
+      end
+
+      it "sets the friendly profile type to 'chapter ambassador'" do
+        expect(registration_invite_validator.call.friendly_profile_type).to eq("chapter ambassador")
+      end
+    end
+  end
+
+  context "when the invite is not pending" do
+    let(:pending_invite) { false }
+
+    it "is valid" do
+      expect(registration_invite_validator.call.valid?).to eq(false)
+    end
+  end
+end

--- a/spec/system/admin/invite_users_spec.rb
+++ b/spec/system/admin/invite_users_spec.rb
@@ -1,252 +1,36 @@
 require "rails_helper"
 
-RSpec.describe "Admins invite users to signup", :js do
+RSpec.describe "Registration invites", :js do
   let(:admin) { FactoryBot.create(:admin) }
 
-  before { sign_in(admin) }
-
-  %i{chapter_ambassador mentor student}.each do |scope|
-    it "Inviting a user with profile type #{scope}" do
-      email = "#{scope}@example.com"
-
-      click_link "Invite users"
-
-      expect {
-        select scope.to_s.titleize, from: "Profile type"
-        fill_in "Email", with: email
-        click_button "Send invitation"
-      }.to change {
-        UserInvitation.sent.count
-      }.from(0).to(1)
-
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail).to be_present, "no mail was sent"
-
-      token = UserInvitation.last.admin_permission_token
-      visit send("#{scope}_signup_path", admin_permission_token: token)
-
-      expect(mail.to).to eq([email])
-
-      url = send(
-        "#{scope}_signup_url",
-        admin_permission_token: token,
-        host: ENV.fetch("HOST_DOMAIN"),
-      )
-      expect(mail.body).to include("href=\"#{url}\"")
-
-      visit(send("#{scope}_signup_path", admin_permission_token: token))
-
-      expect(current_path).to eq(send("#{scope}_signup_path"))
-    end
-
-    it "#{scope} signs up, registering their invite" do
-      email = "#{scope}@example.com"
-      UserInvitation.create!(
-        profile_type: scope,
-        email: email,
-      )
-
-      token = UserInvitation.last.admin_permission_token
-      visit send("#{scope}_signup_path", admin_permission_token: token)
-
-      birthdate = case scope
-                  when :student
-                    Date.today - 15.years
-                  else
-                    Date.today - 25.years
-                  end
-
-      fill_in "First name", with: "Pamela"
-      fill_in "Last name", with: "Beasley"
-
-      select_chosen_date birthdate, from: "Date of birth"
-
-      case scope
-      when :student
-        fill_in "School name", with: "John Hughes High"
-      when :mentor
-        select_gender(:random)
-        fill_in "School or company name", with: "John Hughes High"
-        fill_in "Job title", with: "Janitor / Man of the Year"
-        check "Industry professional"
-      when :judge
-        select_gender(:random)
-        fill_in "School or company name", with: "John Hughes High"
-        fill_in "Job title", with: "Janitor / Man of the Year"
-      when :chapter_ambassador
-        select_gender(:random)
-        fill_in "Organization/company name", with: "John Hughes High"
-        fill_in "Job title", with: "Janitor / Man of the Year"
-        fill_in "Tell us about yourself",
-          with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ut diam vel felis fringilla amet."
+  %i[student mentor judge].each do |profile_type|
+    context "as an admin" do
+      before do
+        sign_in(admin)
       end
 
-      fill_in "Create a password", with: "my-secret-password"
+      context "when sending an invite to a #{profile_type}" do
+        it "sends an email with a link with an invite code to register" do
+          email = "#{profile_type}@example.com"
 
-      click_button "Create Your Account"
+          click_link "Invite users"
 
-      if scope != :chapter_ambassador
-        expect(page).to have_current_path(
-          edit_terms_agreement_path, ignore_query: true
-        )
+          expect {
+            select profile_type.to_s.titleize, from: "Profile type"
+            fill_in "Email", with: email
+            click_button "Send invitation"
+          }.to change {
+            UserInvitation.sent.count
+          }.from(0).to(1)
 
-        expect(page).to have_selector('#terms_agreement_checkbox', visible: true)
+          mail = ActionMailer::Base.deliveries.last
+          expect(mail).to be_present, "no mail was sent"
 
-        check "terms_agreement_checkbox"
-
-        click_button "Submit"
-
-        if scope != :student
-          expect(page).to have_current_path(
-            send("#{scope}_location_details_path"), ignore_query: true
-          )
-
-          expect(page).to have_selector('#location_city', visible: true)
-          expect(page).to have_selector('#location_state', visible: true)
-          expect(page).to have_selector('#location_country', visible: true)
-
-          fill_in "State / Province", with: "California"
-          fill_in "City", with: "Los Angeles"
-          fill_in "Country", with: "United States"
-
-          click_button "Next"
-
-          expect(page).to have_selector(:button, text: "Confirm", visible: true)
-
-          click_button "Confirm"
-        end
-
-        if scope == :student
-          expect(page).to have_current_path(student_profile_path)
-        else
-          expect(page).to have_current_path(send("#{scope}_dashboard_path"), ignore_query: true)
+          invite_code = UserInvitation.last.admin_permission_token
+          url = signup_url(invite_code: invite_code, host: ENV.fetch("HOST_DOMAIN"))
+          expect(mail.body).to include("href=\"#{url}\"")
         end
       end
-
-      invite = UserInvitation.last
-      expect(invite).to be_registered
-      expect(invite.account).to eq(Account.last)
-
-      if scope == :chapter_ambassador
-        expect(page).to have_current_path(send("#{scope}_location_details_path"), ignore_query: true)
-        expect(ChapterAmbassadorProfile.last).to be_approved
-      end
     end
-
-    it "#{scope} uses the invite link a second time" do
-      email = "#{scope}@example.com"
-
-      invite = UserInvitation.create!(
-        profile_type: scope,
-        email: email,
-      )
-
-      profile = FactoryBot.create(
-        scope,
-        account: FactoryBot.create(:account, email: email)
-      )
-
-      invite.update(
-        account: profile.account,
-        status: :registered,
-      )
-
-      token = invite.admin_permission_token
-
-      visit send(
-        "#{scope}_signup_path",
-        admin_permission_token: token,
-      )
-
-      expect(current_path).to eq(send("#{scope}_dashboard_path"))
-    end
-  end
-
-  it "invite a chapter ambassador who has an existing mentor account" do
-    email = "chapter_ambassador@example.com"
-    mentor = FactoryBot.create(
-      :mentor,
-      :onboarded,
-      account: FactoryBot.create(:account, email: email)
-    )
-    expect(mentor.account.reload.email).to eq(email)
-
-    UserInvitation.create!(
-      profile_type: "chapter_ambassador",
-      email: email,
-    )
-
-    token = UserInvitation.last.admin_permission_token
-
-    visit chapter_ambassador_signup_path(admin_permission_token: token)
-
-    birthdate = Date.today - 25.years
-
-    fill_in "First name", with: "Pamela"
-    fill_in "Last name", with: "Beasley"
-
-    select_chosen_date birthdate, from: "Date of birth"
-
-    select_gender(:random)
-
-    fill_in "Organization/company name", with: "John Hughes High"
-    fill_in "Job title", with: "Janitor / Man of the Year"
-    fill_in "Tell us about yourself",
-      with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ut diam vel felis fringilla amet."
-
-    fill_in "Create a password", with: "my-secret-password"
-
-    click_button "Create Your Account"
-
-    expect(current_path).to eq(chapter_ambassador_location_details_path)
-
-    invite = UserInvitation.last
-    expect(invite.account.mentor_profile).to eq(mentor)
-  end
-
-  it "invite a chapter ambassador who has an existing judge account" do
-    email = "chapter_ambassador@example.com"
-    judge = FactoryBot.create(
-      :judge,
-      account: FactoryBot.create(:account, email: email)
-    )
-    expect(judge.account.reload.email).to eq(email)
-
-    UserInvitation.create!(
-      profile_type: "chapter_ambassador",
-      email: email,
-    )
-
-    token = UserInvitation.last.admin_permission_token
-
-    visit chapter_ambassador_signup_path(
-      admin_permission_token: token,
-      host: Capybara.app_host
-    )
-
-    birthdate = Date.today - 25.years
-
-    fill_in "First name", with: "Pamela"
-    fill_in "Last name", with: "Beasley"
-
-    select_chosen_date birthdate, from: "Date of birth"
-
-    select_gender(:random)
-
-    fill_in "Organization/company name", with: "John Hughes High"
-    fill_in "Job title", with: "Janitor / Man of the Year"
-    fill_in "Tell us about yourself",
-      with: "Lorem ipsum dolor sit amet, " +
-            "consectetur adipiscing elit. " +
-            "Phasellus ut diam vel felis fringilla amet."
-
-    fill_in "Create a password", with: "my-secret-password"
-
-    click_button "Create Your Account"
-
-    expect(current_path).to eq(chapter_ambassador_location_details_path)
-
-    invite = UserInvitation.last
-    expect(invite.account.reload.judge_profile).to eq(judge)
   end
 end

--- a/spec/system/api/registration_invites_spec.rb
+++ b/spec/system/api/registration_invites_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Registration Invites" do
+  before do
+    allow(RegistrationInviteValidator).to receive_message_chain(:new, :call)
+      .and_return(registration_invite_validator_response)
+  end
+
+  let(:registration_invite_validator_response) do
+    double("registration_invite_validator_response",
+      valid?: true,
+      profile_type: "student",
+      friendly_profile_type: "student")
+  end
+
+  it "returns registration invite details" do
+    get api_registration_invite_path(id: "someinvitecode")
+
+    expect(JSON.parse(response.body)).to eq(
+      {
+        "isValid" => registration_invite_validator_response.valid?,
+        "profileType" => registration_invite_validator_response.profile_type,
+        "friendlyProfileType" => registration_invite_validator_response.friendly_profile_type
+      }
+    )
+  end
+end


### PR DESCRIPTION
This will make it so that when an admin invites a judge, mentor, or student it will go to the new registration system; chapter ambassadors will still use the old/existing registration system.

Basic overview of the work here:
- Update invite emails
- Rename `admin_permission_token` to `invite_code`
- A new back-end API endpoint that will get invite details
- Front-end will use new invite details endpoint, and:
  - Pre-select invited profile type
  - Disable non-invited profile types