### PR TITLE
PT3 - Checkr International Background Check Integration - Invitation Status updates

### DIFF
--- a/app/controllers/concerns/background_check_controller.rb
+++ b/app/controllers/concerns/background_check_controller.rb
@@ -8,7 +8,13 @@ module BackgroundCheckController
   end
 
   def show
-    BackgroundChecking.new(current_profile.background_check).execute
+    if current_profile.background_check.invitation_id.present?
+      InvitationChecking.new(current_profile.background_check).execute
+    end
+
+    if current_profile.background_check.report_id.present?
+      BackgroundChecking.new(current_profile.background_check).execute
+    end
     @background_check = current_profile.background_check
   end
 

--- a/app/services/custom_checkr/api_client.rb
+++ b/app/services/custom_checkr/api_client.rb
@@ -44,7 +44,6 @@ module CustomCheckr
         if invitation_response.status == 201
           profile.account.update(background_check_attributes: {
             candidate_id: candidate_response_body[:id],
-            report_id: "international",
             invitation_id: invitation_response_body[:id],
             invitation_status: invitation_response_body[:status],
             status: :invitation_sent
@@ -68,14 +67,26 @@ module CustomCheckr
       end
     end
 
-    # todo: get request for invitation status update from checkr
-    # def get_checkr_invitation()
-    # end
+    def retrieve_invitation(invitation_id)
+      invitation_response = connection.get("/v1/invitations/#{invitation_id}")
+
+      invitation_response_body = JSON.parse(invitation_response.body, symbolize_names: true)
+
+      if invitation_response.status == 200
+        Result.new(success?: true, payload: invitation_response_body)
+      else
+        error = "[CHECKR] Error requesting invitation for #{background_check.id} - #{invitation_response_body[:error]}"
+        logger.error(error)
+        error_notifier.notify(error)
+
+        Result.new(success?: false)
+      end
+    end
 
     private
 
     attr_reader :connection, :logger, :error_notifier
 
-    Result = Struct.new(:success?, :message, keyword_init: true)
+    Result = Struct.new(:success?, :message, :payload, keyword_init: true)
   end
 end

--- a/app/technovation/invitation_checking.rb
+++ b/app/technovation/invitation_checking.rb
@@ -1,0 +1,28 @@
+class InvitationChecking
+  def initialize(bg_check, options = {})
+    @bg_check = bg_check
+    @invitation = CustomCheckr::ApiClient.new.retrieve_invitation(@bg_check.invitation_id)
+    @logger = options.fetch(:logger) { Logger.new("/dev/null") }
+  end
+
+  def execute
+    if @invitation.success?
+      if @invitation[:payload][:status] != @bg_check.invitation_status
+        @bg_check.update(
+          invitation_status: @invitation[:payload][:status]
+        )
+        @logger.info("Invitation Status UPDATED TO #{@invitation[:payload][:status]} for #{@bg_check.account.id}")
+      end
+
+      if @bg_check.report_id.blank? && @invitation[:payload][:report_id].present?
+        @bg_check.update(
+          report_id: @invitation[:payload][:report_id]
+        )
+        @logger.info("Report ID UPDATED TO #{@invitation[:payload][:report_id]} for #{@bg_check.account.id}")
+      end
+
+    else
+      @logger.info("Issue getting invitation from checkr for #{@bg_check.account.id}")
+    end
+  end
+end

--- a/app/views/background_checks/_international_background_check.html.erb
+++ b/app/views/background_checks/_international_background_check.html.erb
@@ -20,7 +20,7 @@
 
           <p>
             Then, Checkr gives us a secret, randomized token to keep track of the
-            status of your background check. At no point does your actual information
+            status of your invitation request and background check. At no point does your actual information
             reach our servers.
           </p>
 
@@ -90,7 +90,9 @@
   <div class="grid__col-sm-5">
     <div class="panel">
       <h3><%= t("views.background_checks.new.international_title") %></h3>
-      <%= link_to "Request background check invitation", mentor_international_background_check_url %>
+      <%= link_to "Request background check invitation",
+                  mentor_international_background_check_url,
+                  class: "button" %>
     </div>
   </div>
 </div>

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -1,6 +1,17 @@
 <div class="grid grid--justify-space-around">
   <div class="grid__col-sm-8">
     <div class="panel">
+      <% if @background_check.invitation_pending? %>
+        <p>An invitation was sent to your email on <%= @background_check.created_at.strftime("%B %d, %Y") %> from Checkr.
+          <br>
+          Please check your email to accept the invitation and complete the background check through the Checkr portal.
+        </p>
+      <% elsif @background_check.invitation_completed?  %>
+        <p>
+          Thank you for completing your background check through the Checkr portal.
+        </p>
+      <% end %>
+
       <p>
         Your background check status is:
         <strong><%= @background_check.status.humanize %></strong>

--- a/db/migrate/20230914204523_remove_not_null_report_id_constraint_from_background_checks.rb
+++ b/db/migrate/20230914204523_remove_not_null_report_id_constraint_from_background_checks.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullReportIdConstraintFromBackgroundChecks < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :background_checks, :report_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -235,7 +235,7 @@ CREATE TABLE public.ar_internal_metadata (
 CREATE TABLE public.background_checks (
     id integer NOT NULL,
     candidate_id character varying NOT NULL,
-    report_id character varying NOT NULL,
+    report_id character varying,
     account_id integer NOT NULL,
     status integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -3331,6 +3331,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230727123214'),
 ('20230809190653'),
 ('20230810134239'),
-('20230905194750');
+('20230905194750'),
+('20230914204523');
 
 


### PR DESCRIPTION
Refs #4180 

This PR is part 3 of the background check work. This update was needed in order to capture the invitation status and the background check report ID from checkr.

Current flow for requesting an international bg check invitation:
1. Mentors in certain countries are required to complete a bg check
2. Mentor clicks button "request bg check invitation"
3. Candidate is created, then invitation using candidate id is created
4. This invitation is sent to mentor's email address
5. Mentor will click on the link in the email from checkr which will lead them to the Checkr portal
6. They will complete the bg check in the the checkr portal
7. When they log back into technovation platform there is an option to check the invitation status. This is where this PR comes into place. There is new logic that will request the invitation from checkr. 
8. We can save the updated status ( options are pending, completed, expired) and the now available `report_id`
9. Then the flow continues with report status check