### PR TITLE
Update Sidekiq gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "friendly_id", "~> 5.5"
 
 gem "bcrypt", "~> 3.1"
 
-gem "sidekiq", "~> 6.4.0"
+gem "sidekiq", "~> 7.0"
 
 gem "airbrake", "~> 11.0.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,6 +402,8 @@ GEM
       ffi (~> 1.0)
     rbtree3 (0.7.0)
     redis (4.8.1)
+    redis-client (0.17.0)
+      connection_pool
     regexp_parser (2.8.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -465,10 +467,11 @@ GEM
       websocket (~> 1.0)
     semantic_range (3.0.0)
     sexp_processor (4.15.3)
-    sidekiq (6.4.2)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
+    sidekiq (7.1.4)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -612,7 +615,7 @@ DEPENDENCIES
   rspec-retry
   sass-rails (~> 6.0)
   selenium-webdriver
-  sidekiq (~> 6.4.0)
+  sidekiq (~> 7.0)
   simple_form (~> 5.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)

--- a/app/technovation/season_toggles.rb
+++ b/app/technovation/season_toggles.rb
@@ -1,3 +1,5 @@
+require "redis"
+
 require "season_toggles/signup_toggles"
 require "season_toggles/dashboard_notices"
 require "season_toggles/survey_links"
@@ -27,6 +29,7 @@ class SeasonToggles
     end
 
     private
+
     def store
       @@store ||= Redis.new(ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
     end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
-Sidekiq.default_worker_options = {
+Sidekiq.default_job_options = {
   backtrace: true,
-  retry: 3,
+  retry: 3
 }
 
 Sidekiq.configure_server do |config|
@@ -11,9 +11,8 @@ Sidekiq.configure_server do |config|
     }
   }
 
-
-  if database_url = ENV['DATABASE_URL']
-    pool = ENV.fetch("SIDEKIQ_DB_POOL_SIZE") { 25 }
+  if (database_url = ENV["DATABASE_URL"])
+    pool = ENV.fetch("SIDEKIQ_DB_POOL_SIZE", 25)
     ActiveRecord::Base.establish_connection "#{database_url}?pool=#{pool}"
   end
 end


### PR DESCRIPTION
A high security vulnerability came in yesterday, the changes in this PR will update Sidekiq to address this:
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/164

I also had to make a few other updates to account for this upgrade (we upgraded from 6.x to 7.x):
- Addressing this deprecation warning:
  - DEPRECATION WARNING: default_worker_options= is deprecated and will be removed from Sidekiq 7.0 (use default_job_options= instead)
- Requiring "redis" to address this error:
  - NameError (uninitialized constant Redis)

I also included a couple of code style updates.

I tested this by viewing and updating "Content & Settings", I was running into issues at first^ and then addressed those, and now it's working for me locally.
