### PR TITLE
Admin invites for Chapter Ambassadors using new registration system

### DIFF
--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -19,6 +19,8 @@ class NewRegistrationController < ApplicationController
       @profile = MentorProfile.new(mentor_params)
     when "judge"
       @profile = JudgeProfile.new(judge_params)
+    when "chapter_ambassador"
+      @profile = ChapterAmbassadorProfile.new(chapter_ambassador_params)
     end
 
     if @profile.save
@@ -78,6 +80,15 @@ class NewRegistrationController < ApplicationController
     }
   end
 
+  def chapter_ambassador_params
+    {
+      organization_company_name: registration_params[:chapterAmbassadorOrganizationCompanyName],
+      job_title: registration_params[:chapterAmbassadorJobTitle],
+      bio: registration_params[:chapterAmbassadorBio],
+      account_attributes: account_attributes.merge({gender: registration_params[:gender]})
+    }
+  end
+
   def account_attributes
     {
       first_name: registration_params[:firstName],
@@ -113,6 +124,9 @@ class NewRegistrationController < ApplicationController
       :mentorBio,
       :judgeSchoolCompanyName,
       :judgeJobTitle,
+      :chapterAmbassadorOrganizationCompanyName,
+      :chapterAmbassadorJobTitle,
+      :chapterAmbassadorBio,
       mentorExpertises: [],
       mentorTypes: []
     )

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -1,0 +1,180 @@
+<template>
+  <div id="step-two">
+    <ContainerHeader header-text="Basic Profile" />
+
+    <div class="form-wrapper">
+      <div id="step-two-chapter-ambassador">
+        <h2 class="registration-title">Chapter Ambassador Information</h2>
+
+        <div class="formulate-input-wrapper name-group">
+          <FormulateInput
+            name="firstName"
+            id="firstName"
+            type="text"
+            label="First Name"
+            placeholder="First Name"
+            validation="required"
+            validation-name="First name"
+            @keyup="checkValidation"
+            @blur="checkValidation"
+            class="flex-grow pr-2"
+          />
+
+          <FormulateInput
+            name="lastName"
+            id="lastName"
+            type="text"
+            label="Last Name"
+            placeholder="Last Name"
+            validation="required"
+            validation-name="Last name"
+            @keyup="checkValidation"
+            @blur="checkValidation"
+            class="flex-grow pl-2"
+          />
+        </div>
+
+        <FormulateInput
+          name="gender"
+          :options="genderOptions"
+          type="select"
+          placeholder="Select an option"
+          validation="required"
+          validation-name="Gender identity"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+          label="Gender Identity"
+          id="genderIdentity"
+          input-class="ChapterAmbassadorSelectClass"
+        />
+
+        <FormulateInput
+          name="dateOfBirth"
+          id="dateOfBirth"
+          type="date"
+          label="Birthday"
+          placeholder="Birthday"
+          validation="required|chapter_ambassador_age|after:01/01/1900|before:01/01/2020"
+          :validation-messages="{
+            after: 'Please enter a valid birthday.',
+            before: 'Please enter a valid birthday.'
+          }"
+          validation-name="Birthday"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+          @change="checkValidation"
+        />
+
+        <FormulateInput
+          name="chapterAmbassadorOrganizationCompanyName"
+          id="chapterAmbassadorOrganizationCompanyName"
+          type="text"
+          label="Company Name"
+          placeholder="Company Name"
+          validation="required"
+          validation-name="Company name"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+        />
+
+        <FormulateInput
+          name="chapterAmbassadorJobTitle"
+          id="chapterAmbassadorJobTitle"
+          type="text"
+          label="Job Title"
+          placeholder="Job Title"
+          validation="required"
+          validation-name="Job title"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+        />
+
+        <div class="chapter-ambassador-information">
+          <h2 class="registration-title">Set your personal summary</h2>
+
+          <p class="text-left pb-2">
+            Add a description of yourself to your profile to help students get to know you.
+            Entering at least 100 characters is required.
+            You can change this later.<span class="formulate-required-field">*</span>
+          </p>
+          <FormulateInput
+            name="chapterAmbassadorBio"
+            id="chapterAmbassadorBio"
+            type="textarea"
+            validation="required|min:100,length"
+            validation-name="Personal summary"
+            @keyup="checkValidation"
+            @blur="checkValidation"
+          />
+        </div>
+      </div>
+    </div>
+
+    <ReferredBy />
+
+    <div class="registration-btn-wrapper">
+      <PreviousButton @prev="$emit('prev')"/>
+      <NextButton @next="$emit('next')" :disabled="hasValidationErrors" />
+    </div>
+  </div>
+</template>
+
+<script>
+import ContainerHeader from "./ContainerHeader";
+import ReferredBy from "./ReferredBy";
+import PreviousButton from "./PreviousButton";
+import NextButton from "./NextButton";
+
+export default {
+  name: "ChapterAmbassadorStepTwo",
+  components: {
+    ContainerHeader,
+    ReferredBy,
+    PreviousButton,
+    NextButton
+  },
+  data () {
+    return {
+      genderOptions: [
+        'Female',
+        'Male',
+        'Non-binary',
+        'Prefer not to say'
+      ],
+      hasValidationErrors: true
+    }
+  },
+  methods: {
+    checkValidation() {
+      const validationErrorMessages = Array.from(
+        document.getElementsByClassName('validation-error-message')
+      ).map(element => element.innerText)
+
+      if (document.getElementById('firstName').value.length === 0 ||
+        document.getElementById('lastName').value.length === 0 ||
+        document.getElementById('dateOfBirth').value.length === 0 ||
+        document.getElementById('chapterAmbassadorOrganizationCompanyName').value.length === 0 ||
+        document.getElementById('chapterAmbassadorJobTitle').value.length === 0 ||
+        document.getElementById('chapterAmbassadorBio').value.length < 100 ||
+        validationErrorMessages.some((message) => {
+          return (
+            message.indexOf('years old to participate') >= 0 ||
+            message.indexOf('Please enter a valid birthday') >= 0 ||
+            message.indexOf('Personal summary must be at least') >= 0
+          )
+        })) {
+
+        this.hasValidationErrors = true
+      } else {
+        this.hasValidationErrors = false
+      }
+    }
+  },
+  props: {
+    formValues: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>

--- a/app/javascript/new_registration/components/FormWrapper.vue
+++ b/app/javascript/new_registration/components/FormWrapper.vue
@@ -24,6 +24,11 @@
         @next="next"
         @prev="prev"
       />
+      <ChapterAmbassadorStepTwo v-else-if="formValues.profileType === 'chapter_ambassador'"
+        :form-values="formValues"
+        @next="next"
+        @prev="prev"
+      />
       <StudentStepTwo v-else
         :form-values="formValues"
         @next="next"
@@ -50,6 +55,7 @@ import StepOne from './StepOne';
 import MentorStepTwo from './MentorStepTwo';
 import StudentStepTwo from './StudentStepTwo';
 import JudgeStepTwo from "./JudgeStepTwo";
+import ChapterAmbassadorStepTwo from "./ChapterAmbassadorStepTwo";
 import StepThree from './StepThree';
 import StepFour from './StepFour';
 
@@ -60,6 +66,7 @@ export default {
     MentorStepTwo,
     StudentStepTwo,
     JudgeStepTwo,
+    ChapterAmbassadorStepTwo,
     StepThree,
     StepFour
   },
@@ -119,6 +126,9 @@ export default {
             break
           case 'judge':
             window.location.href = '/judge/dashboard'
+            break
+          case 'chapter_ambassador':
+            window.location.href = '/pending_chapter_ambassador/dashboard'
             break
         }
       }

--- a/app/javascript/new_registration/components/StepOne.vue
+++ b/app/javascript/new_registration/components/StepOne.vue
@@ -10,7 +10,7 @@
           <p v-else>
             This invitation is no longer valid.
           </p>
-      </div>
+        </div>
       </div>
 
       <div v-if="anyDisabledProfileTypes" class="border-l-2 border-red-700 bg-red-50 p-2 mb-4">
@@ -19,7 +19,7 @@
         </p>
       </div>
 
-      <div v-if="typeof registrationInvite != 'undefined'">
+      <div v-if="Object.keys(registrationInvite).length !== 0">
         <div v-if="registrationInvite.isValid == true">
           <h2 class="registration-title">
             Welcome to Technovation Girls!
@@ -135,6 +135,10 @@ export default {
       if (this.isJudgeRegistrationOpen) {
         this.profileTypes.push(this.judgeProfileType())
       }
+
+      if (this.registrationInvite.isValid && this.registrationInvite.profileType == 'chapter_ambassador') {
+        this.profileTypes.push(this.chapterAmbassadorProfileType())
+      }
     },
     setupDisabledProfileTypes() {
       let disabledProfiles = []
@@ -207,6 +211,13 @@ export default {
         label: `<img src="${require('signup/myTG-mentor.png')}" alt="" class="judge"> <span class="judge s1-label-text">I am over 18 years old and will <span class="judge font-bold">judge submissions</span>`,
         value: 'judge',
         id: 'judge'
+      }
+    },
+    chapterAmbassadorProfileType() {
+      return {
+        label: `<img src="${require('signup/myTG-mentor.png')}" alt="" class="chapter_ambassador"> <span class="chapter_ambassador s1-label-text">Chapter Ambassador</span>`,
+        value: 'chapter_ambassador',
+        id: 'chapter_ambassador'
       }
     },
     displayDivisionCutoffDescription() {

--- a/app/javascript/new_registration/index.js
+++ b/app/javascript/new_registration/index.js
@@ -35,6 +35,9 @@ Vue.use(VueFormulate, {
       judgeAge() {
         return "You must be at least 18 years old to participate as a judge.";
       },
+      chapterAmbassadorAge() {
+        return "You must be at least 18 years old to participate as a chapter ambassador.";
+      },
     },
   },
   rules: {
@@ -42,6 +45,7 @@ Vue.use(VueFormulate, {
       verifyStudentAge({ birthday: value, division }),
     mentorAge: ({ value }) => verifyOlderThanEighteen({ birthday: value }),
     judgeAge: ({ value }) => verifyOlderThanEighteen({ birthday: value }),
+    chapterAmbassadorAge: ({ value }) => verifyOlderThanEighteen({ birthday: value }),
   },
   slotComponents: {
     label: "CustomLabel",

--- a/app/javascript/new_registration/index.js
+++ b/app/javascript/new_registration/index.js
@@ -5,8 +5,7 @@ import App from "./App";
 import CustomLabel from "./components/CustomLabel";
 import {
   verifyStudentAge,
-  verifyMentorAge,
-  verifyJudgeAge,
+  verifyOlderThanEighteen,
 } from "utilities/age-helpers.js";
 
 Vue.component("CustomLabel", CustomLabel);
@@ -41,8 +40,8 @@ Vue.use(VueFormulate, {
   rules: {
     studentAge: ({ value }, division) =>
       verifyStudentAge({ birthday: value, division }),
-    mentorAge: ({ value }) => verifyMentorAge({ birthday: value }),
-    judgeAge: ({ value }) => verifyJudgeAge({ birthday: value }),
+    mentorAge: ({ value }) => verifyOlderThanEighteen({ birthday: value }),
+    judgeAge: ({ value }) => verifyOlderThanEighteen({ birthday: value }),
   },
   slotComponents: {
     label: "CustomLabel",

--- a/app/javascript/utilities/age-helpers.js
+++ b/app/javascript/utilities/age-helpers.js
@@ -28,11 +28,7 @@ function verifyStudentAge({birthday, division}) {
   }
 }
 
-function verifyMentorAge({birthday}) {
-  return (ageToday(birthday) >= 18)
-}
-
-function verifyJudgeAge({birthday}) {
+function verifyOlderThanEighteen({birthday}) {
   return (ageToday(birthday) >= 18)
 }
 
@@ -42,8 +38,7 @@ function exampleStudentBirthday() {
 
 export {
   verifyStudentAge,
-  verifyMentorAge,
-  verifyJudgeAge,
+  verifyOlderThanEighteen,
   calculateAgeByDivisionCutoffDate,
   exampleStudentBirthday
 }

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -16,11 +16,7 @@ class RegistrationMailer < ApplicationMailer
     invite_code = invitation.admin_permission_token
 
     if invite_code.present?
-      if invitation.profile_type == "chapter_ambassador"
-        @url = chapter_ambassador_signup_url(admin_permission_token: invite_code)
-      else
-        @url = signup_url(invite_code: invite_code)
-      end
+      @url = signup_url(invite_code: invite_code)
 
       mail to: invitation.email,
         subject: t("registration_mailer.admin_permission.subject", season_year: Season.current.year) do |f|

--- a/spec/javascript/utilities/age-helpers.spec.js
+++ b/spec/javascript/utilities/age-helpers.spec.js
@@ -1,7 +1,6 @@
 import {
   verifyStudentAge,
-  verifyMentorAge,
-  verifyJudgeAge
+  verifyOlderThanEighteen
 } from "utilities/age-helpers.js";
 
 const currentEnv = process.env;
@@ -107,12 +106,12 @@ describe("verifyStudentAge", () => {
   });
 });
 
-describe("verifyMentorAge", () => {
+describe("verifyOlderThanEighteen", () => {
   describe("when a mentor is older than 18", () => {
     const birthday = "2000-01-01";
 
     it("returns true", () => {
-      expect(verifyMentorAge({ birthday })).toBe(true);
+      expect(verifyOlderThanEighteen({ birthday })).toBe(true);
     });
   });
 
@@ -120,25 +119,7 @@ describe("verifyMentorAge", () => {
     const birthday = "2010-01-01";
 
     it("returns false", () => {
-      expect(verifyMentorAge({ birthday })).toBe(false);
-    });
-  });
-});
-
-describe("verifyJudgeAge", () => {
-  describe("when a judge is older than 18", () => {
-    const birthday = "2000-01-01";
-
-    it("returns true", () => {
-      expect(verifyJudgeAge({ birthday })).toBe(true);
-    });
-  });
-
-  describe("when a judge is younger than 18", () => {
-    const birthday = "2010-01-01";
-
-    it("returns false", () => {
-      expect(verifyJudgeAge({ birthday })).toBe(false);
+      expect(verifyOlderThanEighteen({ birthday })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This will add the basic functionality so that when an admin invites a chapter ambassador:
- the invite email will have a link with an invite code that will go to the new registration system
- a new chapter ambassador profile (which needs a new icon) will be pre-selected
  - this new profile type should only be shown with a valid chapter ambassador invite code
- after the new chapter ambassador profile has been created, they will be put back into the regular/existing "pending" chapter ambassador flow