### PR TITLE
Fix mentor type validation during registration

### DIFF
--- a/app/javascript/new_registration/components/MentorStepTwo.vue
+++ b/app/javascript/new_registration/components/MentorStepTwo.vue
@@ -90,7 +90,9 @@
         />
 
         <div class="mentor-information" v-show="mentorTypeOptions.length > 0">
-          <h4 class="registration-title">As a mentor you may call me a...</h4>
+          <h4 class="registration-title">
+            As a mentor you may call me a...<span class="formulate-required-field">*</span>
+          </h4>
 
           <FormulateInput
             name="mentorTypes"

--- a/app/javascript/new_registration/components/MentorStepTwo.vue
+++ b/app/javascript/new_registration/components/MentorStepTwo.vue
@@ -103,6 +103,7 @@
             :validation-messages="{ required: 'This field is required.' }"
             @keyup="checkValidation"
             @blur="checkValidation"
+            @input="checkValidation"
           />
         </div>
 
@@ -183,12 +184,15 @@ export default {
         document.getElementsByClassName('validation-error-message')
       ).map(element => element.innerText)
 
+      const hasMentorTypeChecked = !!(document.querySelector('[name="mentorTypes"]:checked'));
+
       if (document.getElementById('firstName').value.length === 0 ||
         document.getElementById('lastName').value.length === 0 ||
         document.getElementById('dateOfBirth').value.length === 0 ||
         document.getElementById('mentorSchoolCompanyName').value.length === 0 ||
         document.getElementById('mentorJobTitle').value.length === 0 ||
         document.getElementById('mentorBio').value.length < 100 ||
+        hasMentorTypeChecked === false ||
         validationErrorMessages.some((message) => {
           return (
             message.indexOf('years old to participate') >= 0 ||


### PR DESCRIPTION
This will make the "As a mentor you may call me a..." field required, making it so that the "Next" button should be disabled if a mentor type isn't selected/picked.