### PR TITLE
Added checkr background check country codes to environment variables

### DIFF
--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -69,13 +69,14 @@ export default {
   },
 
   isBackgroundCheckWaived(state) {
-    const backgroundCheckCountries = ["US", "CA", "IN"];
+    const backgroundCheckCountryCodes =
+      state.settings.backgroundCheckCountryCodes;
 
     const isBackgroundCheckCountry = digStateAttributes(
       state,
       "currentAccount",
       "countryCode",
-      (code) => backgroundCheckCountries.includes(code)
+      (code) => backgroundCheckCountryCodes.includes(code)
     );
 
     const isAgeAppropriate = digStateAttributes(

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -300,9 +300,14 @@ class MentorProfile < ActiveRecord::Base
   end
 
   def requires_background_check?
-    (account.valid? and account.age >= 18) and
-      (account.country_code == "US" or account.country_code == "IN") and
-        not (background_check.present? and background_check.clear?)
+    (account.valid? && account.age >= 18) &&
+      in_background_check_country? &&
+      !(background_check.present? && background_check.clear?)
+  end
+
+  def in_background_check_country?
+    country_codes = ENV.fetch("BACKGROUND_CHECK_COUNTRY_CODES", "").split(",")
+    country_codes.include?(account.country_code)
   end
 
   def bio_complete?

--- a/app/views/background_checks/_new.html.erb
+++ b/app/views/background_checks/_new.html.erb
@@ -1,5 +1,5 @@
 <% if current_account.country_code == "US" %>
   <%= render "background_checks/us_background_check", url: url %>
-<% elsif current_account.country_code == "IN" %>
+<% else %>
   <%= render "background_checks/international_background_check" %>
 <% end %>

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -9,7 +9,10 @@
       current_teams: TeamSerializer.new(current_mentor.current_teams).serialized_json,
       consent_waiver: ConsentSerializer.new(current_mentor.consent_waiver).serialized_json,
       background_check: BackgroundCheckSerializer.new(current_mentor.background_check).serialized_json,
-      settings: { canDisplayScores: SeasonToggles.display_scores? }.to_json
+      settings: {
+        canDisplayScores: SeasonToggles.display_scores?,
+        backgroundCheckCountryCodes: ENV.fetch("BACKGROUND_CHECK_COUNTRY_CODES")
+      }.to_json
     } %>
   <app
     :profile-icons="{

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ jobs:
           AIRBRAKE_PROJECT_KEY: n-a
           AIRBRAKE_RAILS_ENV: test
           AWS_BUCKET_NAME: technovation-attachments-test
+          BACKGROUND_CHECK_COUNTRY_CODES: "US,IN,CA"
           BING_MAPS_API_KEY: n-a
           CAMPAIGN_MONITOR_API_KEY: n-a
           CHAPTER_AMBASSADOR_SLACK_URL: n-a

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -1,4 +1,6 @@
-import getters from 'mentor/store/getters'
+import getters from "mentor/store/getters";
+
+const backgroundCheckCountryCodes = "IN, CA, US";
 
 describe("mentor/store/getters.js", () => {
   describe("isBackgroundCheckWaived", () => {
@@ -12,10 +14,13 @@ describe("mentor/store/getters.js", () => {
             },
           },
         },
-      }
+        settings: {
+          backgroundCheckCountryCodes: backgroundCheckCountryCodes,
+        },
+      };
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(true)
-    })
+      expect(getters.isBackgroundCheckWaived(state)).toBe(true);
+    });
 
     it("is false when currentAccount.countryCode is US", () => {
       const state = {
@@ -27,10 +32,13 @@ describe("mentor/store/getters.js", () => {
             },
           },
         },
-      }
+        settings: {
+          backgroundCheckCountryCodes: backgroundCheckCountryCodes,
+        },
+      };
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(false)
-    })
+      expect(getters.isBackgroundCheckWaived(state)).toBe(false);
+    });
 
     it("is true when currentAccount.age is under 18", () => {
       const state = {
@@ -42,36 +50,41 @@ describe("mentor/store/getters.js", () => {
             },
           },
         },
-      }
+        settings: {
+          backgroundCheckCountryCodes: backgroundCheckCountryCodes,
+        },
+      };
 
-      expect(getters.isBackgroundCheckWaived(state)).toBe(true)
-    })
-  })
+      expect(getters.isBackgroundCheckWaived(state)).toBe(true);
+    });
+  });
 
   describe("isOnTeam", () => {
-    it ("is true if the mentor has a team in currentTeams", () => {
+    it("is true if the mentor has a team in currentTeams", () => {
       const state = {
-        currentTeams: [{
-          data: {
-            id: 'db123',
+        currentTeams: [
+          {
+            data: {
+              id: "db123",
+            },
           },
-        }],
-      }
+        ],
+      };
 
-      expect(getters.isOnTeam(state)).toBeTruthy()
-    })
+      expect(getters.isOnTeam(state)).toBeTruthy();
+    });
 
-    it ("is false if the mentor has no teams in currentTeams", () => {
+    it("is false if the mentor has no teams in currentTeams", () => {
       const state = {
         currentTeams: [],
-      }
+      };
 
-      expect(getters.isOnTeam(state)).toBeFalsy()
-    })
-  })
+      expect(getters.isOnTeam(state)).toBeFalsy();
+    });
+  });
 
   describe("canJoinTeams", () => {
-    it ("is true if the currentMentor isOnboarded", () => {
+    it("is true if the currentMentor isOnboarded", () => {
       const state = {
         currentMentor: {
           data: {
@@ -80,14 +93,14 @@ describe("mentor/store/getters.js", () => {
             },
           },
         },
-      }
+      };
 
-      expect(getters.canJoinTeams(state)).toBeTruthy()
-    })
-  })
+      expect(getters.canJoinTeams(state)).toBeTruthy();
+    });
+  });
 
   describe("isOnboarded", () => {
-    it ("is true if the currentMentor isOnboarded", () => {
+    it("is true if the currentMentor isOnboarded", () => {
       const state = {
         currentMentor: {
           data: {
@@ -96,23 +109,23 @@ describe("mentor/store/getters.js", () => {
             },
           },
         },
-      }
+      };
 
-      expect(getters.isOnboarded(state)).toBeTruthy()
-    })
-  })
+      expect(getters.isOnboarded(state)).toBeTruthy();
+    });
+  });
 
   describe("canDisplayScores", () => {
     it("returns true when the display_scores setting is enabled", () => {
-      const state = { settings: { canDisplayScores: true } }
+      const state = { settings: { canDisplayScores: true } };
 
-      expect(getters.canDisplayScores(state)).toBe(true)
-    })
+      expect(getters.canDisplayScores(state)).toBe(true);
+    });
 
     it("returns false when the display_scores setting is disabled", () => {
-      const state = { settings: { canDisplayScores: false } }
+      const state = { settings: { canDisplayScores: false } };
 
-      expect(getters.canDisplayScores(state)).toBe(false)
-    })
-  })
-})
+      expect(getters.canDisplayScores(state)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Refs #4193 

Added env variables for background check countries. You will need to add the following to your `.env` file
`BACKGROUND_CHECK_COUNTRY_CODES="US,IN,CA"`. I will also need to add this variable to QA and PROD env variables

With this update, anytime we want to add another country for background checks, we will need to add the 2 letter ISO country code this variable. 

This change also affects the green checkmark for background checks in the side mentor profile menu. It will not be checked if they mentor's account is one of these countries. 