### PR TITLE
Added logic to freeze time to earlier part of season if within 6 days of new season launch

### DIFF
--- a/spec/features/survey_links_spec.rb
+++ b/spec/features/survey_links_spec.rb
@@ -5,7 +5,16 @@ RSpec.feature "Survey links" do
     before do
       SeasonToggles.set_survey_link(scope, "survey", "http")
 
-      allow(ImportantDates).to receive(:new_season_switch).and_return(Date.new(2020, 1, 1))
+      new_season_switch = ImportantDates.new_season_switch
+      six_days_before_new_season_switch = new_season_switch - 6.days
+
+      if Time.now.between?(six_days_before_new_season_switch, new_season_switch)
+        Timecop.freeze(Time.local(Season.current.year - 1, 10, 15))
+      end
+    end
+
+    after do
+      Timecop.return
     end
 
     scenario "a new #{scope} waits 2 days from profile creation" do


### PR DESCRIPTION
Refs #4231 

We recently had a previous issue pop up ([here](https://github.com/Iridescent-CM/technovation-app/commit/5332e9d2967475cdf5d707edf3ffa631a14d85a0) & [here](https://github.com/Iridescent-CM/technovation-app/commit//d0ea25e41cfb54543d8cb40515cd4062a5c749e7)) on CircleCi related to the new season launch dates. We discovered tests in `survey_links_spec` would fail if we were within a 4-day window of a new season launching. After investigating this further, I actually think these tests would fail if we were in a 6-day window (explanation below). This happens because some of the tests "time travel" into the future.

 For example, the ` no #{scope}s get reminded after the 2nd time` scenario travels 6 days into the future. There are 3 instances of ` Timecop.travel(2.days.from_now)` in this scenario which equals 6 days total. So the issue happens because if for example the tests are run today the date is 9-27-2023.
- The test goes 2 days into the future which is 9-29-2023 (current season)
- Then the test goes 2 days past that - 10-01-2023 <---- 10-01-23 happens to be the new season start date (new season)
- Then the test goes 2 days past that - 10-03-2023

The test is failing because it is searching for a survey reminder from a previous season in the new season which doesn't exist in the new season. 

TLDR - I added logic to see if we were within a 6day window of the new season starting. If we are in that window then freeze the time to an earlier part of the current season! This should also allow us to remove the extra line that changes the `new_season_switch dates` for this test
