### PR TITLE
Specs for registration steps and fields 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports.
   config.consider_all_requests_local = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Chapter ambassadors registering", :js do
+  let(:chapter_ambassado_registration_invite) {
+    UserInvitation.create!(
+      profile_type: :chapter_ambassador,
+      email: "chapter_ambassador_invite@example.com"
+    )
+  }
+
+  before do
+    SeasonToggles.registration_open!
+
+    visit signup_path(invite_code: chapter_ambassado_registration_invite.admin_permission_token)
+  end
+
+  scenario "Chapter ambassador registration steps and fields" do
+    expect(page).to have_content("Chapter Ambassador")
+
+    choose "Chapter Ambassador"
+    click_button "Next"
+
+    expect(page).to have_content("Chapter Ambassador Information")
+
+    fill_in "First Name", with: "Hopeful Heart"
+    fill_in "Last Name", with: "Bear"
+    select "Prefer not to say", from: "Gender Identity"
+    fill_in "Birthday", with: 32.years.ago
+    fill_in "Company Name", with: "Care-a-Lot Inc."
+    fill_in "Job Title", with: "Kindness spreader"
+    fill_in "chapterAmbassadorBio", with: "I am always brimming with hope, happiness, and positivity. I am the kind of bear that will tell you everything's going to be all right in the end. I see the silver lining around every dark cloud, and know that no matter how dire a situation may seem, there's always chance to make things better."
+    click_button "Next"
+
+    expect(page).to have_content("Data Use Terms")
+
+    check "I AGREE TO THESE DATA USE TERMS"
+    click_button "Next"
+
+    expect(page).to have_content("Set your email and password")
+
+    fill_in "Email Address", with: "hopeful.heart@test.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Submit this form"
+  end
+end

--- a/spec/features/registration/judge_spec.rb
+++ b/spec/features/registration/judge_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Judges registering", :js do
+  before do
+    SeasonToggles.registration_open!
+
+    visit "/signup"
+  end
+
+  scenario "Judge registration steps and fields" do
+    choose "I am over 18 years old and will judge submissions"
+    click_button "Next"
+
+    expect(page).to have_content("Judge Information")
+
+    fill_in "First Name", with: "Funshine"
+    fill_in "Last Name", with: "Bear"
+    select "Prefer not to say", from: "Gender Identity"
+    fill_in "Birthday", with: 41.years.ago
+    fill_in "Company Name", with: "Care-a-Lot"
+    fill_in "Job Title", with: "Class clown"
+    click_button "Next"
+
+    expect(page).to have_content("Data Use Terms")
+
+    check "I AGREE TO THESE DATA USE TERMS"
+    click_button "Next"
+
+    expect(page).to have_content("Set your email and password")
+
+    fill_in "Email Address", with: "funshine@test.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Submit this form"
+  end
+end

--- a/spec/features/registration/mentor_spec.rb
+++ b/spec/features/registration/mentor_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.feature "Mentors registering", :js do
+  before do
+    SeasonToggles.registration_open!
+
+    visit "/signup"
+  end
+
+  scenario "Mentor registration steps and fields" do
+    choose "I am over 18 years old and will guide a team"
+    click_button "Next"
+
+    expect(page).to have_content("Mentor Information")
+
+    fill_in "First Name", with: "Cheer"
+    fill_in "Last Name", with: "Bear"
+    select "Prefer not to say", from: "Gender Identity"
+    fill_in "Birthday", with: 39.years.ago
+    fill_in "Company Name", with: "Care-a-Lot Castle"
+    fill_in "Job Title", with: "Spellcaster"
+    check "Industry professional"
+    fill_in "mentorBio", with: "I'm a very happy and perky bear who lives up to my name, I made it my goal to help everyone to be joyous as me. Known to break into cheers and chants at the drop of a hat. I'm exuberant, bouncy, and just a plain happy ball of pink fluff!"
+    click_button "Next"
+
+    expect(page).to have_content("Data Use Terms")
+
+    check "I AGREE TO THESE DATA USE TERMS"
+    click_button "Next"
+
+    expect(page).to have_content("Set your email and password")
+
+    fill_in "Email Address", with: "cheer@test.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Submit this form"
+  end
+end

--- a/spec/features/registration/parent_spec.rb
+++ b/spec/features/registration/parent_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Parents registering", :js do
+  before do
+    SeasonToggles.registration_open!
+
+    visit "/signup"
+  end
+
+  scenario "Parent registration steps and fields" do
+    choose "I am registering my 8-12 year old* daughter"
+    click_button "Next"
+
+    expect(page).to have_content("Student Information")
+
+    fill_in "First Name", with: "Lotsa Heart"
+    fill_in "Last Name", with: "Elephant"
+    fill_in "Birthday", with: 9.years.ago
+    fill_in "School Name", with: "Care-a-Lot Elementary School"
+    within "#parent-information" do
+      fill_in "Name", with: "Wish Bear"
+      fill_in "Parent Email Address", with: "wish.bear@test.com"
+    end
+    click_button "Next"
+
+    expect(page).to have_content("Data Use Terms")
+
+    check "I AGREE TO THESE DATA USE TERMS"
+    click_button "Next"
+
+    expect(page).to have_content("Set your email and password")
+
+    fill_in "Password", with: "secret12345"
+    click_button "Submit this form"
+  end
+end

--- a/spec/features/registration/student_spec.rb
+++ b/spec/features/registration/student_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Students registering", :js do
+  before do
+    SeasonToggles.registration_open!
+
+    visit "/signup"
+  end
+
+  scenario "Student registration steps and fields" do
+    choose "I am registering myself and am 13-18 years old"
+    click_button "Next"
+
+    expect(page).to have_content("Student Information")
+
+    fill_in "First Name", with: "Harmony"
+    fill_in "Last Name", with: "Bear"
+    fill_in "Birthday", with: 17.years.ago
+    fill_in "School Name", with: "Care-a-Lot High School"
+    within "#parent-information" do
+      fill_in "Name", with: "Brave Heart Lion"
+    end
+    click_button "Next"
+
+    expect(page).to have_content("Data Use Terms")
+
+    check "I AGREE TO THESE DATA USE TERMS"
+    click_button "Next"
+
+    expect(page).to have_content("Set your email and password")
+
+    fill_in "Email Address", with: "harmony@test.com"
+    fill_in "Password", with: "secret12345"
+    click_button "Submit this form"
+  end
+end

--- a/spec/system/registration/invites_spec.rb
+++ b/spec/system/registration/invites_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Using registration invite codes", :js do
   {
     student: "student",
+    mentor: "mentor",
     judge: "judge",
     chapter_ambassador: "chapter ambassador"
   }.each do |profile_type, friendly_profile_type|


### PR DESCRIPTION
This will add some basic specs to test registration steps and fields for students, parents, mentors, judges, and chapter ambassadors, the specs will:
- Select the appropriate profile type, click next
- Make sure the appropriate page/step is displayed
  - Fill in the required fields for the selected profile type, click next
- Make sure the data terms page/step is displayed, click next
- Make sure the email, password page/step is displayed

There is no step after this, but I think there should be, like expecting a welcome message or ensuring the account got created. But for some reason the form isn't being submitted to the backend, I verified this by putting some `put` statements in the controller action, but they're not getting called, which afaict it means it's something with the form, Vue Formulate, which I can't figure out, all the fields are being filled out afaict. If you feel like taking a look at this, feel free! Anywho, the specs cover the majority of the registration flow, except for the final submit step.