### PR TITLE
Remove pending team invites to mentors

### DIFF
--- a/lib/tasks/remove_pending_team_invites_to_mentors.rake
+++ b/lib/tasks/remove_pending_team_invites_to_mentors.rake
@@ -1,0 +1,11 @@
+task remove_pending_team_invites_to_mentors: :environment do
+  pending_team_invites_to_mentors = TeamMemberInvite
+    .where(invitee_type: "MentorProfile", status: "pending")
+    .where("created_at < '2023-07-01'")
+
+  puts "Removing #{pending_team_invites_to_mentors.count} pending team invites"
+
+  pending_team_invites_to_mentors.delete_all
+
+  puts "Done"
+end

--- a/lib/tasks/reset_for_season.rake
+++ b/lib/tasks/reset_for_season.rake
@@ -19,6 +19,9 @@ task :reset_for_season, [:force] => :environment do |t, args|
     puts "Resetting mentor trainings"
     MentorProfile.update_all(training_completed_at: nil)
 
+    puts "Removing pending team invites to mentors"
+    TeamMemberInvite.where(invitee_type: "MentorProfile", status: "pending").delete_all
+
     puts "Resetting judge trainings"
     JudgeProfile.update_all(completed_training_at: nil)
 


### PR DESCRIPTION
This will:
* Remove all existing team invites to mentors sent before July 1, 2023
* Update the season reset task to remove all pending team invites to mentors (which doesn't need a date/where clause, since it'll remove all the current/existing pending invites up to the point when the season reset is run)