### PR TITLE
removed staff name and updated text for pending and declined cha accounts

### DIFF
--- a/app/views/chapter_ambassador/dashboards/show_declined.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show_declined.en.html.erb
@@ -3,7 +3,7 @@
     <div class="panel">
       <p>
         Your Chapter Ambassador profile is declined.
-        Speak with Ophelie for help.
+        Please email <%= mail_to "chapters@technovation.org" %> for help.
       </p>
     </div>
   </div>

--- a/app/views/chapter_ambassador/dashboards/show_pending.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show_pending.en.html.erb
@@ -2,8 +2,9 @@
   <div class="grid__col-auto">
     <div class="panel">
       <p>
-        Your Chapter Ambassador profile is pending.
-        Speak with Ophelie for help.
+        Your Chapter profile is pending. Please email <%= mail_to "chapters@technovation.org" %> for help.
+        Note that you need to have completed all onboarding steps, including signing your
+        MOU before getting access to your Chapter Account.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Refs #4225 

Updated the text (removed staff name) on the ChA dashboard for pending and declined accounts.