### PR TITLE
Registration invite updates

### DIFF
--- a/app/controllers/admin/user_invitation_emails_controller.rb
+++ b/app/controllers/admin/user_invitation_emails_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class UserInvitationEmailsController < AdminController
     def create
       @user_invitation = UserInvitation.sent.find(params[:invitation_id])
-      RegistrationMailer.admin_permission(@user_invitation.id).deliver_later
+      RegistrationMailer.invitation(@user_invitation.id).deliver_later
       redirect_to admin_user_invitations_path,
         success: "You re-sent the #{@user_invitation.profile_type.titleize} invitation to #{@user_invitation.email}"
     end

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -1,12 +1,11 @@
 module Admin
   class UserInvitationsController < AdminController
-    helper_method :invitation_token
+    include DatagridController
 
-    def index
-      @user_invitation = UserInvitation.new
-      @user_invitations = UserInvitation.order('created_at desc')
-        .page(params[:page])
-    end
+    helper_method :invitation_token
+    use_datagrid with: UserInvitationsGrid
+
+    before_action :new_invitation, only: :index
 
     def new
       @user_invitation = UserInvitation.new
@@ -37,6 +36,18 @@ module Admin
     end
 
     private
+
+    def new_invitation
+      @user_invitation = UserInvitation.new
+    end
+
+    def grid_params
+      grid = params[:user_invitations_grid] ||= {}
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
+    end
 
     def user_invitation_params
       params.require(:user_invitation).permit(

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -41,6 +41,7 @@ module Admin
     def user_invitation_params
       params.require(:user_invitation).permit(
         :profile_type,
+        :name,
         :email,
         :register_at_any_time
       )

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -2,7 +2,6 @@ module Admin
   class UserInvitationsController < AdminController
     include DatagridController
 
-    helper_method :invitation_token
     use_datagrid with: UserInvitationsGrid
 
     before_action :new_invitation, only: :index
@@ -56,16 +55,6 @@ module Admin
         :email,
         :register_at_any_time
       )
-    end
-
-    def invitation_token
-      (GlobalInvitation.active.last || NullInvitation.new("")).token
-    end
-
-    class NullInvitation < Struct.new(:token)
-      def present?
-        false
-      end
     end
   end
 end

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -34,6 +34,15 @@ module Admin
       end
     end
 
+    def destroy
+      invite = UserInvitation.find(params.fetch(:id))
+
+      invite.destroy
+
+      redirect_to admin_user_invitations_path,
+        success: "You deleted the invitation to #{invite.email}"
+    end
+
     private
 
     def new_invitation

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -16,7 +16,7 @@ module Admin
       @user_invitation = UserInvitation.new(user_invitation_params)
 
       if @user_invitation.save
-        RegistrationMailer.admin_permission(@user_invitation.id)
+        RegistrationMailer.invitation(@user_invitation.id)
           .deliver_later
 
         redirect_to admin_user_invitations_path,

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -13,7 +13,7 @@ module Admin
     end
 
     def create
-      @user_invitation = UserInvitation.new(user_invitation_params)
+      @user_invitation = UserInvitation.new(user_invitation_params.merge({invited_by_id: current_account.id}))
 
       if @user_invitation.save
         RegistrationMailer.invitation(@user_invitation.id)

--- a/app/controllers/chapter_ambassador/event_assignments_controller.rb
+++ b/app/controllers/chapter_ambassador/event_assignments_controller.rb
@@ -2,7 +2,7 @@ module ChapterAmbassador
   class EventAssignmentsController < ChapterAmbassadorController
     def create
       event = RegionalPitchEvent.find(assignment_params.fetch(:event_id))
-      CreateEventAssignment.(event, assignment_params)
+      CreateEventAssignment.call(event, assignment_params.merge({invited_by_id: current_ambassador.account.id}))
 
       render json: {
         flash: {

--- a/app/data_grids/user_invitations_grid.rb
+++ b/app/data_grids/user_invitations_grid.rb
@@ -1,0 +1,64 @@
+class UserInvitationsGrid
+  include Datagrid
+
+  scope do
+    UserInvitation.order(created_at: :desc)
+  end
+
+  column :profile_type, header: "Registration Type", mandatory: true do |registration_invite|
+    case registration_invite.profile_type
+    when "parent_student"
+      "Parent"
+    else
+      registration_invite.profile_type.titleize
+    end
+  end
+
+  column :email, header: "Invitee", mandatory: true, html: true do |registration_invite|
+    if registration_invite.name.present?
+      "#{registration_invite.name} - #{registration_invite.email}"
+    else
+      registration_invite.email
+    end
+  end
+
+  column :status, mandatory: true do |registration_invite|
+    registration_invite.status.capitalize
+  end
+
+  column :account, mandatory: true, html: true do |registration_invite|
+    if registration_invite.account.present?
+      link_to(
+        registration_invite.account.full_name,
+        admin_participant_path(registration_invite.account)
+      )
+    else
+      "-"
+    end
+  end
+
+  column :invited_by, header: "Invited By", mandatory: true, html: true do |registration_invite|
+    if registration_invite.invited_by.present?
+      link_to(
+        registration_invite.invited_by.full_name,
+        admin_participant_path(registration_invite.invited_by)
+      )
+    else
+      "-"
+    end
+  end
+
+  column :actions, mandatory: true, html: true do |registration_invite|
+    render "admin/user_invitations/actions", registration_invite: registration_invite
+  end
+
+  filter :profile_type,
+    :enum,
+    header: "Registration Type",
+    select: UserInvitation::PROFILE_TYPES
+
+  filter :status,
+    :enum,
+    header: "Invite Status",
+    select: UserInvitation.statuses.transform_keys(&:capitalize)
+end

--- a/app/javascript/chapter_ambassador/events/EventJudgeList.vue
+++ b/app/javascript/chapter_ambassador/events/EventJudgeList.vue
@@ -83,7 +83,7 @@
                 </template>
 
                 <template v-else>
-                  {{ judge.name }}
+                  {{ judge.name == "" ? "Invited Judge" : judge.name }}
                 </template>
 
                 <ul class="list--reset list--indented font-small">
@@ -283,7 +283,7 @@
 
           form.append(
             `event_assignment[invites][${idx}][]name`,
-            judge.name
+            judge.name == null ? "" : judge.name
           )
 
           form.append(

--- a/app/javascript/new_registration/components/StepOne.vue
+++ b/app/javascript/new_registration/components/StepOne.vue
@@ -132,6 +132,10 @@ export default {
       else if (this.registrationInvite.isValid && this.registrationInvite.profileType == 'student' && this.registrationInvite.canRegisterAtAnyTime == true) {
         this.profileTypes.push(this.studentProfileType())
       }
+      else if (this.registrationInvite.isValid && this.registrationInvite.profileType == 'parent' && this.registrationInvite.canRegisterAtAnyTime == true) {
+        this.profileTypes.push(this.parentProfileType())
+      }
+
 
       if (this.isMentorRegistrationOpen ||
         (this.registrationInvite.isValid && this.registrationInvite.profileType == 'mentor' && this.registrationInvite.canRegisterAtAnyTime == true)) {

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -16,6 +16,7 @@ class RegistrationMailer < ApplicationMailer
     invite_code = invitation.admin_permission_token
 
     if invite_code.present?
+      @name = invitation.name
       @url = signup_url(invite_code: invite_code)
 
       mail to: invitation.email,

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -11,18 +11,17 @@ class RegistrationMailer < ApplicationMailer
     end
   end
 
-  def admin_permission(user_invitation_id)
+  def invitation(user_invitation_id)
     invitation = UserInvitation.find(user_invitation_id)
     invite_code = invitation.admin_permission_token
 
     if invite_code.present?
       @name = invitation.name
+      @registration_type = invitation.profile_type
       @url = signup_url(invite_code: invite_code)
 
       mail to: invitation.email,
-        subject: t("registration_mailer.admin_permission.subject", season_year: Season.current.year) do |f|
-        f.html { render :confirm_email }
-      end
+        subject: t("registration_mailer.invitation.subject")
     else
       raise AdminPermissionTokenNotPresent,
         "UserInvitation ID: #{invitation.id}"

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -119,6 +119,8 @@ class Account < ActiveRecord::Base
     class_name: "ConsentWaiver",
     dependent: :destroy
 
+  has_many :registration_invites, class_name: "UserInvitation", foreign_key: :invited_by_id
+
   has_one :background_check, dependent: :destroy
   accepts_nested_attributes_for :background_check
 

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -4,6 +4,7 @@ class UserInvitation < ApplicationRecord
     judge
     mentor
     student
+    parent_student
   }
 
   enum status: %i{
@@ -11,6 +12,16 @@ class UserInvitation < ApplicationRecord
     opened
     registered
   }
+
+  PROFILE_TYPES = UserInvitation.profile_types.keys.map do |profile_type|
+    if profile_type == "student"
+      ["Student (Jr/Sr Division)", profile_type]
+    elsif profile_type == "parent_student"
+      ["Parent (Beginner Division)", profile_type]
+    else
+      [profile_type.titleize, profile_type]
+    end
+  end
 
   validates :profile_type, :email, presence: true
   validates :email, uniqueness: true, email: true

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -43,6 +43,7 @@ class UserInvitation < ApplicationRecord
   has_and_belongs_to_many :events, class_name: "RegionalPitchEvent"
   belongs_to :account, required: false
   belongs_to :current_account, -> { current }, required: false
+  belongs_to :invited_by, class_name: "Account", required: false
 
   has_many :judge_assignments, as: :assigned_judge, dependent: :destroy
   has_many :assigned_teams,

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -148,10 +148,6 @@ class UserInvitation < ApplicationRecord
     email
   end
 
-  def name
-    "Invited judge - #{email}"
-  end
-
   def id_for_event
     if persisted?
       id

--- a/app/services/registration_invite_validator.rb
+++ b/app/services/registration_invite_validator.rb
@@ -14,6 +14,13 @@ class RegistrationInviteValidator
           profile_type: "student",
           friendly_profile_type: "student"
         )
+      elsif invite.parent_student? && (SeasonToggles.student_registration_open? || invite.register_at_any_time?)
+        return Result.new(
+          valid?: true,
+          register_at_any_time?: invite.register_at_any_time?,
+          profile_type: "parent",
+          friendly_profile_type: "parent"
+        )
       elsif invite.mentor? && (SeasonToggles.mentor_registration_open? || invite.register_at_any_time?)
         return Result.new(
           valid?: true,

--- a/app/technovation/create_event_assignment.rb
+++ b/app/technovation/create_event_assignment.rb
@@ -1,6 +1,7 @@
 module CreateEventAssignment
   def self.call(event, assignment_params)
     invite_params = assignment_params.fetch(:invites)
+    invited_by_id = assignment_params[:invited_by_id]
 
     invite_params.each do |_, par|
       # params come in strange
@@ -13,6 +14,7 @@ module CreateEventAssignment
           email: opts[:email],
           name: opts[:name],
           profile_type: :judge,
+          invited_by_id: invited_by_id
         });
       end
 

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -55,7 +55,7 @@
       data: { turbolinks: false },
       class: al(admin_paper_media_consents_path) %>
 
-    <%= link_to "Invite users",
+    <%= link_to "Registration Invites",
       admin_user_invitations_path,
       class: al(admin_user_invitations_path) %>
 

--- a/app/views/admin/user_invitations/_actions.html.erb
+++ b/app/views/admin/user_invitations/_actions.html.erb
@@ -1,0 +1,7 @@
+<% if registration_invite.sent? %>
+  <%= link_to "Re-send invite email",
+    admin_user_invitation_emails_path(invitation_id: registration_invite),
+    data: { method: :post },
+    class: "button small gray"
+  %>
+<% end %>

--- a/app/views/admin/user_invitations/_actions.html.erb
+++ b/app/views/admin/user_invitations/_actions.html.erb
@@ -5,3 +5,15 @@
     class: "button small gray"
   %>
 <% end %>
+
+<% if !registration_invite.registered? %>
+  <%= link_to(
+    "Delete",
+    admin_user_invitation_path(registration_invite),
+    class: "button small danger",
+    data: {
+      method: :delete,
+      confirm: "You are about to delete the invitation to #{registration_invite.email}"
+    }
+  ) %>
+<% end %>

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :profile_type, for: :user_invitation_profile_type %>
+    <%= f.label :profile_type, "Registration Type", for: :user_invitation_profile_type %>
     <%= f.select :profile_type,
       UserInvitation::PROFILE_TYPES,
       include_blank: true,
@@ -37,7 +37,7 @@
     </span>
   </div>
 
-  <div class="actions">
+  <div class="actions margin--t-xlarge">
     <p>
       <%= f.submit "Send invitation", class: "button" %>
     </p>

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -21,6 +21,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :name, for: :user_invitation_name %>
+    <%= f.text_field :name, id: :user_invitation_name, placeholder: "Optional" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email, for: :user_invitation_email %>
     <%= f.email_field :email, id: :user_invitation_email %>
   </div>

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -31,8 +31,10 @@
   </div>
 
   <div class="field">
-    <%= f.label :register_at_any_time, "Register at any time (bypass registration settings)" %>
-    <%= f.check_box :register_at_any_time %>
+    <span class="inline-checkbox">
+      <%= f.check_box :register_at_any_time %>
+      <%= f.label :register_at_any_time, "Register at any time (bypass registration settings)" %>
+    </span>
   </div>
 
   <div class="actions">

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -14,7 +14,7 @@
   <div class="field">
     <%= f.label :profile_type, for: :user_invitation_profile_type %>
     <%= f.select :profile_type,
-      UserInvitation.profile_types.keys.map { |k| [k.titleize, k] },
+      UserInvitation::PROFILE_TYPES,
       include_blank: true,
       id: :user_invitation_profile_type
     %>

--- a/app/views/admin/user_invitations/index.en.html.erb
+++ b/app/views/admin/user_invitations/index.en.html.erb
@@ -22,33 +22,8 @@
   </div>
 </div>
 
-<div class="grid">
-  <div class="grid__col-auto">
-    <h3>Invited Users</h3>
-
-    <div class="panel">
-      <table class="datagrid">
-        <thead>
-          <tr>
-            <th>Profile type</th>
-            <th>Email</th>
-            <th>Account</th>
-            <th>Status</th>
-            <th>Action</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <% @user_invitations.each do |invitation| %>
-            <tr>
-              <%= render "admin/user_invitations/user_invitation_row",
-                invitation: invitation %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-
-      <%= will_paginate(@user_invitations) %>
-    </div>
-  </div>
-</div>
+<%= render 'datagrid/datagrid',
+  grid: @user_invitations_grid,
+  form_url: admin_user_invitations_path,
+  model_name: "registation_invites",
+  scope: :admin %>

--- a/app/views/admin/user_invitations/index.en.html.erb
+++ b/app/views/admin/user_invitations/index.en.html.erb
@@ -8,14 +8,6 @@
       <%= render 'admin/user_invitations/form',
         invitation: @user_invitation %>
     </div>
-
-    <% if invitation_token.present? %>
-      <h3>Judge Invitation URL</h3>
-
-      <div class="panel">
-        <%= judge_signup_url(invitation: invitation_token) %>
-      </div>
-    <% end %>
   </div>
 </div>
 

--- a/app/views/admin/user_invitations/index.en.html.erb
+++ b/app/views/admin/user_invitations/index.en.html.erb
@@ -2,7 +2,7 @@
 
 <div class="grid">
   <div class="grid__col-auto grid__col--bleed-y">
-    <h1>Invite someone to register</h1>
+    <h3>Invite someone to register</h3>
 
     <div class="panel">
       <%= render 'admin/user_invitations/form',
@@ -11,8 +11,14 @@
   </div>
 </div>
 
-<%= render 'datagrid/datagrid',
-  grid: @user_invitations_grid,
-  form_url: admin_user_invitations_path,
-  model_name: "registation_invites",
-  scope: :admin %>
+<div class="grid margin--t-xlarge">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <h3>Registration invites</h3>
+
+    <%= render 'datagrid/datagrid',
+      grid: @user_invitations_grid,
+      form_url: admin_user_invitations_path,
+      model_name: "registation_invites",
+      scope: :admin %>
+  </div>
+</div>

--- a/app/views/admin/user_invitations/index.en.html.erb
+++ b/app/views/admin/user_invitations/index.en.html.erb
@@ -7,9 +7,6 @@
     <div class="panel">
       <%= render 'admin/user_invitations/form',
         invitation: @user_invitation %>
-
-      <%= render 'admin/user_invitations/existing_preview',
-        invitation: @existing %>
     </div>
 
     <% if invitation_token.present? %>

--- a/app/views/admin/user_invitations/new.en.html.erb
+++ b/app/views/admin/user_invitations/new.en.html.erb
@@ -1,8 +1,8 @@
-<% provide :title, "Invite users to Technovation" %>
+<% provide :title, "Registration Invite" %>
 
 <div class="grid">
   <div class="grid__col-10">
-    <h1>Invite a user to the platform</h1>
+    <h1>Invite someone to register</h1>
 
     <div class="panel">
       <%= render 'admin/user_invitations/form',

--- a/app/views/event_mailer/invite.en.html.erb
+++ b/app/views/event_mailer/invite.en.html.erb
@@ -4,7 +4,11 @@
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td class="content-block">
-          Dear <%= @invite.name %>,
+          <% if @invite.name.present? %>
+            Dear <%= @invite.name %>,
+          <% else %>
+            Hello,
+          <% end %>
         </td>
       </tr>
       <tr>

--- a/app/views/event_mailer/notify_removed.en.html.erb
+++ b/app/views/event_mailer/notify_removed.en.html.erb
@@ -4,7 +4,11 @@
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td class="content-block">
-          Dear <%= @removed.name %>,
+          <% if @removed.name.present? %>
+            Dear <%= @removed.name %>,
+          <% else %>
+            Hello,
+          <% end %>
         </td>
       </tr>
       <tr>

--- a/app/views/registration_mailer/invitation.en.html.erb
+++ b/app/views/registration_mailer/invitation.en.html.erb
@@ -1,0 +1,66 @@
+<tr>
+  <td class="content-wrap">
+    <meta itemprop="name" content="Confirm Email"/>
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td class="content-block">
+          <% if @name.present? %>
+            Hi <%= @name %>,
+          <% else %>
+            Hello,
+          <% end %>
+        </td>
+      </tr>
+
+      <% case @registration_type %>
+      <% when "student" %>
+        <tr>
+          <td class="content-block">
+            You are receiving this email because you have been invited to join Technovation Girls!
+          </td>
+        </tr>
+      <% when "parent_student" %>
+        <tr>
+          <td class="content-block">
+            You are receiving this email because you have been invited to join Technovation Girls!
+          </td>
+        </tr>
+      <% when "mentor" %>
+        <tr>
+          <td class="content-block">
+            You are receiving this email because you have been invited to join Technovation Girls!
+          </td>
+        </tr>
+      <% when "judge" %>
+        <tr>
+          <td class="content-block">
+            You are receiving this email because you have been invited to join Technovation Girls!
+          </td>
+        </tr>
+      <% when "chapter_ambassador" %>
+        <tr>
+          <td class="content-block">
+            You are receiving this email because you have been invited to join Technovation Girls!
+          </td>
+        </tr>
+      <% end %>
+
+      <tr>
+        <td class="content-block"
+            itemprop="handler"
+            itemscope
+            itemtype="http://schema.org/HttpActionHandler">
+          <%= link_to "Sign Up Here", @url,
+            class: "btn-primary",
+            itemprop: "url" %>
+        </td>
+      </tr>
+
+      <tr>
+        <td class="content-block">
+          — The Technovation Team
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -26,8 +26,8 @@ en:
       subject: "Your daughter needs permission to participate in Technovation!"
 
   registration_mailer:
-    admin_permission:
-      subject: "Technovation Girls Invitation: Sign up for your %{season_year} account"
+    invitation:
+      subject: "You have been invited to join Technovation Girls!"
     confirm_email:
       subject: "Confirm your email for Technovation %{season_year}"
     welcome_mentor:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,7 +264,7 @@ Rails.application.routes.draw do
     end
 
     resources :participant_sessions, only: [:show, :destroy]
-    resources :user_invitations, only: [:new, :create, :index]
+    resources :user_invitations, only: [:new, :create, :index, :destroy]
     resources :user_invitation_emails, only: :create
 
     resources :student_conversions, only: :create

--- a/db/migrate/20231005145350_add_invited_by_to_user_invitations.rb
+++ b/db/migrate/20231005145350_add_invited_by_to_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddInvitedByToUserInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_invitations, :invited_by_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1751,7 +1751,8 @@ CREATE TABLE public.user_invitations (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     name character varying,
-    register_at_any_time boolean
+    register_at_any_time boolean,
+    invited_by_id integer
 );
 
 
@@ -3335,6 +3336,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230905194750'),
 ('20230914204523'),
 ('20230921190613'),
-('20230925171243');
+('20230925171243'),
+('20231005145350');
 
 

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -127,4 +127,19 @@ RSpec.describe UserInvitation do
       end
     end
   end
+
+  describe "#invited_by" do
+    let(:admin) { FactoryBot.create(:admin) }
+
+    let(:invite) do
+      UserInvitation.new(
+        profile_type: :student,
+        invited_by_id: admin.account.id
+      )
+    end
+
+    it "return the account of the person who sent the inviation" do
+      expect(invite.invited_by).to eq(admin.account)
+    end
+  end
 end

--- a/spec/services/registration_invite_validator_spec.rb
+++ b/spec/services/registration_invite_validator_spec.rb
@@ -24,6 +24,7 @@ describe RegistrationInviteValidator do
     instance_double(UserInvitation,
       pending?: pending_invite,
       student?: student_invite,
+      parent_student?: parent_student_invite,
       mentor?: mentor_invite,
       judge?: judge_invite,
       chapter_ambassador?: chapter_ambassador_invite,
@@ -32,6 +33,7 @@ describe RegistrationInviteValidator do
 
   let(:pending_invite) { false }
   let(:student_invite) { false }
+  let(:parent_student_invite) { false }
   let(:mentor_invite) { false }
   let(:judge_invite) { false }
   let(:chapter_ambassador_invite) { false }
@@ -56,6 +58,42 @@ describe RegistrationInviteValidator do
 
         it "sets the friendly profile type to 'student'" do
           expect(registration_invite_validator.call.friendly_profile_type).to eq("student")
+        end
+      end
+
+      context "when student registration is closed" do
+        let(:student_registration_open) { false }
+
+        it "is not valid" do
+          expect(registration_invite_validator.call.valid?).to eq(false)
+        end
+
+        context "when an invite can be used at any time" do
+          let(:register_at_any_time) { true }
+
+          it "is valid" do
+            expect(registration_invite_validator.call.valid?).to eq(true)
+          end
+        end
+      end
+    end
+
+    context "when the invite is for a parent/beginner student" do
+      let(:parent_student_invite) { true }
+
+      context "when student registration is open" do
+        let(:student_registration_open) { true }
+
+        it "is valid" do
+          expect(registration_invite_validator.call.valid?).to eq(true)
+        end
+
+        it "sets the profile type to 'parent'" do
+          expect(registration_invite_validator.call.profile_type).to eq("parent")
+        end
+
+        it "sets the friendly profile type to 'parent'" do
+          expect(registration_invite_validator.call.friendly_profile_type).to eq("parent")
         end
       end
 

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Registration invites", :js do
 
     context "when an admin invites a #{item[:friendly_profile_type]}" do
       it "sends an email with a link with an invite code to register" do
-        click_link "Invite users"
+        click_link "Registration Invites"
 
         expect {
           select item[:select_option], from: "Profile type"
@@ -63,7 +63,7 @@ RSpec.describe "Registration invites", :js do
 
   context "when an admin sends an invite" do
     it "sets the 'invited by account' to the admin who sent the invite" do
-      click_link "Invite users"
+      click_link "Registration Invites"
 
       select "Judge", from: "Profile type"
       fill_in "Email", with: "jugdge_invite@example.com"

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -7,15 +7,41 @@ RSpec.describe "Registration invites", :js do
     sign_in(admin)
   end
 
-  %i[student mentor judge chapter_ambassador].each do |profile_type|
-    let(:email_address) { "#{profile_type}@example.com" }
+  [
+    {
+      invite_profile_type: "student",
+      friendly_profile_type: "student",
+      select_option: "Student (Jr/Sr Division)"
+    },
+    {
+      invite_profile_type: "parent_student",
+      friendly_profile_type: "parent",
+      select_option: "Parent (Beginner Division)"
+    },
+    {
+      invite_profile_type: "mentor",
+      friendly_profile_type: "mentor",
+      select_option: "Mentor"
+    },
+    {
+      invite_profile_type: "judge",
+      friendly_profile_type: "juge",
+      select_option: "Judge"
+    },
+    {
+      invite_profile_type: "chapter_ambassador",
+      friendly_profile_type: "chapter ambassador",
+      select_option: "Chapter Ambassador"
+    }
+  ].each do |item|
+    let(:email_address) { "#{item[:invite_profile_type]}@example.com" }
 
-    context "when an admin invites a #{profile_type.to_s.humanize(capitalize: false)}" do
+    context "when an admin invites a #{item[:friendly_profile_type]}" do
       it "sends an email with a link with an invite code to register" do
         click_link "Invite users"
 
         expect {
-          select profile_type.to_s.titleize, from: "Profile type"
+          select item[:select_option], from: "Profile type"
           fill_in "Email", with: email_address
           click_button "Send invitation"
         }.to change {

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -60,4 +60,16 @@ RSpec.describe "Registration invites", :js do
       end
     end
   end
+
+  context "when an admin sends an invite" do
+    it "sets the 'invited by account' to the admin who sent the invite" do
+      click_link "Invite users"
+
+      select "Judge", from: "Profile type"
+      fill_in "Email", with: "jugdge_invite@example.com"
+      click_button "Send invitation"
+
+      expect(UserInvitation.last.invited_by).to eq(admin.account)
+    end
+  end
 end

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Registration invites", :js do
       select_option: "Chapter Ambassador"
     }
   ].each do |item|
+    let(:name) { "Devin #{item[:friendly_profile_type]}" }
     let(:email_address) { "#{item[:invite_profile_type]}@example.com" }
 
     context "when an admin invites a #{item[:friendly_profile_type]}" do
@@ -42,6 +43,7 @@ RSpec.describe "Registration invites", :js do
 
         expect {
           select item[:select_option], from: "Profile type"
+          fill_in "Name", with: name
           fill_in "Email", with: email_address
           click_button "Send invitation"
         }.to change {
@@ -53,6 +55,7 @@ RSpec.describe "Registration invites", :js do
 
         invite_code = UserInvitation.last.admin_permission_token
         url = signup_url(invite_code: invite_code, host: ENV.fetch("HOST_DOMAIN"))
+        expect(mail.body).to include("Hi #{name}")
         expect(mail.body).to include("href=\"#{url}\"")
       end
     end

--- a/spec/system/registration/invites_spec.rb
+++ b/spec/system/registration/invites_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe "Using registration invite codes", :js do
       friendly_profile_type: "parent"
     },
     {
+      profile_type: "mentor",
+      invite_profile_type: "mentor",
+      registration_profile_type: "mentor",
+      friendly_profile_type: "mentor"
+    },
+    {
       profile_type: "judge",
       invite_profile_type: "judge",
       registration_profile_type: "judge",

--- a/spec/system/registration/invites_spec.rb
+++ b/spec/system/registration/invites_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Using registration invite codes", :js do
           expect(page).to have_selector("input[type=radio]:checked##{item[:registration_profile_type]}")
         end
 
-        context "when a #{item[:friendly_profile_type]} invite code has alredy been used" do
+        context "when a #{item[:friendly_profile_type]} invite code has already been used" do
           before do
             registration_invite.update(
               account: profile.account,
@@ -84,23 +84,9 @@ RSpec.describe "Using registration invite codes", :js do
         end
       end
 
-      it "pre-selects the invited profile type" do
-        visit signup_path(invite_code: registration_invite.admin_permission_token)
-
-        expect(page).to have_selector("input[type=radio]:checked##{profile_type}")
-      end
-
-      context "when a #{item[:friendly_profile_type]} invite code has alredy been used" do
+      context "when registration is closed" do
         before do
-          SeasonToggles.enable_signup(item[:profile_type])
-        end
-
-        if item[:profile_type] != "chapter_ambassador"
-          it "does not allow a #{item[:friendly_profile_type]} to register" do
-            visit signup_path(invite_code: registration_invite.admin_permission_token)
-
-            expect(page).to have_content("This invitation is no longer valid")
-          end
+          SeasonToggles.disable_signups!
         end
 
         context "when the invitation can be used at any time" do


### PR DESCRIPTION
This PR has a lot of miscellaneous updates related to registration invites:
- Allow admins to invite parents/beginner students (#4215)
- Add name field to registration invites (#4216)
  - This field already existed in the database
- Update registration invite email (#4200)
  - Adding name
  - Adding a new email a template, it was using the email confirmation template (which is way it had weird verbiage about confirming your email address)
- Convert registration invites table into a datagrid (#4233)
- Add field for who sent the invite (#4232)
  - This new field wlll be displayed a field on the new datagrid
- Allow admins to delete a registration invite (#4223)
- General clean up and feedback (#4241)
  - Removing judge signup URL
  - Making anytime invite checkbox and label appear on the same line


Let me know if you have any questions!
