### PR TITLE
Update jquery-ui-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "uglifier", "~> 3.2"
 
 gem "turbolinks", "~> 5.2"
 gem "jquery-rails", "~> 4.3"
-gem "jquery-ui-rails", "~> 6.0"
+gem "jquery-ui-rails", "~> 7.0", git: "https://github.com/jquery-ui-rails/jquery-ui-rails.git"
 gem "lodash-rails", "~> 4.17"
 gem "dropzonejs-rails", "~> 0.8"
 gem "webpacker", "~> 5.x"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
     city-state (0.0.13)
       rubyzip (~> 1.1)
 
+GIT
+  remote: https://github.com/jquery-ui-rails/jquery-ui-rails.git
+  revision: c7460b447589eb04aa948ecaf0d1245c88f6ff45
+  specs:
+    jquery-ui-rails (7.0.0)
+      railties (>= 3.2.16)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -255,8 +262,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
-      railties (>= 3.2.16)
     json (2.5.1)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -267,7 +272,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lodash-rails (4.17.21)
       railties (>= 3.1)
-    loofah (2.21.3)
+    loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -292,7 +297,7 @@ GEM
     mini_magick (4.9.4)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
-    minitest (5.18.1)
+    minitest (5.20.0)
     msgpack (1.5.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -378,7 +383,7 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.1.1)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -535,7 +540,7 @@ GEM
     wkhtmltopdf-heroku (2.12.6.1.pre.jammy)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   ruby
@@ -583,7 +588,7 @@ DEPENDENCIES
   i18n-js (~> 4.0)
   indefinite_article (~> 0.2)
   jquery-rails (~> 4.3)
-  jquery-ui-rails (~> 6.0)
+  jquery-ui-rails (~> 7.0)!
   letter_opener (~> 1.6)
   listen (~> 3.1)
   lodash-rails (~> 4.17)


### PR DESCRIPTION
This will update jquery-ui-rails to version 7.0 to address these security vulnerabilities:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/170
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/167
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/166
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/165
