### PR TITLE
Added invitation_url to background checks for easier access to checkr portal

### DIFF
--- a/app/services/checkr_api_client/api_client.rb
+++ b/app/services/checkr_api_client/api_client.rb
@@ -47,6 +47,7 @@ module CheckrApiClient
             candidate_id: candidate_response_body[:id],
             invitation_id: invitation_response_body[:id],
             invitation_status: invitation_response_body[:status],
+            invitation_url: invitation_response_body[:invitation_url],
             status: :invitation_sent
           })
 

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -4,7 +4,16 @@
       <% if @background_check.invitation_pending? %>
         <p>An invitation was sent to your email on <%= @background_check.created_at.strftime("%B %d, %Y") %> from Checkr.
           <br>
-          Please check your email to accept the invitation and complete the background check through the Checkr portal.
+          Please check your email to accept the invitation and complete the background check through the Checkr portal
+          <% if @background_check.invitation_url.present? %>
+            <br>
+            or
+            <%= link_to "click here",
+              @background_check.invitation_url,
+              target: "_blank"
+            %>
+            to access your invitation on the Checkr portal.
+          <% end %>
         </p>
       <% elsif @background_check.invitation_completed?  %>
         <p>

--- a/db/migrate/20231016221100_add_invitation_url_to_background_checks.rb
+++ b/db/migrate/20231016221100_add_invitation_url_to_background_checks.rb
@@ -1,0 +1,5 @@
+class AddInvitationUrlToBackgroundChecks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :background_checks, :invitation_url, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -241,7 +241,8 @@ CREATE TABLE public.background_checks (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     invitation_id character varying,
-    invitation_status integer
+    invitation_status integer,
+    invitation_url character varying
 );
 
 
@@ -3337,6 +3338,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230914204523'),
 ('20230921190613'),
 ('20230925171243'),
-('20231005145350');
+('20231005145350'),
+('20231016221100');
 
 


### PR DESCRIPTION
![CleanShot 2023-10-16 at 20 33 31@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/97b46bb4-9f6f-4f4c-9c88-a393db6ec72a)


This PR adds the `invitation_url` to the background checks table and also adds a link on the background check status page
so that participants may access the checkr portal more directly. They will still receive the email from checkr. Open to wording changes! Refs #4259 