### PR TITLE
Added functionality to handle expired checkr background check invitations 

### DIFF
--- a/app/controllers/concerns/background_check_controller.rb
+++ b/app/controllers/concerns/background_check_controller.rb
@@ -1,10 +1,4 @@
 module BackgroundCheckController
-  extend ActiveSupport::Concern
-
-  included do
-    before_action :verify_background_check_invitation_required, only: [:international_background_check]
-  end
-
   def new
     if current_profile.background_check_candidate_id.present?
       redirect_to send("#{current_scope}_background_check_path", id: current_profile.background_check_candidate_id)
@@ -15,7 +9,7 @@ module BackgroundCheckController
 
   def show
     if current_profile.background_check.invitation_id.present?
-      InvitationChecking.new(current_profile).execute
+      InvitationChecking.new(current_account).execute
     end
 
     if current_profile.background_check.report_id.present?
@@ -53,14 +47,6 @@ module BackgroundCheckController
       :copy_requested
     ).tap do |tapped|
       tapped[:driver_license_state] = tapped[:driver_license_state].strip.upcase
-    end
-  end
-
-  def verify_background_check_invitation_required
-    unless current_profile.in_background_check_invitation_country? &&
-        (current_profile.background_check.blank? || current_profile.background_check.invitation_expired?)
-      redirect_to send("#{current_scope}_dashboard_path"),
-                  alert: t("controllers.application.unauthorized")
     end
   end
 end

--- a/app/controllers/concerns/background_check_controller.rb
+++ b/app/controllers/concerns/background_check_controller.rb
@@ -24,14 +24,6 @@ module BackgroundCheckController
     @background_check = current_profile.background_check
   end
 
-  def international_background_check
-    RequestCheckrBackgroundCheckInvitationJob.perform_later(candidate: current_profile)
-
-    redirect_to send("#{current_scope}_dashboard_path"),
-      success: t("controllers.background_checks.invite.success")
-
-  end
-
   def create
     @candidate = BackgroundCheckCandidate.new(candidate_params)
 

--- a/app/controllers/concerns/background_check_controller.rb
+++ b/app/controllers/concerns/background_check_controller.rb
@@ -15,7 +15,7 @@ module BackgroundCheckController
 
   def show
     if current_profile.background_check.invitation_id.present?
-      InvitationChecking.new(current_profile.background_check).execute
+      InvitationChecking.new(current_profile).execute
     end
 
     if current_profile.background_check.report_id.present?

--- a/app/controllers/concerns/background_check_invitation_controller.rb
+++ b/app/controllers/concerns/background_check_invitation_controller.rb
@@ -1,0 +1,8 @@
+module BackgroundCheckInvitationController
+  def background_check_invitation
+    RequestCheckrBackgroundCheckInvitationJob.perform_later(candidate: current_profile)
+
+    redirect_to send("#{current_scope}_dashboard_path"),
+      success: t("controllers.background_checks.invite.success")
+  end
+end

--- a/app/controllers/concerns/background_check_invitation_controller.rb
+++ b/app/controllers/concerns/background_check_invitation_controller.rb
@@ -1,8 +1,24 @@
 module BackgroundCheckInvitationController
-  def background_check_invitation
-    RequestCheckrBackgroundCheckInvitationJob.perform_later(candidate: current_profile)
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :verify_background_check_invitation_required, only: [:create_invitation]
+  end
+
+  def create_invitation
+    RequestCheckrBackgroundCheckInvitationJob.perform_later(account_id: current_account.id)
 
     redirect_to send("#{current_scope}_dashboard_path"),
       success: t("controllers.background_checks.invite.success")
+  end
+
+  private
+
+  def verify_background_check_invitation_required
+    unless current_profile.in_background_check_invitation_country? &&
+        (current_profile.background_check.blank? || current_profile.background_check.invitation_expired?)
+      redirect_to send("#{current_scope}_dashboard_path"),
+                  alert: t("controllers.application.unauthorized")
+    end
   end
 end

--- a/app/controllers/mentor/background_checks_controller.rb
+++ b/app/controllers/mentor/background_checks_controller.rb
@@ -1,6 +1,7 @@
 module Mentor
   class BackgroundChecksController < MentorController
     include BackgroundCheckController
+    include BackgroundCheckInvitationController
     private
     def current_profile
       current_mentor

--- a/app/controllers/mentor/background_checks_controller.rb
+++ b/app/controllers/mentor/background_checks_controller.rb
@@ -2,7 +2,9 @@ module Mentor
   class BackgroundChecksController < MentorController
     include BackgroundCheckController
     include BackgroundCheckInvitationController
+
     private
+
     def current_profile
       current_mentor
     end

--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -154,9 +154,9 @@ class AccountsGrid
   column :background_check, if: ->(g) {
     g.admin or Array(g.country)[0] == "US"
   } do
-    if country_code == "US" && mentor_profile.present?
+    if mentor_profile.present? && mentor_profile.in_background_check_country?
       background_check.present? ?
-        background_check.status :
+        background_check.status.humanize :
         "Not submitted"
     elsif mentor_profile.present?
       "-"

--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -165,6 +165,18 @@ class AccountsGrid
     end
   end
 
+  column :invitation_status, if: ->(g) {
+    g.admin || Array(g.country)[0] == "US"
+  } do
+    if mentor_profile.present? && mentor_profile.in_background_check_country?
+      background_check.invitation_status.present? ?
+        background_check.invitation_status.humanize :
+        "-"
+    else
+      "-"
+    end
+  end
+
   column :parental_consent do |account, grid|
     if account.student_profile.present? && account.parental_consent(grid.season).present?
       account.parental_consent(grid.season).status

--- a/app/jobs/request_checkr_background_check_invitation_job.rb
+++ b/app/jobs/request_checkr_background_check_invitation_job.rb
@@ -17,6 +17,6 @@ class RequestCheckrBackgroundCheckInvitationJob < ActiveJob::Base
   end
 
   def perform(candidate:)
-    CheckrApiClient::ApiClient.new.request_checkr_invitation(candidate: candidate)
+    CheckrApiClient::ApiClient.new(candidate).request_checkr_invitation
   end
 end

--- a/app/jobs/request_checkr_background_check_invitation_job.rb
+++ b/app/jobs/request_checkr_background_check_invitation_job.rb
@@ -2,7 +2,8 @@ class RequestCheckrBackgroundCheckInvitationJob < ActiveJob::Base
   queue_as :default
 
   before_enqueue do |job|
-    profile = job.arguments[0][:candidate]
+    account_id = job.arguments[0][:account_id]
+    profile = Account.find(account_id)
 
     Job.create!(
       job_id: job.job_id,
@@ -16,7 +17,8 @@ class RequestCheckrBackgroundCheckInvitationJob < ActiveJob::Base
     db_job.update_column(:status, "complete")
   end
 
-  def perform(candidate:)
-    CheckrApiClient::ApiClient.new(candidate).request_checkr_invitation
+  def perform(account_id:)
+    candidate = Account.find(account_id)
+    CheckrApiClient::ApiClient.new(candidate: candidate).request_checkr_invitation
   end
 end

--- a/app/null_objects/null_background_check.rb
+++ b/app/null_objects/null_background_check.rb
@@ -9,4 +9,5 @@ class NullBackgroundCheck < NullObject
   def suspended?; false; end
   def paranoid?; false; end
   def invitation_pending?; false; end
+  def candidate_id; nil; end
 end

--- a/app/services/checkr_api_client/api_client.rb
+++ b/app/services/checkr_api_client/api_client.rb
@@ -1,6 +1,7 @@
 module CheckrApiClient
   class ApiClient
     def initialize(
+      candidate,
       client_id: ENV.fetch("CHECKR_API_KEY"),
       base_url: ENV.fetch("CHECKR_API_BASE", "https://api.checkr.com"),
       logger: Rails.logger,
@@ -16,55 +17,42 @@ module CheckrApiClient
 
       @logger = logger
       @error_notifier = error_notifier
+      @candidate = candidate
+      @candidate_id = candidate.account.background_check.candidate_id
     end
 
-    def request_checkr_invitation(candidate:)
-      candidate_response = connection.post("/v1/candidates") do |req|
-        req.body = {
-          email: candidate.account.email,
-          first_name: candidate.account.first_name,
-          last_name: candidate.account.last_name,
-          dob: candidate.account.date_of_birth,
-          work_locations: [{country: candidate.account.country_code}]
-        }.to_json
+    def request_checkr_invitation
+      if candidate_id.blank?
+        create_checkr_candidate(candidate: candidate)
       end
 
-      candidate_response_body = JSON.parse(candidate_response.body, symbolize_names: true)
-
-      if candidate_response.success?
-        invitation_response = connection.post("/v1/invitations") do |req|
-          req.body = {
-            package: "international_basic_plus",
-            candidate_id: candidate_response_body[:id],
-            work_locations: [{country: candidate.account.country_code}]
-          }.to_json
-        end
-
-        invitation_response_body = JSON.parse(invitation_response.body, symbolize_names: true)
+      if candidate_id.present?
+        invitation_response = create_checkr_invitation(
+          candidate_country_code: candidate.account.country_code,
+          candidate_id: candidate_id
+        )
 
         if invitation_response.success?
           candidate.account.update(background_check_attributes: {
-            candidate_id: candidate_response_body[:id],
-            invitation_id: invitation_response_body[:id],
-            invitation_status: invitation_response_body[:status],
-            invitation_url: invitation_response_body[:invitation_url],
+            candidate_id: candidate_id,
+            invitation_id: invitation_response.payload[:id],
+            invitation_status: invitation_response.payload[:status],
+            invitation_url: invitation_response.payload[:invitation_url],
             status: :invitation_sent
           })
 
           Result.new(success?: true)
-
         else
-          error = "[CHECKR] Error requesting invitation for #{candidate.account.id} - #{invitation_response_body[:error]}"
+          error = "[CHECKR] Error requesting invitation for #{candidate.account.id} - #{invitation_response.payload[:error]}"
           logger.error(error)
           error_notifier.notify(error)
 
           Result.new(success?: false)
         end
       else
-        error = "[CHECKR] Error creating candidate for #{candidate.account.id} - #{candidate_response_body[:error]}"
+        error = "[CHECKR] Error requesting invitation for #{candidate.account.id} - Candidate ID is missing."
         logger.error(error)
         error_notifier.notify(error)
-
         Result.new(success?: false)
       end
     end
@@ -87,8 +75,51 @@ module CheckrApiClient
 
     private
 
-    attr_reader :connection, :logger, :error_notifier
+    attr_reader :connection, :logger, :error_notifier, :candidate_id, :candidate
 
     Result = Struct.new(:success?, :message, :payload, keyword_init: true)
+
+    def create_checkr_candidate(candidate:)
+      req_body = {
+        email: candidate.account.email,
+        first_name: candidate.account.first_name,
+        last_name: candidate.account.last_name,
+        dob: candidate.account.date_of_birth,
+        work_locations: [{country: candidate.account.country_code}]
+      }
+
+      candidate_response = post("candidates", req_body)
+      candidate_response_body = JSON.parse(candidate_response.body, symbolize_names: true)
+
+      if candidate_response.success?
+        @candidate_id = candidate_response_body[:id]
+        Result.new(success?: true)
+      else
+        error = "[CHECKR] Error creating candidate for #{candidate.account.id} - #{candidate_response_body[:error]}"
+        logger.error(error)
+        error_notifier.notify(error)
+
+        Result.new(success?: false)
+      end
+    end
+
+    def create_checkr_invitation(candidate_country_code:, candidate_id:)
+      req_body = {
+        package: "international_basic_plus",
+        candidate_id: candidate_id,
+        work_locations: [{country: candidate_country_code}]
+      }
+
+      invitation_response = post("invitations", req_body)
+      invitation_response_body = JSON.parse(invitation_response.body, symbolize_names: true)
+
+      Result.new(success?: invitation_response.success?, payload: invitation_response_body)
+    end
+
+    def post(resource, body)
+      connection.post("/v1/#{resource}") do |req|
+        req.body = body.to_json
+      end
+    end
   end
 end

--- a/app/technovation/invitation_checking.rb
+++ b/app/technovation/invitation_checking.rb
@@ -1,16 +1,16 @@
 class InvitationChecking
   def initialize(
-    current_profile,
+    current_account,
     logger: Rails.logger
   )
 
-    @candidate = current_profile
-    @bg_check = current_profile.background_check
+    @candidate = current_account
+    @bg_check = current_account.background_check
     @logger = logger
   end
 
   def execute
-    invitation = CheckrApiClient::ApiClient.new(candidate).retrieve_invitation(bg_check.invitation_id)
+    invitation = CheckrApiClient::ApiClient.new(candidate: candidate).retrieve_invitation(bg_check.invitation_id)
 
     if invitation.success?
       if invitation.payload[:status] != bg_check.invitation_status

--- a/app/technovation/invitation_checking.rb
+++ b/app/technovation/invitation_checking.rb
@@ -1,15 +1,16 @@
 class InvitationChecking
   def initialize(
-    background_check,
+    current_profile,
     logger: Rails.logger
   )
 
-    @bg_check = background_check
+    @candidate = current_profile
+    @bg_check = current_profile.background_check
     @logger = logger
   end
 
   def execute
-    invitation = CheckrApiClient::ApiClient.new.retrieve_invitation(bg_check.invitation_id)
+    invitation = CheckrApiClient::ApiClient.new(candidate).retrieve_invitation(bg_check.invitation_id)
 
     if invitation.success?
       if invitation.payload[:status] != bg_check.invitation_status
@@ -33,5 +34,5 @@ class InvitationChecking
 
   private
 
-  attr_reader :bg_check, :logger
+  attr_reader :bg_check, :logger, :candidate
 end

--- a/app/views/background_checks/_background_check_invitation.html.erb
+++ b/app/views/background_checks/_background_check_invitation.html.erb
@@ -70,7 +70,11 @@
       <%= link_to "Request background check invitation",
                   mentor_background_check_invitation_path,
                   class: "button",
-                  id: "bg-check-invite-btn"%>
+                  id: "bg-check-invite-btn",
+                  data:{
+                    method: :post
+                  }
+      %>
     </div>
   </div>
 </div>

--- a/app/views/background_checks/_background_check_invitation.html.erb
+++ b/app/views/background_checks/_background_check_invitation.html.erb
@@ -68,7 +68,7 @@
     <div class="panel">
       <h3><%= t("views.background_checks.new.international_title") %></h3>
       <%= link_to "Request background check invitation",
-                  mentor_international_background_check_url,
+                  mentor_background_check_invitation_path,
                   class: "button",
                   id: "bg-check-invite-btn"%>
     </div>

--- a/app/views/background_checks/_new.html.erb
+++ b/app/views/background_checks/_new.html.erb
@@ -1,5 +1,5 @@
 <% if current_account.country_code == "US" %>
   <%= render "background_checks/us_background_check", url: url %>
 <% else %>
-  <%= render "background_checks/international_background_check" %>
+  <%= render "background_checks/background_check_invitation" %>
 <% end %>

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -25,7 +25,11 @@
         </p>
         <%= link_to "Request a new invitation",
                     mentor_background_check_invitation_path,
-                    class: "button button--primary" %>
+                    class: "button button--primary",
+                    data: {
+                      method: :post
+                    }
+        %>
       <% end %>
 
 

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -19,7 +19,15 @@
         <p>
           Thank you for completing your background check through the Checkr portal.
         </p>
+      <% elsif @background_check.invitation_expired? %>
+        <p>
+          Your background check invitation has expired. You can request a new invitation by clicking the button below.
+        </p>
+        <%= link_to "Request a new invitation",
+                    mentor_background_check_invitation_path,
+                    class: "button button--primary" %>
       <% end %>
+
 
       <p>
         Your background check status is:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
 
     resources :background_checks, only: [:new, :create, :show]
 
-    get "/international_background_check", to: "background_checks#international_background_check"
+    get "/background_check_invitation", to: "background_checks#background_check_invitation"
 
     resource :regional_pitch_events_team_list, only: :show
     resource :regional_pitch_event_selection, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
 
     resources :background_checks, only: [:new, :create, :show]
 
-    get "/background_check_invitation", to: "background_checks#background_check_invitation"
+    post "/background_check_invitation", to: "background_checks#create_invitation"
 
     resource :regional_pitch_events_team_list, only: :show
     resource :regional_pitch_event_selection, only: :create


### PR DESCRIPTION
Refs #4198 

This PR was needed to handle expired checkr background check invitations. If a mentor's invitation is expired there is new button ( "Request a new invitation") they can click to request a new checkr invitation

Main changes include:
- Adding a more general `background_check_invitation_controller` with `background_check_invitation` method
- Removed `international_background_check_method`
- General cleanup of `CheckrApiClient`
      - Added `create_checkr_candidate` and `create_checkr_invitation` method
- The main  `request_checkr_invitation` method will now check for a candidate_id before creating a new checkr candidate. This was added so that if a mentor has an expired invite an new invite can be requested without creating another candidate on the checkr platform
- Added the background check status for all background check country participants in the admin participants grid 

<img width="1754" alt="CleanShot 2023-10-17 at 13 08 04@2x" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/2e2ee16f-674c-4a3d-bab5-a67913989ff4">
