### PR TITLE
Updates to checkr invitation method so that only accounts that need an invitation can request one

### DIFF
--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -310,6 +310,12 @@ class MentorProfile < ActiveRecord::Base
     country_codes.include?(account.country_code)
   end
 
+  def in_background_check_invitation_country?
+    country_codes = ENV.fetch("BACKGROUND_CHECK_COUNTRY_CODES", "").split(",")
+    country_codes.delete("US")
+    country_codes.include?(account.country_code)
+  end
+
   def bio_complete?
     not bio.blank?
   end

--- a/lib/tasks/remove_pending_background_checks.rake
+++ b/lib/tasks/remove_pending_background_checks.rake
@@ -1,0 +1,17 @@
+task :remove_pending_background_checks_by_id, [:dry_run] => :environment do |t, args|
+  background_check_ids = args.extras
+  dry_run = args[:dry_run] != "run"
+  puts "DRY RUN: #{dry_run ? "on" : "off"}"
+
+  background_check_ids.each do |id|
+    background_check = BackgroundCheck.find(id)
+    puts "Deleting background check #{background_check.id} - for Account #{background_check.account_id} located in #{background_check.account.country} - Candidate Id #{background_check.candidate_id}"
+
+    if !dry_run
+      background_check.destroy
+      puts "Background check #{background_check.id} deleted"
+    end
+  end
+
+  puts "Done"
+end


### PR DESCRIPTION
Refs #4265 

We discovered an issue where background invitations could be requested by navigating to the specific invitation route. More [information here](https://iridescentlearning.slack.com/archives/C06CHBQ4E/p1697721214434789)

This PR includes 2 main changes:
- `remove_pending_background_checks_by_id` rake task to remove the bg checks that were requested by accounts that should not have bg checks. 
     - This rake task needs a list of bg check IDs to delete
 - Added a `before_action` for the `international_background_check` method that verifies the current account actually requires a bg check invitation.


Conditions for a background check invitation 
1. The account is in a country the requires invitations (essentially non US countries that we bg check)
2. And that they currently don't have a bg check OR their current invitation is expired 

[QA Steps are here](https://iridescentlearning.slack.com/archives/C02J1GU8VRA/p1697743743936599)