### PR TITLE
Update Dalli gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "sidekiq", "~> 7.0"
 
 gem "airbrake", "~> 11.0.3"
 
-gem "dalli", "~> 2.7"
+gem "dalli", "~> 3.0"
 
 gem "geocoder", "~> 1.6.0"
 gem "timezone", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     css_parser (1.9.0)
       addressable
     currencies (0.4.2)
-    dalli (2.7.11)
+    dalli (3.2.6)
     datagrid (1.6.3)
       rails (>= 4.0)
     date (3.3.3)
@@ -564,7 +564,7 @@ DEPENDENCIES
   counter_culture (~> 1.12)
   countries (~> 1.2)
   country_state_select (~> 3.0)
-  dalli (~> 2.7)
+  dalli (~> 3.0)
   datagrid (~> 1.5)
   dotenv-rails (~> 2.7)
   dropzonejs-rails (~> 0.8)


### PR DESCRIPTION
This will update Dalli to version 3.2.6 to address this security vulnerability:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/101

We're upgrading from 2.x.x to 3.x.x, I looked over the [changelog](https://github.com/petergoldstein/dalli/blob/main/CHANGELOG.md) and saw some breaking changes, but I don't think they concern us. I searched our codebase for `dalli` and I didn't see setting any configuration options.

From what I can tell, Dalli/memcache is being used via `Rails.cache`, so for example, I noticed the submission "percentage complete" functionality uses `Rails.cache`, so to test this locally I updated a submission (add/removing required fields) and saw the percentage calculating/working as expected.


