### PR TITLE
Team invite validator service

### DIFF
--- a/app/services/team_invite_validator.rb
+++ b/app/services/team_invite_validator.rb
@@ -1,0 +1,31 @@
+class TeamInviteValidator
+  def initialize(team_invite_code:, important_dates: ImportantDates)
+    @team_invite_code = team_invite_code
+    @important_dates = important_dates
+  end
+
+  def call
+    invite = TeamMemberInvite.find_by(invite_token: team_invite_code)
+
+    if invite.present? && invite.pending? && invite.inviter_type == "StudentProfile" &&
+        (important_dates.official_start_of_season..important_dates.submission_deadline).cover?(Date.today)
+
+      registration_profile_type = case invite.invitee_type
+      when "StudentProfile"
+        "student"
+      when "MentorProfile"
+        "mentor"
+      end
+
+      Result.new(valid?: true, registration_profile_type: registration_profile_type)
+    else
+      Result.new(valid?: false, registration_profile_type: "")
+    end
+  end
+
+  private
+
+  Result = Struct.new(:valid?, :registration_profile_type, keyword_init: true)
+
+  attr_reader :team_invite_code, :important_dates
+end

--- a/spec/services/team_invite_validator_spec.rb
+++ b/spec/services/team_invite_validator_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+describe TeamInviteValidator do
+  let(:team_invite_validator) {
+    TeamInviteValidator.new(team_invite_code: team_invite_code, important_dates: important_dates)
+  }
+  let(:team_invite_code) { "987zyxw654tsrq321" }
+  let(:important_dates) {
+    class_double("ImportantDates",
+      official_start_of_season: official_start_of_season,
+      submission_deadline: submission_deadline)
+  }
+
+  let(:official_start_of_season) { Date.parse("2020-10-01") }
+  let(:submission_deadline) { Date.parse("2021-04-15") }
+
+  before do
+    allow(TeamMemberInvite).to receive(:find_by)
+      .with(invite_token: team_invite_code)
+      .and_return(invitation)
+  end
+
+  let(:invitation) do
+    instance_double(TeamMemberInvite,
+      pending?: pending_invite,
+      inviter_type: inviter_profile_type,
+      invitee_type: invitee_profile_type)
+  end
+
+  let(:pending_invite) { false }
+  let(:inviter_profile_type) { "StudentProfile" }
+  let(:invitee_profile_type) { "StudentProfile" }
+
+  context "when a team invite is pending" do
+    let(:pending_invite) { true }
+
+    context "when a student made the invite" do
+      let(:inviter_profile_type) { "StudentProfile" }
+
+      context "when today's date is between the official start of season and the submission deadline" do
+        before do
+          Timecop.freeze(Date.parse("2020-11-17"))
+        end
+
+        after do
+          Timecop.return
+        end
+
+        it "is valid" do
+          expect(team_invite_validator.call.valid?).to eq(true)
+        end
+
+        context "when the invite is for a student" do
+          let(:invitee_profile_type) { "StudentProfile" }
+
+          it "returns 'student' for the registration profile type" do
+            expect(team_invite_validator.call.registration_profile_type).to eq("student")
+          end
+        end
+
+        context "when the invite is for a mentor" do
+          let(:invitee_profile_type) { "MentorProfile" }
+
+          it "returns 'mentor' for the registration profile type" do
+            expect(team_invite_validator.call.registration_profile_type).to eq("mentor")
+          end
+        end
+      end
+    end
+  end
+
+  context "when an invite doesn't exist for the provided team invite code" do
+    before do
+      allow(TeamMemberInvite).to receive(:find_by)
+        .with(invite_token: team_invite_code)
+        .and_return(nil)
+    end
+
+    it "is not valid" do
+      expect(team_invite_validator.call.valid?).to eq(false)
+    end
+  end
+
+  context "when a team invite is not pending" do
+    let(:pending_invite) { false }
+
+    it "is not valid" do
+      expect(team_invite_validator.call.valid?).to eq(false)
+    end
+  end
+
+  context "when a mentor made the invite" do
+    let(:inviter_profile_type) { "MentorProfile" }
+
+    it "is not valid" do
+      expect(team_invite_validator.call.valid?).to eq(false)
+    end
+  end
+
+  context "when today's date is after the submission deadline" do
+    before do
+      Timecop.freeze(Date.parse("2021-04-30"))
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it "is not valid" do
+      expect(team_invite_validator.call.valid?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This new service will validate a team invite.

Pass in a team invite code and the invite will be valid if:
- the invite is pending
- a student sent the invite
- today's date is between the season start date and the submission close date

