### PR TITLE
Add new policy for judge scores

### DIFF
--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -29,6 +29,10 @@ module Judge
     end
 
     def new
+      if params[:score_id].present? && params[:score_id].to_i > 0
+        authorize SubmissionScore.find(params[:score_id]), policy_class: Judge::SubmissionScorePolicy
+      end
+
       respond_to do |f|
         f.html
 

--- a/app/policies/judge/submission_score_policy.rb
+++ b/app/policies/judge/submission_score_policy.rb
@@ -1,0 +1,8 @@
+module Judge
+  class SubmissionScorePolicy < ApplicationPolicy
+    def new?
+      current_account.judge_profile.present? &&
+        current_account.judge_profile.scores.map(&:id).include?(record.id)
+    end
+  end
+end

--- a/app/policies/parental_consent_policy.rb
+++ b/app/policies/parental_consent_policy.rb
@@ -1,6 +1,6 @@
 class ParentalConsentPolicy < ApplicationPolicy
   def show?
-    current_account.admin? ||
-      record.student_profile_id == current_account&.student_profile&.id
+    current_account.student_profile.present? && (current_account.student_profile.id == record.student_profile_id) ||
+      current_account.admin?
   end
 end

--- a/spec/policies/judge/submission_score_policy_spec.rb
+++ b/spec/policies/judge/submission_score_policy_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe Judge::SubmissionScorePolicy do
+  subject { described_class }
+
+  let(:score) { FactoryBot.create(:score) }
+
+  permissions :new? do
+    context "students" do
+      let(:student) { FactoryBot.build(:student) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(student, score)
+      end
+    end
+
+    context "mentors" do
+      let(:student) { FactoryBot.build(:mentor) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(student, score)
+      end
+    end
+
+    context "judges" do
+      let(:judge) { FactoryBot.create(:judge) }
+
+      context "when the score is their own" do
+        let(:score) { FactoryBot.create(:score, judge_profile: judge) }
+
+        it "allows access" do
+          expect(subject).to permit(judge, score)
+        end
+      end
+
+      context "when the score is someone else's" do
+        let(:score) { FactoryBot.create(:score, judge_profile: FactoryBot.create(:judge)) }
+
+        it "does not allow access" do
+          expect(subject).not_to permit(judge, score)
+        end
+      end
+    end
+
+    context "chapter ambassadors" do
+      let(:student) { FactoryBot.build(:chapter_ambassador) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(student, score)
+      end
+    end
+
+    context "admins" do
+      let(:admin) { FactoryBot.build(:admin) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(admin, score)
+      end
+    end
+
+    context "guests" do
+      let(:guest) { NullAuth.new }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(guest, score)
+      end
+    end
+  end
+end

--- a/spec/policies/parental_consent_policy_spec.rb
+++ b/spec/policies/parental_consent_policy_spec.rb
@@ -6,22 +6,6 @@ describe ParentalConsentPolicy do
   let(:parental_consent) { ParentalConsent.new(student_profile_id: 1) }
 
   permissions :show? do
-    context "admins" do
-      let(:admin) { FactoryBot.build(:admin) }
-
-      it "allows access" do
-        expect(subject).to permit(admin, parental_consent)
-      end
-    end
-
-    context "guests" do
-      let(:guest) { NullAuth.new }
-
-      it "does not allow access" do
-        expect(subject).not_to permit(guest, parental_consent)
-      end
-    end
-
     context "students" do
       let(:student) { FactoryBot.build(:student) }
 
@@ -39,6 +23,46 @@ describe ParentalConsentPolicy do
         it "does not allow access" do
           expect(subject).not_to permit(student, parental_consent)
         end
+      end
+    end
+
+    context "mentors" do
+      let(:mentor) { FactoryBot.build(:mentor) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(mentor, parental_consent)
+      end
+    end
+
+    context "judges" do
+      let(:judge) { FactoryBot.build(:judge) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(judge, parental_consent)
+      end
+    end
+
+    context "chapter ambassadors" do
+      let(:chapter_ambassador) { FactoryBot.build(:chapter_ambassador) }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(chapter_ambassador, parental_consent)
+      end
+    end
+
+    context "admins" do
+      let(:admin) { FactoryBot.build(:admin) }
+
+      it "allows access" do
+        expect(subject).to permit(admin, parental_consent)
+      end
+    end
+
+    context "guests" do
+      let(:guest) { NullAuth.new }
+
+      it "does not allow access" do
+        expect(subject).not_to permit(guest, parental_consent)
       end
     end
   end


### PR DESCRIPTION
This will add a new policy to ensure that when judges start a new score or resume a score (which both go to the `new` action) that they can only view/access their own scores.

I also refactored the parental consent policy and specs so that the specs are testing the policy against:
- students
- mentors
- judges
- chapter ambassadors
- admins
- guests

And the conditions/rules of the policy will be in the same order^.