### PR TITLE
PT1 Updated submission rebrand layout and tailwind config

### DIFF
--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -2,9 +2,9 @@
   <div id="screenshot-uploader">
     <template v-if="maxFiles > 0">
       <p class="margin--b-xlarge">
-        You must submit at least 2 images.
-        Upload 2-6 images that showcase your Technovation journey.
-        They should help judges better understand your ideas.
+        You must submit at least 2 images. Upload 2-6 images that showcase your
+        Technovation journey. They should help judges better understand your
+        ideas.
       </p>
 
       <button @click="uploadFile" class="tw-green-btn small">
@@ -13,20 +13,15 @@
     </template>
 
     <template v-else>
-      You have uploaded the maximum of {{ maxAllowed }} images.
-      You need to remove some if you want to add others.
+      You have uploaded the maximum of {{ maxAllowed }} images. You need to
+      remove some if you want to add others.
     </template>
 
     <p v-if="screenshots.length > 1">
-      Sort your images in the order that you want
-      the judges to see them:
+      Sort your images in the order that you want the judges to see them:
     </p>
 
-    <ol
-      v-dragula
-      id="sortable-list"
-      class="submission-pieces__screenshots"
-    >
+    <ol v-dragula id="sortable-list" class="submission-pieces__screenshots">
       <li
         class="sortable-list__item draggable screenshot-wrapper"
         v-for="screenshot in screenshots"
@@ -52,15 +47,15 @@
 </template>
 
 <script>
-import * as filestack from 'filestack-js';
+import * as filestack from "filestack-js";
 export default {
-  name: 'screenshot-uploader',
+  name: "screenshot-uploader",
 
-  data () {
+  data() {
     return {
       maxAllowed: 6,
       screenshots: [],
-    }
+    };
   },
 
   props: {
@@ -85,62 +80,58 @@ export default {
     },
   },
 
-  mounted () {
+  mounted() {
     var vm = this;
 
-    this.loadScreenshots()
+    this.loadScreenshots();
 
-    window.vueDragula.eventBus.$on('drop', (args) => {
-      const dropped = args[1]
-      const list = args[2]
+    window.vueDragula.eventBus.$on("drop", (args) => {
+      const dropped = args[1];
+      const list = args[2];
 
-      const url = this.sortUrl
-      const sortableItems = list.querySelectorAll('.sortable-list__item')
-      const form = new FormData()
+      const url = this.sortUrl;
+      const sortableItems = list.querySelectorAll(".sortable-list__item");
+      const form = new FormData();
 
       sortableItems.forEach((item) => {
-        form.append(
-          "team_submission[screenshots][]",
-          item.dataset.dbId
-        )
-      })
+        form.append("team_submission[screenshots][]", item.dataset.dbId);
+      });
 
-      form.append("team_id", this.teamId)
+      form.append("team_id", this.teamId);
 
-      window.axios.patch(url, form)
-        .then(() => {
-          if (window.timeout) {
-            clearTimeout(window.timeout)
-            window.timeout = null
-          }
+      window.axios.patch(url, form).then(() => {
+        if (window.timeout) {
+          clearTimeout(window.timeout);
+          window.timeout = null;
+        }
 
-          dropped.classList.add('sortable-list--updated')
+        dropped.classList.add("sortable-list--updated");
 
-          window.timeout = setTimeout(() => {
-            dropped.classList.remove('sortable-list--updated')
-          }, 100)
-        })
-    })
+        window.timeout = setTimeout(() => {
+          dropped.classList.remove("sortable-list--updated");
+        }, 100);
+      });
+    });
   },
 
   computed: {
-    maxFiles () {
-      return this.maxAllowed - this.screenshots.length
+    maxFiles() {
+      return this.maxAllowed - this.screenshots.length;
     },
 
-    object () {
-      return this.maxFiles > 1 ? "images" : "image"
+    object() {
+      return this.maxFiles > 1 ? "images" : "image";
     },
 
-    prefix () {
-      return this.maxFiles > 1 ? "up to" : ""
+    prefix() {
+      return this.maxFiles > 1 ? "up to" : "";
     },
   },
 
   methods: {
     uploadFile() {
       const client = filestack.init(process.env.FILESTACK_API_KEY);
-      const TWO_MB_FILE_SIZE = 2 * 1024 * 1024
+      const TWO_MB_FILE_SIZE = 2 * 1024 * 1024;
 
       const fsPickerOptions = {
         accept: ["image/jpeg", "image/jpg", "image/png"],
@@ -151,36 +142,38 @@ export default {
           location: "s3",
           container: process.env.AWS_BUCKET_NAME,
           path: "uploads/screenshot/filestack/" + this.teamSubmissionId + "/",
-          region: "us-east-1"
+          region: "us-east-1",
         },
         onFileSelected: (file) => {
           if (file.size > TWO_MB_FILE_SIZE) {
-            throw new Error("Image is too large. Please select a photo under 2MB.");
+            throw new Error(
+              "Image is too large. Please select a photo under 2MB."
+            );
           }
         },
         onFileUploadFinished: (file) => {
           const form = new FormData();
-          form.append("team_id", this.teamId)
-          form.append("team_submission[image]", file.url)
+          form.append("team_id", this.teamId);
+          form.append("team_submission[image]", file.url);
 
-          window.axios.post(this.screenshotsUrl, form)
-            .then(({data}) => {
-              this.screenshots.push(data)
-            })
-        }
+          window.axios.post(this.screenshotsUrl, form).then(({ data }) => {
+            this.screenshots.push(data);
+          });
+        },
       };
 
       client.picker(fsPickerOptions).open();
     },
 
-    loadScreenshots () {
-      window.axios.get(`${this.screenshotsUrl}?team_id=${this.teamId}`)
-        .then(({data}) => {
-          this.screenshots = data
-        })
+    loadScreenshots() {
+      window.axios
+        .get(`${this.screenshotsUrl}?team_id=${this.teamId}`)
+        .then(({ data }) => {
+          this.screenshots = data;
+        });
     },
 
-    removeScreenshot (screenshot) {
+    removeScreenshot(screenshot) {
       swal({
         text: "Are you sure you want to delete the image?",
         cancelButtonText: "No, go back",
@@ -191,23 +184,22 @@ export default {
         focusCancel: true,
       }).then((result) => {
         if (result.value) {
-          this.handleAlertConfirmation(screenshot)
+          this.handleAlertConfirmation(screenshot);
         }
-      })
+      });
     },
 
-    handleAlertConfirmation (screenshot) {
+    handleAlertConfirmation(screenshot) {
       const index = this.screenshots.indexOf(screenshot);
       this.screenshots.splice(index, 1);
 
-      const url = this.screenshotsUrl +
-                  `/${screenshot.id}?team_id=${this.teamId}`
+      const url =
+        this.screenshotsUrl + `/${screenshot.id}?team_id=${this.teamId}`;
 
-      window.axios.delete(url)
-        .then(() => {
-          window.location.reload()
-        })
+      window.axios.delete(url).then(() => {
+        window.location.reload();
+      });
     },
   },
-}
+};
 </script>

--- a/app/javascript/components/ScreenshotUploader.vue
+++ b/app/javascript/components/ScreenshotUploader.vue
@@ -7,7 +7,7 @@
         They should help judges better understand your ideas.
       </p>
 
-      <button @click="uploadFile" class="button button--small">
+      <button @click="uploadFile" class="tw-green-btn small">
         + Add {{ prefix }} {{ maxFiles }} {{ object }}
       </button>
     </template>

--- a/app/javascript/packs/application_rebrand.js
+++ b/app/javascript/packs/application_rebrand.js
@@ -14,3 +14,4 @@ import "../stylesheets/pagination.css";
 import "../stylesheets/result_card.css";
 import "../stylesheets/filestack.css";
 import "../stylesheets/tooltip.css";
+import "../stylesheets/submissions.css";

--- a/app/javascript/stylesheets/submissions.css
+++ b/app/javascript/stylesheets/submissions.css
@@ -1,0 +1,23 @@
+#submission-container label{
+    @apply font-rubik text-base mb-4;
+}
+
+#submission-container input{
+    @apply mb-0;
+}
+
+#submission-container .tw-green-btn {
+    @apply mr-0;
+}
+
+.submission-actions{
+    @apply flex flex-col items-end mt-4;
+}
+
+#submission-container .button{
+    @apply w-auto px-4 py-2 rounded bg-tg-green text-white font-medium hover:bg-tg-dark-green hover:text-gray-50 hover:cursor-pointer;
+}
+
+#submission-container .btn-wrapper{
+    @apply flex items-center gap-3 justify-end;
+}

--- a/app/javascript/tailwind.config.js
+++ b/app/javascript/tailwind.config.js
@@ -37,6 +37,9 @@ module.exports = {
           },
         },
       },
+      fontFamily: {
+        rubik: ["Rubik", "sans-serif"],
+      },
     },
   },
   plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -1,12 +1,9 @@
-<% provide :root_path, send("#{current_scope}_dashboard_path") %>
-<% provide :menu, render("#{current_scope}/navigation/global_nav") %>
-
 <% if current_session.authenticated? %>
   <% provide :session_bar, render("layouts/session_bar") %>
 <% end %>
 
 <!DOCTYPE html>
-<html>
+<html id="<%= yield :html_id %>">
   <head>
     <%= render 'meta' %>
 
@@ -22,6 +19,10 @@
 
     <%= stylesheet_link_tag determine_manifest %>
 
+    <%#= stylesheet_packs_with_chunks_tag "application" %>
+
+    <%= yield :additional_css %>
+
     <%= filestack_js_include_tag %>
     <%= filestack_js_init_tag %>
 
@@ -29,83 +30,71 @@
       'data-turbolinks-track' => true %>
 
     <%= javascript_packs_with_chunks_tag "application", "submissions" %>
+    <%= javascript_packs_with_chunks_tag "application_rebrand" %>
+    <%= stylesheet_pack_tag 'application_rebrand', 'data-turbolinks-track': 'reload' %>
 
     <%= yield :js %>
   </head>
 
   <body>
-    <div class="header-container">
+    <div>
       <%= yield :session_bar %>
-
-      <%= render 'application/navigation' %>
-
-      <%= yield :subnav %>
+      <%= render 'application_rebrand/global_nav' %>
+      <%= yield :main_header %>
     </div>
 
-    <div class="main-container">
+    <div id="main-content" class="main-container bg-white pt-8">
       <%= render 'application/flash_messages' %>
 
-      <div class="grid">
-        <div class="grid__col-3 col--sticky-parent">
-          <div class="col--sticky-spacer">
-            <div class="submission__sidebar col--sticky">
-              <%= render "team_submissions/menu",
-                submission: @team_submission,
-                embedded: true %>
+      <%= yield :notifications %>
+
+      <div class="container mx-auto" id="submission-container">
+        <div class="flex flex-col lg:flex-row gap-6">
+          <div class="w-full lg:w-1/3">
+            <div class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
+              <div class="bg-energetic-blue text-white p-2">
+                <p class="font-bold">Submission Checklist</p>
+              </div>
+              <div class="p-4">
+                <%= render "team_submissions/menu",
+                           submission: @team_submission,
+                           embedded: true %>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="grid__col-6 submission-pieces col--sticky-parent">
-          <div class="col--sticky-spacer">
-            <div class="col--sticky">
-              <h1><%= yield :title %></h1>
+          <%= render layout: "application/templates/dashboards/energetic_container",
+                     locals: {
+                       heading: yield(:title),
+                       class: "lg:w-auto"
+                     } do %>
 
-              <%= yield %>
+            <%= yield %>
 
-              <nav class="submission-nav">
-                <% if content_for?(:back_link) %>
-                  <%= link_to "Back: #{yield(:back_link_txt)}",
-                    yield(:back_link),
-                    data: { turbolinks: false },
-                    class: "
-                      submission-nav__back-btn
-                      button
-                      button--small
-                    " %>
-                <% else %>
-                  <span></span>
-                <% end %>
+            <nav class="submission-nav pt-8 flex flex-row space-between">
+              <% if content_for?(:back_link) %>
+                <%= link_to "Back: #{yield(:back_link_txt)}",
+                            yield(:back_link),
+                            data: { turbolinks: false },
+                            class: "submission-nav__back-btn w-auto px-4 py-2 rounded bg-tg-green text-white font-medium0"
+                %>
+              <% else %>
+                <span></span>
+              <% end %>
 
-                <% if content_for?(:next_link) %>
-                  <%= link_to "Next: #{yield(:next_link_txt)}",
-                    yield(:next_link),
-                    data: { turbolinks: false },
-                    class: "
-                      submission-nav__next-btn
-                      button
-                      button--small
-                    " %>
-                <% end %>
-              </nav>
-            </div>
-          </div>
-        </div>
-
-        <div class="grid__col-3 col--sticky-parent">
-          <div class="col--sticky-spacer">
-            <div class="col--sticky">
-              <%= render "team_submissions/sidebar_b",
-                submission: @team_submission %>
-            </div>
-          </div>
+              <% if content_for?(:next_link) %>
+                <%= link_to "Next: #{yield(:next_link_txt)}",
+                            yield(:next_link),
+                            data: { turbolinks: false },
+                            class: "submission-nav__next-btn w-auto px-4 py-2 rounded bg-tg-green text-white font-medium" %>
+              <% end %>
+            </nav>
+          <% end %>
         </div>
       </div>
 
-      <%= render 'application/footer' %>
+     <%= render 'application_rebrand/footer' %>
     </div>
-
-    <%= render 'application/queued_jobs' %>
 
     <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
       <script>
@@ -114,7 +103,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '<% ENV.fetch("GOOGLE_ANALYTICS_ID") %>', 'auto');
+        ga('create', '<%= ENV.fetch("GOOGLE_ANALYTICS_ID") %>', 'auto');
         ga('send', 'pageview');
       </script>
     <% end %>

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <!DOCTYPE html>
-<html id="<%= yield :html_id %>">
+<html>
   <head>
     <%= render 'meta' %>
 
@@ -18,8 +18,6 @@
     <%= render 'favicons' %>
 
     <%= stylesheet_link_tag determine_manifest %>
-
-    <%#= stylesheet_packs_with_chunks_tag "application" %>
 
     <%= yield :additional_css %>
 

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -8,7 +8,7 @@
           send("#{current_scope}_team_submission_section_path", submission, section: :start) %>
       </h1>
 
-      <ol class="list--reset">
+      <ol class="ml-4">
         <li>
           <%= link_to submission_progress_web_icon(
             submission,
@@ -20,7 +20,6 @@
             team_submission_id: submission.id
           ) %>
         </li>
-
         <li>
           <%= link_to submission_progress_web_icon(
             submission,
@@ -36,6 +35,8 @@
       </ol>
     </div>
 
+    <%= render 'application/templates/tw_thick_rule'%>
+
     <div class="progress__section">
       <h1>
         <%= link_to "Ideation",
@@ -46,7 +47,7 @@
           ) %>
       </h1>
 
-      <ol class="list--reset">
+      <ol class="ml-4">
         <li>
           <%= link_to submission_progress_web_icon(
             submission,
@@ -119,6 +120,8 @@
       </ol>
     </div>
 
+    <%= render 'application/templates/tw_thick_rule'%>
+
     <div class="progress__section">
       <h1>
         <%= link_to "Pitch",
@@ -130,7 +133,7 @@
         %>
       </h1>
 
-      <ol class="list--reset">
+      <ol class="ml-4">
         <li>
           <%= link_to submission_progress_web_icon(
             submission,
@@ -161,6 +164,8 @@
       </ol>
     </div>
 
+    <%= render 'application/templates/tw_thick_rule'%>
+
     <div class="progress__section">
       <h1>
         <%= link_to "Technical Elements",
@@ -172,7 +177,7 @@
         %>
       </h1>
 
-      <ol class="list--reset">
+      <ol class="ml-4">
         <li>
           <%= link_to submission_progress_web_icon(
             submission,
@@ -203,6 +208,8 @@
       </ol>
     </div>
 
+    <%= render 'application/templates/tw_thick_rule'%>
+
     <div class="progress__section">
       <h1>
         <%= link_to "Entrepreneurship",
@@ -214,7 +221,7 @@
         %>
       </h1>
 
-      <ol class="list--reset">
+      <ol class="ml-4">
         <li>
           <small>
             junior and senior division teams only:
@@ -234,5 +241,21 @@
         </li>
       </ol>
     </div>
-  <% end %>
+
+    <%= render 'application/templates/tw_thick_rule'%>
+
+    <div class="progress__section">
+      <h1>
+       Submit
+      </h1>
+
+      <ol class="ml-4">
+
+        <li>
+          <%= render "team_submissions/finalize", submission: @team_submission %>
+        </li>
+      </ol>
+    </div>
+
+<% end %>
 </div>

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -252,7 +252,7 @@
       <ol class="ml-4">
 
         <li>
-          <%= render "team_submissions/finalize", submission: @team_submission %>
+          <%= render "team_submissions/finalize", submission: submission %>
         </li>
       </ol>
     </div>

--- a/app/views/team_submissions/_qualified_students_reminder.en.html.erb
+++ b/app/views/team_submissions/_qualified_students_reminder.en.html.erb
@@ -4,7 +4,7 @@
     Every member of <%= team.name %> is qualified to compete. Well done!
 
     <%= link_to "what is this?", "#",
-      class: "small",
+      class: "small tw-link",
       data: {
         opens_modal: "explain_qualified_students_reminder",
       } %>
@@ -63,7 +63,7 @@
     A team that is qualified to compete has students, and every
     student on the team has finished these required steps:
 
-    <ul>
+    <ul class="list-disc ml-8">
       <li>Got their parent or guardian's permission to participate</li>
       <li>Has entered a location on their account</li>
       <li>Confirmed their email, if they changed it</li>

--- a/app/views/team_submissions/pieces/_piece.en.html.erb
+++ b/app/views/team_submissions/pieces/_piece.en.html.erb
@@ -8,9 +8,9 @@
 
 <div
   id="<%= dom_id(submission) %>_<%= attribute %>"
-  class="panel submission-piece <%= completion_css_class %>"
+  class="my-8" <%= completion_css_class %>
 >
-  <h3 class="panel--heading submission-piece--name"><%= title %></h3>
+  <h3 class="font-semibold mb-4"><%= title %></h3>
 
   <div
     class="
@@ -19,29 +19,32 @@
       <%= completion_css_class %>
     "
   >
-    <% if value_is_complete %>
-      <% if yield.blank? %>
-        <p class="value"><%= submission.public_send(attribute) %></p>
+    <div class="ml-8">
+      <% if value_is_complete %>
+        <% if yield.blank? %>
+          <p class="value"><%= submission.public_send(attribute) %></p>
+        <% else %>
+          <%= yield %>
+        <% end %>
+
+        <div class="mt-4">
+          <%= link_to cta_when_filled,
+            send(base_path_name, submission, piece: attribute),
+            { class: "green-btn small" }.merge(link_options) %>
+        </div>
       <% else %>
-        <%= yield %>
+        <p class="scent">
+          There's nothing here yet, but your team can
+          update this part whenever it's ready!
+        </p>
+
+        <div class="panel--footer">
+          <%= link_to cta_when_empty,
+            send(base_path_name, submission, piece: attribute),
+            { class: "tw-gray-btn small" }.merge(link_options) %>
+        </div>
       <% end %>
 
-      <div class="panel--footer">
-        <%= link_to cta_when_filled,
-          send(base_path_name, submission, piece: attribute),
-          { class: "button small secondary" }.merge(link_options) %>
-      </div>
-    <% else %>
-      <p class="scent">
-        There's nothing here yet, but your team can
-        update this part whenever it's ready!
-      </p>
-
-      <div class="panel--footer">
-        <%= link_to cta_when_empty,
-          send(base_path_name, submission, piece: attribute),
-          { class: "button small" }.merge(link_options) %>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/team_submissions/pieces/_piece.en.html.erb
+++ b/app/views/team_submissions/pieces/_piece.en.html.erb
@@ -30,7 +30,7 @@
         <div class="mt-4">
           <%= link_to cta_when_filled,
             send(base_path_name, submission, piece: attribute),
-            { class: "green-btn small" }.merge(link_options) %>
+            { class: "tw-green-btn small" }.merge(link_options) %>
         </div>
       <% else %>
         <p class="scent">

--- a/app/views/team_submissions/pieces/app_description.en.html.erb
+++ b/app/views/team_submissions/pieces/app_description.en.html.erb
@@ -1,54 +1,53 @@
-<div class="panel">
-  <h3 class="panel--heading">Description</h3>
+<% provide :title, "Description" %>
 
-  <%= form_with(
-    model: @team_submission,
-    url: send("#{current_scope}_team_submission_path"),
-    local: true
-  ) do |f| %>
-    <%= hidden_field_tag :piece, piece_name %>
+<%= form_with(
+  model: @team_submission,
+  url: send("#{current_scope}_team_submission_path"),
+  local: true
+) do |f| %>
+  <%= hidden_field_tag :piece, piece_name %>
 
-    <div class="field">
-      <%= f.label :app_description,
-        "Describe your #{t("submissions.app")} in a few sentences (100 words or less)",
-        for: :team_submission_app_description %>
+  <div class="field">
+    <%= f.label :app_description,
+      "Describe your #{t("submissions.app")} in a few sentences (100 words or less)",
+      for: :team_submission_app_description %>
 
-      <%= f.text_area :app_description,
-        id: :team_submission_app_description,
-        data: {
-          word_count: true,
-          word_count_limit: 100,
-        },
-        rows: 6 %>
+    <%= f.text_area :app_description,
+      id: :team_submission_app_description,
+      data: {
+        word_count: true,
+        word_count_limit: 100,
+      },
+      rows: 6 %>
 
-      <p class="scent scent--strong">
-        <strong>Remember:</strong>
-        only write a few sentences!
-        The judges will have a lot of these to read, so keep it short!
-      </p>
-    </div>
+    <p class="scent scent--strong">
+      <strong>Remember:</strong>
+      only write a few sentences!
+      The judges will have a lot of these to read, so keep it short!
+    </p>
+  </div>
 
-    <div class="actions">
-      <p>
-        <%= f.submit "Save this description", class: "button" %>
-        or
-        <%= link_to "cancel",
-          send(
-            "#{current_scope}_team_submission_section_path",
-            @team_submission,
-            section: @submission_section
-          ) %>
-      </p>
+  <div class="actions submission-actions">
+    <p class="btn-wrapper">
+      <%= f.submit "Save this description", class: "tw-green-btn cursor-pointer" %>
+      or
+      <%= link_to "cancel",
+        send(
+          "#{current_scope}_team_submission_section_path",
+          @team_submission,
+          section: @submission_section
+        ) %>
+    </p>
 
-      <p class="scent word-counter">
-        Number of words typed:
-        <br />
-        <span class="word-count__total word-count--plenty-remaining">
-          0
-        </span>
-        /
-        <span class="word-count__limit"></span>
-      </p>
-    </div>
-  <% end %>
-</div>
+    <p class="scent word-counter">
+      Number of words typed:
+      <br />
+      <span class="word-count__total word-count--plenty-remaining">
+        0
+      </span>
+      /
+      <span class="word-count__limit"></span>
+    </p>
+  </div>
+<% end %>
+

--- a/app/views/team_submissions/pieces/app_details.en.html.erb
+++ b/app/views/team_submissions/pieces/app_details.en.html.erb
@@ -1,7 +1,6 @@
-<div class="panel">
-  <h3 class="panel--heading">Additional Information</h3>
+<% provide :title, "Additional Information" %>
 
-  <% if @team_submission.errors.full_messages.any? %>
+<% if @team_submission.errors.full_messages.any? %>
     <div class="notice notice--alert">
       Sorry, there was a problem saving your responses.<br>
       Please check the fields below.
@@ -179,9 +178,9 @@
       </div>
     </div>
 
-    <div class="actions margin--t-xlarge">
-      <p>
-        <%= f.submit "Save my responses", class: "button" %>
+    <div class="actions mt-8 submission-actions">
+      <p class="btn-wrapper">
+        <%= f.submit "Save my responses", class: "tw-green-btn cursor-pointer" %>
         or
         <%= link_to "cancel",
           send(
@@ -192,4 +191,3 @@
       </p>
     </div>
   <% end %>
-</div>

--- a/app/views/team_submissions/pieces/app_name.en.html.erb
+++ b/app/views/team_submissions/pieces/app_name.en.html.erb
@@ -1,26 +1,23 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    <%= t("submissions.app").titlecase %>  name
-  </h3>
+<% provide :title, "Project Name" %>
 
-  <%= form_with(
-    model: @team_submission,
-    url: send("#{current_scope}_team_submission_path"),
-    local: true
-  ) do |f| %>
-    <%= hidden_field_tag :piece, piece_name %>
+<%= form_with(
+  model: @team_submission,
+  url: send("#{current_scope}_team_submission_path"),
+  local: true
+) do |f| %>
+  <%= hidden_field_tag :piece, piece_name %>
 
-    <div class="field">
-      <%= f.label :app_name, "Your #{t("submissions.app")}'s name", for: :team_submission_app_name %>
-      <%= f.text_field :app_name, id: :team_submission_app_name %>
-    </div>
+  <div class="field">
+    <%= f.label :app_name, "Your #{t("submissions.app")}'s name", for: :team_submission_app_name %>
+    <%= f.text_field :app_name, id: :team_submission_app_name %>
+  </div>
 
-    <div class="actions">
-      <p>
-        <%= f.submit "Save this name", class: "button" %>
-        or
-        <%= link_to "cancel", send("#{current_scope}_team_submission_path", @team_submission) %>
-      </p>
-    </div>
-  <% end %>
-</div>
+  <div class="actions submission-actions">
+    <p class="btn-wrapper">
+      <%= f.submit "Save this name", class: "tw-green-btn cursor-pointer" %>
+      or
+      <%= link_to "cancel", send("#{current_scope}_team_submission_path", @team_submission) %>
+    </p>
+  </div>
+<% end %>
+

--- a/app/views/team_submissions/pieces/business_plan.en.html.erb
+++ b/app/views/team_submissions/pieces/business_plan.en.html.erb
@@ -1,11 +1,4 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    <% if @team.junior? %>
-      User Adoption Plan
-    <% else %>
-      Business plan
-    <% end %>
-  </h3>
+<% provide :title, @team.junior? ? "User Adoption Plan" : "Business Plan" %>
 
   <% if @team.senior? || @team.junior? %>
     <% if @team_submission.business_plan_url_complete? %>
@@ -35,7 +28,7 @@
         <%= f.label :business_plan, "Upload your team's plan", for: :team_submission_business_plan %>
         <%= f.file_field :business_plan, id: "team_submission_business_plan" %>
         <%= f.hidden_field :business_plan_cache %>
-        <%= f.submit "Upload", class: "button" %>
+        <%= f.submit "Upload", class: "tw-green-btn" %>
       </div>
 
     <% end %>
@@ -47,10 +40,10 @@
           @team_submission,
           section: @submission_section
         ) ,
-          class: "button" %>
+          class: "tw-green-btn" %>
     </p>
 
-    <p class="after-dropzone-save">
+    <p class="after-dropzone-save flex flex-row justify-end">
       <%= link_to "cancel",
         send(
           "#{current_scope}_team_submission_section_path",
@@ -73,7 +66,8 @@
       <%= link_to(
         "here",
         "https://docs.google.com/document/d/1VWqsYbForZO5PERUUwCwkUUmlijl_pkAOvGg3WVkwSs/edit?usp=sharing",
-        target: "_blank"
+        target: "_blank",
+        class: "tw-link"
       ) %>
   <% end %>
     </p>
@@ -106,4 +100,3 @@
       )
     %>
   <% end %>
-</div>

--- a/app/views/team_submissions/pieces/demo_video_link.en.html.erb
+++ b/app/views/team_submissions/pieces/demo_video_link.en.html.erb
@@ -1,7 +1,5 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    <%= t("submissions.demo_video").titleize %>
-  </h3>
+<% provide :title, t("submissions.demo_video").titleize %>
+
 
   <%= form_with(
     model: @team_submission,
@@ -17,9 +15,9 @@
         value: params[:value] || @team_submission.send(piece_name) %>
     </div>
 
-    <div class="actions">
-      <p>
-        <%= f.submit "Next", class: "button" %>
+    <div class="actions submission-actions">
+      <p class="btn-wrapper">
+        <%= f.submit "Next", class: "tw-green-btn cursor-pointer" %>
         or
         <%= link_to "cancel",
         send("#{current_scope}_team_submission_section_path", @team_submission, section: @submission_section) %>
@@ -33,7 +31,8 @@
     <%= link_to(
       "Beginner",
       "https://beginner.technovationchallenge.org/path-player?courseid=beginners&unit=beginners_1630333562723_0Unit",
-      target: "_blank"
+      target: "_blank",
+      class: "tw-link"
     ) %>
 
     or
@@ -41,9 +40,9 @@
     <%= link_to(
       "Junior/Senior",
       "https://technovationchallenge.org/curriculum/pitch-3-outline-your-demo-video/",
-      target: "_blank"
+      target: "_blank",
+      class: "tw-link"
     ) %>
 
     curriculum units.
   </p>
-</div>

--- a/app/views/team_submissions/pieces/development_platform.en.html.erb
+++ b/app/views/team_submissions/pieces/development_platform.en.html.erb
@@ -1,15 +1,12 @@
 <% embedded ||= false %>
+<% provide :title, "Submission Type" %>
 
-<div class="<%= 'panel' if !embedded %>">
+<div>
   <% if embedded %>
     <p>
       To upload your technical work,
       we need to know about your development platform first.
     </p>
-  <% else %>
-    <h3 class="panel--heading">
-      Submission Type
-    </h3>
   <% end %>
 
   <p class="scent scent--strong">
@@ -108,7 +105,7 @@
         <p class="hint">
           To get the URL to your Thunkable Project page, go to "Share" and select "Project Details Page."
           <a href="https://iridescentsupport.zendesk.com/hc/en-us/articles/360019590314-How-do-I-submit-my-source-code-"
-             target="_blank">For more information, go here.</a>
+             target="_blank" class="tw-link">For more information, go here.</a>
         </p>
       </div>
 
@@ -120,10 +117,10 @@
       </div>
     </div>
 
-    <div class="actions">
-      <p>
+    <div class="actions submission-actions">
+      <p class="btn-wrapper">
         <%= f.submit "Save",
-          class: "button" %>
+          class: "tw-green-btn cursor-pointer" %>
         or
         <%= link_to "cancel",
         send("#{current_scope}_team_submission_section_path",

--- a/app/views/team_submissions/pieces/honor_code.en.html.erb
+++ b/app/views/team_submissions/pieces/honor_code.en.html.erb
@@ -1,15 +1,5 @@
-<div class="panel">
-  <h3><%= Season.current.year %> Technovation Honor Code</h3>
+<% provide :title, "Honor Code" %>
 
-  <%= render "team_submissions/honor_code" %>
+<h3><%= Season.current.year %> Technovation Honor Code</h3>
 
-  <p>
-    <%= link_to "Back",
-      send(
-        "#{current_scope}_team_submission_section_path",
-        @team_submission,
-        section: "ideation"
-      ),
-      class: "button button--small" %>
-  </p>
-</div>
+<%= render "team_submissions/honor_code" %>

--- a/app/views/team_submissions/pieces/learning_journey.en.html.erb
+++ b/app/views/team_submissions/pieces/learning_journey.en.html.erb
@@ -1,53 +1,52 @@
-<div class="panel">
-  <h3 class="panel--heading">Learning Journey</h3>
+<% provide :title, "Learning Journey" %>
 
-  <%= form_with(
+<%= form_with(
     model: @team_submission,
     url: send("#{current_scope}_team_submission_path"),
     local: true
   ) do |f| %>
     <%= hidden_field_tag :piece, piece_name %>
 
-    <div class="field">
-      <%= f.label :app_description,
-        "Describe your learning journey in a few sentences (200 words or less)",
-        for: :team_submission_learning_journey %>
+  <div class="field">
+    <%= f.label :app_description,
+      "Describe your learning journey in a few sentences (200 words or less)",
+      for: :team_submission_learning_journey %>
 
-      <%= f.text_area :learning_journey,
-        id: :team_submission_learning_journey,
-        data: {
-          word_count: true,
-          word_count_limit: 200,
-        },
-        rows: 6 %>
+    <%= f.text_area :learning_journey,
+      id: :team_submission_learning_journey,
+      data: {
+        word_count: true,
+        word_count_limit: 200,
+      },
+      rows: 6 %>
 
-      <p class="scent scent--strong">
-        What did your team learn (technically or otherwise)?
-        How did you overcome challenges? What resources did you use to build on (examples, tutorials, open source code)?
-      </p>
-    </div>
+    <p class="scent scent--strong">
+      What did your team learn (technically or otherwise)?
+      How did you overcome challenges? What resources did you use to build on (examples, tutorials, open source code)?
+    </p>
+  </div>
 
-    <div class="actions">
-      <p>
-        <%= f.submit "Save", class: "button" %>
-        or
-        <%= link_to "cancel",
-          send(
-            "#{current_scope}_team_submission_section_path",
-            @team_submission,
-            section: @submission_section
-          ) %>
-      </p>
+  <div class="actions submission-actions">
+    <p class="btn-wrapper">
+      <%= f.submit "Save", class: "tw-green-btn cursor-pointer" %>
+      or
+      <%= link_to "cancel",
+        send(
+          "#{current_scope}_team_submission_section_path",
+          @team_submission,
+          section: @submission_section
+        ) %>
+    </p>
 
-      <p class="scent word-counter">
-        Number of words typed:
-        <br />
-        <span class="word-count__total word-count--plenty-remaining">
-          0
-        </span>
-        /
-        <span class="word-count__limit"></span>
-      </p>
-    </div>
-  <% end %>
-</div>
+    <p class="scent word-counter">
+      Number of words typed:
+      <br />
+      <span class="word-count__total word-count--plenty-remaining">
+        0
+      </span>
+      /
+      <span class="word-count__limit"></span>
+    </p>
+  </div>
+<% end %>
+

--- a/app/views/team_submissions/pieces/pitch_video_link.en.html.erb
+++ b/app/views/team_submissions/pieces/pitch_video_link.en.html.erb
@@ -1,7 +1,6 @@
-<div class="panel">
-  <h3 class="panel--heading">Pitch Video</h3>
+<% provide :title, "Pitch Video" %>
 
-  <%= form_with(
+<%= form_with(
     model: @team_submission,
     url: send("#{current_scope}_team_submission_path"),
     local: true
@@ -15,9 +14,9 @@
         value: params[:value] || @team_submission.send(piece_name) %>
     </div>
 
-    <div class="actions">
-      <p>
-        <%= f.submit "Next", class: "button" %>
+    <div class="actions submission-actions">
+      <p class="btn-wrapper">
+        <%= f.submit "Next", class: "tw-green-btn cursor-pointer" %>
         or
         <%= link_to "cancel",
           send("#{current_scope}_team_submission_section_path", @team_submission, section: @submission_section) %>
@@ -31,7 +30,7 @@
     <%= link_to(
       "pitch video curriculum unit.",
       "https://technovationchallenge.org/curriculum/pitch-1-outline-your-pitch-video/",
-      target: "_blank"
+      target: "_blank",
+      class: "tw-link"
     ) %>
   </p>
-</div>

--- a/app/views/team_submissions/pieces/screenshots.en.html.erb
+++ b/app/views/team_submissions/pieces/screenshots.en.html.erb
@@ -1,8 +1,8 @@
+<% provide :title, "Images" %>
+
 <div
   id="screenshots"
-  class="panel"
 >
-  <h3 class="panel--heading">Images</h3>
 
   <div id="vue-screenshot-uploader">
     <screenshot-uploader
@@ -23,7 +23,7 @@
   </p>
   <p class="grid__cell--padding-sm-y">
     Review the
-    <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank">submission guidelines</a>
+    <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank" class="tw-link">submission guidelines</a>
     for recommendations.
   </p>
 </div>

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -1,9 +1,6 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    Technical Additions
-  </h3>
+<% provide :title, "Technical Additions" %>
 
-  <% if @team_submission.source_code_url_complete? %>
+<% if @team_submission.source_code_url_complete? %>
     <div class="field__existing-value">
       Your team has previously uploaded
       <%= link_to @team_submission.source_code_filename,
@@ -27,7 +24,10 @@
           <%= f.text_field :source_code_external_url %>
         </p>
 
-        <%= f.submit "Save", class: "button" %>
+      <div class="flex flex-row justify-end">
+        <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
+      </div>
+
       <% end %>
     <% elsif @team_submission.submission_type == "Mobile App" %>
       <p>Mobile App source code should be submitted depending on the language used:</p>
@@ -49,7 +49,7 @@
       <% end %>
     <% elsif @team_submission.submission_type == "AI Project" %>
       <p>AI Projects should include 1 zip file that contains:</p>
-      <ul>
+      <ul class="list-disc ml-8">
         <li>Screenshot of dataset training (ML4Kids, TeachableMachine, App Inventor, etc.) or spreadsheet or link to images/sounds folder</li>
         <li>Picture(s) of prototype (cardboard model, drawings, devices)</li>
         <li>(For online inventions) Any link with demo login information</li>
@@ -65,15 +65,14 @@
           Sorry, you tried to upload an invalid file type.
         </div>
 
-        <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
+        <%= f.submit "Upload", class: "tw-green-btn source-code-uploader__submit-button" %>
       <% end %>
     <% end %>
 
     <p class="grid__cell--padding-sm-y">
       For help submitting your technical work, check
-      <a href="https://iridescentsupport.zendesk.com/hc/en-us/articles/360019590314-How-do-I-submit-my-source-code-" target="_blank">
+      <a href="https://iridescentsupport.zendesk.com/hc/en-us/articles/360019590314-How-do-I-submit-my-source-code-" target="_blank" class="tw-link">
         here
       </a>.
     </p>
   <% end %>
-</div>

--- a/app/views/team_submissions/pieces/team_photo.html.erb
+++ b/app/views/team_submissions/pieces/team_photo.html.erb
@@ -1,7 +1,8 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    Team Photo
-  </h3>
-  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg filestack-team-photo" %>
-  <%= render "filestack_uploads/team_photo_upload" %>
+<% provide :title, "Team Photo" %>
+
+<div class="flex flex-col">
+  <%= image_tag @team.team_photo_url, class: "thumbnail--mdlg filestack-team-photo mx-auto" %>
+  <div class="mx-auto">
+    <%= render "filestack_uploads/team_photo_upload" %>
+  </div>
 </div>

--- a/app/views/team_submissions/sections/business.en.html.erb
+++ b/app/views/team_submissions/sections/business.en.html.erb
@@ -10,13 +10,12 @@
 <div
   id="<%= dom_id(@team_submission) %>_business_plan"
   class="
-    panel
     submission-piece
     business_plan
     <%= completion_css(@team_submission, :business_plan_url) %>
   "
 >
-  <h3 class="panel--heading">
+  <h3>
     <% if @team.junior? %>
       User Adoption Plan
     <% else %>
@@ -26,7 +25,7 @@
 
   <% if @team.senior? || @team.junior? %>
     <% if @team_submission.business_plan_url_complete? %>
-      <p>
+      <p class="mb-4">
         Your team has uploaded:
         <%= link_to @team_submission.business_plan_filename,
           @team_submission.business_plan_url %>
@@ -39,7 +38,7 @@
             @team_submission,
             piece: :business_plan
           ),
-          class: "button secondary small" %>
+          class: "tw-green-btn cursor-pointer small" %>
       </div>
     <% else %>
       <p class="scent">
@@ -54,7 +53,7 @@
             @team_submission,
             piece: :business_plan
           ),
-          class: "button small" %>
+          class: "tw-gray-btn small" %>
       </div>
     <% end %>
   <% else %>

--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -49,6 +49,8 @@
   <% end %>
 <% end %>
 
+<%= render 'application/templates/tw_thick_rule'%>
+
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
   title: "Technical Additions",

--- a/app/views/team_submissions/sections/ideation.en.html.erb
+++ b/app/views/team_submissions/sections/ideation.en.html.erb
@@ -22,6 +22,8 @@
   cta_when_empty: "Set your #{t("submissions.app")}'s name",
   cta_when_filled: "Change your #{t("submissions.app")}'s name" %>
 
+<%= render 'application/templates/tw_thick_rule'%>
+
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
   title: "Describe Your #{t("submissions.app").titlecase}",
@@ -33,6 +35,8 @@
   <%= simple_format(@team_submission.app_description) %>
 <% end %>
 
+<%= render 'application/templates/tw_thick_rule'%>
+
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
   title: "Learning Journey",
@@ -43,6 +47,8 @@
 
   <%= simple_format(@team_submission.learning_journey) %>
 <% end %>
+
+<%= render 'application/templates/tw_thick_rule'%>
 
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
@@ -60,6 +66,8 @@
     <% end %>
   </div>
 <% end %>
+
+<%= render 'application/templates/tw_thick_rule'%>
 
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,

--- a/app/views/team_submissions/sections/pitch.en.html.erb
+++ b/app/views/team_submissions/sections/pitch.en.html.erb
@@ -24,7 +24,7 @@
 
   <%= link_to web_icon("play-circle-o", text: "Watch the #{t("submissions.demo_video")}"),
     "#",
-    class: "button button--small",
+    class: "tw-gold-btn small",
     data: {
       opens_modal: "video-modal-#{@team_submission.video_id(:demo)}",
       modal_fetch: send(
@@ -42,6 +42,8 @@
   </div>
 <% end %>
 
+<%= render 'application/templates/tw_thick_rule'%>
+
 <%= render 'team_submissions/pieces/piece',
   submission: @team_submission,
   title: "Pitch video",
@@ -52,7 +54,7 @@
 
   <%= link_to web_icon("play-circle-o", text: "Watch the pitch video"),
     "#",
-    class: "button button--small",
+    class: "tw-gold-btn small",
     data: {
       opens_modal: "video-modal-#{@team_submission.video_id(:pitch)}",
       modal_fetch: send(

--- a/app/views/team_submissions/sections/start.en.html.erb
+++ b/app/views/team_submissions/sections/start.en.html.erb
@@ -7,20 +7,21 @@
   section: :ideation
 ) %>
 
-<div class="panel panel--left">
-  <h1 class="panel__heading">
+  <h1 class="text-xl">
     <%= Season.current.year %> Technovation Honor Code
   </h1>
-
   <%= render "team_submissions/honor_code" %>
-</div>
 
-  <%= render 'team_submissions/pieces/piece',
-             submission: @team_submission,
-             title: "Your Team Photo",
-             scope: current_scope,
-             attribute: :team_photo,
-             cta_when_empty: "Upload your team photo",
-             cta_when_filled: "Change your team photo" do %>
-    <%= image_tag @team.team_photo_url, class: "grid__cell-img filestack-team-photo" %>
-  <% end %>
+  <%= render 'application/templates/tw_thick_rule' %>
+
+  <div class="flex flex-col mx-auto justify-center">
+    <%= render 'team_submissions/pieces/piece',
+               submission: @team_submission,
+               title: "Your Team Photo",
+               scope: current_scope,
+               attribute: :team_photo,
+               cta_when_empty: "Upload your team photo",
+               cta_when_filled: "Change your team photo" do %>
+    <%= image_tag @team.team_photo_url, class: "w-full lg:w-1/4" %>
+    <% end %>
+  </div>

--- a/spec/features/admin/edit_team_submissions_spec.rb
+++ b/spec/features/admin/edit_team_submissions_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Toggling editable team submissions" do
         check "team_submission[integrity_affirmed]"
         click_button "Start now!"
 
-        expect(page).to have_css('.button', text: "Upload your team photo")
+        expect(page).to have_css('.tw-gray-btn', text: "Upload your team photo")
 
         visit mentor_dashboard_path
 

--- a/spec/features/student/submission_spec.rb
+++ b/spec/features/student/submission_spec.rb
@@ -37,10 +37,6 @@ RSpec.feature "Student team submissions" do
     expect(current_path).to eq(
       student_team_submission_section_path(TeamSubmission.last)
     )
-    expect(page).to have_link(
-      "My Submission",
-      href: student_team_submission_path(TeamSubmission.last)
-    )
   end
 
   scenario "Start the submission from the table of contents" do
@@ -132,7 +128,6 @@ RSpec.feature "Student team submissions" do
       date_of_birth: senior_dob
     })
 
-    click_link "My Submission"
     click_link "Entrepreneurship"
 
     expect(page).to have_link(

--- a/spec/system/admin/edit_team_submissions_spec.rb
+++ b/spec/system/admin/edit_team_submissions_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Toggling editable team submissions", :js do
       check "team_submission[integrity_affirmed]"
       click_button "Start now!"
 
-      expect(page).to have_css('.button', text: "Upload your team photo")
+      expect(page).to have_css('.tw-gray-btn', text: "Upload your team photo")
 
       visit student_dashboard_path
       click_button "Submit your project"


### PR DESCRIPTION
Refs #4067 

This PR is the 1st change for all the submission rebrand work
It includes the following:
- Updated the submission layout with the energetic main container and the side left submission checklist container
- Added custom tailwind `submissions.css` file
- Added `rubik` to the tailwind config so now rubik font can be accesses like this `font-rubik` 
- Removed the right side `sidebar_b` wich was incorporated into the left submission checklist menu