### PR TITLE
Add team name to email mentors receive when one of their team is removed from an RPE

### DIFF
--- a/app/controllers/chapter_ambassador/event_assignments_controller.rb
+++ b/app/controllers/chapter_ambassador/event_assignments_controller.rb
@@ -28,6 +28,7 @@ module ChapterAmbassador
               membership.member_type,
               membership.member_id,
               event.id,
+              team_name: attendee.name
             ).deliver_later
           end
         else

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -1,7 +1,8 @@
 class EventMailer < ApplicationMailer
-  def notify_removed(removed_klass_name, removed_id, event_id)
+  def notify_removed(removed_klass_name, removed_id, event_id, team_name: "")
     @removed = removed_klass_name.constantize.find(removed_id)
     @event = RegionalPitchEvent.find(event_id)
+    @team_name = team_name
 
     @ambassador_name = @event.ambassador.name
     @ambassador_email = @event.ambassador.email

--- a/app/views/event_mailer/notify_removed.en.html.erb
+++ b/app/views/event_mailer/notify_removed.en.html.erb
@@ -13,7 +13,11 @@
       </tr>
       <tr>
         <td class="content-block">
-          A Chapter Ambassador has just removed you from the event:
+          A Chapter Ambassador has just removed your team
+          <% if @team_name.present? && @removed.class.to_s == "MentorProfile" %>
+            "<%= @team_name %>"
+          <% end %>
+          from the event:
           <strong><%= @event.name %></strong>
         </td>
       </tr>


### PR DESCRIPTION
This will make it so that when a mentor's team is removed from an RPE, the email the mentor receives will include the team name in it.


