### PR TITLE
Update meet your cha section tailwind styles

### DIFF
--- a/app/javascript/stylesheets/student_profile.css
+++ b/app/javascript/stylesheets/student_profile.css
@@ -52,10 +52,6 @@
     @apply text-white py-2 px-4 rounded-t hover:text-energetic-blue hover:bg-white
 }
 
-.sub-nav-item:first-child{
-    @apply pl-0
-}
-
 .sub-nav-item-active{
     @apply bg-white text-energetic-blue py-2 px-4 rounded-tr-3xl font-semibold
 }
@@ -70,4 +66,16 @@
 
 .tw-dropdown-menu a, #student-nav-wrapper a{
    @apply hover:text-energetic-blue
+}
+
+#cha-social-links {
+    @apply mt-8 grid grid-cols-1 lg:grid-cols-2 gap-2;
+}
+
+#cha-social-links span {
+    @apply text-energetic-blue hover:text-tg-magenta
+}
+
+#cha-avatar img {
+    @apply max-h-80 mx-auto
 }

--- a/app/views/dashboards/rebrand/_chapter_ambassador_intro.en.html.erb
+++ b/app/views/dashboards/rebrand/_chapter_ambassador_intro.en.html.erb
@@ -1,28 +1,26 @@
 <% if chapter_ambassador.provided_intro? %>
   <div id="cha-student-intro-wrapper">
     <div class="bg-white p-6 rounded-md flex flex-col lg:flex-row justify-between">
-      <section id="cha-avatar" class="mx-4 mb-4 lg:mb-0">
+      <div id="cha-avatar" class="mx-4 mb-4 lg:mb-0 w-full lg:w-1/3 flex items-center">
         <%= image_tag chapter_ambassador.profile_image_url,
-                      class: "rounded-bl-3xl rounded-tr-3xl h-48" %>
-      </section>
-      <section id="cha-profile-summary" class="mx-4 mb-4 lg:mb-0 p-0 lg:px-8">
+                      class: "rounded-bl-3xl rounded-tr-3xl" %>
+      </div>
+      <div id="cha-profile-summary" class="mb-4 lg:mb-0 p-0 lg:px-8 w-full lg:w-2/3">
         <p class="font-bold text-2xl"><%= chapter_ambassador.full_name %></p>
         <p class="font-bold"><%= chapter_ambassador.program_name %> Chapter Ambassador</p>
         <p class="mt-8"><%= chapter_ambassador.intro_summary %></p>
-      </section>
-      <section id=cha-social-links class="mx-4 mb-4 lg:mb-0 w-full lg:w-1/6">
-        <ul>
+        <div id="cha-social-links">
           <% chapter_ambassador.regional_links.each do |link| %>
-            <li class="tw-link">
+            <span>
               <% if link.name == "email" %>
                 <%= mail_to link.value, web_icon("envelope-o", text: link.value) %>
               <% else %>
                 <%= link_to web_icon(link.icon, text: link.display_text), link.url %>
               <% end %>
-            </li>
+            </span>
           <% end %>
-        </ul>
-      </section>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/student/navigation/rebrand/_tg_global_nav.html.erb
+++ b/app/views/student/navigation/rebrand/_tg_global_nav.html.erb
@@ -2,7 +2,7 @@
   # TODO: Fix hover issue in IE11/Win7
 %>
 
-<nav class="list-reset flex">
+<nav class="list-reset flex flex-col lg:flex-row">
 
     <%= link_to t("views.application.dashboards.menu.dashboard"),
                 student_dashboard_path,

--- a/app/views/student/navigation/rebrand/_tg_green_header.html.erb
+++ b/app/views/student/navigation/rebrand/_tg_green_header.html.erb
@@ -1,7 +1,7 @@
 <div class="tg-green-stripes rubik h-auto mx-auto pt-16 flex flex-col mb-8">
   <div class="banner-text-wrapper w-full lg:w-3/4 mx-auto pb-16">
     <div class="text-white text-4xl md:text-6xl font-black mb-8 uppercase">Technovation Girls <%= chapter_ambassador.program_name %> </div>
-    <div class="text-white text-lg md:text-3xl font-bold mb-8">
+    <div class="text-white text-3xl font-bold mb-8">
       <span id="cha-student-meet" class="cursor-pointer hover:text-energetic-blue">
           Meet your Chapter Ambassador &#8227;
       </span>


### PR DESCRIPTION
Refs #4327 

- A few updates to the "meet your ChA section." Moved the links below the intro summary and updated the photo due to - potential distortion issues.
- Also updated the student subnav so it is now more mobile responsive. Previously the sub nav links would overflow horizontally. 

<img width="1653" alt="CleanShot 2023-11-17 at 17 58 30@2x" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/acdee08b-fb54-4dd0-9cc3-d50a86b711af">

![CleanShot 2023-11-17 at 18 29 35@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/5e9bce32-bcfd-4491-99a4-377a19ae6442)

