### PR TITLE
Various style updates from QA feedback for student submission rebrand

### DIFF
--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -103,7 +103,7 @@ module StudentHelper
     if status == :complete
       web_icon("check-circle", { class: "icon--green", text: text })
     elsif status == :not_required
-      web_icon("circle-o", { class: "not-required", text: text })
+      web_icon("check-circle", { class: "not-required", text: text })
     else
       web_icon("circle-o", { class: "icon--orange", text: text })
     end

--- a/app/javascript/stylesheets/submissions.css
+++ b/app/javascript/stylesheets/submissions.css
@@ -25,3 +25,7 @@
 .field-existing-value {
     @apply my-4 p-2 bg-gray-100 rounded;
 }
+
+#development-platform label {
+    @apply mt-8
+}

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -267,8 +267,8 @@ class TeamSubmission < ActiveRecord::Base
     if demo_video_link == pitch_video_link
       errors.add(
         :base,
-        "#{I18n.t("submissions.demo_video").truncate_words(1, omission: "").capitalize}
-          and pitch video links cannot be the same! Please add a valid video link."
+        "Your #{I18n.t("submissions.demo_video").truncate_words(1, omission: "").capitalize}
+          and pitch videos are the same link. Please update one of the links."
       )
     end
   end
@@ -599,15 +599,17 @@ class TeamSubmission < ActiveRecord::Base
     video_url = VideoUrl.new(video || video_link_for(video_type))
 
     if video_url.valid?
+      height = 415
       src = "#{video_url.root}#{video_url.video_id}"
     else
+      height = "100%"
       src = "/video-link-broken.html"
     end
 
     %{<iframe
         src="#{src}"
         width="100%"
-        height="415"
+        height="#{height}"
         frameborder="0"
         allowfullscreen>
       </iframe>}.strip_heredoc

--- a/app/views/team_submission_video_link_reviews/new.en.html.erb
+++ b/app/views/team_submission_video_link_reviews/new.en.html.erb
@@ -22,7 +22,7 @@
     <p class="mb-0">
       Review the area above this message.
       If there is a problem with viewing your video,
-      you should GO BACK and fix the <%= video_link_text %>
+      you should GO BACK and fix the <%= video_link_text.to_s.humanize %>
     </p>
   </div>
 
@@ -38,7 +38,9 @@
           @team_submission,
           piece: @method,
           value: @review_value
-        ) %>
+        ),
+        class: "tw-gray-btn"
+      %>
     </p>
   </div>
 <% end %>

--- a/app/views/team_submissions/pieces/business_plan.en.html.erb
+++ b/app/views/team_submissions/pieces/business_plan.en.html.erb
@@ -98,6 +98,7 @@
         @team_submission,
         :section,
         section: @submission_section,
-      )
+      ),
+      class: "px-4 py-2 rounded bg-gray-200 hover:bg-gray-400"
     %>
   <% end %>

--- a/app/views/team_submissions/pieces/development_platform.en.html.erb
+++ b/app/views/team_submissions/pieces/development_platform.en.html.erb
@@ -1,7 +1,7 @@
 <% embedded ||= false %>
 <% provide :title, "Submission Type" %>
 
-<div>
+<div id="development-platform">
   <% if embedded %>
     <p>
       To upload your technical work,
@@ -37,7 +37,7 @@
 
     </div>
 
-    <div id="mobile-app">
+    <div id="mobile-app" class="mt-8">
       <div class="field">
         <%= f.label :development_platform,
           "Which coding language did your team use?",
@@ -56,8 +56,8 @@
         id: :team_submission_development_platform %>
       </div>
 
-      <div id="app_inventor_fields">
-        <p class="scent">
+      <div id="app_inventor_fields" class="mt-8">
+        <p class="tw-hint">
           We want to ask you two questions about your use of
           App Inventor.
         </p>
@@ -77,14 +77,14 @@
       <%= f.text_field :app_inventor_gmail,
         id: :team_submission_app_inventor_gmail %>
 
-      <p class="hint">
+      <p class="tw-hint">
         We are keeping this information private; it will help us improve how
         our program works with App Inventor.
       </p>
       </div>
 
-      <div id="thunkable_fields">
-        <p class="scent">
+      <div id="thunkable_fields" class="mt-8">
+        <p class="tw-hint">
           We want to ask you two questions about your use of Thunkable.
         </p>
 
@@ -102,7 +102,7 @@
         <%= f.text_field :thunkable_project_url,
           id: :team_submission_thunkable_project_url %>
 
-        <p class="hint">
+        <p class="tw-hint">
           To get the URL to your Thunkable Project page, go to "Share" and select "Project Details Page."
           <a href="https://iridescentsupport.zendesk.com/hc/en-us/articles/360019590314-How-do-I-submit-my-source-code-"
              target="_blank" class="tw-link">For more information, go here.</a>

--- a/public/video-link-broken.html
+++ b/public/video-link-broken.html
@@ -7,9 +7,9 @@
 <body>
   <div class="main">
     <div class="container">
-      <h1 class="flash flash--alert">
+      <h2 class="flash flash--alert">
         Your video link is incorrect. You should GO BACK and fix the link.
-      </h1>
+      </h2>
     </div>
   </div>
 

--- a/spec/features/mentor/submission_piece_spec.rb
+++ b/spec/features/mentor/submission_piece_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Next"
     click_button "Save"
 
-    expect(page).to have_css(".flash.flash--alert", text: "Technical and pitch video links cannot be the same! Please add a valid video link.")
+    expect(page).to have_css(".flash.flash--alert", text: "Technical and pitch videos are the same link. Please update one of the links.")
   end
 
   scenario "Upload a .pdf business plan" do

--- a/spec/features/student/submission_piece_spec.rb
+++ b/spec/features/student/submission_piece_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature "Students edit submission pieces" do
     click_button "Next"
     click_button "Save"
 
-    expect(page).to have_css(".flash.flash--alert", text: "Technical and pitch video links cannot be the same! Please add a valid video link.")
+    expect(page).to have_css(".flash.flash--alert", text: "Technical and pitch videos are the same link. Please update one of the links.")
   end
 
   scenario "Upload a .pdf business plan" do


### PR DESCRIPTION
Refs #4297 

This PR contains a updates to the submission rebrand based on QA

- Text change when a user uploads the same video twice. Please have the error text in the red banner say "Your technical and pitch videos are the same link. Please update one of the links."
- The "Your plan" section already check marked for beginner division students who don't need to complete it
- Added styling to the "go back" button on the beginner division business plan page
- Review video URL page (listed in the ticket)
- submission type page spacing (listed in the ticket)