### PR TITLE
RPE scores should not be marked as suspicious

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -31,6 +31,17 @@ class ScoresGrid
     scope.public_send(value)
   end
 
+  filter :live_or_virtual,
+    :enum,
+    select: -> {
+      [
+        ["Virtual scores", "virtual"],
+        ["Live event scores", "live"]
+      ]
+    } do |value, scope|
+    scope.public_send(value)
+  end
+
   scope do
     SubmissionScore.current.judge_not_deleted
       .includes({ team_submission: :team })

--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -136,7 +136,7 @@ class ScoresGrid
   end
 
   column :view, html: true do |submission_score|
-    link_to(
+    html = link_to(
       web_icon("list-ul", size: 16, remote: true),
       send("#{current_scope}_score_path", id: submission_score.id),
       data: {
@@ -144,5 +144,21 @@ class ScoresGrid
       },
       class: "view-details"
     )
+
+    html += " "
+    html += link_to(
+      web_icon("list-alt", size: 16, remote: true),
+      send("#{current_scope}_score_detail_path", id: submission_score.team_submission.id),
+      {
+        "v-tooltip" => "'Read score details'",
+        :data => {turbolinks: false}
+      }
+    )
+
+    html
+  end
+
+  column :score_details_link, html: false do |submission_score|
+    Rails.application.routes.url_helpers.url_for(controller: "admin/score_details", action: "show", id: submission_score.id)
   end
 end

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -20,11 +20,16 @@ class SubmissionScore < ActiveRecord::Base
   after_commit :update_team_score_summaries
 
   after_commit -> {
+    if event_type == "virtual"
+      update_columns(
+        completed_too_fast: detect_if_completed_too_fast,
+        completed_too_fast_repeat_offense: detect_if_too_fast_repeat_offense,
+        seems_too_low: detect_if_raw_total_seems_too_low
+      )
+    end
+
     update_columns(
-      completed_too_fast: detect_if_completed_too_fast,
-      completed_too_fast_repeat_offense: detect_if_too_fast_repeat_offense,
-      seems_too_low: detect_if_raw_total_seems_too_low,
-      approved_at: can_automatically_approve? ? Time.current : nil,
+      approved_at: can_automatically_approve? ? Time.current : nil
     )
   }, on: [:create, :update], if: :complete?
 
@@ -524,7 +529,8 @@ class SubmissionScore < ActiveRecord::Base
   end
 
   def can_automatically_approve?
-    !detect_if_too_fast_repeat_offense && !detect_if_raw_total_seems_too_low
+    event_type == "live" ||
+      !detect_if_too_fast_repeat_offense && !detect_if_raw_total_seems_too_low
   end
 
   def pending_approval?

--- a/spec/factories/submission_scores.rb
+++ b/spec/factories/submission_scores.rb
@@ -41,6 +41,14 @@ FactoryBot.define do
       approved_at { Time.current }
     end
 
+    trait :virtual do
+      event_type { "virtual" }
+    end
+
+    trait :live do
+      event_type { "live" }
+    end
+
     trait :score_too_low do
       after :create do |score|
         score.update_columns(seems_too_low: true,

--- a/spec/models/suspicious_submission_scores_spec.rb
+++ b/spec/models/suspicious_submission_scores_spec.rb
@@ -9,9 +9,63 @@ RSpec.describe SuspiciousSubmissionScores do
     SeasonToggles.judging_round = :off
   end
 
+  let(:judge) { FactoryBot.create(:judge) }
+
+  context "when a judge completes a 'virtual' score too fast" do
+    let(:score) { FactoryBot.create(:score, :virtual, :minimum_auto_approved_total, judge_profile: judge) }
+
+    before do
+      score.complete!
+    end
+
+    it "marks it as being completed too fast" do
+      expect(score.completed_too_fast?).to eq(true)
+    end
+  end
+
+  context "when a judge gives a low score to a 'virtual' score" do
+    let(:score) { FactoryBot.create(:score, :virtual, :minimum_auto_approved_total, judge_profile: judge) }
+
+    before do
+      score.update({ideation_1: 0, ideation_2: 0, pitch_1: 0, pitch_2: 0})
+      score.complete!
+    end
+
+    it "marks it as being scored too low" do
+      expect(score.seems_too_low?).to eq(true)
+    end
+  end
+
+  context "when a judge completes a 'live' score too fast" do
+    let(:score) { FactoryBot.create(:score, :live, :minimum_auto_approved_total, judge_profile: judge) }
+
+    before do
+      score.complete!
+    end
+
+    it "does not mark it as being completed too fast" do
+      expect(score.completed_too_fast?).to eq(false)
+      expect(SuspiciousSubmissionScores.new.scores).to be_empty
+    end
+  end
+
+  context "when a judge gives a low score to a 'live' score" do
+    let(:score) { FactoryBot.create(:score, :live, :minimum_auto_approved_total, judge_profile: judge) }
+
+    before do
+      score.update({ideation_1: 0, ideation_2: 0, pitch_1: 0, pitch_2: 0})
+      score.complete!
+    end
+
+    it "does not mark it as being scored too low" do
+      expect(score.seems_too_low?).to eq(false)
+      expect(SuspiciousSubmissionScores.new.scores).to be_empty
+    end
+  end
+
   describe "when same judge completes 2 scores too fast" do
     it "includes those scores" do
-      judge  = FactoryBot.create(:judge)
+      judge = FactoryBot.create(:judge)
       score = FactoryBot.create(:score, :minimum_auto_approved_total, judge_profile: judge)
       score2 = FactoryBot.create(:score, :minimum_auto_approved_total, judge_profile: judge)
       score3 = FactoryBot.create(:score, :minimum_auto_approved_total, judge_profile: judge)


### PR DESCRIPTION
This will make RPE scores (aka "live" scores) be marked as non-suspicious scores.


