### PR TITLE
Add event type filter to scores export datagrid

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -31,6 +31,17 @@ class ScoresGrid
     scope.public_send(value)
   end
 
+  filter :live_or_virtual,
+    :enum,
+    select: -> {
+      [
+        ["Virtual scores", "virtual"],
+        ["Live event scores", "live"]
+      ]
+    } do |value, scope|
+    scope.public_send(value)
+  end
+
   scope do
     SubmissionScore.current.judge_not_deleted
       .includes({ team_submission: :team })


### PR DESCRIPTION
This will add an event type filter (either "live" or "virtual") to the scores export datagrid, allowing someone to view/download only "live" or only "virtual" scores.


