### PR TITLE
Updated class for result card image in teams and mentor search result

### DIFF
--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -1,13 +1,20 @@
 <template>
-  <div class="card-result">
+  <div class="card-result bg-gray-50">
     <div class="relative">
-      <img :src="cardImage" :class="coverImageClass(coverImage)" @error="imgBroken" />
+      <img
+        :src="cardImage"
+        class="object-contain h-48 w-96"
+        @error="imgBroken"
+      />
 
       <div class="card-photo-placeholder hidden" :id="imgPlaceholderId">
-        <p class="text-xl font-bold text-black-200">No picture<p/>
+        <p class="text-xl font-bold text-black-200">No picture</p>
       </div>
 
-      <div v-if="showBadges" class="flex flex-col items-end absolute bottom-1 right-0">
+      <div
+        v-if="showBadges"
+        class="flex flex-col items-end absolute bottom-1 right-0"
+      >
         <span :class="badge('team', isOnTeam)">{{ onTeamText }}</span>
         <span :class="badge('virtual', isVirtual)">{{ virtualText }}</span>
       </div>
@@ -19,63 +26,64 @@
       <div class="card-text">{{ cardContent }}</div>
 
       <div v-if="declined" class="search-card-footer">
-          <p>You asked to join {{ name }}, and they declined.</p>
+        <p>You asked to join {{ name }}, and they declined.</p>
       </div>
       <div v-else-if="full" class="search-card-footer">
         <p>This team is currently full.</p>
       </div>
       <div v-else class="search-card-footer">
-        <a :href="linkPath" class="tw-link text-base md:text-base lg:text-base" >{{ linkText }}</a>
+        <a
+          :href="linkPath"
+          class="tw-link text-base md:text-base lg:text-base"
+          >{{ linkText }}</a
+        >
       </div>
     </div>
   </div>
 </template>
 
 <script>
-  export default {
-    name: 'result-card',
-    props: {
-      cardId:       { type: String,  required: true },
-      cardImage:    { type: String,  required: false },
-      cardTitle:    { type: String,  required: false },
-      cardSubtitle: { type: String,  required: false },
-      cardContent:  { type: String,  required: false },
-      name:         { type: String,  required: false },
-      linkText:     { type: String,  required: false },
-      linkPath:     { type: String,  required: false },
-      onTeamText:   { type: String,  required: false },
-      virtualText:  { type: String,  required: false },
-      coverImage:   { type: Boolean, required: false },
-      declined:     { type: Boolean, required: false },
-      full:         { type: Boolean, required: false },
-      showBadges:   { type: Boolean, required: false },
-      isOnTeam:     { type: Boolean, required: false },
-      isVirtual:    { type: Boolean, required: false },
+export default {
+  name: "result-card",
+  props: {
+    cardId: { type: String, required: true },
+    cardImage: { type: String, required: false },
+    cardTitle: { type: String, required: false },
+    cardSubtitle: { type: String, required: false },
+    cardContent: { type: String, required: false },
+    name: { type: String, required: false },
+    linkText: { type: String, required: false },
+    linkPath: { type: String, required: false },
+    onTeamText: { type: String, required: false },
+    virtualText: { type: String, required: false },
+    coverImage: { type: Boolean, required: false },
+    declined: { type: Boolean, required: false },
+    full: { type: Boolean, required: false },
+    showBadges: { type: Boolean, required: false },
+    isOnTeam: { type: Boolean, required: false },
+    isVirtual: { type: Boolean, required: false },
+  },
+  methods: {
+    imgBroken(e) {
+      e.target.classList.add("hidden");
+      e.target.nextElementSibling.classList.remove("hidden");
+      e.target.nextElementSibling.classList.add("flex");
     },
-    methods: {
-      imgBroken(e) {
-        e.target.classList.add("hidden")
-        e.target.nextElementSibling.classList.remove("hidden")
-        e.target.nextElementSibling.classList.add("flex")
-      },
-      badge(type, flag) {
-        let bgs = {
-          'team': { on: 'bg-blue-600', off:'bg-pink-600' },
-          'virtual': { on: 'bg-pink-600', off:'bg-blue-600' }
-        }
-        
-        let bg = flag ? bgs[type].on : bgs[type].off
-        
-        return `list-badge ${bg} left-arrow uppercase`
-      },
-      coverImageClass(flag) {
-        return flag ? 'w-full' : 'object-contain h-48 w-96'
-      }
+    badge(type, flag) {
+      let bgs = {
+        team: { on: "bg-blue-600", off: "bg-pink-600" },
+        virtual: { on: "bg-pink-600", off: "bg-blue-600" },
+      };
+
+      let bg = flag ? bgs[type].on : bgs[type].off;
+
+      return `list-badge ${bg} left-arrow uppercase`;
     },
-    computed: {
-      imgPlaceholderId() {
-        return `img-ph-${this.cardId}`;
-      }
-    }
-  }
+  },
+  computed: {
+    imgPlaceholderId() {
+      return `img-ph-${this.cardId}`;
+    },
+  },
+};
 </script>


### PR DESCRIPTION
Refs #4344 

A bug was discovered in the result card for the team and mentor search. The team info would sometimes be hidden in the result card depending on image size. This change updates the class for the result card image to avoid this issue. Now all images regardless of size, will fit at the top of the result card. There is also a lot of auto formatting from the linter. 