### PR TITLE
Updated/rebranded RPE presentation slides 

### DIFF
--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -97,7 +97,8 @@ module TeamSubmissionController
       back: request.fullpath
     )
 
-    if SeasonToggles.team_submissions_editable? or piece_name == 'pitch_presentation'
+    if SeasonToggles.team_submissions_editable? ||
+        (piece_name == "pitch_presentation" || section_name == "pitch_presentation")
       render piece_or_full_edit
     else
       notify_on_dashboard
@@ -182,6 +183,10 @@ module TeamSubmissionController
     else
       "submissions"
     end
+  end
+
+  def section_name
+    params.fetch(:section) { "" }
   end
 
   def piece_name

--- a/app/views/application/templates/dashboards/_energetic_container.html.erb
+++ b/app/views/application/templates/dashboards/_energetic_container.html.erb
@@ -1,4 +1,6 @@
-<div class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue w-full" >
+<% css_class ||= "" %>
+
+<div class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue w-full <%= css_class %>" >
   <div class="sm-header-wrapper ">
     <p class="font-bold" id="energetic-heading"><%= heading %></p>
   </div>

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -64,7 +64,7 @@
           <%= render layout: "application/templates/dashboards/energetic_container",
                      locals: {
                        heading: yield(:title),
-                       class: "lg:w-auto"
+                       css_class: "#{SeasonToggles.team_submissions_editable? ? 'w-full' : 'lg:w-3/4 mx-auto'}"
                      } do %>
 
             <%= yield %>

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -48,18 +48,20 @@
 
       <div class="container mx-auto" id="submission-container">
         <div class="flex flex-col lg:flex-row gap-6">
-          <div class="w-full lg:w-1/3">
-            <div class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
-              <div class="bg-energetic-blue text-white p-2">
-                <p class="font-bold">Submission Checklist</p>
-              </div>
-              <div class="p-4">
-                <%= render "team_submissions/menu",
-                           submission: @team_submission,
-                           embedded: true %>
+          <% if SeasonToggles.team_submissions_editable? %>
+            <div class="w-full lg:w-1/3">
+              <div class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
+                <div class="bg-energetic-blue text-white p-2">
+                  <p class="font-bold">Submission Checklist</p>
+                </div>
+                <div class="p-4">
+                  <%= render "team_submissions/menu",
+                             submission: @team_submission,
+                             embedded: true %>
+                </div>
               </div>
             </div>
-          </div>
+          <% end %>
 
           <%= render layout: "application/templates/dashboards/energetic_container",
                      locals: {

--- a/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
@@ -1,8 +1,6 @@
-<div class="panel">
-  <h3 class="panel--heading">
-    Pitch presentation slides
-  </h3>
+<% provide :title, "Pitch Presentation Slides" %>
 
+<div>
   <% if team.selected_regional_pitch_event.live? %>
     <% if submission.pitch_presentation_url_complete? %>
       <div class="field__existing-value">
@@ -12,7 +10,7 @@
       </div>
     <% end %>
 
-    <p class="hint">File types allowed: *.ppt, *.pptx, *.pdf</p>
+    <p class="tw-hint">File types allowed: *.ppt, *.pptx, *.pdf</p>
 
     <%= form_with model: submission,
       url: send("#{current_scope}_team_submission_path", submission, multipart: true),
@@ -32,32 +30,34 @@
       </div>
     <% end %>
 
-    <p class="dropzone-save" style="display: none;">
+    <p class="dropzone-save mt-8" style="display: none;">
       <%= link_to "Save this upload",
         send("#{current_scope}_team_submission_path", submission,
         :section,
         section: @submission_section),
-        class: "button"
+        class: "tw-green-btn"
       %>
     </p>
 
-    <p class="after-dropzone-save">
+    <p class="after-dropzone-save mt-4 flex flex-row justify-end">
       <%= link_to "cancel",
         send("#{current_scope}_team_submission_path", submission,
         :section,
         section: @submission_section),
-        class: "button"
+        class: "tw-gray-btn small"
       %>
     </p>
 
-    <p class="grid__cell--padding-sm-y">
+    <p class="py-2">
       Get some help putting your slides together in the
       <%= link_to "pitch presentation unit",
         "https://technovationchallenge.org/curriculum/pitch-4-create-a-pitch-presentation/",
-        target: "_blank" %>
+        target: "_blank",
+        class: "tw-link"
+      %>
     </p>
   <% else %>
-    <p class="scent--strong">
+    <p class="tw-hint-strong">
       No team will submit pitch presentation slides here because all
       official Regional Pitch Events are canceled due to COVID this season.
     </p>

--- a/app/views/team_submissions/sections/pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/sections/pitch_presentation.en.html.erb
@@ -12,7 +12,6 @@
 <div
   id="<%= dom_id(@team_submission) %>_pitch_presentation"
   class="
-    panel
     submission-piece
     <%= completion_css(
       @team_submission,
@@ -20,7 +19,7 @@
     ) %>
   "
 >
-  <h3 class="panel--heading">
+  <h3 class="font-semibold mb-4">
     Pitch presentation slides
   </h3>
 
@@ -32,22 +31,22 @@
           @team_submission.pitch_presentation_url %>
       </p>
 
-      <div class="panel--footer">
+      <div class="mt-4">
         <%= link_to "Change your upload",
           send(
             "edit_#{current_scope}_team_submission_path",
             @team_submission,
             piece: :pitch_presentation
           ),
-          class: "button secondary small" %>
+          class: "tw-gray-btn small" %>
       </div>
     <% else %>
-      <p class="scent">
+      <p class="tw-hint">
         There's nothing here yet,
         but your team can update this part whenever it's ready!
       </p>
 
-      <div class="panel--footer">
+      <div>
         <%= link_to(
           "Upload the pitch presentation slides " +
           "for your live event",
@@ -56,12 +55,12 @@
             @team_submission,
             piece: :pitch_presentation
           ),
-          class: "button small"
+          class: "tw-green-btn small"
         ) %>
       </div>
     <% end %>
   <% else %>
-    <p class="scent--strong">
+    <p class="tw-hint-strong">
       No team will submit pitch presentation slides here because all
       official Regional Pitch Events are canceled due to COVID this season.
     </p>


### PR DESCRIPTION
Refs #4331 

This PR rebrands the RPE presentation slides to match the updated submission styles. We may want to discuss when RPE slides are editable ** Just saw the ticket for this - #4315 **. Currently, they are only editable if submissions are disabled, if the round is quarterfinals or earlier, and if the team is part of a live event. Noting the side nav is intentionally hidden (following current setup). 

QA Steps 
1. Set the proper conditions (Team is attending a live event, submissions are disabled, and judging round is QF or off)
2. Click the "Submit your project" link 
3. Upload slides / follow flow

![CleanShot 2023-11-28 at 15 09 24@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/dd4e71d7-c6db-4127-b698-67b2f94586ad)

![CleanShot 2023-11-28 at 14 14 21@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/92635e9f-2af5-4602-b2b5-a1f857b6af68)
