### PR TITLE
Groundwork for Salesforce integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem "dotenv-rails", "~> 2.7"
 gem "pdfkit", "~> 0.8.7.0"
 
 gem "gibbon", "~> 3.4.4"
+gem "restforce", "~> 7.0.0"
 
 gem "net-smtp", require: false
 gem "net-imap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,10 @@ GEM
     faraday (2.5.2)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.0.0)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
@@ -238,6 +242,7 @@ GEM
       activesupport (>= 6.1)
     hashdiff (1.0.1)
     hashery (2.1.2)
+    hashie (5.0.0)
     highline (2.0.3)
     hirb (0.7.3)
     hiredis (0.6.3)
@@ -260,6 +265,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.5.1)
+    jwt (2.7.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -295,6 +301,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.5.4)
     multi_json (1.15.0)
+    multipart-post (2.3.0)
     net-imap (0.4.2)
       date
       net-protocol
@@ -411,6 +418,13 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    restforce (7.0.0)
+      faraday (>= 1.1.0, < 2.8.0)
+      faraday-follow_redirects (<= 0.3.0, < 1.0.0)
+      faraday-multipart (>= 1.0.0, < 2.0.0)
+      faraday-net_http (< 4.0.0)
+      hashie (>= 1.2.0, < 6.0)
+      jwt (>= 1.5.6)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -611,6 +625,7 @@ DEPENDENCIES
   rails-i18n (~> 6.0.0)
   rails_autoscale_agent
   redis
+  restforce (~> 7.0.0)
   rexml
   rspec-rails (~> 5.0)
   rspec-retry

--- a/app/jobs/subscribe_account_to_email_list_job.rb
+++ b/app/jobs/subscribe_account_to_email_list_job.rb
@@ -5,5 +5,6 @@ class SubscribeAccountToEmailListJob < ActiveJob::Base
     account = Account.find(account_id)
 
     Mailchimp::MailingList.new.subscribe(account: account, profile_type: profile_type)
+    Salesforce::ApiClient.new.add_contact(account: account)
   end
 end

--- a/app/jobs/update_account_on_email_list_job.rb
+++ b/app/jobs/update_account_on_email_list_job.rb
@@ -5,5 +5,6 @@ class UpdateAccountOnEmailListJob < ActiveJob::Base
     account = Account.find(account_id)
 
     Mailchimp::MailingList.new.update(account: account, currently_subscribed_as: currently_subscribed_as)
+    Salesforce::ApiClient.new.update_contact(account: account)
   end
 end

--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -1,0 +1,79 @@
+module Salesforce
+  class ApiClient
+    def initialize(
+      url: ENV.fetch("SALESFORCE_INSTANCE_URL"),
+      access_token: ENV.fetch("SALESFORCE_ACCESS_TOKEN"),
+      version: ENV.fetch("SALESFORCE_API_VERSION"),
+      enabled: ENV.fetch("SALESFORCE_ENABLED", false),
+      client_constructor: Restforce,
+      logger: Rails.logger,
+      error_notifier: Airbrake
+    )
+
+      if enabled
+        @client = client_constructor.new(
+          oauth_token: access_token,
+          instance_url: url,
+          api_version: version
+        )
+
+        @logger = logger
+        @error_notifier = error_notifier
+      else
+        logger.info "[SALESFORCE DISABLED] Trying to initialize Salesforce API client"
+
+        raise "Salesforce is disabled"
+      end
+    end
+
+    def add_contact(account:)
+      salesforce_id = nil
+
+      handle_request do
+        salesforce_id = client.create!(
+          "Contact",
+          FirstName: account.first_name,
+          LastName: account.last_name,
+          Email: account.email
+        )
+      end
+
+      if salesforce_id.present?
+        account.update_attribute(:salesforce_id, salesforce_id)
+      end
+    end
+
+    def update_contact(account:)
+      if account.salesforce_id.present?
+        handle_request do
+          client.update!(
+            "Contact",
+            Id: account.salesforce_id,
+            FirstName: account.first_name,
+            LastName: account.last_name,
+            Email: account.email
+          )
+        end
+      end
+    end
+
+    def delete_contact(salesforce_id:)
+      if salesforce_id.present?
+        handle_request do
+          client.destroy!("Contact", salesforce_id)
+        end
+      end
+    end
+
+    private
+
+    attr_reader :client, :logger, :error_notifier
+
+    def handle_request(&block)
+      block.call
+    rescue => error
+      logger.error("[SALESFORCE] #{error}")
+      error_notifier.notify("[SALESFORCE] #{error}")
+    end
+  end
+end

--- a/circle.yml
+++ b/circle.yml
@@ -92,6 +92,10 @@ jobs:
           JUDGE_TRAINING_URL: n-a
           MAILCHIMP_API_KEY: n-a
           MAILCHIMP_LIST_ID: n-a
+          SALESFORCE_ENABLED: 0
+          SALESFORCE_INSTANCE_URL: n-a
+          SALESFORCE_ACCESS_TOKEN: n-a
+          SALESFORCE_API_VERSION: n-a
           MENTOR_SLACK_SIGNUP_URL: n-a
           NEWSLETTER_URL: "https://some/other/url"
           GENERAL_NEWSLETTER_URL: "https://some/general/url"

--- a/db/migrate/20231205164341_add_salesforce_id_to_accounts.rb
+++ b/db/migrate/20231205164341_add_salesforce_id_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSalesforceIdToAccounts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :accounts, :salesforce_id, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -120,7 +120,8 @@ CREATE TABLE public.accounts (
     geocoding_fixed_at timestamp without time zone,
     terms_agreed_at timestamp without time zone,
     parent_registered boolean DEFAULT false NOT NULL,
-    learn_worlds_user_id character varying
+    learn_worlds_user_id character varying,
+    salesforce_id character varying
 );
 
 
@@ -3191,6 +3192,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231016140526'),
 ('20231016221100'),
 ('20231017170356'),
-('20231115134722');
+('20231115134722'),
+('20231205164341');
 
 

--- a/spec/jobs/subscribe_account_to_email_list_job_spec.rb
+++ b/spec/jobs/subscribe_account_to_email_list_job_spec.rb
@@ -6,11 +6,20 @@ RSpec.describe SubscribeAccountToEmailListJob do
 
   before do
     allow(Account).to receive(:find).with(account.id).and_return(account)
+    allow(Mailchimp::MailingList).to receive_message_chain(:new, :subscribe)
+    allow(Salesforce::ApiClient).to receive_message_chain(:new, :add_contact)
   end
 
   it "calls the Mailchimp service that will subscribe the account" do
-    expect(Mailchimp::MailingList).to receive_message_chain(:new, :subscribe).
-      with(account: account, profile_type: profile_type)
+    expect(Mailchimp::MailingList).to receive_message_chain(:new, :subscribe)
+      .with(account: account, profile_type: profile_type)
+
+    SubscribeAccountToEmailListJob.perform_now(account_id: account.id, profile_type: profile_type)
+  end
+
+  it "calls the Salesforce service that will subscribe the account" do
+    expect(Salesforce::ApiClient).to receive_message_chain(:new, :add_contact)
+      .with(account: account)
 
     SubscribeAccountToEmailListJob.perform_now(account_id: account.id, profile_type: profile_type)
   end

--- a/spec/jobs/update_account_on_email_list_job_spec.rb
+++ b/spec/jobs/update_account_on_email_list_job_spec.rb
@@ -6,11 +6,23 @@ RSpec.describe UpdateAccountOnEmailListJob do
 
   before do
     allow(Account).to receive(:find).with(account.id).and_return(account)
+    allow(Mailchimp::MailingList).to receive_message_chain(:new, :update)
+    allow(Salesforce::ApiClient).to receive_message_chain(:new, :update_contact)
   end
 
   it "calls the Mailchimp service that will update the account for the provided email address" do
-    expect(Mailchimp::MailingList).to receive_message_chain(:new, :update).
-      with(currently_subscribed_as: currently_subscribed_as, account: account)
+    expect(Mailchimp::MailingList).to receive_message_chain(:new, :update)
+      .with(currently_subscribed_as: currently_subscribed_as, account: account)
+
+    UpdateAccountOnEmailListJob.perform_now(
+      account_id: account.id,
+      currently_subscribed_as: currently_subscribed_as
+    )
+  end
+
+  it "calls the Salesforce service that will update the account" do
+    expect(Salesforce::ApiClient).to receive_message_chain(:new, :update_contact)
+      .with(account: account)
 
     UpdateAccountOnEmailListJob.perform_now(
       account_id: account.id,

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -1,0 +1,235 @@
+require "rails_helper"
+
+RSpec.describe Salesforce::ApiClient do
+  let(:salesforce_api_client) do
+    Salesforce::ApiClient.new(
+      url: salesforce_url,
+      access_token: salesforce_access_token,
+      version: salesforce_version,
+      enabled: salesforce_enabled,
+      client_constructor: client_constructor,
+      logger: logger,
+      error_notifier: error_notifier
+    )
+  end
+
+  let(:salesforce_url) { "https://test-salesforce.com/" }
+  let(:salesforce_access_token) { "1234-09876-5432" }
+  let(:salesforce_version) { "60" }
+  let(:salesforce_enabled) { true }
+  let(:client_constructor) { class_double(Restforce).as_stubbed_const }
+  let(:logger) { double("Logger") }
+  let(:error_notifier) { double("Airbrake") }
+
+  before do
+    allow(client_constructor).to receive(:new).with(
+      oauth_token: salesforce_access_token,
+      instance_url: salesforce_url,
+      api_version: salesforce_version
+    ).and_return(salesforce_client)
+
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:error)
+    allow(error_notifier).to receive(:notify)
+  end
+
+  let(:salesforce_client) { double("SalesforceClent") }
+  let(:account) do
+    instance_double(
+      Account,
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      salesforce_id: salesforce_id
+    )
+  end
+  let(:first_name) { "Luna" }
+  let(:last_name) { "Lovegood" }
+  let(:email) { "luna@example.com" }
+  let(:salesforce_id) { nil }
+
+  describe "adding a new contact to Salesforce" do
+    context "when Salesforce is enabled" do
+      let(:salesforce_enabled) { true }
+    end
+
+    it "calls the create! method to create a new contact in Salesforce" do
+      expect(salesforce_client).to receive(:create!).with(
+        "Contact",
+        FirstName: account.first_name,
+        LastName: account.last_name,
+        Email: account.email
+      )
+
+      salesforce_api_client.add_contact(account: account)
+    end
+
+    context "when create! was successful" do
+      before do
+        allow(salesforce_client).to receive(:create!).and_return(salesforce_id)
+      end
+
+      let(:salesforce_id) { "789122654" }
+
+      it "saves the Salesforce ID to the account" do
+        expect(account).to receive(:update_attribute).with(:salesforce_id, salesforce_id)
+
+        salesforce_api_client.add_contact(account: account)
+      end
+    end
+
+    context "when create! was unsuccessful" do
+      before do
+        allow(salesforce_client).to receive(:create!).and_raise(error_message)
+      end
+
+      let(:error_message) { "ADD CONTACT ERROR" }
+
+      it "logs the error" do
+        expect(logger).to receive(:error).with("[SALESFORCE] #{error_message}")
+
+        salesforce_api_client.add_contact(account: account)
+      end
+
+      it "notifies the error_notifier with the error" do
+        expect(error_notifier).to receive(:notify).with("[SALESFORCE] #{error_message}")
+
+        salesforce_api_client.add_contact(account: account)
+      end
+    end
+
+    context "when Salesforce is disabled" do
+      let(:salesforce_enabled) { false }
+
+      it "logs and raises an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+
+        expect {
+          salesforce_api_client.add_contact
+        }.to raise_error("Salesforce is disabled")
+      end
+    end
+  end
+
+  describe "updating a contact in Salesforce" do
+    context "when Salesforce is enabled" do
+      let(:salesforce_enabled) { true }
+    end
+
+    context "when the account has a salesforce_id" do
+      let(:salesforce_id) { "9876fghij54321" }
+
+      it "calls the update! method to update the contact in Salesforce" do
+        expect(salesforce_client).to receive(:update!).with(
+          "Contact",
+          Id: account.salesforce_id,
+          FirstName: account.first_name,
+          LastName: account.last_name,
+          Email: account.email
+        )
+
+        salesforce_api_client.update_contact(account: account)
+      end
+
+      context "when update! was unsuccessful" do
+        before do
+          allow(salesforce_client).to receive(:update!).and_raise(error_message)
+        end
+
+        let(:error_message) { "UPDATE ERROR" }
+
+        it "logs the error" do
+          expect(logger).to receive(:error).with("[SALESFORCE] #{error_message}")
+
+          salesforce_api_client.update_contact(account: account)
+        end
+
+        it "notifies the error_notifier with the error" do
+          expect(error_notifier).to receive(:notify).with("[SALESFORCE] #{error_message}")
+
+          salesforce_api_client.update_contact(account: account)
+        end
+      end
+    end
+
+    context "when the account does not have salesforce_id" do
+      let(:salesforce_id) { nil }
+
+      it "does not call the update! method" do
+        expect(salesforce_client).not_to receive(:update!)
+
+        salesforce_api_client.update_contact(account: account)
+      end
+    end
+
+    context "when Salesforce is disabled" do
+      let(:salesforce_enabled) { false }
+
+      it "logs and raises an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+
+        expect {
+          salesforce_api_client.update_contact
+        }.to raise_error("Salesforce is disabled")
+      end
+    end
+  end
+
+  describe "deleting a contact in Salesforce" do
+    context "when Salesforce is enabled" do
+      let(:salesforce_enabled) { true }
+    end
+
+    context "when the account has a salesforce_id" do
+      let(:salesforce_id) { "rstuv34567wxy" }
+
+      it "calls the destroy! method to delete the contact in Salesforce" do
+        expect(salesforce_client).to receive(:destroy!).with("Contact", salesforce_id)
+
+        salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
+      end
+
+      context "when destroy! was unsuccessful" do
+        before do
+          allow(salesforce_client).to receive(:destroy!).and_raise(error_message)
+        end
+
+        let(:error_message) { "DESTROY ERROR" }
+
+        it "logs the error" do
+          expect(logger).to receive(:error).with("[SALESFORCE] #{error_message}")
+
+          salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
+        end
+
+        it "notifies the error_notifier with the error" do
+          expect(error_notifier).to receive(:notify).with("[SALESFORCE] #{error_message}")
+
+          salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
+        end
+      end
+    end
+
+    context "when the account does not have salesforce_id" do
+      let(:salesforce_id) { nil }
+
+      it "does not call the destroy! method" do
+        expect(salesforce_client).not_to receive(:destroy!)
+
+        salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
+      end
+    end
+
+    context "when Salesforce is disabled" do
+      let(:salesforce_enabled) { false }
+
+      it "logs and raises an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+
+        expect {
+          salesforce_api_client.delete_contact
+        }.to raise_error("Salesforce is disabled")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will add the groundwork for the Salesforce integration.

Overview:
- Use restforce gem for the integration
- Add basic functionality to add, update and remove a Salesforce contact
  - The add and update functionality will only include first name, last name and email for now
- Add logging and error handling
- Add ENVs for config settings
- Add specs



