### PR TITLE
Update score details link

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -170,6 +170,6 @@ class ScoresGrid
   end
 
   column :score_details_link, html: false do |submission_score|
-    Rails.application.routes.url_helpers.url_for(controller: "admin/score_details", action: "show", id: submission_score.id)
+    Rails.application.routes.url_helpers.url_for(controller: "admin/score_details", action: "show", id: submission_score.team_submission.id)
   end
 end


### PR DESCRIPTION
This will update the score details link to use the team submission id (instead of the score id).


