### PR TITLE
WIP: Allow students to send invites until submissions close

### DIFF
--- a/app/models/team_member_invite.rb
+++ b/app/models/team_member_invite.rb
@@ -50,6 +50,10 @@ class TeamMemberInvite < ActiveRecord::Base
            :mailer_token,
     to: :invitee, prefix: true
 
+  def self.students_sending_invites_enabled?(important_dates: ImportantDates)
+    (important_dates.official_start_of_season..important_dates.submission_deadline).cover?(Date.today)
+  end
+
   def to_param
     invite_token
   end

--- a/app/views/student/teams/_mentors.html.erb
+++ b/app/views/student/teams/_mentors.html.erb
@@ -18,7 +18,7 @@
         team: team %>
     </div>
 
-    <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
+    <% if TeamMemberInvite.students_sending_invites_enabled? %>
       <%= render "student/teams/pending_mentor_invites",
         team: team,
         invites: team.pending_mentor_invites %>
@@ -41,28 +41,30 @@
         team: team,
         join_requests: team.pending_mentor_join_requests %>
 
-      <div class="mt-10">
-        <%= render "application/templates/content_well" do %>
-          <h2 class="mb-2 text-lg text-gray-600">
-            Do you want more mentors?
-          </h2>
+      <% if SeasonToggles.team_building_enabled? %>
+        <div class="mt-10">
+          <%= render "application/templates/content_well" do %>
+            <h2 class="mb-2 text-lg text-gray-600">
+              Do you want more mentors?
+            </h2>
 
-          <%= form_with model: team,
-            data: { submit_on_change: true },
-            url: student_team_path(
-              team,
-              { format: :json }
-            ),
-            method: :patch do |f| %>
+            <%= form_with model: team,
+              data: { submit_on_change: true },
+              url: student_team_path(
+                team,
+                { format: :json }
+              ),
+              method: :patch do |f| %>
 
-            <%= f.check_box :accepting_mentor_requests,
-              id: :team_accepting_mentor_requests %>
+              <%= f.check_box :accepting_mentor_requests,
+                id: :team_accepting_mentor_requests %>
 
-            <%= f.label :accepting_mentor_requests,
-              "Allow mentors to find your team and request to join", for: :team_accepting_mentor_requests %>
+              <%= f.label :accepting_mentor_requests,
+                "Allow mentors to find your team and request to join", for: :team_accepting_mentor_requests %>
+            <% end %>
           <% end %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/student/teams/_students.en.html.erb
+++ b/app/views/student/teams/_students.en.html.erb
@@ -17,7 +17,7 @@
       team: team
     %>
 
-    <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
+    <% if TeamMemberInvite.students_sending_invites_enabled? %>
       <%= render "student/teams/pending_student_invites",
         team: team,
         preview_method: :invitee_email,
@@ -34,26 +34,28 @@
         join_requests: team.pending_student_join_requests
       %>
 
-      <div class="mt-10">
-        <%= render "application/templates/content_well" do %>
-          <h2 class="mb-2 text-lg text-gray-600">
-            Do you want more teammates?
-          </h2>
+      <% if SeasonToggles.team_building_enabled? %>
+        <div class="mt-10">
+          <%= render "application/templates/content_well" do %>
+            <h2 class="mb-2 text-lg text-gray-600">
+              Do you want more teammates?
+            </h2>
 
-          <%= form_with model: team,
-            data: { submit_on_change: true },
-            url: student_team_path(team, { format: :json }),
-            method: :patch do |f| %>
+            <%= form_with model: team,
+              data: { submit_on_change: true },
+              url: student_team_path(team, { format: :json }),
+              method: :patch do |f| %>
 
-            <%= f.check_box :accepting_student_requests,
-              id: :team_accepting_student_requests %>
+              <%= f.check_box :accepting_student_requests,
+                id: :team_accepting_student_requests %>
 
-            <%= f.label :accepting_student_requests,
-              "Allow other students to find your team and request to join",
-              for: :team_accepting_student_requests %>
+              <%= f.label :accepting_student_requests,
+                "Allow other students to find your team and request to join",
+                for: :team_accepting_student_requests %>
+            <% end %>
           <% end %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/spec/models/team_member_invite_spec.rb
+++ b/spec/models/team_member_invite_spec.rb
@@ -1,6 +1,46 @@
 require "rails_helper"
 
 RSpec.describe TeamMemberInvite do
+  describe ".students_sending_invites_enabled?" do
+    let(:students_sending_invites_enabled) { TeamMemberInvite.students_sending_invites_enabled?(important_dates: important_dates) }
+    let(:important_dates) {
+      class_double("ImportantDates",
+        official_start_of_season: official_start_of_season,
+        submission_deadline: submission_deadline)
+    }
+
+    let(:official_start_of_season) { Date.parse("2023-01-01") }
+    let(:submission_deadline) { Date.parse("2023-10-15") }
+
+    context "when today's date is between the official start of season and the submission deadline" do
+      before do
+        Timecop.freeze(Date.parse("2023-10-12"))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "is returns true" do
+        expect(students_sending_invites_enabled).to eq(true)
+      end
+    end
+
+    context "when today's date is NOT between the official start of season and the submission deadline" do
+      before do
+        Timecop.freeze(Date.parse("2024-10-17"))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "is returns false" do
+        expect(students_sending_invites_enabled).to eq(false)
+      end
+    end
+  end
+
   it "prevents duplicate pending invites for the same team" do
     original_invite = FactoryBot.create(:team_member_invite)
 

--- a/spec/system/student/mentor_request_to_join_a_team_spec.rb
+++ b/spec/system/student/mentor_request_to_join_a_team_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "A mentor requesting to join a student's team", :js do
-  before { SeasonToggles.team_building_enabled = "yes" }
+  before do
+    allow(TeamMemberInvite).to receive(:students_sending_invites_enabled?).and_return(true)
+  end
 
   let(:student) { FactoryBot.create(:student, :geocoded, :on_team) }
   let!(:mentor) { FactoryBot.create(:mentor, :onboarded, :geocoded) }

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe "Students request to join a team",
   vcr: {match_requests_on: [:method, :host]} do
   include ActionView::RecordIdentifier
 
-  before { SeasonToggles.team_building_enabled! }
+  before do
+    SeasonToggles.team_building_enabled!
+    allow(TeamMemberInvite).to receive(:students_sending_invites_enabled?).and_return(true)
+  end
 
   it "students already on a team don't see the link" do
     student = FactoryBot.create(:student, :on_team, :onboarded)


### PR DESCRIPTION
This will:
- let students send invites to both students and mentors until submissions close
- let students view all their pending invites until submissions close


