### PR TITLE
Salesforce auth token refresh and caching

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -1,7 +1,7 @@
 module Salesforce
   class ApiClient
     def initialize(
-      enabled: ENV.fetch("SALESFORCE_ENABLED", false),
+      enabled: ENV.fetch("ENABLE_SALESFORCE", false),
       instance_url: ENV.fetch("SALESFORCE_INSTANCE_URL"),
       api_version: ENV.fetch("SALESFORCE_API_VERSION"),
       client_id: ENV.fetch("SALESFORCE_CLIENT_ID"),

--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -16,7 +16,7 @@ module Salesforce
       error_notifier: Airbrake
     )
 
-      if enabled
+      if ActiveModel::Type::Boolean.new.cast(enabled)
         @client = client_constructor.new(
           instance_url: instance_url,
           api_version: api_version,

--- a/circle.yml
+++ b/circle.yml
@@ -92,7 +92,7 @@ jobs:
           JUDGE_TRAINING_URL: n-a
           MAILCHIMP_API_KEY: n-a
           MAILCHIMP_LIST_ID: n-a
-          SALESFORCE_ENABLED: 0
+          ENABLE_SALESFORCE: 0
           SALESFORCE_INSTANCE_URL: n-a
           SALESFORCE_API_VERSION: n-a
           SALESFORCE_CLIENT_ID: n-a

--- a/circle.yml
+++ b/circle.yml
@@ -94,8 +94,10 @@ jobs:
           MAILCHIMP_LIST_ID: n-a
           SALESFORCE_ENABLED: 0
           SALESFORCE_INSTANCE_URL: n-a
-          SALESFORCE_ACCESS_TOKEN: n-a
           SALESFORCE_API_VERSION: n-a
+          SALESFORCE_CLIENT_ID: n-a
+          SALESFORCE_CLIENT_SECRET: n-a
+          SALESFORCE_REFRESH_TOKEN: n-a
           MENTOR_SLACK_SIGNUP_URL: n-a
           NEWSLETTER_URL: "https://some/other/url"
           GENERAL_NEWSLETTER_URL: "https://some/general/url"

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Salesforce::ApiClient do
   let(:first_name) { "Luna" }
   let(:last_name) { "Lovegood" }
   let(:email) { "luna@example.com" }
-  let(:salesforce_id) { nil }
+  let(:salesforce_id) { 123 }
 
   describe "adding a new contact to Salesforce" do
     context "when Salesforce is enabled" do
@@ -113,24 +113,20 @@ RSpec.describe Salesforce::ApiClient do
     context "when Salesforce is disabled" do
       let(:salesforce_enabled) { false }
 
-      it "logs and raises an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+      it "logs an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
 
-        expect {
-          salesforce_api_client.add_contact
-        }.to raise_error("Salesforce is disabled")
+        salesforce_api_client.add_contact(account: account)
       end
     end
 
     context "when Salesforce is disabled via a 'false' string setting" do
       let(:salesforce_enabled) { "false" }
 
-      it "logs and raises an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+      it "logs an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
 
-        expect {
-          salesforce_api_client.add_contact
-        }.to raise_error("Salesforce is disabled")
+        salesforce_api_client.add_contact(account: account)
       end
     end
   end
@@ -189,12 +185,20 @@ RSpec.describe Salesforce::ApiClient do
     context "when Salesforce is disabled" do
       let(:salesforce_enabled) { false }
 
-      it "logs and raises an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+      it "logs an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
 
-        expect {
-          salesforce_api_client.update_contact
-        }.to raise_error("Salesforce is disabled")
+        salesforce_api_client.update_contact(account: account)
+      end
+    end
+
+    context "when Salesforce is disabled via a 'false' string setting" do
+      let(:salesforce_enabled) { false }
+
+      it "logs an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+
+        salesforce_api_client.update_contact(account: account)
       end
     end
   end
@@ -248,11 +252,19 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { false }
 
       it "logs and raises an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
 
-        expect {
-          salesforce_api_client.delete_contact
-        }.to raise_error("Salesforce is disabled")
+        salesforce_api_client.delete_contact(salesforce_id: 12345)
+      end
+    end
+
+    context "when Salesforce is disabled via a 'false' string setting" do
+      let(:salesforce_enabled) { "false" }
+
+      it "logs an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+
+        salesforce_api_client.delete_contact(salesforce_id: 12345)
       end
     end
   end

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -3,9 +3,13 @@ require "rails_helper"
 RSpec.describe Salesforce::ApiClient do
   let(:salesforce_api_client) do
     Salesforce::ApiClient.new(
-      url: salesforce_url,
-      access_token: salesforce_access_token,
-      version: salesforce_version,
+      instance_url: salesforce_instance_url,
+      api_version: salesforce_api_version,
+      client_id: salesforce_client_id,
+      client_secret: salesforce_client_secret,
+      refresh_token: salesforce_refresh_token,
+      oauth_token: salesforce_oauth_token,
+      authentication_callback: salesforce_authentication_callback,
       enabled: salesforce_enabled,
       client_constructor: client_constructor,
       logger: logger,
@@ -13,9 +17,13 @@ RSpec.describe Salesforce::ApiClient do
     )
   end
 
-  let(:salesforce_url) { "https://test-salesforce.com/" }
-  let(:salesforce_access_token) { "1234-09876-5432" }
-  let(:salesforce_version) { "60" }
+  let(:salesforce_instance_url) { "https://test-salesforce.com/" }
+  let(:salesforce_api_version) { "60" }
+  let(:salesforce_client_id) { "1234-09876-5432" }
+  let(:salesforce_client_secret) { "8766-qwerty-54321" }
+  let(:salesforce_oauth_token) { "aaaaa-bbbb-ccc" }
+  let(:salesforce_refresh_token) { "11111-22222-3333333" }
+  let(:salesforce_authentication_callback) { double("authentication_callback") }
   let(:salesforce_enabled) { true }
   let(:client_constructor) { class_double(Restforce).as_stubbed_const }
   let(:logger) { double("Logger") }
@@ -23,9 +31,13 @@ RSpec.describe Salesforce::ApiClient do
 
   before do
     allow(client_constructor).to receive(:new).with(
-      oauth_token: salesforce_access_token,
-      instance_url: salesforce_url,
-      api_version: salesforce_version
+      instance_url: salesforce_instance_url,
+      api_version: salesforce_api_version,
+      client_id: salesforce_client_id,
+      client_secret: salesforce_client_secret,
+      refresh_token: salesforce_refresh_token,
+      oauth_token: salesforce_oauth_token,
+      authentication_callback: salesforce_authentication_callback
     ).and_return(salesforce_client)
 
     allow(logger).to receive(:info)

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe Salesforce::ApiClient do
         }.to raise_error("Salesforce is disabled")
       end
     end
+
+    context "when Salesforce is disabled via a 'false' string setting" do
+      let(:salesforce_enabled) { "false" }
+
+      it "logs and raises an error" do
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Trying to initialize Salesforce API client")
+
+        expect {
+          salesforce_api_client.add_contact
+        }.to raise_error("Salesforce is disabled")
+      end
+    end
   end
 
   describe "updating a contact in Salesforce" do

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Salesforce::ApiClient do
   let(:account) do
     instance_double(
       Account,
+      id: 45678,
       first_name: first_name,
       last_name: last_name,
       email: email,
@@ -114,7 +115,7 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { false }
 
       it "logs an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Adding account #{account.id}")
 
         salesforce_api_client.add_contact(account: account)
       end
@@ -124,7 +125,7 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { "false" }
 
       it "logs an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Adding account #{account.id}")
 
         salesforce_api_client.add_contact(account: account)
       end
@@ -186,7 +187,7 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { false }
 
       it "logs an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Updating account #{account.id}")
 
         salesforce_api_client.update_contact(account: account)
       end
@@ -196,7 +197,7 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { false }
 
       it "logs an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Updating account #{account.id}")
 
         salesforce_api_client.update_contact(account: account)
       end
@@ -252,9 +253,9 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { false }
 
       it "logs and raises an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Deleting account with Salesforce Id #{salesforce_id}")
 
-        salesforce_api_client.delete_contact(salesforce_id: 12345)
+        salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
       end
     end
 
@@ -262,9 +263,9 @@ RSpec.describe Salesforce::ApiClient do
       let(:salesforce_enabled) { "false" }
 
       it "logs an error" do
-        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Cannot use Salesforce API client")
+        expect(logger).to receive(:info).with("[SALESFORCE DISABLED] Deleting account with Salesforce Id #{salesforce_id}")
 
-        salesforce_api_client.delete_contact(salesforce_id: 12345)
+        salesforce_api_client.delete_contact(salesforce_id: salesforce_id)
       end
     end
   end


### PR DESCRIPTION
These are restforce configuration changes will allow us to refresh and cache the Salesforce auth token.

If the `oauth_token` is expired, restforce will use the `refresh_token` to get another `oauth_token` which we will cache.

So, the flow is:
1. Use cached `oauth_token`
2. If expired, get a new one
3. Cache new `oauth_token`
4. Repeat