### PR TITLE
Add score range to scores export datagrid

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -76,12 +76,20 @@ class ScoresGrid
     team_submission.quarterfinals_average_score
   end
 
+  column :submission_quarterfinals_score_range do
+    team_submission.quarterfinals_score_range
+  end
+
   column :submission_unofficial_score do
     team_submission.average_unofficial_score
   end
 
   column :submission_semifinals_score do
     team_submission.semifinals_average_score
+  end
+
+  column :submission_semifinals_score_range do
+    team_submission.semifinals_score_range
   end
 
   column :complete do


### PR DESCRIPTION
This will add the score range (max/min score difference) to the scores export datagrid, for both quarterfinal scores and semifinal scores.


