### PR TITLE
Update team invite registration validation

### DIFF
--- a/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
+++ b/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
@@ -23,6 +23,21 @@
       >Forming teams allowed</label>
     </p>
 
+    <div style="background-color: #f5f5f5; padding: 12px 8px; margin-bottom: 12px; font-size: 1rem;">
+      <p>"Forming teams allowed" enables:</p>
+      <ul style="margin-top: 0; font-size: 1rem;">
+        <li>Creating teams</li>
+        <li>Team invites</li>
+        <li>Team join requests</li>
+        <li>The checkbox for "Allow other students to find our team and request to join us"</li>
+      </ul>
+    </div>
+
+    <p class="notice info hint">
+      <icon name="exclamation-circle" :size="16" color="00529B" />
+      Please note that when the "Forming teams allowed" box is checked, students can invite people to register and join their team even if registration is closed.
+    </p>
+
     <div v-if="judgingEnabled" class="notice info hint user-notice">
       <icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, teams cannot be formed

--- a/app/services/team_invite_code_validator.rb
+++ b/app/services/team_invite_code_validator.rb
@@ -1,14 +1,13 @@
 class TeamInviteCodeValidator
-  def initialize(team_invite_code:, important_dates: ImportantDates)
+  def initialize(team_invite_code:)
     @team_invite_code = team_invite_code
-    @important_dates = important_dates
   end
 
   def call
     invite = TeamMemberInvite.find_by(invite_token: team_invite_code)
 
     if invite.present? && invite.pending? && invite.inviter_type == "StudentProfile" &&
-        (important_dates.official_start_of_season..important_dates.submission_deadline).cover?(Date.today)
+        SeasonToggles.team_building_enabled?
 
       registration_profile_type = case invite.invitee_type
       when "StudentProfile", nil
@@ -35,5 +34,5 @@ class TeamInviteCodeValidator
 
   Result = Struct.new(:valid?, :registration_profile_type, :success_message, :error_message, keyword_init: true)
 
-  attr_reader :team_invite_code, :important_dates
+  attr_reader :team_invite_code
 end

--- a/spec/javascript/admin/content-settings/components/TeamsAndSubmissions.spec.js
+++ b/spec/javascript/admin/content-settings/components/TeamsAndSubmissions.spec.js
@@ -1,141 +1,137 @@
-import Vuex from 'vuex'
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from "vuex";
+import { shallowMount, createLocalVue } from "@vue/test-utils";
 
-import mockStore from 'admin/content-settings/store/__mocks__'
-import TeamsAndSubmissions from 'admin/content-settings/components/TeamsAndSubmissions'
-import Icon from 'components/Icon'
+import mockStore from "admin/content-settings/store/__mocks__";
+import TeamsAndSubmissions from "admin/content-settings/components/TeamsAndSubmissions";
+import Icon from "components/Icon";
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
-describe('Admin Content & Settings - TeamsAndSubmissions component', () => {
-
-  let wrapper
+describe("Admin Content & Settings - TeamsAndSubmissions component", () => {
+  let wrapper;
 
   beforeEach(() => {
-    wrapper = shallowMount(
-      TeamsAndSubmissions,
-      {
+    wrapper = shallowMount(TeamsAndSubmissions, {
+      localVue,
+      store: mockStore.createMocks().store,
+    });
+  });
+
+  it("has a name attribute", () => {
+    expect(TeamsAndSubmissions.name).toEqual("teams-and-submissions-section");
+  });
+
+  describe("markup", () => {
+    it("contains the proper HTML based on data", () => {
+      const teamBuildingEnabledCheckbox = wrapper.find(
+        "#season_toggles_team_building_enabled"
+      );
+      const teamBuildingEnabledCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_team_building_enabled"]'
+      );
+      const teamSubmissionsEditableCheckbox = wrapper.find(
+        "#season_toggles_team_submissions_editable"
+      );
+      const teamSubmissionsEditableCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_team_submissions_editable"]'
+      );
+
+      expect(wrapper.vm.judgingEnabled).toBe(false);
+
+      expect(teamBuildingEnabledCheckbox.exists()).toBe(true);
+      expect(teamBuildingEnabledCheckboxLabel.exists()).toBe(true);
+      expect(teamSubmissionsEditableCheckbox.exists()).toBe(true);
+      expect(teamSubmissionsEditableCheckboxLabel.exists()).toBe(true);
+    });
+
+    it("disables checkboxes and sets values to 0 is judging is enabled", () => {
+      wrapper = shallowMount(TeamsAndSubmissions, {
         localVue,
-        store: mockStore.createMocks().store,
-      }
-    )
-  })
-
-  it('has a name attribute', () => {
-    expect(TeamsAndSubmissions.name).toEqual('teams-and-submissions-section')
-  })
-
-  describe('markup', () => {
-
-    it('contains the proper HTML based on data', () => {
-      const teamBuildingEnabledCheckbox = wrapper
-        .find('#season_toggles_team_building_enabled')
-      const teamBuildingEnabledCheckboxLabel = wrapper
-        .find('label[for="season_toggles_team_building_enabled"]')
-      const teamSubmissionsEditableCheckbox = wrapper
-        .find('#season_toggles_team_submissions_editable')
-      const teamSubmissionsEditableCheckboxLabel = wrapper
-        .find('label[for="season_toggles_team_submissions_editable"]')
-
-      expect(wrapper.vm.judgingEnabled).toBe(false)
-
-      expect(teamBuildingEnabledCheckbox.exists()).toBe(true)
-      expect(teamBuildingEnabledCheckboxLabel.exists()).toBe(true)
-      expect(teamSubmissionsEditableCheckbox.exists()).toBe(true)
-      expect(teamSubmissionsEditableCheckboxLabel.exists()).toBe(true)
-    })
-
-    it('disables checkboxes and sets values to 0 is judging is enabled', () => {
-      wrapper = shallowMount(
-        TeamsAndSubmissions,
-        {
-          localVue,
-          store: mockStore.createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-          }).store,
-        }
-      )
+          },
+        }).store,
+      });
 
-      const teamBuildingEnabledCheckbox = wrapper
-        .find('#season_toggles_team_building_enabled')
-      const teamBuildingEnabledCheckboxLabel = wrapper
-        .find('label[for="season_toggles_team_building_enabled"]')
-      const teamSubmissionsEditableCheckbox = wrapper
-        .find('#season_toggles_team_submissions_editable')
-      const teamSubmissionsEditableCheckboxLabel = wrapper
-        .find('label[for="season_toggles_team_submissions_editable"]')
+      const teamBuildingEnabledCheckbox = wrapper.find(
+        "#season_toggles_team_building_enabled"
+      );
+      const teamBuildingEnabledCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_team_building_enabled"]'
+      );
+      const teamSubmissionsEditableCheckbox = wrapper.find(
+        "#season_toggles_team_submissions_editable"
+      );
+      const teamSubmissionsEditableCheckboxLabel = wrapper.find(
+        'label[for="season_toggles_team_submissions_editable"]'
+      );
 
-      expect(wrapper.vm.judgingEnabled).toBe(true)
+      expect(wrapper.vm.judgingEnabled).toBe(true);
 
       expect(teamBuildingEnabledCheckbox.attributes()).toEqual(
         expect.objectContaining({
-          id: 'season_toggles_team_building_enabled',
-          type: 'checkbox',
-          disabled: 'disabled',
-          value: '0',
+          id: "season_toggles_team_building_enabled",
+          type: "checkbox",
+          disabled: "disabled",
+          value: "0",
         })
-      )
+      );
 
       expect(teamBuildingEnabledCheckboxLabel.attributes()).toEqual(
         expect.objectContaining({
-          class: 'label--disabled',
+          class: "label--disabled",
         })
-      )
+      );
 
       expect(teamSubmissionsEditableCheckbox.attributes()).toEqual(
         expect.objectContaining({
-          id: 'season_toggles_team_submissions_editable',
-          type: 'checkbox',
-          disabled: 'disabled',
-          value: '0',
+          id: "season_toggles_team_submissions_editable",
+          type: "checkbox",
+          disabled: "disabled",
+          value: "0",
         })
-      )
+      );
 
       expect(teamSubmissionsEditableCheckboxLabel.attributes()).toEqual(
         expect.objectContaining({
-          class: 'label--disabled',
+          class: "label--disabled",
         })
-      )
-    })
+      );
+    });
 
-    it('displays warning notices if judging is enabled', () => {
-      wrapper = shallowMount(
-        TeamsAndSubmissions,
-        {
-          localVue,
-          store: mockStore.createMocks({
-            getters: {
-              judgingEnabled: () => {
-                return true
-              },
+    it("displays warning notices if judging is enabled", () => {
+      wrapper = shallowMount(TeamsAndSubmissions, {
+        localVue,
+        store: mockStore.createMocks({
+          getters: {
+            judgingEnabled: () => {
+              return true;
             },
-          }).store,
-        }
-      )
+          },
+        }).store,
+      });
 
-      expect(wrapper.vm.judgingEnabled).toBe(true)
+      expect(wrapper.vm.judgingEnabled).toBe(true);
 
-      const notices = wrapper.findAll('.notice')
+      const notices = wrapper.findAll(".notice");
 
-      expect(notices.length).toEqual(2)
+      expect(notices.length).toEqual(3);
       notices.wrappers.forEach((notice) => {
-        const props = notice.find(Icon).props()
+        const props = notice.find(Icon).props();
 
         expect(props).toEqual(
           expect.objectContaining({
-            name: 'exclamation-circle',
+            name: "exclamation-circle",
             size: 16,
-            color: '00529B',
+            color: "00529B",
           })
-        )
-      })
-    })
+        );
+      });
+    });
+  });
+});
 
-  })
-
-})

--- a/spec/services/team_invite_code_validator_spec.rb
+++ b/spec/services/team_invite_code_validator_spec.rb
@@ -2,23 +2,19 @@ require "rails_helper"
 
 describe TeamInviteCodeValidator do
   let(:team_invite_code_validator) {
-    TeamInviteCodeValidator.new(team_invite_code: team_invite_code, important_dates: important_dates)
+    TeamInviteCodeValidator.new(team_invite_code: team_invite_code)
   }
   let(:team_invite_code) { "987zyxw654tsrq321" }
-  let(:important_dates) {
-    class_double("ImportantDates",
-      official_start_of_season: official_start_of_season,
-      submission_deadline: submission_deadline)
-  }
-
-  let(:official_start_of_season) { Date.parse("2020-10-01") }
-  let(:submission_deadline) { Date.parse("2021-04-15") }
 
   before do
     allow(TeamMemberInvite).to receive(:find_by)
       .with(invite_token: team_invite_code)
       .and_return(invitation)
+
+    allow(SeasonToggles).to receive(:team_building_enabled?).and_return(team_building_enabled)
   end
+
+  let(:team_building_enabled) { false }
 
   let(:invitation) do
     instance_double(TeamMemberInvite,
@@ -38,14 +34,8 @@ describe TeamInviteCodeValidator do
     context "when a student made the invite" do
       let(:inviter_profile_type) { "StudentProfile" }
 
-      context "when today's date is between the official start of season and the submission deadline" do
-        before do
-          Timecop.freeze(Date.parse("2020-11-17"))
-        end
-
-        after do
-          Timecop.return
-        end
+      context "when team building is enabled" do
+        let(:team_building_enabled) { true }
 
         it "is valid" do
           expect(team_invite_code_validator.call.valid?).to eq(true)
@@ -118,14 +108,8 @@ describe TeamInviteCodeValidator do
     end
   end
 
-  context "when today's date is after the submission deadline" do
-    before do
-      Timecop.freeze(Date.parse("2021-04-30"))
-    end
-
-    after do
-      Timecop.return
-    end
+  context "when team building is disabled" do
+    let(:team_building_enabled) { false }
 
     it "is not valid" do
       expect(team_invite_code_validator.call.valid?).to eq(false)


### PR DESCRIPTION
This will make it so that team invites to register will be valid when "Forming teams allowed" is enabled in the admin (instead of using the submission close date). And I added some very basic, rudimentary help text to the admin; and updated the JS specs accordingly.