### PR TITLE
Update Puma gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.14.5)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -355,7 +355,7 @@ GEM
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
     public_suffix (5.0.3)
-    puma (5.6.7)
+    puma (5.6.8)
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
This will update the Puma gem from version `5.6.7` to `5.6.8` to address this security vulnerabilty:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/175


