### PR TITLE
Added rake task to update bg check internal invitation status

### DIFF
--- a/lib/tasks/update_bg_check_internal_invitation_status.rake
+++ b/lib/tasks/update_bg_check_internal_invitation_status.rake
@@ -1,0 +1,17 @@
+desc "Update background check internal invitation status"
+task :update_bg_check_internal_invitation_status, [:dry_run] => :environment do |t, args|
+  dry_run = args[:dry_run] != "run"
+
+  background_checks = BackgroundCheck.where.not(invitation_status: nil)
+
+  puts "DRY RUN: #{dry_run ? "on" : "off"}"
+  puts("Updating internal invitation status for #{background_checks.count} background checks")
+
+  if !dry_run
+    puts("Starting update")
+    background_checks.find_each do |background_check|
+      background_check.update_column(:internal_invitation_status, 1)
+    end
+    puts("Update complete")
+  end
+end


### PR DESCRIPTION
Refs #4247

This rake task is needed to update the new `internal_invitation_status` field for background checks. It will get all background checks that have a value for `invitation_status` (meaning that an invitation has been sent) and then update those records to `invitation_sent`. 

Running locally: 
`bundle exec rake 'update_bg_check_internal_invitation_status[run]'`

There is also a dry mode
`bundle exec rake 'update_bg_check_internal_invitation_status[dry]'`

On QA:
dry first, then run
`heroku run bundle exec rake 'update_bg_check_internal_invitation_status[dry]' --app technovation-qa`

On PROD:
dry first, then run
`heroku run bundle exec rake 'update_bg_check_internal_invitation_status[dry]' --app technovation`

As of right now, Jan 19, 2024 @ 10:04CST there are 202 records on production that will be updated. 