### PR TITLE
Add background checks admin page

### DIFF
--- a/app/controllers/admin/background_checks_controller.rb
+++ b/app/controllers/admin/background_checks_controller.rb
@@ -1,17 +1,16 @@
 module Admin
   class BackgroundChecksController < AdminController
-    def index
-      params[:status] = "pending" if params[:status].blank?
-      params[:page] = 1 if params[:page].blank?
-      params[:per_page] = 15 if params[:per_page].blank?
+    include DatagridController
+    use_datagrid with: BackgroundChecksGrid
 
-      @background_checks = BackgroundCheck.send(params[:status])
-        .page(params[:page].to_i)
-        .per_page(params[:per_page].to_i)
+    private
 
-      if @background_checks.empty?
-        @background_checks = @background_checks.page(1)
-      end
+    def grid_params
+      grid = params[:background_checks_grid] ||= {}
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
     end
   end
 end

--- a/app/data_grids/background_checks_grid.rb
+++ b/app/data_grids/background_checks_grid.rb
@@ -1,0 +1,56 @@
+class BackgroundChecksGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    BackgroundCheck.order(created_at: :desc)
+  end
+
+  column :account, mandatory: true, html: true do |background_check|
+    if background_check.account.present?
+      link_to(
+        background_check.account.full_name,
+        admin_participant_path(background_check.account)
+      )
+    else
+      "-"
+    end
+  end
+
+  column :profile_type, header: "Profile Type" do |background_check|
+    background_check.account.scope_name.titleize
+  end
+
+  column :country, header: "Country" do |background_check|
+    FriendlyCountry.new(background_check.account).country_name
+  end
+
+  column :background_check, header: "Background Check", mandatory: true do |background_check|
+    background_check.status.titleize
+  end
+
+  column :invitation_status, header: "Invitation Status", mandatory: true do |background_check|
+    if background_check.invitation_status.present?
+      background_check.invitation_status.titleize
+    else
+      "-"
+    end
+  end
+
+  filter :status,
+    :enum,
+    header: "Background Check Status",
+    select: BackgroundCheck.statuses.transform_keys(&:humanize)
+
+  filter :invitation_status,
+    :enum,
+    header: "Invitation Status",
+    select: BackgroundCheck.invitation_statuses.transform_keys(&:capitalize)
+
+  column_names_filter(
+    header: "More columns",
+    filter_group: "more-columns",
+    multiple: true
+  )
+end

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -66,6 +66,10 @@
       admin_user_invitations_path,
       class: al(admin_user_invitations_path) %>
 
+    <%= link_to "Background Checks",
+      admin_background_checks_path,
+      class: al(admin_background_checks_path) %>
+
     <%= link_to "Admins",
       admin_admins_path,
       class: al(admin_admins_path) %>

--- a/app/views/admin/background_checks/index.html.erb
+++ b/app/views/admin/background_checks/index.html.erb
@@ -1,44 +1,10 @@
-<div class="flex-row">
-  <div class="flex-col-md-4">
-    <div class="admin-search__filter-options">
-      <%= render 'admin/background_checks/filter_options' %>
-    </div>
-  </div>
-
-  <div class="flex-col-md-8 wrapper__report-column">
-    <div class="admin-results-table">
-      <div class="admin-results-header-table">
-        <div class="header">Account type</div>
-        <div class="header">Submitted</div>
-        <div class="header">Email</div>
-        <div class="header">Status</div>
-      </div>
-
-      <div class="admin-results-data-table">
-        <% @background_checks.order('created_at DESC').each do |bg_check| %>
-          <div class="row">
-            <div class="cell">
-              <%= bg_check.account.scope_name %>
-            </div>
-
-            <div class="cell">
-              <%= time_ago_in_words(bg_check.created_at) %> ago
-            </div>
-
-            <div class="cell">
-              <%= bg_check.account.email %>
-            </div>
-
-            <div class="cell">
-              <%= bg_check.status %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="wrapper__report-footer">
-      <%= render 'admin/background_checks/footer' %>
-    </div>
+<div class="grid margin--t-xlarge">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <h3>Background Checks</h3>
+    <%= render 'datagrid/datagrid',
+               grid: @background_checks_grid,
+               form_url: admin_background_checks_path,
+               model_name: "background_check",
+               scope: :admin %>
   </div>
 </div>

--- a/spec/factories/background_checks.rb
+++ b/spec/factories/background_checks.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     status { BackgroundCheck.statuses[:clear] }
     report_id { "123abcREPORT_ID" }
     candidate_id { "123abcCANDIDATE_ID" }
+
+    trait :invitation_pending do
+      status { BackgroundCheck.statuses[:invitation_required] }
+      invitation_id { "123abcINVITATION_ID" }
+      invitation_status { BackgroundCheck.invitation_statuses[:pending] }
+      candidate_id { nil }
+      report_id { nil }
+    end
   end
 end

--- a/spec/features/admin/view_background_checks_spec.rb
+++ b/spec/features/admin/view_background_checks_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.feature "Admin view background check datagrid", js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  before do
+    us_based_mentors =  FactoryBot.create_list(:mentor, 2, :geocoded)
+    india_based_mentors = FactoryBot.create_list(:mentor, 2, :india)
+
+    india_based_mentors.each do |mentor|
+      mentor.background_check.destroy
+      FactoryBot.create(
+        :background_check,
+        :invitation_pending,
+        account: mentor.account
+      )
+    end
+
+    @all_mentors = us_based_mentors + india_based_mentors
+
+    sign_in(admin)
+    visit admin_background_checks_path
+  end
+
+  scenario "Clicking on admin background checks link displays a datagrid of all background checks" do
+    page.save_and_open_page
+    expect(page).to have_content("#{@all_mentors.size} background checks found")
+
+    @all_mentors.each do |mentor|
+      expect(page).to have_link(mentor.account.name, href: admin_participant_path(mentor.account))
+
+      expect(page).to have_selector("tr#background_check_#{mentor.background_check.id}")
+
+      within("tr#background_check_#{mentor.background_check.id}") do
+        expect(page).to have_css("td.background_check", text: mentor.background_check.status.titleize)
+
+        invitation_status_text = mentor.account.country_code == "US" ? "-" : mentor.background_check.invitation_status.titleize
+        expect(page).to have_css("td.invitation_status", text: invitation_status_text)
+      end
+    end
+  end
+end

--- a/spec/features/admin/view_background_checks_spec.rb
+++ b/spec/features/admin/view_background_checks_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "Admin view background check datagrid", js: true do
   end
 
   scenario "Clicking on admin background checks link displays a datagrid of all background checks" do
-    page.save_and_open_page
     expect(page).to have_content("#{@all_mentors.size} background checks found")
 
     @all_mentors.each do |mentor|


### PR DESCRIPTION
Refs #4470 

This PR will add a background checks tab/datagrid to the admin portal. This is the basic foundation for future background check admin tools. I still need to complete the "sync now" functionality. This has been logged in #4483 

![CleanShot 2024-02-06 at 22 06 42@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/a43e3d6f-23b3-4c47-a0bc-845eecf9595d)
