### PR TITLE
Fix axios CSRF issue

### DIFF
--- a/app/javascript/config/axios.js
+++ b/app/javascript/config/axios.js
@@ -1,30 +1,34 @@
-import axios from 'axios'
-import applyConverters from 'axios-case-converter'
+import axios from "axios";
+import applyConverters from "axios-case-converter";
 
 // Polyfill Promise for IE11 to support axios
-require('es6-promise').polyfill()
+require("es6-promise").polyfill();
 
-window.axios = applyConverters(axios.create())
+window.axios = applyConverters(axios.create());
 
-document.addEventListener('turbolinks:load', () => {
-  const csrfTokenMetaTag = document.querySelector('meta[name="csrf-token"]')
+document.addEventListener("turbolinks:load", () => {
+  const csrfTokenMetaTag = document.querySelector('meta[name="csrf-token"]');
 
-  window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+  window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
 
   if (csrfTokenMetaTag) {
-    window.axios.interceptors.request.use(function (config) {
-      if (config.url && config.url.match(/^\//)) {
-        // The following headers must be in "Header-Case" because
-        // of axios-case-converter (see their documentation)
-        config.headers.common = {
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-Csrf-Token' : csrfTokenMetaTag.getAttribute('content')
+    window.axios.interceptors.request.use(
+      function (config) {
+        if (config.url && config.url.match(/^\//)) {
+          // The following headers must be in "Header-Case" because
+          // of axios-case-converter (see their documentation)
+          config.headers = {
+            "X-Requested-With": "XMLHttpRequest",
+            "X-Csrf-Token": csrfTokenMetaTag.getAttribute("content"),
+          };
         }
-      }
 
-      return config
-    }, function (error) {
-      return Promise.reject(error);
-    })
+        return config;
+      },
+      function (error) {
+        return Promise.reject(error);
+      }
+    );
   }
-})
+});
+


### PR DESCRIPTION
The changes here will properly include the CSRF token in the headers for axios calls. This will fix the location issue, judge recusal popup submission issue, and most likely a few others too.