### PR TITLE
Added admin view all chapters + basic foundation of the individual chapter details page

### DIFF
--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -1,8 +1,7 @@
 module Admin
   class ChaptersController < AdminController
-    def index
-      @chapters = Chapter.all
-    end
+    include DatagridController
+    use_datagrid with: ChaptersGrid
 
     def show
       @chapter = Chapter.find(params[:id])
@@ -28,6 +27,14 @@ module Admin
       params.require(:chapter).permit(
         :id,
         :organization_name
+      )
+    end
+
+    def grid_params
+      grid = params[:chapters_grid] ||= {}
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
       )
     end
   end

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -1,0 +1,38 @@
+class ChaptersGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Chapter.order(id: :desc)
+  end
+
+  column :name, header: "Chapters (Program Name)", mandatory: true, html: true do |chapter|
+    link_to(
+      chapter.name.present? ? chapter.name : "-",
+      admin_chapter_path(chapter)
+    )
+  end
+
+  column :organization_name, header: "Organization", mandatory: true, html: true
+
+  filter :program_name do |value|
+    where("name ilike ?",
+      "#{value}%")
+  end
+
+  filter :organization_name do |value|
+    where("organization_name ilike ?",
+      "#{value}%")
+  end
+
+  column :actions, mandatory: true, html: true do |chapter|
+    render "admin/chapters/actions", chapter: chapter
+  end
+
+  column_names_filter(
+    header: "More columns",
+    filter_group: "more-columns",
+    multiple: true
+  )
+end

--- a/app/views/admin/chapters/_actions.html.erb
+++ b/app/views/admin/chapters/_actions.html.erb
@@ -1,0 +1,14 @@
+<%= link_to(
+  "View",
+  admin_chapter_path(chapter),
+  class: "button small gray",
+  target: :_blank,
+  data: {turbolinks: false}
+) %>
+
+<%= link_to(
+  "Invite a ChA PLACEHOLDER",
+  admin_chapter_path(chapter),
+  class: "button small green",
+  data: {turbolinks: false}
+) %>

--- a/app/views/admin/chapters/index.html.erb
+++ b/app/views/admin/chapters/index.html.erb
@@ -1,23 +1,15 @@
-<h1>View Chapters</h1>
+<div class="grid margin--t-xlarge">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <h3>View Chapters</h3>
 
-<table>
-  <thead>
-    <tr>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
+    <div class="panel">
+      <p><%= link_to "Setup a new chapter", new_admin_chapter_path, class: "button" %></p>
+    </div>
 
-  <tbody>
-    <% @chapters.each do |chapter| %>
-      <tr>
-        <td><%= link_to chapter.organization_name, admin_chapter_path(chapter) %></td>
-<!--        <td><%#= link_to 'Edit', edit_admin_chapter_path(admin_chapter) %></td>-->
-<!--        <td><%#= link_to 'Destroy', admin_chapter, method: :delete, data: { confirm: 'Are you sure?' } %></td>-->
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<br>
-
-<p><%= link_to "Setup a new chapter", new_admin_chapter_path, class: "button" %></p>
+    <%= render 'datagrid/datagrid',
+               grid: @chapters_grid,
+               form_url: admin_chapters_path,
+               model_name: "chapter",
+               scope: :admin %>
+  </div>
+</div>

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -1,5 +1,33 @@
-<h1>Organization Name</h1>
-<h1><%= @chapter.organization_name %></h1>
+<div class="grid__cell--padding-sm-x">
+  <%= link_to "View Chapters", admin_chapters_path, class: "button button--small" %>
+</div>
 
-<p>Please use the invite button below to invite a user to be the Chapter Ambassador for this chapter.</p>
-<%= link_to "Invite a chapter ambassador PLACEHOLDER", class: "button" %>
+<div class="grid grid--justify-center">
+  <div class="grid__col-12">
+    <div class="panel">
+      <h3><%= @chapter.name.present? ? @chapter.name : "NOT SET" %></h3>
+      <dl>
+        <dt>Organization Name</dt>
+        <dd><%= @chapter.organization_name %></dd>
+
+        <dt>Location</dt>
+        <dd>------</dd>
+
+        <dt>Ambassador</dt>
+        <dd>------</dd>
+
+        <dt>Program Summary</dt>
+        <dd>------</dd>
+
+        <dt>Program Links</dt>
+        <dd>------</dd>
+      </dl>
+
+
+      <p>Please use the invite button below to invite a user to be the Chapter Ambassador for this chapter.</p>
+      <%= link_to "Invite a chapter ambassador PLACEHOLDER", class: "button" %>
+    </div>
+  </div>
+</div>
+
+

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :chapter do
+    sequence(:name) { |n| "FactoryBot Program #{n}" }
+    sequence(:organization_name) { |n| "FactoryBot Organization #{n}" }
+  end
+end

--- a/spec/features/admin/manage_chapters_spec.rb
+++ b/spec/features/admin/manage_chapters_spec.rb
@@ -16,4 +16,17 @@ RSpec.feature "Admins managing chapters", :js do
     expect(page).to have_content("Please use the invite button below to invite a user to be the Chapter Ambassador for this chapter.")
     expect(Chapter.count).to eq(1)
   end
+
+  scenario "Admin view all chapters" do
+    chapters = FactoryBot.create_list(:chapter, 2)
+    visit admin_chapters_path
+
+    chapters.each do |chapter|
+      expect(page).to have_selector("tr#chapter_#{chapter.id}")
+      within("tr#chapter_#{chapter.id}") do
+        expect(page).to have_link(chapter.name, href: admin_chapter_path(chapter))
+        expect(page).to have_css("td.organization_name", text: chapter.organization_name)
+      end
+    end
+  end
 end

--- a/spec/features/admin/manage_chapters_spec.rb
+++ b/spec/features/admin/manage_chapters_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature "Admins managing chapters", :js do
   end
 
   scenario "Admin add a chapter" do
-    click_link "Chapters"
+    visit admin_chapters_path
     click_link "Setup a new chapter"
 
     fill_in "Organization name", with: "Hello World"
     click_button "Add"
 
-    expect(page).to have_content(Chapter.last.organization_name)
+    expect(page).to have_content("Hello World")
     expect(page).to have_content("Please use the invite button below to invite a user to be the Chapter Ambassador for this chapter.")
     expect(Chapter.count).to eq(1)
   end

--- a/spec/features/admin/manage_chapters_spec.rb
+++ b/spec/features/admin/manage_chapters_spec.rb
@@ -9,7 +9,9 @@ RSpec.feature "Admins managing chapters", :js do
     visit admin_chapters_path
     click_link "Setup a new chapter"
 
-    fill_in "Organization name", with: "Hello World"
+    fill_in "organization_name", with: "Hello World"
+    expect(page).to have_field("organization_name", with: "Hello World")
+
     click_button "Add"
 
     expect(page).to have_content("Hello World")


### PR DESCRIPTION
Refs #4446 (and foundation for #4472)

This PR adds the view chapters page for admin, which includes a new Chapters datagrid. I also added the foundation for the individual chapter details page in #4472.

Currently, you can search by program name or organization name. As the additional fields are added/confirmed in the Chapter table, then new filters can be added. I captured this in #4506.

<img width="1730" alt="CleanShot 2024-02-15 at 09 42 53@2x" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/8945ea99-d24e-4180-a197-1effbbcae7bf">

<img width="1485" alt="CleanShot 2024-02-15 at 09 43 03@2x" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/db968e93-50ea-4080-b808-93662d9492b1">


