### PR TITLE
Update Follow Redirects node module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "datagrid", "~> 1.5"
 gem "simple_form", "~> 5.0"
 gem "country_state_select", "~> 3.0"
 
-gem "nokogiri", "~> 1.14.0"
+gem "nokogiri", "~> 1.16.0"
 
 gem "friendly_id", "~> 5.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,10 +313,10 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
-    nokogiri (1.14.5)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.5-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     normalize-rails (4.1.1)
     options (2.3.2)
@@ -359,7 +359,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rack-proxy (0.7.0)
       rack
@@ -606,7 +606,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (~> 1.14.0)
+  nokogiri (~> 1.16.0)
   normalize-rails (~> 4.1)
   paranoia (~> 2.4)
   pdf-forms (~> 1.2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,12 +5144,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
-
-follow-redirects@^1.15.4:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.15.4:
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==


### PR DESCRIPTION
This is a very minor version bump from `1.15.3` to `1.15.5` for the Follow Redirects node module that will address this security vulnerability:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/176

