### PR TITLE
Update nokogirl gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "datagrid", "~> 1.5"
 gem "simple_form", "~> 5.0"
 gem "country_state_select", "~> 3.0"
 
-gem "nokogiri", "~> 1.14.0"
+gem "nokogiri", "~> 1.16.0"
 
 gem "friendly_id", "~> 5.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,10 +313,10 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
-    nokogiri (1.14.5)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.5-x86_64-linux)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     normalize-rails (4.1.1)
     options (2.3.2)
@@ -359,7 +359,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.8)
     rack-proxy (0.7.0)
       rack
@@ -606,7 +606,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  nokogiri (~> 1.14.0)
+  nokogiri (~> 1.16.0)
   normalize-rails (~> 4.1)
   paranoia (~> 2.4)
   pdf-forms (~> 1.2)


### PR DESCRIPTION
This will update nokogiri from `1.14.5` to version `1.16.2` to address security vulnerabilty:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/177

I also looked over the changelog for nokogiri and didn't see any breaking changes:

- https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md



