### PR TITLE
Inviting chapter ambassadors to chapters

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -71,17 +71,23 @@ document.addEventListener("turbolinks:load", function () {
     });
   });
 
-  const invitationProfileType = document.getElementById("user_invitation_profile_type");
+  const invitationProfileType = document.getElementById(
+    "user_invitation_profile_type"
+  );
 
   if (invitationProfileType) {
     invitationProfileType.addEventListener("change", () => {
-      const registerAtAnyTime = document.getElementById("user_invitation_register_at_any_time");
+      const registerAtAnyTime = document.getElementById(
+        "user_invitation_register_at_any_time"
+      );
+      const chapterSelect = document.getElementById("chapter");
 
       if (invitationProfileType.value == "chapter_ambassador") {
+        chapterSelect.style.display = "block";
         registerAtAnyTime.checked = true;
         registerAtAnyTime.disabled = true;
-      }
-      else {
+      } else {
+        chapterSelect.style.display = "none";
         registerAtAnyTime.checked = false;
         registerAtAnyTime.disabled = false;
       }

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -66,7 +66,8 @@ module Admin
         :profile_type,
         :name,
         :email,
-        :register_at_any_time
+        :register_at_any_time,
+        :chapter_id
       )
     end
   end

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -1,5 +1,6 @@
 class NewRegistrationController < ApplicationController
   after_action :update_registration_invite, only: :create
+  after_action :assign_chapter_ambassador_to_chapter, only: :create
 
   layout "new_registration"
 
@@ -147,9 +148,20 @@ class NewRegistrationController < ApplicationController
   end
 
   def update_registration_invite
-    UpdateRegistrationInviteJob.perform_later(
-      invite_code: params[:inviteCode],
-      account_id: @profile.account.id
-    )
+    if params[:inviteCode].present?
+      UpdateRegistrationInviteJob.perform_now(
+        invite_code: params[:inviteCode],
+        account_id: @profile.account.id
+      )
+    end
+  end
+
+  def assign_chapter_ambassador_to_chapter
+    if params[:inviteCode].present? && params[:profileType] == "chapter_ambassador"
+      AssignChapterAmbassadorToChapterJob.perform_later(
+        invite_code: params[:inviteCode],
+        chapter_ambassador_profile_id: @profile.id
+      )
+    end
   end
 end

--- a/app/data_grids/user_invitations_grid.rb
+++ b/app/data_grids/user_invitations_grid.rb
@@ -72,6 +72,17 @@ class UserInvitationsGrid
     end
   end
 
+  column :chapter, html: true do |registration_invite|
+    if registration_invite.chapter.present?
+      link_to(
+        registration_invite.chapter.organization_name,
+        admin_chapter_path(registration_invite.chapter)
+      )
+    else
+      "-"
+    end
+  end
+
   column :actions, mandatory: true, html: true do |registration_invite|
     render "admin/user_invitations/actions", registration_invite: registration_invite
   end

--- a/app/jobs/assign_chapter_ambassador_to_chapter_job.rb
+++ b/app/jobs/assign_chapter_ambassador_to_chapter_job.rb
@@ -1,0 +1,12 @@
+class AssignChapterAmbassadorToChapterJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(invite_code:, chapter_ambassador_profile_id:)
+    invite = UserInvitation.find_by(admin_permission_token: invite_code)
+    chapter_ambassador = ChapterAmbassadorProfile.find(chapter_ambassador_profile_id)
+
+    if invite.present? && invite.chapter_id.present?
+      chapter_ambassador.update_columns(chapter_id: invite.chapter_id)
+    end
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,3 +1,4 @@
 class Chapter < ActiveRecord::Base
   has_many :chapter_ambassador_profiles
+  has_many :registration_invites, class_name: "UserInvitation"
 end

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -25,6 +25,7 @@ class UserInvitation < ApplicationRecord
 
   validates :profile_type, :email, presence: true
   validates :email, uniqueness: true, email: true
+  validates :chapter, presence: true, if: -> { profile_type == "chapter_ambassador" }
 
   validate ->(invitation) {
     if inviting_existing_chapter_ambassador_to_be_a_chapter_ambassador?
@@ -44,6 +45,7 @@ class UserInvitation < ApplicationRecord
   belongs_to :account, required: false
   belongs_to :current_account, -> { current }, required: false
   belongs_to :invited_by, class_name: "Account", required: false
+  belongs_to :chapter, required: false
 
   has_many :judge_assignments, as: :assigned_judge, dependent: :destroy
   has_many :assigned_teams,

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -20,6 +20,11 @@
     %>
   </div>
 
+  <div id="chapter" class="field margin--b-large" style="display: none;">
+    <%= f.label :chapter_id, "Chapter", for: :chapter_id %>
+    <%= f.collection_select(:chapter_id, Chapter.all.order(organization_name: :asc), :id, :organization_name) %>
+  </div>
+
   <div class="field">
     <%= f.label :name, "Name (displayed in the invite email)", for: :user_invitation_name %>
     <%= f.text_field :name, id: :user_invitation_name, placeholder: "Optional" %>

--- a/db/migrate/20240221211159_add_chapter_to_user_invitations.rb
+++ b/db/migrate/20240221211159_add_chapter_to_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddChapterToUserInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :user_invitations, :chapter, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1702,7 +1702,8 @@ CREATE TABLE public.user_invitations (
     updated_at timestamp without time zone NOT NULL,
     name character varying,
     register_at_any_time boolean,
-    invited_by_id integer
+    invited_by_id integer,
+    chapter_id bigint
 );
 
 
@@ -2699,6 +2700,13 @@ CREATE INDEX index_unconfirmed_email_addresses_on_account_id ON public.unconfirm
 
 
 --
+-- Name: index_user_invitations_on_chapter_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_invitations_on_chapter_id ON public.user_invitations USING btree (chapter_id);
+
+
+--
 -- Name: pitch_events_team_ids; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2837,6 +2845,14 @@ ALTER TABLE ONLY public.mentor_profile_mentor_types
 
 ALTER TABLE ONLY public.regional_pitch_events_user_invitations
     ADD CONSTRAINT fk_rails_3bbe8623e3 FOREIGN KEY (user_invitation_id) REFERENCES public.user_invitations(id);
+
+
+--
+-- Name: user_invitations fk_rails_4e77e2e432; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_invitations
+    ADD CONSTRAINT fk_rails_4e77e2e432 FOREIGN KEY (chapter_id) REFERENCES public.chapters(id);
 
 
 --
@@ -3269,6 +3285,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240202203152'),
 ('20240202203636'),
 ('20240206173222'),
-('20240208195151');
+('20240208195151'),
+('20240221211159');
 
 

--- a/spec/controllers/new_registration_controller_spec.rb
+++ b/spec/controllers/new_registration_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe NewRegistrationController do
+  describe "POST #create" do
+    context "when registering as a chapter ambassador" do
+      let(:registration_invite) {
+        UserInvitation.create!(
+          profile_type: :chapter_ambassador,
+          email: "chapter_ambassador_invite@example.com",
+          chapter_id: chapter.id
+        )
+      }
+      let(:chapter) { FactoryBot.create(:chapter) }
+
+      before do
+        post :create, params: {
+          profileType: "chapter_ambassador", 
+          inviteCode: registration_invite.admin_permission_token,
+          new_registration: {
+            email: "sjones@example.com", 
+            firstName: "Sylvia", 
+            lastName: "Jones", 
+            gender: "Female", 
+            dateOfBirth: "2001-01-21", 
+            chapterAmbassadorOrganizationCompanyName: "Museum of Natural History", 
+            chapterAmbassadorJobTitle: "Curator", 
+            chapterAmbassadorBio: "We live inside a treehouse at the center of the museum, we have been protecting the museum's secrets for generations. We making sure that everyone is safe and happy – without the outside world learning about the museum's secrets.",
+            dataTermsAgreedTo: true, 
+            password: "123abc*&^"
+          }
+        }
+      end
+
+      it "assigns the chapter from the invite to the newly created chapter ambassador" do
+        expect(ChapterAmbassadorProfile.last.chapter_id).to eq(registration_invite.chapter_id)
+      end
+
+      it "updates the invitation to a registered status" do
+        expect(registration_invite.reload.registered?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -4,8 +4,12 @@ RSpec.feature "Chapter ambassadors registering", :js do
   let(:chapter_ambassado_registration_invite) {
     UserInvitation.create!(
       profile_type: :chapter_ambassador,
-      email: "chapter_ambassador_invite@example.com"
+      email: "chapter_ambassador_invite@example.com",
+      chapter_id: chapter.id
     )
+  }
+  let(:chapter) {
+    FactoryBot.create(:chapter)
   }
 
   before do

--- a/spec/jobs/assign_chapter_ambassador_to_chapter_job_spec.rb
+++ b/spec/jobs/assign_chapter_ambassador_to_chapter_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe AssignChapterAmbassadorToChapterJob do
+  let(:registration_invite) {
+    UserInvitation.create!(
+      profile_type: :chapter_ambassador,
+      email: "chapter_ambassador_invite@example.com",
+      chapter_id: chapter.id
+    )
+  }
+  let(:chapter) { FactoryBot.create(:chapter) }
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+
+  before do
+    allow(UserInvitation).to receive(:find_by)
+      .with(admin_permission_token: registration_invite.admin_permission_token)
+      .and_return(registration_invite)
+
+    allow(ChapterAmbassadorProfile).to receive(:find)
+      .with(chapter_ambassador.id)
+      .and_return(chapter_ambassador)
+  end
+
+  it "assigns the chapter from the invite to the chapter ambassador" do
+    AssignChapterAmbassadorToChapterJob.perform_now(
+      invite_code: registration_invite.admin_permission_token,
+      chapter_ambassador_profile_id: chapter_ambassador.id
+    )
+
+    expect(chapter_ambassador.chapter_id).to eq(registration_invite.chapter_id)
+  end
+end

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -52,28 +52,6 @@ RSpec.describe UserInvitation do
     end
   end
 
-  it "allows an existing mentor to be moved for a chapter ambassador" do
-    mentor = FactoryBot.create(:mentor, :onboarded)
-
-    invite = UserInvitation.new(
-      profile_type: :chapter_ambassador,
-      email: mentor.email
-    )
-
-    expect(invite).to be_valid
-  end
-
-  it "allows an existing judge to be moved for a chapter ambassador" do
-    judge = FactoryBot.create(:judge)
-
-    invite = UserInvitation.new(
-      profile_type: :chapter_ambassador,
-      email: judge.email
-    )
-
-    expect(invite).to be_valid
-  end
-
   it "updates judges assigned to events after signing up" do
     event = FactoryBot.create(:event)
 
@@ -140,6 +118,21 @@ RSpec.describe UserInvitation do
 
     it "return the account of the person who sent the inviation" do
       expect(invite.invited_by).to eq(admin.account)
+    end
+  end
+
+  describe "#chapter_id" do
+    let(:chapter) { FactoryBot.create(:chapter) }
+
+    let(:invite) do
+      UserInvitation.new(
+        profile_type: :chapter_ambassador,
+        chapter_id: chapter.id
+      )
+    end
+
+    it "return the chapter_id associated to the invitation" do
+      expect(invite.chapter_id).to eq(chapter.id)
     end
   end
 end

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Registration invites", :js do
   let(:admin) { FactoryBot.create(:admin) }
+  let!(:chapter) { FactoryBot.create(:chapter) }
 
   before do
     sign_in(admin)
@@ -45,6 +46,7 @@ RSpec.describe "Registration invites", :js do
           select item[:select_option], from: "Registration Type"
           fill_in "Name", with: name
           fill_in "Email", with: email_address
+
           click_button "Send invitation"
         }.to change {
           UserInvitation.sent.count

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Registration invites", :js do
     },
     {
       invite_profile_type: "judge",
-      friendly_profile_type: "juge",
+      friendly_profile_type: "judge",
       select_option: "Judge"
     },
     {

--- a/spec/system/registration/invites_spec.rb
+++ b/spec/system/registration/invites_spec.rb
@@ -34,13 +34,25 @@ RSpec.describe "Using registration invite codes", :js do
     }
   ].each do |item|
     context "when a #{item[:friendly_profile_type]} is registering using an invite code" do
-      let(:registration_invite) {
-        UserInvitation.create!(
-          profile_type: item[:invite_profile_type],
-          email: email_address,
-          register_at_any_time: register_at_any_time
-        )
-      }
+      if item[:profile_type] == "chapter_ambassador"
+        let(:registration_invite) {
+          UserInvitation.create!(
+            profile_type: item[:invite_profile_type],
+            email: email_address,
+            register_at_any_time: register_at_any_time,
+            chapter_id: chapter.id
+          )
+        }
+        let(:chapter) { FactoryBot.create(:chapter) }
+      else
+        let(:registration_invite) {
+          UserInvitation.create!(
+            profile_type: item[:invite_profile_type],
+            email: email_address,
+            register_at_any_time: register_at_any_time,
+          )
+        }
+      end
 
       let(:profile) {
         FactoryBot.create(
@@ -50,6 +62,11 @@ RSpec.describe "Using registration invite codes", :js do
       }
       let(:email_address) { "#{item[:registration_profile_type]}@example.com" }
       let(:register_at_any_time) { false }
+
+      after :each do
+        UserInvitation.delete_all
+        Chapter.delete_all
+      end
 
       context "when registration is open" do
         before do
@@ -112,9 +129,11 @@ RSpec.describe "Using registration invite codes", :js do
     let(:chapter_ambassado_registration_invite) {
       UserInvitation.create!(
         profile_type: :chapter_ambassador,
-        email: "chapter_ambassador_invite@example.com"
+        email: "chapter_ambassador_invite@example.com",
+        chapter_id: chapter.id
       )
     }
+    let(:chapter) { FactoryBot.create(:chapter) }
 
     context "when visiting the registration page with a chapter ambassador invite code" do
       before do


### PR DESCRIPTION
This will:
- Allow admins to invite chapter ambassadors to a chapter
- After the chapter ambassador registers, it will associate them to that chapter