### PR TITLE
Updated created async method for adding judges to rpe bug

### DIFF
--- a/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
+++ b/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
@@ -15,14 +15,12 @@
         New teams cannot be added to events at this time.
       </p>
 
-      <div
-        class="modal-container"
-        v-show="searching"
-      >
+      <div class="modal-container" v-show="searching">
         <div class="modal">
           <div v-if="eventAtCapacity()" class="margin--b-xlarge">
             <div class="flash flash--error margin--none">
-              This event is currently at capacity. No additional teams can be added.
+              This event is currently at capacity. No additional teams can be
+              added.
             </div>
           </div>
 
@@ -32,17 +30,11 @@
             v-model="query"
           />
 
-          <div
-            class="align-center padding-small"
-            v-show="fetching"
-          >
+          <div class="align-center padding-small" v-show="fetching">
             <icon class="spin" name="spinner" />
           </div>
 
-          <div
-            class="padding-small"
-            v-show="!fetching && !items.length"
-          >
+          <div class="padding-small" v-show="!fetching && !items.length">
             <slot name="no-results" />
           </div>
 
@@ -80,10 +72,7 @@
           </div>
 
           <div class="modal-footer">
-            <button
-              class="button--unmask"
-              @click="searching = false"
-            >
+            <button class="button--unmask" @click="searching = false">
               Done
             </button>
           </div>
@@ -94,185 +83,202 @@
 </template>
 
 <script>
-  import axios from 'axios'
-  import debounce from "lodash/debounce"
+import axios from "axios";
+import debounce from "lodash/debounce";
 
-  import { airbrake } from 'utilities/utilities'
-  import Icon from "../../components/Icon";
-  import Attendee from "./Attendee";
-  import EventBus from '../../components/EventBus';
+import { airbrake } from "utilities/utilities";
+import Icon from "../../components/Icon";
+import Attendee from "./Attendee";
+import EventBus from "../../components/EventBus";
 
-  export default {
-    components: {
-      Icon,
+export default {
+  components: {
+    Icon,
+  },
+
+  data() {
+    return {
+      query: "",
+      searching: false,
+      fetching: false,
+      items: [],
+      selectableItems: [],
+      canAddTeamsToEvents: false,
+    };
+  },
+
+  props: {
+    addBtnText: String,
+    searchPlaceholder: String,
+    handleSelection: {
+      type: Function,
+      required: true,
     },
-
-    data () {
-      return {
-        query: "",
-        searching: false,
-        fetching: false,
-        items: [],
-        selectableItems: [],
-        canAddTeamsToEvents: false
-      };
+    handleDeselection: {
+      type: Function,
+      required: true,
     },
-
-    props: {
-      addBtnText: String,
-      searchPlaceholder: String,
-      handleSelection: {
-        type: Function,
-        required: true,
-      },
-      handleDeselection: {
-        type: Function,
-        required: true,
-      },
-      event: {
-        type: Object,
-        required: true,
-      },
-      type: {
-        type: String,
-        required: true,
-      },
+    event: {
+      type: Object,
+      required: true,
     },
+    type: {
+      type: String,
+      required: true,
+    },
+  },
 
-    created() {
-      EventBus.$on([
+  async created() {
+    EventBus.$on(
+      [
         "EventTeamList.saveAssignments",
         "EventJudgeList.saveAssignments",
         "EventTeamList.removeTeam",
         "EventJudgeList.removeJudge",
-      ], () => {
+      ],
+      () => {
         this.fetchRemoteItems();
-      });
+      }
+    );
 
-      this.debouncedFetchRemoteItems = debounce(() => {
-        this.fetchRemoteItems({ expandSearch: 1 });
-      }, 300);
-    },
+    this.debouncedFetchRemoteItems = debounce(() => {
+      this.fetchRemoteItems({ expandSearch: 1 });
+    }, 300);
 
-    computed: {
-      filteredItems () {
-        if (this.type == 'team') {
-          return Array.from(this.selectableItems || []).filter(i => {
-            return i.selected ||
-              !Array.from(this.$store.state.teams || []).map(t => t.id).includes(i.id)
-          })
-        } else {
-          return this.selectableItems
-        }
-      },
+    await this.getRegionalPitchEventSettings();
+  },
 
-      selectionDisabledTooltip () {
-        if (!this.eventAtCapacity()) {
-          return false;
-        }
-
-        return 'You have reached the maximum number of teams for this event';
-      },
-    },
-
-    watch: {
-      query (val) {
-        if (val.length >= 3) {
-          this.debouncedFetchRemoteItems();
-        }
-      },
-
-      searching (current) {
-        if (current && !this.items.length)
-          this.fetchRemoteItems();
-      },
-    },
-
-    methods: {
-      toggleSelection (item) {
-        if (item.selected) {
-          this.handleDeselection(item);
-        } else if (!this.eventAtCapacity()) {
-          this.handleSelection(item);
-        }
-      },
-
-      eventAtCapacity() {
-        if (this.type !== 'team') {
-          return false;
-        }
-
-        return Boolean(this.event.capacity) &&
-          this.event.selectedTeams.length >= this.event.capacity;
-      },
-
-      fetchRemoteItems (opts) {
-        if (this.fetching) return false
-
-        opts = opts || { expandSearch: 0 };
-
-        const vm = this,
-              url = "/chapter_ambassador" +
-                    "/possible_event_attendees.json" +
-                    "?type=" + this.type +
-                    "&event_id=" + this.event.id +
-                    "&query=" + encodeURIComponent(this.query) +
-                    "&expand_search=" + opts.expandSearch;
-
-        $.ajax({
-          url: url,
-
-          beforeSend: () => {
-            vm.fetching = true;
-          },
-
-          success: (json) => {
-            vm.$set(vm, 'items', []);
-            vm.$set(vm, 'selectableItems', []);
-
-            Array.from(json.data || []).forEach(obj => {
-              // Need to massage this data since serializers modify the JSON structure
-              obj.attributes.id = obj.id
-              const item = new Attendee(obj.attributes)
-              let idx
-
-              if (vm.type === 'team') {
-                idx = Array.from(vm.items || []).findIndex(i => i.id === item.id)
-              } else {
-                idx = Array.from(vm.items || []).findIndex(i => i.email === item.email)
-              }
-
-              if (idx === -1) {
-                vm.items.push(item);
-                vm.selectableItems.push(item);
-              }
-            });
-          },
-
-          complete: () => {
-            vm.fetching = false;
-          },
+  computed: {
+    filteredItems() {
+      if (this.type == "team") {
+        return Array.from(this.selectableItems || []).filter((i) => {
+          return (
+            i.selected ||
+            !Array.from(this.$store.state.teams || [])
+              .map((t) => t.id)
+              .includes(i.id)
+          );
         });
-      },
-      async getRegionalPitchEventSettings() {
-        try {
-          const response = await axios.get('/api/regional_pitch_events/settings')
-
-          this.canAddTeamsToEvents = response.data.canAddTeamsToEvents
-        }
-        catch(error) {
-          airbrake.notify({
-            error: `[REGIONAL PITCH EVENTS] Error getting event settings - ${error.response.data}`
-          })
-        }
-      },
+      } else {
+        return this.selectableItems;
+      }
     },
 
-    async created() {
-      await this.getRegionalPitchEventSettings()
-    }
-  };
+    selectionDisabledTooltip() {
+      if (!this.eventAtCapacity()) {
+        return false;
+      }
+
+      return "You have reached the maximum number of teams for this event";
+    },
+  },
+
+  watch: {
+    query(val) {
+      if (val.length >= 3) {
+        this.onQueryChange();
+      }
+    },
+
+    searching(current) {
+      if (current && !this.items.length) this.fetchRemoteItems();
+    },
+  },
+
+  methods: {
+    toggleSelection(item) {
+      if (item.selected) {
+        this.handleDeselection(item);
+      } else if (!this.eventAtCapacity()) {
+        this.handleSelection(item);
+      }
+    },
+
+    eventAtCapacity() {
+      if (this.type !== "team") {
+        return false;
+      }
+
+      return (
+        Boolean(this.event.capacity) &&
+        this.event.selectedTeams.length >= this.event.capacity
+      );
+    },
+
+    onQueryChange() {
+      this.debouncedFetchRemoteItems();
+    },
+
+    fetchRemoteItems(opts) {
+      if (this.fetching) return false;
+
+      opts = opts || { expandSearch: 0 };
+
+      const vm = this,
+        url =
+          "/chapter_ambassador" +
+          "/possible_event_attendees.json" +
+          "?type=" +
+          this.type +
+          "&event_id=" +
+          this.event.id +
+          "&query=" +
+          encodeURIComponent(this.query) +
+          "&expand_search=" +
+          opts.expandSearch;
+
+      $.ajax({
+        url: url,
+
+        beforeSend: () => {
+          vm.fetching = true;
+        },
+
+        success: (json) => {
+          vm.$set(vm, "items", []);
+          vm.$set(vm, "selectableItems", []);
+
+          Array.from(json.data || []).forEach((obj) => {
+            // Need to massage this data since serializers modify the JSON structure
+            obj.attributes.id = obj.id;
+            const item = new Attendee(obj.attributes);
+            let idx;
+
+            if (vm.type === "team") {
+              idx = Array.from(vm.items || []).findIndex(
+                (i) => i.id === item.id
+              );
+            } else {
+              idx = Array.from(vm.items || []).findIndex(
+                (i) => i.email === item.email
+              );
+            }
+
+            if (idx === -1) {
+              vm.items.push(item);
+              vm.selectableItems.push(item);
+            }
+          });
+        },
+
+        complete: () => {
+          vm.fetching = false;
+        },
+      });
+    },
+    async getRegionalPitchEventSettings() {
+      try {
+        const response = await axios.get("/api/regional_pitch_events/settings");
+
+        this.canAddTeamsToEvents = response.data.canAddTeamsToEvents;
+      } catch (error) {
+        airbrake.notify({
+          error: `[REGIONAL PITCH EVENTS] Error getting event settings - ${error.response.data}`,
+        });
+      }
+    },
+  },
+};
 </script>
 
-<style lang="scss" scoped>
-</style>
+<style lang="scss" scoped></style>


### PR DESCRIPTION
Refs #4520 

This PR addresses a bug in the ChA RPE management page. There are a lot of code style updates but the main update for this PR was removing a 2nd async create method and adding the logic to the 1st/original created method. 

As a ChA, the auto filter/search does not work when trying to search or add a judge. Similarly, when trying to add a judge by inviting them, there is a lag and a very weird flow. The error in the console is
`TypeError: this.debouncedFetchRemoteItems is not a function`. This led me to review the initial created method, which includes the following code
``` 
this.debouncedFetchRemoteItems = debounce(() => {
      this.fetchRemoteItems({ expandSearch: 1 });
    }, 300);
 ```
I also discovered a 2nd async created method. I believe that because of this 2nd created method, the 1st created method was not being called properly, leading to the `is not a function` error message. I added the logic from the 2nd async method to the original created method, and everything is working as expected, including the "search" option. 
 