### PR TITLE
Fixed background check invitation status bug on admin profile

### DIFF
--- a/app/views/admin/participants/_background_check_invitation_status.html.erb
+++ b/app/views/admin/participants/_background_check_invitation_status.html.erb
@@ -1,5 +1,10 @@
 <% if profile.in_background_check_invitation_country? %>
-  <% if profile.background_check.invitation_completed? %>
+  <% if profile.background_check.invitation_pending? %>
+    <%= web_icon(
+          "exclamation-circle icon--orange",
+          text:  profile.background_check.invitation_status.humanize
+        ) %>
+ <% elsif profile.background_check.invitation_completed? %>
     <%= web_icon(
           "check-circle icon-green",
           text: profile.background_check.invitation_status.humanize
@@ -18,10 +23,15 @@
           "exclamation-circle icon-red",
           text: profile.background_check.error_message.present? ? "Error from Checkr: #{profile.background_check.error_message}" : "No error message recorded. Review Checkr logs."
         ) %>
+  <% elsif profile.background_check.blank?  %>
+    <%= web_icon(
+          "exclamation-circle icon--orange",
+          text: "Background check invitation not yet requested"
+        ) %>
   <% else %>
     <%= web_icon(
           "exclamation-circle icon--orange",
-          text: profile.background_check.invitation_status.humanize
+          text:  "Error - please contact the dev team"
         ) %>
   <% end %>
 <% else %>

--- a/spec/features/admin/profile_debugging_spec.rb
+++ b/spec/features/admin/profile_debugging_spec.rb
@@ -106,4 +106,24 @@ RSpec.feature "When an admin is debugging a profile" do
     expect(page).to have_content("Background check invitation not required in this country")
     expect(page).to have_content("Background check not required in this country")
   end
+
+  scenario "they view the background check invitation status in the mentor debugging section of a mentor based in India who has not requested a background check invitation" do
+    mentor = FactoryBot.create(
+      :mentor,
+      :india
+    )
+
+    mentor.background_check.destroy
+
+    sign_in(:admin)
+
+    click_link "Participants"
+
+    within_results_page_with("#account_#{mentor.account_id}") do
+      click_link "view"
+    end
+
+    expect(page).to have_content("Background check invitation not yet requested")
+    expect(page).to have_css(".web-icon-text", text: "Not submitted")
+  end
 end


### PR DESCRIPTION
Discovered a bug in admin portal related to the logic for the bg check invitation status details in the profile debugging section. The template errors out for profiles in background check countries for profiles that have not yet requested an invite. The bug is currently on production, so I'm hoping for a quick additional deployment tomorrow. This change updates the logic and adds a catch-all for edge cases. 

You can recreate this on QA by signing up as a new mentor in a background check country. Then, view the mentor details in the admin portal, and the platform will display the default error page. 

spinoff from #4457 