### PR TITLE
Update chapter ambassador registration fields

### DIFF
--- a/app/controllers/api/registration/chapter_organization_names_controller.rb
+++ b/app/controllers/api/registration/chapter_organization_names_controller.rb
@@ -1,0 +1,11 @@
+module Api::Registration
+  class ChapterOrganizationNamesController < ActionController::API
+    def show
+      invite = UserInvitation.find_by(admin_permission_token: params[:invite_code])
+
+      render json: {
+        chapterOrganizationName: invite.chapter.organization_name
+      }
+    end
+  end
+end

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -98,7 +98,6 @@ class NewRegistrationController < ApplicationController
   def chapter_ambassador_params
     {
       job_title: registration_params[:chapterAmbassadorJobTitle],
-      bio: registration_params[:chapterAmbassadorBio],
       account_attributes: account_attributes.merge({gender: registration_params[:gender]})
     }
   end

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -98,6 +98,7 @@ class NewRegistrationController < ApplicationController
   def chapter_ambassador_params
     {
       job_title: registration_params[:chapterAmbassadorJobTitle],
+      organization_status: registration_params[:chapterAmbassadorOrganizationStatus],
       account_attributes: account_attributes.merge({gender: registration_params[:gender]})
     }
   end
@@ -139,6 +140,7 @@ class NewRegistrationController < ApplicationController
       :judgeJobTitle,
       :chapterAmbassadorJobTitle,
       :chapterAmbassadorBio,
+      :chapterAmbassadorOrganizationStatus,
       mentorExpertises: [],
       mentorTypes: []
     )

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -99,6 +99,7 @@ class NewRegistrationController < ApplicationController
     {
       job_title: registration_params[:chapterAmbassadorJobTitle],
       organization_status: registration_params[:chapterAmbassadorOrganizationStatus],
+      phone_number: registration_params[:chapterAmbassadorPhoneNumber],
       account_attributes: account_attributes.merge({gender: registration_params[:gender]})
     }
   end
@@ -141,6 +142,7 @@ class NewRegistrationController < ApplicationController
       :chapterAmbassadorJobTitle,
       :chapterAmbassadorBio,
       :chapterAmbassadorOrganizationStatus,
+      :chapterAmbassadorPhoneNumber,
       mentorExpertises: [],
       mentorTypes: []
     )

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -97,7 +97,6 @@ class NewRegistrationController < ApplicationController
 
   def chapter_ambassador_params
     {
-      organization_company_name: registration_params[:chapterAmbassadorOrganizationCompanyName],
       job_title: registration_params[:chapterAmbassadorJobTitle],
       bio: registration_params[:chapterAmbassadorBio],
       account_attributes: account_attributes.merge({gender: registration_params[:gender]})
@@ -139,7 +138,6 @@ class NewRegistrationController < ApplicationController
       :mentorBio,
       :judgeSchoolCompanyName,
       :judgeJobTitle,
-      :chapterAmbassadorOrganizationCompanyName,
       :chapterAmbassadorJobTitle,
       :chapterAmbassadorBio,
       mentorExpertises: [],

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -96,6 +96,15 @@
           id="organizationStatus"
           input-class="ChapterAmbassadorSelectClass"
         />
+
+        <FormulateInput
+          name="chapterAmbassadorPhoneNumber"
+          id="chapterAmbassadorPhoneNumber"
+          type="tel"
+          label="Phone Number (optional)"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+        />
       </div>
     </div>
 

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -66,18 +66,6 @@
         />
 
         <FormulateInput
-          name="chapterAmbassadorOrganizationCompanyName"
-          id="chapterAmbassadorOrganizationCompanyName"
-          type="text"
-          label="Company Name"
-          placeholder="Company Name"
-          validation="required"
-          validation-name="Company name"
-          @keyup="checkValidation"
-          @blur="checkValidation"
-        />
-
-        <FormulateInput
           name="chapterAmbassadorJobTitle"
           id="chapterAmbassadorJobTitle"
           type="text"
@@ -153,7 +141,6 @@ export default {
       if (document.getElementById('firstName').value.length === 0 ||
         document.getElementById('lastName').value.length === 0 ||
         document.getElementById('dateOfBirth').value.length === 0 ||
-        document.getElementById('chapterAmbassadorOrganizationCompanyName').value.length === 0 ||
         document.getElementById('chapterAmbassadorJobTitle').value.length === 0 ||
         document.getElementById('chapterAmbassadorBio').value.length < 100 ||
         validationErrorMessages.some((message) => {

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -76,25 +76,6 @@
           @keyup="checkValidation"
           @blur="checkValidation"
         />
-
-        <div class="chapter-ambassador-information">
-          <h2 class="registration-title">Set your personal summary</h2>
-
-          <p class="text-left pb-2">
-            Add a description of yourself to your profile to help students get to know you.
-            Entering at least 100 characters is required.
-            You can change this later.<span class="formulate-required-field">*</span>
-          </p>
-          <FormulateInput
-            name="chapterAmbassadorBio"
-            id="chapterAmbassadorBio"
-            type="textarea"
-            validation="required|min:100,length"
-            validation-name="Personal summary"
-            @keyup="checkValidation"
-            @blur="checkValidation"
-          />
-        </div>
       </div>
     </div>
 
@@ -142,7 +123,6 @@ export default {
         document.getElementById('lastName').value.length === 0 ||
         document.getElementById('dateOfBirth').value.length === 0 ||
         document.getElementById('chapterAmbassadorJobTitle').value.length === 0 ||
-        document.getElementById('chapterAmbassadorBio').value.length < 100 ||
         validationErrorMessages.some((message) => {
           return (
             message.indexOf('years old to participate') >= 0 ||

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -76,6 +76,16 @@
           @keyup="checkValidation"
           @blur="checkValidation"
         />
+
+        <FormulateInput
+          name="chapterOrganizationName"
+          id="chapterOrganizationName"
+          type="text"
+          label="Organization"
+          readOnly="true"
+          disabled="true"
+        />
+
       </div>
     </div>
 
@@ -89,6 +99,9 @@
 </template>
 
 <script>
+import axios from "axios"
+
+import { airbrake } from "utilities/utilities"
 import ContainerHeader from "./ContainerHeader";
 import ReferredBy from "./ReferredBy";
 import PreviousButton from "./PreviousButton";
@@ -104,6 +117,7 @@ export default {
   },
   data () {
     return {
+      inviteCode:  new URLSearchParams(document.location.search).get('invite_code'),
       genderOptions: [
         'Female',
         'Male',
@@ -114,6 +128,20 @@ export default {
     }
   },
   methods: {
+    async getOrganizationName() {
+      try {
+        const response = await axios.get('/api/registration/chapter_organization_name', {
+          params: { invite_code: this.inviteCode }
+        })
+
+        document.getElementById("chapterOrganizationName").value = response.data.chapterOrganizationName
+      }
+      catch(error) {
+        airbrake.notify({
+          error: `[REGISTRATION] Error getting chapter organization name - ${error.response.data}`
+        })
+      }
+    },
     checkValidation() {
       const validationErrorMessages = Array.from(
         document.getElementsByClassName('validation-error-message')
@@ -142,6 +170,9 @@ export default {
       type: Object,
       required: true
     }
+  },
+  async created() {
+    await this.getOrganizationName()
   }
 }
 </script>

--- a/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
+++ b/app/javascript/new_registration/components/ChapterAmbassadorStepTwo.vue
@@ -86,6 +86,16 @@
           disabled="true"
         />
 
+        <FormulateInput
+          name="chapterAmbassadorOrganizationStatus"
+          :options="organizationStatusOptions"
+          type="select"
+          @keyup="checkValidation"
+          @blur="checkValidation"
+          label="Status with Organization"
+          id="organizationStatus"
+          input-class="ChapterAmbassadorSelectClass"
+        />
       </div>
     </div>
 
@@ -124,6 +134,10 @@ export default {
         'Non-binary',
         'Prefer not to say'
       ],
+      organizationStatusOptions: {
+        employee: 'Employee',
+        volunteer: 'Volunteer'
+      },
       hasValidationErrors: true
     }
   },

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -23,7 +23,7 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
 
   enum status: %i[pending approved declined spam]
 
-  validates :job_title, :bio, presence: true
+  validates :job_title, presence: true
 
   has_many :saved_searches, as: :searcher
 

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -23,10 +23,7 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
 
   enum status: %i[pending approved declined spam]
 
-  validates :organization_company_name,
-    :job_title,
-    :bio,
-    presence: true
+  validates :job_title, :bio, presence: true
 
   has_many :saved_searches, as: :searcher
 

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -22,6 +22,10 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
   after_update :after_status_changed, if: :saved_change_to_status?
 
   enum status: %i[pending approved declined spam]
+  enum organization_status: {
+    employee: "employee",
+    volunteer: "volunteer"
+  }
 
   validates :job_title, presence: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,8 @@ Rails.application.routes.draw do
 
       resources :mentor_expertises, only: :index
       resources :mentor_types, only: :index
+
+      resource :chapter_organization_name, only: :show
     end
 
     namespace :regional_pitch_events do

--- a/db/migrate/20240229195416_change_column_chapter_ambassador_organization_company_name.rb
+++ b/db/migrate/20240229195416_change_column_chapter_ambassador_organization_company_name.rb
@@ -1,0 +1,5 @@
+class ChangeColumnChapterAmbassadorOrganizationCompanyName < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:chapter_ambassador_profiles, :organization_company_name, true)
+  end
+end

--- a/db/migrate/20240229200318_add_organization_status_to_chapter_ambassador_profiles.rb
+++ b/db/migrate/20240229200318_add_organization_status_to_chapter_ambassador_profiles.rb
@@ -1,0 +1,17 @@
+class AddOrganizationStatusToChapterAmbassadorProfiles < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      CREATE TYPE chapter_ambassador_organization_status AS ENUM ('employee', 'volunteer');
+    SQL
+
+    add_column :chapter_ambassador_profiles, :organization_status, :chapter_ambassador_organization_status
+  end
+
+  def down
+    remove_column :chapter_ambassador_profiles, :organization_status
+
+    execute <<-SQL
+      DROP TYPE chapter_ambassador_organization_status;
+    SQL
+  end
+end

--- a/db/migrate/20240229201836_add_phone_number_to_chapter_ambassador_profiles.rb
+++ b/db/migrate/20240229201836_add_phone_number_to_chapter_ambassador_profiles.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToChapterAmbassadorProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :chapter_ambassador_profiles, :phone_number, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -52,6 +52,16 @@ COMMENT ON EXTENSION unaccent IS 'text search dictionary that removes accents';
 
 
 --
+-- Name: chapter_ambassador_organization_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.chapter_ambassador_organization_status AS ENUM (
+    'employee',
+    'volunteer'
+);
+
+
+--
 -- Name: judge_recusal_from_submission_reason; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -354,7 +364,8 @@ CREATE TABLE public.chapter_ambassador_profiles (
     intro_summary text,
     secondary_regions character varying[] DEFAULT '{}'::character varying[],
     program_name character varying,
-    chapter_id bigint
+    chapter_id bigint,
+    organization_status public.chapter_ambassador_organization_status
 );
 
 
@@ -3287,6 +3298,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240206173222'),
 ('20240208195151'),
 ('20240221211159'),
-('20240229195416');
+('20240229195416'),
+('20240229200318');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -344,7 +344,7 @@ ALTER SEQUENCE public.certificates_id_seq OWNED BY public.certificates.id;
 
 CREATE TABLE public.chapter_ambassador_profiles (
     id integer NOT NULL,
-    organization_company_name character varying NOT NULL,
+    organization_company_name character varying,
     job_title character varying NOT NULL,
     account_id integer NOT NULL,
     status integer DEFAULT 0 NOT NULL,
@@ -3286,6 +3286,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240202203636'),
 ('20240206173222'),
 ('20240208195151'),
-('20240221211159');
+('20240221211159'),
+('20240229195416');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -365,7 +365,8 @@ CREATE TABLE public.chapter_ambassador_profiles (
     secondary_regions character varying[] DEFAULT '{}'::character varying[],
     program_name character varying,
     chapter_id bigint,
-    organization_status public.chapter_ambassador_organization_status
+    organization_status public.chapter_ambassador_organization_status,
+    phone_number character varying
 );
 
 
@@ -3299,6 +3300,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240208195151'),
 ('20240221211159'),
 ('20240229195416'),
-('20240229200318');
+('20240229200318'),
+('20240229201836');
 
 

--- a/spec/factories/ambassadors.rb
+++ b/spec/factories/ambassadors.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
   ] do
     organization_company_name { "FactoryBot" }
     job_title { "Engineer" }
+    organization_status { "employee" }
     bio { "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus ut diam vel felis fringilla amet." }
 
     account

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -31,7 +31,6 @@ RSpec.feature "Chapter ambassadors registering", :js do
     select "Prefer not to say", from: "Gender Identity"
     fill_in "Birthday", with: 32.years.ago
     fill_in "Job Title", with: "Kindness spreader"
-    fill_in "chapterAmbassadorBio", with: "I am always brimming with hope, happiness, and positivity. I am the kind of bear that will tell you everything's going to be all right in the end. I see the silver lining around every dark cloud, and know that no matter how dire a situation may seem, there's always chance to make things better."
     click_button "Next"
 
     expect(page).to have_content("Data Use Terms")

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -30,7 +30,6 @@ RSpec.feature "Chapter ambassadors registering", :js do
     fill_in "Last Name", with: "Bear"
     select "Prefer not to say", from: "Gender Identity"
     fill_in "Birthday", with: 32.years.ago
-    fill_in "Company Name", with: "Care-a-Lot Inc."
     fill_in "Job Title", with: "Kindness spreader"
     fill_in "chapterAmbassadorBio", with: "I am always brimming with hope, happiness, and positivity. I am the kind of bear that will tell you everything's going to be all right in the end. I see the silver lining around every dark cloud, and know that no matter how dire a situation may seem, there's always chance to make things better."
     click_button "Next"


### PR DESCRIPTION
This will make a few changes to the registration flow for chapter ambassadors:
- Removing company name
- Removing personal summary
- Adding the chapter's organization name as a readonly field
  - This required a new API call to get the organization name that the invite code is associated with
- Adding "Status with Organization"
- Adding phone number