### PR TITLE
Update ChA button spec

### DIFF
--- a/spec/system/admin/add_chapter_ambassador_profile_to_account_spec.rb
+++ b/spec/system/admin/add_chapter_ambassador_profile_to_account_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Admin add chapter ambassador profile to an account" do
       chapter_ambassador = FactoryBot.create(:chapter_ambassador, :approved, intro_summary: "Here is my intro summary!")
 
       sign_in(chapter_ambassador)
+      click_link "Chapter Admin Activity"
       click_link "Participants"
 
       visit chapter_ambassador_participant_path(mentor.account)


### PR DESCRIPTION
This will update the spec to ensure the "Add Chapter Ambassador profile" button isn't available to chapter ambassadors; the spec is expecting to see/click on "Participants" after logging in, but on Preview, a chapter ambassador has to first click "Chapter Admin Activity", and then click "Participants", that's what is being updated here.

