### PR TITLE
Remove dob from checkr request

### DIFF
--- a/app/services/checkr_api_client/api_client.rb
+++ b/app/services/checkr_api_client/api_client.rb
@@ -85,7 +85,6 @@ module CheckrApiClient
         email: candidate.email,
         first_name: candidate.first_name,
         last_name: candidate.last_name,
-        dob: candidate.date_of_birth,
         work_locations: [{country: candidate.country_code}]
       }
 


### PR DESCRIPTION
Refs #4538 

Removes dob from the checkr request when creating a candidate. This was needed due to the change in DOB collection for ChA in #4537 