### PR TITLE
Restore force location functionality for students

### DIFF
--- a/app/controllers/concerns/force_location.rb
+++ b/app/controllers/concerns/force_location.rb
@@ -10,12 +10,12 @@ module ForceLocation
   def require_location
     return if request.xhr?
 
-    return if current_scope == "admin" || current_scope == "student"
+    return if current_scope == "admin"
 
     if logged_in_and_has_profile && !valid_location && !on_location_form
       redirect_to send(
-        "#{current_scope}_location_details_path",
-        return_to: send("#{current_scope}_dashboard_path")
+        :"#{current_scope}_location_details_path",
+        return_to: send(:"#{current_scope}_dashboard_path")
       ),
         notice: t("controllers.application.invalid_location") and return
     end
@@ -23,8 +23,8 @@ module ForceLocation
 
   def logged_in_and_has_profile
     current_account.authenticated? &&
-      current_account.respond_to?("#{current_scope}_profile") &&
-      !!current_account.send("#{current_scope}_profile")
+      current_account.respond_to?(:"#{current_scope}_profile") &&
+      !!current_account.send(:"#{current_scope}_profile")
   end
 
   def valid_location
@@ -38,7 +38,7 @@ module ForceLocation
     )
 
     location_form_path = Rails.application.routes.recognize_path(
-      send("#{current_scope}_location_details_path")
+      send(:"#{current_scope}_location_details_path")
     )
 
     original_request_path == location_form_path


### PR DESCRIPTION
This will bring back the force location (interrupt screen) functionality for students, making it so that they can't view their dashboard until they have entered their location. (This PR also includes some StandardRB formatting fixes for the relevant file.)