### PR TITLE
Parental consent "signed/pending" status bug

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -178,8 +178,8 @@ class AccountsGrid
   end
 
   column :parental_consent do |account, grid|
-    if account.student_profile.present? && account.parental_consent(grid.season).present?
-      account.parental_consent(grid.season).status
+    if account.student_profile&.parental_consent.present?
+      account.student_profile.parental_consent_signed?(grid.season) ? "Signed" : "Pending"
     else
       "-"
     end
@@ -265,7 +265,7 @@ class AccountsGrid
   column :actions, mandatory: true, html: true do |account, grid|
     html = link_to(
       "view",
-      send("#{current_scope}_participant_path", account),
+      send(:"#{current_scope}_participant_path", account),
       data: {turbolinks: false}
     )
 
@@ -337,7 +337,7 @@ class AccountsGrid
     if: ->(g) {
       (%w[judge student chapter_ambassador] & (g.scope_names || [])).empty?
     } do |value, scope, grid|
-      scope.send("#{value}_mentors")
+      scope.send(:"#{value}_mentors")
     end
 
   filter :onboarded_judges,

--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -363,7 +363,7 @@ class StudentProfile < ActiveRecord::Base
 
   def can_be_marked_onboarded?
     account.present? &&
-      signed_parental_consent.present? &&
+      parental_consent_signed? &&
       !account.email_confirmed_at.blank? &&
       account.valid_coordinates? &&
       account.terms_agreed_at?

--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -124,13 +124,13 @@ class StudentProfile < ActiveRecord::Base
     to: :parental_consent,
     prefix: true
 
-  def method_missing(method_name, *args)
+  def method_missing(method_name, *args) # standard:disable all
     # TODO: stop using this strategy
 
     super
   rescue
     begin
-      account.public_send(method_name, *args)
+      account.public_send(method_name, *args) # standard:disable all
     rescue
       raise NoMethodError,
         "undefined method `#{method_name}' not found for #{self}"
@@ -259,8 +259,8 @@ class StudentProfile < ActiveRecord::Base
     pending_team_invitations.detect { |i| i.team == team }
   end
 
-  def parental_consent_signed?
-    !!parental_consent && parental_consent.signed?
+  def parental_consent_signed?(season = Season.current.year)
+    parental_consents.by_season(season).any?(&:signed?)
   end
 
   def media_consent_signed?

--- a/app/views/admin/participants/_student_debugging.html.erb
+++ b/app/views/admin/participants/_student_debugging.html.erb
@@ -18,7 +18,7 @@
 
     <dt>Parental Consent</dt>
     <dd>
-      <% if profile.consent_signed? %>
+      <% if profile.parental_consent_signed? %>
         <%= web_icon("check-circle icon-green", text: "Signed! Yay!") %>
       <% else %>
         <%= web_icon("exclamation-circle icon-red",


### PR DESCRIPTION
I'm not sure how, but it's possible that a student can have multiple parental consent forms for a season. Our app cannot handle this if this happens, the participants datagrid can display a different result than the student profile debugging section, one could display signed and the other pending.

To fix this, I created one source, `parental_consent_signed?` to check if *any* of the parental consents for the season are signed, this method will be used in both the datagrid and the student profile debugging section.
