### PR TITLE
Addresses bug affecting teams when a student who is on that team already is converted to mentor 

### DIFF
--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -57,7 +57,7 @@ class Division < ActiveRecord::Base
     divisions = Membership.where(
       team: team,
       member_type: "StudentProfile"
-    ).map(&:member).collect { |student_profile| for_account(student_profile.account) }
+    ).map(&:member).compact.collect { |student_profile| for_account(student_profile.account) }
 
     return none_assigned_yet if divisions.blank?
 

--- a/app/services/student_to_mentor_converter.rb
+++ b/app/services/student_to_mentor_converter.rb
@@ -7,6 +7,7 @@ class StudentToMentorConverter
     if account.student_profile.present?
       create_mentor_profile
       delete_pending_join_requests
+      delete_team_memberships
       delete_student_profile
 
       Result.new(success?: true, message: {success: "#{account.name} has been successfully converted to a mentor"})
@@ -36,6 +37,10 @@ class StudentToMentorConverter
 
   def delete_pending_join_requests
     account.student_profile&.join_requests&.pending&.delete_all
+  end
+
+  def delete_team_memberships
+    account.student_profile&.memberships&.delete_all
   end
 
   def delete_student_profile

--- a/spec/services/student_to_mentor_converter_spec.rb
+++ b/spec/services/student_to_mentor_converter_spec.rb
@@ -13,6 +13,7 @@ describe StudentToMentorConverter do
     allow(account).to receive(:update_columns)
     allow(student_profile).to receive(:delete)
     allow(student_profile).to receive_message_chain(:join_requests, :pending, :delete_all)
+    allow(student_profile).to receive_message_chain(:memberships, :delete_all)
   end
 
   it "creates a mentor profile (that's marked as being a former student)" do
@@ -38,6 +39,12 @@ describe StudentToMentorConverter do
 
   it "deletes any pending join requests" do
     expect(student_profile).to receive_message_chain(:join_requests, :pending, :delete_all)
+
+    student_to_mentor_converter.call
+  end
+
+  it "deletes any team memberships" do
+    expect(student_profile).to receive_message_chain(:memberships, :delete_all)
 
     student_to_mentor_converter.call
   end


### PR DESCRIPTION
Refs #4574 

This PR addresses a bug related to student to mentor conversions. [More details on the ticket ](https://app.zenhub.com/workspaces/technovation-605271851956b1000ec2f24d/issues/gh/iridescent-cm/technovation-app/4574)

- Added compact method to remove any nil student profile elements
- Added `delete_team_memberships` method for student to mentor conversion