### PR TITLE
Adds ChA admin page/datagrid

### DIFF
--- a/app/controllers/admin/chapter_ambassadors_controller.rb
+++ b/app/controllers/admin/chapter_ambassadors_controller.rb
@@ -1,34 +1,8 @@
 module Admin
   class ChapterAmbassadorsController < AdminController
-    def index
-      params[:status] ||= :pending
-      params[:page] = 1 if params[:page].blank?
-      params[:per_page] = 15 if params[:per_page].blank?
+    include DatagridController
 
-      chapter_ambassadors = Account.joins(:chapter_ambassador_profile)
-        .where("chapter_ambassador_profiles.status = ?",
-          ChapterAmbassadorProfile.statuses[params.fetch(:status)])
-
-      unless params[:text].blank?
-        results = chapter_ambassadors.search({
-          query: {
-            query_string: {
-              query: params[:text]
-            }
-          },
-          from: 0,
-          size: 10_000
-        }).results
-
-        chapter_ambassadors = chapter_ambassadors.where(id: results.flat_map { |r| r._source.id })
-      end
-
-      @chapter_ambassadors = chapter_ambassadors.page(params[:page].to_i).per_page(params[:per_page].to_i)
-
-      if @chapter_ambassadors.empty?
-        @chapter_ambassadors = @chapter_ambassadors.page(1)
-      end
-    end
+    use_datagrid with: ChapterAmbassadorsGrid
 
     def show
       @chapter_ambassador = ChapterAmbassadorProfile.find_by(account_id: params.fetch(:id))
@@ -41,6 +15,13 @@ module Admin
       ambassador.public_send("#{params.fetch(:status)}!")
       redirect_back fallback_location: admin_chapter_ambassadors_path,
         success: "#{ambassador.full_name} was marked as #{params.fetch(:status)}"
+    end
+
+    def grid_params
+      grid = params[:chapter_ambassadors_grid] ||= {}
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
     end
   end
 end

--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -1,0 +1,156 @@
+class ChapterAmbassadorsGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Account.includes(:chapter_ambassador_profile).where.not(chapter_ambassador_profiles: {id: nil}).order(id: :desc)
+  end
+
+  column :name, header: "Chapters (Program Name)", mandatory: true, html: true do |account|
+    if account.chapter_ambassador_profile.chapter.present?
+      link_to(
+        account.chapter_ambassador_profile.chapter.name.presence || "-",
+        admin_chapter_path(account.chapter_ambassador_profile.chapter)
+      )
+    else
+      "No chapter"
+    end
+  end
+
+  column :chapter, header: "Chapter(Program Name)", html: false do |account|
+    if account.chapter_ambassador_profile.chapter.present?
+      account.chapter_ambassador_profile.chapter.name.presence || "-"
+    else
+      "No chapter"
+    end
+  end
+
+  column :organization_name, header: "Organization Name", mandatory: true do |account|
+    if account.chapter_ambassador_profile.chapter.present?
+      account.chapter_ambassador_profile.chapter.organization_name.presence || "-"
+    else
+      "No chapter"
+    end
+  end
+
+  column :organization_name, header: "Organization Name", html: false do |account|
+    if account.chapter_ambassador_profile.chapter.present?
+      account.chapter_ambassador_profile.chapter.organization_name.presence || "-"
+    else
+      "No chapter"
+    end
+  end
+
+  column :first_name, mandatory: true
+  column :last_name, mandatory: true
+  column :email, mandatory: true
+  column :id, header: "Participant ID"
+
+  column :gender, header: "Gender Identity" do
+    gender.presence || "-"
+  end
+
+  column :phone_number do
+    chapter_ambassador_profile.phone_number.presence || "-"
+  end
+
+  column :organization_status do
+    chapter_ambassador_profile.organization_status.presence || "-"
+  end
+
+  column :mentor, header: "Mentor?" do
+    mentor_profile.present? ? "yes" : "no"
+  end
+
+  column :city
+
+  column :state_province, header: "State" do
+    FriendlySubregion.call(self, prefix: false)
+  end
+
+  column :country do
+    FriendlyCountry.new(self).country_name
+  end
+
+  column :actions, mandatory: true, html: true do |account|
+    link_to(
+      "view",
+      send("#{current_scope}_participant_path", account),
+      data: {turbolinks: false}
+    )
+  end
+
+  filter :has_mentor_profile,
+    :enum,
+    select: [
+      ["Yes, is also a mentor", "yes"],
+      ["No", "no"]
+    ],
+    filter_group: "common" do |value, scope, grid|
+      is_is_not = (value === "yes") ? "IS NOT" : "IS"
+
+      scope.left_outer_joins(:mentor_profile).where(
+        "mentor_profiles.id #{is_is_not} NULL"
+      )
+  end
+
+  filter :assigned_to_chapter,
+    :enum,
+    select: [
+      ["Yes", "yes"],
+      ["No", "no"]
+    ],
+    filter_group: "common" do |value, scope, grid|
+      is_is_not = (value === "yes") ? "IS NOT" : "IS"
+
+      scope.left_outer_joins(:chapter_ambassador_profile).where(
+        "chapter_ambassador_profiles.chapter_id #{is_is_not} NULL"
+      )
+  end
+
+  filter :season,
+    :enum,
+    select: (2015..Season.current.year).to_a.reverse,
+    html: {
+      class: "and-or-field"
+    },
+    multiple: true do |value, scope, grid|
+    scope.by_season(value)
+  end
+
+
+  filter :name_email,
+    header: "Name or Email",
+    filter_group: "common" do |value, scope, grid|
+      names = value.strip.downcase.split(" ").map { |n|
+        I18n.transliterate(n).gsub("'", "''")
+      }
+      scope.fuzzy_search({
+        first_name: names.first,
+        last_name: names.last || names.first,
+        email: names.first
+      }, false)
+        .left_outer_joins(:chapter_ambassador_profile)
+    end
+
+  filter :program_name do |value, scope|
+    scope
+      .left_outer_joins(:chapter_ambassador_profile)
+      .left_outer_joins(chapter_ambassador_profile: :chapter)
+      .where("chapters.name ilike ?", "#{value}%")
+  end
+
+  filter :organization_name do |value, scope|
+    scope
+      .left_outer_joins(:chapter_ambassador_profile)
+      .left_outer_joins(chapter_ambassador_profile: :chapter)
+      .where("chapters.organization_name ilike ?", "#{value}%")
+  end
+
+  column_names_filter(
+    header: "More columns",
+    filter_group: "more-columns",
+    multiple: true
+  )
+end

--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -7,20 +7,14 @@ class ChapterAmbassadorsGrid
     Account.includes(:chapter_ambassador_profile).where.not(chapter_ambassador_profiles: {id: nil}).order(id: :desc)
   end
 
-  column :name, header: "Chapters (Program Name)", mandatory: true, html: true do |account|
+  column :name, header: "Chapters (Program Name)", mandatory: true do |account|
     if account.chapter_ambassador_profile.chapter.present?
-      link_to(
-        account.chapter_ambassador_profile.chapter.name.presence || "-",
-        admin_chapter_path(account.chapter_ambassador_profile.chapter)
-      )
-    else
-      "No chapter"
-    end
-  end
-
-  column :chapter, header: "Chapter(Program Name)", html: false do |account|
-    if account.chapter_ambassador_profile.chapter.present?
-      account.chapter_ambassador_profile.chapter.name.presence || "-"
+      format(account.name) do
+        link_to(
+          account.chapter_ambassador_profile.chapter.name.presence || "-",
+          admin_chapter_path(account.chapter_ambassador_profile.chapter)
+        )
+      end
     else
       "No chapter"
     end
@@ -30,15 +24,7 @@ class ChapterAmbassadorsGrid
     if account.chapter_ambassador_profile.chapter.present?
       account.chapter_ambassador_profile.chapter.organization_name.presence || "-"
     else
-      "No chapter"
-    end
-  end
-
-  column :organization_name, header: "Organization Name", html: false do |account|
-    if account.chapter_ambassador_profile.chapter.present?
-      account.chapter_ambassador_profile.chapter.organization_name.presence || "-"
-    else
-      "No chapter"
+      "No organization"
     end
   end
 
@@ -118,7 +104,6 @@ class ChapterAmbassadorsGrid
     multiple: true do |value, scope, grid|
     scope.by_season(value)
   end
-
 
   filter :name_email,
     header: "Name or Email",

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -78,6 +78,10 @@
                 admin_chapters_path,
       class: al(admin_chapters_path) %>
 
+    <%= link_to "Chapter Ambassadors",
+                admin_chapter_ambassadors_path,
+      class: al(admin_chapter_ambassadors_path) %>
+
     <%= link_to "Background jobs",
       "/sidekiq",
       target: :_blank,

--- a/app/views/admin/chapter_ambassadors/index.html.erb
+++ b/app/views/admin/chapter_ambassadors/index.html.erb
@@ -1,0 +1,11 @@
+<div class="grid margin--t-xlarge">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <h3>View Chapter Ambassadors</h3>
+
+      <%= render 'datagrid/datagrid',
+                 grid: @chapter_ambassadors_grid,
+                 form_url: admin_chapter_ambassadors_path,
+                 model_name: "chapter_ambassador",
+                 scope: :admin %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,8 @@ Rails.application.routes.draw do
       resources :invites, only: :create, controller: "chapter_invites"
     end
 
+    resources :chapter_ambassadors, only: :index
+
     resources :chapter_ambassador_status, only: :update
 
     resources :profile_locations, only: :edit


### PR DESCRIPTION
Refs #4465 

Adds the Chapter Ambassador admin datagrid & page

Interestingly, I found an [old commit](https://github.com/Iridescent-CM/technovation-app/commit/942ebf42798616f99bd087ab2bac4aadc5c5b796) that looks like it removed a ChA admin management page! 🤔 
![CleanShot 2024-03-25 at 15 15 29@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/2ec4d4e4-d5ef-41c5-b22e-77eaa4c761fa)
