### PR TITLE
4609 add sidenav to cha profile

### DIFF
--- a/app/controllers/chapter_ambassador/location_details_controller.rb
+++ b/app/controllers/chapter_ambassador/location_details_controller.rb
@@ -4,10 +4,6 @@ module ChapterAmbassador
 
     layout "chapter_ambassador_rebrand"
 
-    def show
-      render template: "location_details/show"
-    end
-
     private
 
     def current_profile

--- a/app/controllers/chapter_ambassador/program_information_controller.rb
+++ b/app/controllers/chapter_ambassador/program_information_controller.rb
@@ -1,0 +1,6 @@
+module ChapterAmbassador
+  class ProgramInformationController < ChapterAmbassadorController
+    layout "chapter_ambassador_rebrand"
+
+  end
+end

--- a/app/controllers/chapter_ambassador/public_information_controller.rb
+++ b/app/controllers/chapter_ambassador/public_information_controller.rb
@@ -1,0 +1,6 @@
+module ChapterAmbassador
+  class PublicInformationController < ChapterAmbassadorController
+    layout "chapter_ambassador_rebrand"
+
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,8 @@ module ApplicationHelper
       dashboards
       location_details
       profiles
+      program_information
+      public_information
       training_completions
       mous
     ]

--- a/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
@@ -2,9 +2,23 @@
     <ol role="list" class="space-y-6 mb-6 overflow-hidden">
       <%= render "application/templates/completion_step",
         name: "Public Info",
-        url: nil,
-        is_complete: nil,
-        is_active_item: nil
+        url: chapter_ambassador_public_information_path,
+        is_complete: false,
+        is_active_item: al(chapter_ambassador_public_information_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
+        name: "Chapter Location",
+        url: chapter_ambassador_location_details_path,
+        is_complete: false,
+        is_active_item: al(chapter_ambassador_location_details_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
+        name: "Program Info",
+        url: chapter_ambassador_program_information_path,
+        is_complete: false,
+        is_active_item: al(chapter_ambassador_program_information_path).present?
       %>
     </ol>
   </nav>

--- a/app/views/chapter_ambassador/location_details/show.en.html.erb
+++ b/app/views/chapter_ambassador/location_details/show.en.html.erb
@@ -1,0 +1,7 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Location Details" } do %>
+    <p>location details here</p>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/program_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/program_information/show.en.html.erb
@@ -1,0 +1,7 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Program Info" } do %>
+    <p>program details here</p>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/public_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/show.en.html.erb
@@ -1,0 +1,41 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Public Info" } do %>
+
+    <div>
+      <p class="mb-4">This information will be publicly visible to students, mentors, and visitors to the Technovation website.</p>
+
+      <% if current_ambassador.chapter.present? %>
+        <div class="ml-8">
+          <p class="font-semibold">Organization <span class="text-sm italic">(Pre-set by admin)</span></p>
+          <p class="mb-4"><%= current_ambassador.chapter.organization_name.presence || "Not set" %></p>
+
+          <p class="font-semibold">Chapter Name</p>
+          <p class="mb-4"><%= current_ambassador.chapter.name.presence || "Not set" %></p>
+
+          <p class="font-semibold">Program Summary</p>
+          <p class="mb-4"><%= current_ambassador.chapter.summary.presence || "Not set" %></p>
+
+          <p class="font-semibold">Program Links</p>
+          <p class="mb-4">Program Links here</p>
+
+          <p class="font-semibold">Primary Contact Visibility</p>
+          <p>Primary contact here</p>
+          <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
+
+          <p class="font-semibold">Public Map Visibility</p>
+          <p>This chapter <span class="font-semibold">is/is not</span> included on the map of chapters on the Technovation website</p>
+        </div>
+
+        <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
+          <%= link_to nil, "Update chapter public info",
+                      class: "tw-green-btn mx-auto" %>
+        </div>
+
+      <% else %>
+        <p>You are not associated with a chapter. Please contact ....</p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,6 @@ Rails.application.routes.draw do
   namespace :chapter_ambassador do
     resource :profile_details_confirmation, only: [:create, :update]
 
-    resource :location_details, only: :show
     resource :current_location, only: :show
     resource :location, only: [:update, :create]
 
@@ -144,7 +143,11 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show
     resources :data_analyses, only: :show
     resource :profile, only: [:show, :edit, :update]
+
     resource :chapter_profile, only: :show, controller: "chapter_profile"
+    resource :public_information, only: :show, controller: "public_information"
+    resource :location_details, only: :show
+    resource :program_information, only: :show, controller: "program_information"
 
     resource :introduction, only: [:edit, :update]
 


### PR DESCRIPTION
Refs #4609 & #4610. This may also include #4615 (placeholder containers for location and program info) but I will clarify next week. 

Adds sidenav links and placeholder containers (Pubic Info, Location Details, & Program Info) to the ChA Profile sidenav.

Also adds the public info text. Program links, visibility section, & update button are placeholders 


![CleanShot 2024-04-05 at 20 03 11@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/be667336-896d-42e9-9888-571d55d7dae3)
