### PR TITLE
Fixes issue where setting/updating location not available for ChAs

### DIFF
--- a/app/controllers/chapter_ambassador/chapter_locations_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_locations_controller.rb
@@ -1,0 +1,6 @@
+module ChapterAmbassador
+  class ChapterLocationsController < ChapterAmbassadorController
+    layout "chapter_ambassador_rebrand"
+
+  end
+end

--- a/app/controllers/chapter_ambassador/location_details_controller.rb
+++ b/app/controllers/chapter_ambassador/location_details_controller.rb
@@ -4,6 +4,10 @@ module ChapterAmbassador
 
     layout "chapter_ambassador_rebrand"
 
+    def show
+      render template: "location_details/show"
+    end
+
     private
 
     def current_profile

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,7 @@ module ApplicationHelper
     rebranded_chapter_ambassador_sections = %w[
       background_checks
       chapter_ambassador
+      chapter_locations
       chapter_profile
       dashboards
       location_details

--- a/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
@@ -2,6 +2,6 @@
   <%= render "chapter_ambassador/chapter_profile/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Location Details" } do %>
-    <p>location details here</p>
+    <p>chapter location details here</p>
   <% end %>
 </div>

--- a/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
@@ -9,9 +9,9 @@
 
       <%= render "application/templates/completion_step",
         name: "Chapter Location",
-        url: chapter_ambassador_location_details_path,
+        url: chapter_ambassador_chapter_location_path,
         is_complete: false,
-        is_active_item: al(chapter_ambassador_location_details_path).present?
+        is_active_item: al(chapter_ambassador_chapter_location_path).present?
       %>
 
       <%= render "application/templates/completion_step",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
 
     resource :current_location, only: :show
     resource :location, only: [:update, :create]
+    resource :location_details, only: :show
 
     resource :chapter_admin, only: :show, controller: "chapter_admin"
     resource :dashboard, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
 
     resource :chapter_profile, only: :show, controller: "chapter_profile"
     resource :public_information, only: :show, controller: "public_information"
-    resource :location_details, only: :show
+    resource :chapter_location, only: :show
     resource :program_information, only: :show, controller: "program_information"
 
     resource :introduction, only: [:edit, :update]


### PR DESCRIPTION
Refs #4626 

- Reverted original "location details" logic/routes so ChAs can set and update their location
- Added `chapter_location` route/controller so chapter location can eventually be set/updated

These change resolve the bug described in #4626. 