### PR TITLE
Select primary contact for chapter

### DIFF
--- a/app/controllers/chapter_ambassador/public_information_controller.rb
+++ b/app/controllers/chapter_ambassador/public_information_controller.rb
@@ -19,6 +19,7 @@ module ChapterAmbassador
       params.require(:chapter).permit(
         :name,
         :summary,
+        :primary_contact_id,
         regional_links_attributes: [
           :id,
           :_destroy,

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -8,6 +8,11 @@
           <dt>Organization</dt>
           <dd><%= @chapter.organization_name %></dd>
 
+          <dt>Primary Contact</dt>
+          <dd>
+            <%= @chapter.primary_contact.present? ? (link_to @chapter.primary_contact.full_name, admin_participant_path(@chapter.primary_contact.account)) : "Not Set" %>
+          </dd>
+
           <dt>Location</dt>
           <dd><%= @chapter.address_details.presence || "-" %></dd>
 

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for current_ambassador.chapter,
+<%= simple_form_for current_chapter,
   url: chapter_ambassador_public_information_path do |f| %>
 
   <div class="mb-4">
@@ -34,6 +34,18 @@
         <%= "character".pluralize((f.object.summary || "").length) %>
       </span>
     <% end %>
+  </div>
+
+  <div>
+    <%= f.input :primary_contact_id,
+                collection: current_chapter.chapter_ambassador_profiles,
+                prompt: "Select a primary contact",
+                label: "Primary Contact",
+                value_method: :id,
+                label_method: :full_name,
+                selected: current_chapter.primary_contact&.id %>
+
+    <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
   </div>
 
   <p class="mt-8">

--- a/app/views/chapter_ambassador/public_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/show.en.html.erb
@@ -21,7 +21,7 @@
           <p class="mb-4">Program Links here</p>
 
           <p class="font-semibold">Primary Contact Visibility</p>
-          <p>Primary contact here</p>
+          <%= current_chapter.primary_contact&.full_name.presence || "Please select a primary contact" %>
           <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
 
           <p class="font-semibold">Public Map Visibility</p>


### PR DESCRIPTION
Refs #4611 

This PR adds the following: 
- UI for ChAs  to select a primary contact on the edit form
- Displays the primary contact's full name (if set) on the ChA public info view
- Displays the primary contact's full name (if set) on the Admin Chapter details view