### PR TITLE
Add ability for ChAs to update their chapter's public map visibility status

### DIFF
--- a/app/controllers/chapter_ambassador/public_information_controller.rb
+++ b/app/controllers/chapter_ambassador/public_information_controller.rb
@@ -20,6 +20,7 @@ module ChapterAmbassador
         :name,
         :summary,
         :primary_contact_id,
+        :visible_on_map,
         regional_links_attributes: [
           :id,
           :_destroy,

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -30,6 +30,10 @@ class ChaptersGrid
       "#{value}%")
   end
 
+  filter(:visible_on_map, :xboolean)
+
+  column :visible_on_map, header: "Visible on map"
+
   column :actions, mandatory: true, html: true do |chapter|
     render "admin/chapters/actions", chapter: chapter
   end

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -16,6 +16,11 @@
           <dt>Location</dt>
           <dd><%= @chapter.address_details.presence || "-" %></dd>
 
+          <dt>Public Map Visibility</dt>
+          <dd>
+            <%= @chapter.visible_on_map? ?  "Display on map" : "Do not display on map"%>
+          </dd>
+
           <dt>Chapter Links</dt>
           <dd>
             <ul>

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -18,7 +18,7 @@
 
           <dt>Public Map Visibility</dt>
           <dd>
-            <%= @chapter.visible_on_map? ?  "Display on map" : "Do not display on map"%>
+            <%= @chapter.visible_on_map? ?  "Display on map" : "Do not display on map" %>
           </dd>
 
           <dt>Chapter Links</dt>

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -48,9 +48,29 @@
     <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
   </div>
 
+  <div>
+    <%= f.label :visible_on_map, "Public Map Visibility" %>
+
+    <p class="text-base">By default, this chapter will be included on the publicly visible
+      chapter map on the Technovation website. We will include
+      the following information:</p>
+
+    <ul class="list-disc text-base mb-4">
+      <li class="ml-8">Chapter Name</li>
+      <li class="ml-8">Name of the chapter ambassador set as the primary contact</li>
+      <li class="ml-8">Address of the organization headquarters</li>
+      <li class="ml-8">The first link set in the program links section</li>
+    </ul>
+
+    <%= f.input :visible_on_map,
+                as: :radio_buttons,
+                collection: [["Yes, display my chapter information", true], ["No, do not display my chapter information", false]],
+                label: false %>
+  </div>
+
   <p class="mt-8">
     <%= f.submit "Save", class: "tw-green-btn" %>
       or
-    <%= link_to 'cancel', chapter_ambassador_public_information_path %>
+    <%= link_to "cancel", chapter_ambassador_public_information_path %>
   </p>
 <% end %>

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -51,9 +51,11 @@
   <div>
     <%= f.label :visible_on_map, "Public Map Visibility" %>
 
-    <p class="text-base">By default, this chapter will be included on the publicly visible
+    <p class="text-base">
+      By default, this chapter will be included on the publicly visible
       chapter map on the Technovation website. We will include
-      the following information:</p>
+      the following information:
+    </p>
 
     <ul class="list-disc text-base mb-4">
       <li class="ml-8">Chapter Name</li>

--- a/app/views/chapter_ambassador/public_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/show.en.html.erb
@@ -25,7 +25,8 @@
           <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
 
           <p class="font-semibold">Public Map Visibility</p>
-          <p>This chapter <%= current_chapter.visible_on_map? ? "is" : "is not" %>
+          <p>
+            This chapter <%= current_chapter.visible_on_map? ? "is" : "is not" %>
             displayed on the map of chapters on the Technovation website
           </p>
         </div>

--- a/app/views/chapter_ambassador/public_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/show.en.html.erb
@@ -25,7 +25,9 @@
           <p class="text-sm italic mb-4">This Chapter Ambassador is the primary contact displayed to students and mentors</p>
 
           <p class="font-semibold">Public Map Visibility</p>
-          <p>This chapter <span class="font-semibold">is/is not</span> included on the map of chapters on the Technovation website</p>
+          <p>This chapter <%= current_chapter.visible_on_map? ? "is" : "is not" %>
+            displayed on the map of chapters on the Technovation website
+          </p>
         </div>
 
         <div class="w-full lg:w-1/3 flex mt-8 mx-auto">

--- a/db/migrate/20240417195826_add_visible_on_map_to_chapters.rb
+++ b/db/migrate/20240417195826_add_visible_on_map_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddVisibleOnMapToChapters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :chapters, :visible_on_map, :boolean, default: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -403,7 +403,8 @@ CREATE TABLE public.chapters (
     city character varying,
     state_province character varying,
     country character varying,
-    primary_contact_id bigint
+    primary_contact_id bigint,
+    visible_on_map boolean DEFAULT true
 );
 
 
@@ -3469,4 +3470,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240321122808'),
 ('20240321123201'),
 ('20240326155545'),
-('20240415201850');
+('20240415201850'),
+('20240417195826');

--- a/spec/factories/ambassadors.rb
+++ b/spec/factories/ambassadors.rb
@@ -45,6 +45,13 @@ FactoryBot.define do
       end
     end
 
+    trait :assigned_to_chapter do
+      before(:create) do |c|
+        chapter = FactoryBot.create(:chapter)
+        c.chapter_id = chapter.id
+      end
+    end
+
     before(:create) do |r, e|
       {
         city: e.city,

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :chapter do
     sequence(:name) { |n| "FactoryBot Program #{n}" }
     sequence(:organization_name) { |n| "FactoryBot Organization #{n}" }
+    visible_on_map { true }
   end
 end

--- a/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Chapter ambassadors edit public chapter information" do
+  let(:chapter) { FactoryBot.create(:chapter) }
+
+  before do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+    sign_in(chapter_ambassador)
+    click_link "Chapter Profile"
+    click_link "Public Info"
+  end
+
+  scenario "Chapter ambassador edits their public chapter information" do
+    click_link "Update chapter public info"
+
+    expect(page).to have_checked_field('chapter_visible_on_map_true')
+
+    fill_in "chapter_name", with: "Chapter Legoland"
+    fill_in "chapter_summary", with: "Hello this is our awesome chapter!"
+    click_button "Save"
+
+    expect(page).to have_content "Chapter Legoland"
+    expect(page).to have_content "Hello this is our awesome chapter!"
+  end
+
+  scenario "Chapter ambassador changes their public chapter visibility status to 'do not display'" do
+    expect(page).to have_content "This chapter is displayed on the map of chapters on the Technovation website"
+    click_link "Update chapter public info"
+
+    choose("chapter_visible_on_map_false")
+    click_button "Save"
+
+    expect(page).to have_content "This chapter is not displayed on the map of chapters on the Technovation website"
+  end
+end

--- a/spec/features/chapter_ambassador/view_chapter_public_information_spec.rb
+++ b/spec/features/chapter_ambassador/view_chapter_public_information_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.feature "Chapter Ambassadors can click on chapter profile tab" do
+  let(:chapter) { FactoryBot.create(:chapter) }
+
+  scenario "All Chapter Details links are visible in the side navigation" do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+
+    within("#tab-wrapper") do
+      expect(page).to have_link("Public Info")
+      expect(page).to have_link("Chapter Location")
+      expect(page).to have_link("Program Info")
+    end
+  end
+
+  scenario "A Chapter Ambassador assigned to a chapter can view chapter public information" do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Public Info"
+
+    expect(page).to have_content(chapter.organization_name)
+    expect(page).to have_content(chapter.name)
+    expect(page).to have_content("Please select a primary contact")
+    expect(page).to have_content("This chapter is displayed on the map of chapters on the Technovation website")
+  end
+
+  scenario "A Chapter Ambassador not assigned to a chapter does not see chapter public information" do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador)
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Public Info"
+
+    expect(page).to have_content("You are not associated with a chapter.")
+  end
+end


### PR DESCRIPTION
Refs #4642 

This PR adds the following
- Ability for ChAs to change their chapter public visibility setting
- Basic specs for chapter public info features

![CleanShot 2024-04-17 at 16 01 25@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/18983c4a-b4f8-49dc-a0a2-a1932085c7ab)
