### PR TITLE
Add view/edit judge types for admin and judge profile

### DIFF
--- a/app/controllers/judge/profiles_controller.rb
+++ b/app/controllers/judge/profiles_controller.rb
@@ -10,7 +10,8 @@ module Judge
         :industry_other,
         :skills,
         :degree,
-        :survey_completed
+        :survey_completed,
+        judge_type_ids: []
       ]
     end
 

--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -39,6 +39,14 @@ class AccountsGrid
     end
   end
 
+  column :judge_types do
+    if judge_profile.present?
+      judge_profile.judge_profile_judge_types.joins(:judge_type).pluck(:name).join(", ")
+    else
+      "-"
+    end
+  end
+
   column :judge_industry do
     if judge_profile.present?
       judge_profile.industry_text
@@ -542,6 +550,20 @@ class AccountsGrid
     scope.includes(mentor_profile: :mentor_types)
       .references(:mentor_profiles, :mentor_profile_mentor_types)
       .where(mentor_profile_mentor_types: {mentor_type_id: values})
+  end
+
+  filter :judge_types,
+    :enum,
+    header: "Judge Type",
+    select: proc { JudgeType.all.map { |j| [j.name, j.id] } },
+    filter_group: "more-specific",
+    html: {
+      class: "and-or-field"
+    },
+    multiple: true do |values, scope|
+    scope.includes(judge_profile: :judge_types)
+      .references(:judge_profile, :judge_profile_judge_types)
+      .where(judge_profile_judge_types: {judge_type_id: values})
   end
 
   filter :country,

--- a/app/views/admin/participants/_judge_profile.en.html.erb
+++ b/app/views/admin/participants/_judge_profile.en.html.erb
@@ -7,10 +7,14 @@
 
   <dt><%= t('models.judge_profile.judge_types') %></dt>
   <dd>
-    <ul>
-      <% profile.judge_types.each do |judge_type| %>
-        <li><%= judge_type.name %></li>
-      <% end %>
-    </ul>
+    <% if profile.judge_types.any? %>
+      <ul>
+        <% profile.judge_types.each do |judge_type| %>
+          <li><%= judge_type.name %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      No judge types selected
+    <% end %>
   </dd>
 </dl>

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -99,6 +99,33 @@
     <% end %>
     <br>
 
+    <% if f.object.judge_profile.present? %>
+      <%= f.fields_for :judge_profile do |m| %>
+        <p>
+          <%= m.label :judge_types %>
+
+          <%= m.collection_check_boxes :judge_type_ids, JudgeType.all, :id, :name,
+            checked: ->(value) { f.object.judge_profile.judge_types.include?(value) } do |b| %>
+
+           <%= b.check_box %>
+           <%= b.label %>
+           <br>
+         <% end %>
+        </p>
+
+        <% if f.object.judge_profile.errors.present? %>
+          <ul class="list--reset field_with_errors">
+            <% f.object.judge_profile.errors.each do |error| %>
+              <li class="error">
+                <%= error.message %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    <% end %>
+    <br>
+
     <p>
       <%= f.label :profile_image %>
 

--- a/app/views/judge/profiles/rebrand/_basic.en.html.erb
+++ b/app/views/judge/profiles/rebrand/_basic.en.html.erb
@@ -15,6 +15,19 @@
 
       <dt>Job title</dt>
       <dd><%= current_judge.job_title %></dd>
+
+      <dt>Judge Type</dt>
+      <dd>
+        <% if current_judge.judge_types.any? %>
+          <ul class="list-disc">
+            <% current_judge.judge_types.each do |judge_type| %>
+              <li class="ml-8"><%= judge_type.name %></li>
+            <% end %>
+          </ul>
+        <% else %>
+          No judge types selected
+        <% end %>
+      </dd>
     </dl>
 
     <span class="mt-8">

--- a/app/views/signups/_judge_profile_fields.html.erb
+++ b/app/views/signups/_judge_profile_fields.html.erb
@@ -9,3 +9,8 @@
   label: "School or company name" %>
 
 <%= f.input :job_title %>
+
+<div class="mb-8">
+  <h4 class="text-base"><%= t('views.judge.form.judge_types') %></h4>
+  <%= f.association :judge_types, as: :check_boxes, label: false %>
+</div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -103,6 +103,10 @@ en:
         message: "Review their profile and respond below"
         missing: "Sorry, but this request appears to be missing."
 
+    judge:
+      form:
+        judge_types: "As a judge you may call me a..."
+
     parental_consents:
       new:
         submit: "I agree"


### PR DESCRIPTION
Refs #4573 

This PR adds the following
- Judge Profile: View & Edit judge type from basic profile details
- Admin Profile: View judge type in datagrid
- Admin Profile: Edit judge type in participants edit