### PR TITLE
Updated the live_event_eligible account scope to include chapter ambassador profiles that have a pending status

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -184,7 +184,8 @@ class Account < ActiveRecord::Base
         "judge_profiles.id IS NOT NULL AND " +
         # temporary fix, see: https://github.com/Iridescent-CM/technovation-app/issues/2111
         # "mentor_profiles.id IS NULL AND " +
-        "chapter_ambassador_profiles.id IS NULL"
+        "(chapter_ambassador_profiles.id IS NULL OR " +
+        "chapter_ambassador_profiles.status = #{ChapterAmbassadorProfile.statuses[:pending]})"
       )
   }
 

--- a/spec/models/attendees_spec.rb
+++ b/spec/models/attendees_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe Attendees do
 
     it "finds live event eligible judges" do
       judge = FactoryBot.create(:judge, :live_event_eligible)
-      FactoryBot.create(:chapter_ambassador, :has_judge_profile)
+      FactoryBot.create(:chapter_ambassador, :approved, :has_judge_profile)
+      2.times do
+        FactoryBot.create(:chapter_ambassador, :has_judge_profile)
+      end
 
       results = Attendees.for(
         type: "account",
@@ -32,8 +35,7 @@ RSpec.describe Attendees do
         event: event
       )
 
-      expect(results.count).to be 1
-      expect(results.first.record).to eq(judge.account)
+      expect(results.count).to be 3
     end
 
     it "finds user invitations" do


### PR DESCRIPTION
Refs #4662 

I updated the live_event_eligible account scope to include chapter ambassador profiles that have a status of pending. I will add a more detailed write-up on the ticket.