### PR TITLE
Adds length validation for chapter summary

### DIFF
--- a/app/controllers/chapter_ambassador/public_information_controller.rb
+++ b/app/controllers/chapter_ambassador/public_information_controller.rb
@@ -8,7 +8,7 @@ module ChapterAmbassador
         redirect_to chapter_ambassador_public_information_path,
                   success: "You updated your chapter public information!"
       else
-        flash.now[:alert] = "Error updating chapter details. Please try again later."
+        flash.now[:alert] = "Error updating chapter details."
         render :edit
       end
     end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -6,6 +6,8 @@ class Chapter < ActiveRecord::Base
   has_many :student_profiles
   has_many :registration_invites, class_name: "UserInvitation"
 
+  validates :summary, length: {maximum: 280}
+
   validates :legal_contact_email_address,
     email: true,
     if: -> { legal_contact_email_address.present? }

--- a/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
@@ -10,10 +10,10 @@ RSpec.feature "Chapter ambassadors edit public chapter information" do
     click_link "Public Info"
   end
 
-  scenario "Chapter ambassador edits their public chapter information" do
+  scenario "Chapter ambassador edits chapter name and chapter summary" do
     click_link "Update chapter public info"
 
-    expect(page).to have_checked_field('chapter_visible_on_map_true')
+    expect(page).to have_checked_field("chapter_visible_on_map_true")
 
     fill_in "chapter_name", with: "Chapter Legoland"
     fill_in "chapter_summary", with: "Hello this is our awesome chapter!"
@@ -21,6 +21,22 @@ RSpec.feature "Chapter ambassadors edit public chapter information" do
 
     expect(page).to have_content "Chapter Legoland"
     expect(page).to have_content "Hello this is our awesome chapter!"
+  end
+
+  scenario "Chapter ambassador saves a chapter summary longer than 280 characters" do
+    click_link "Update chapter public info"
+
+    fill_in "chapter_summary",
+            with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+              "Praesent luctus dapibus lacus vitae interdum. " +
+              "Praesent lacinia accumsan ligula, sit amet ultrices " +
+              "velit venenatis id. Duis ac nibh euismod, " +
+              "porta risus ut, molestie tortor. Nam quis nulla. Integer malesuada. " +
+              "In in enim a arcu imperdiet malesuada In in enim a arcu imperdiet malesuada."
+
+    click_button "Save"
+
+    expect(page).to have_css(".flash.flash--alert", text: "Error updating chapter details.")
   end
 
   scenario "Chapter ambassador changes their public chapter visibility status to 'do not display'" do


### PR DESCRIPTION
Refs #4643 

Adds validation to chapter summary so that a summary can be a max of 280 characters 