### PR TITLE
Mentor mode button

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -757,7 +757,9 @@ class Account < ActiveRecord::Base
     if is_an_ambassador?
       true
     elsif is_a_judge?
-      !!ENV.fetch("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", false)
+      !!ENV.fetch("ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR", false) ||
+        SeasonToggles.mentor_signup? ||
+        (!SeasonToggles.mentor_signup? && is_a_mentor?)
     else
       false
     end


### PR DESCRIPTION
This will make it so that judges have the option to switch to mentor mode, if:

- ENABLE_SWITCH_BETWEEN_JUDGE_AND_MENTOR is set to true OR
- mentor registration is open OR
- mentor registration is closed AND the judge already has a mentor profile
