### PR TITLE
Add host to Saleforce API calls

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -3,6 +3,7 @@ module Salesforce
     def initialize(
       enabled: ENV.fetch("ENABLE_SALESFORCE", false),
       instance_url: ENV.fetch("SALESFORCE_INSTANCE_URL"),
+      host: ENV.fetch("SALESFORCE_HOST"),
       api_version: ENV.fetch("SALESFORCE_API_VERSION"),
       client_id: ENV.fetch("SALESFORCE_CLIENT_ID"),
       client_secret: ENV.fetch("SALESFORCE_CLIENT_SECRET"),
@@ -18,6 +19,7 @@ module Salesforce
 
       @client = client_constructor.new(
         instance_url: instance_url,
+        host: host,
         api_version: api_version,
         client_id: client_id,
         client_secret: client_secret,

--- a/circle.yml
+++ b/circle.yml
@@ -94,6 +94,7 @@ jobs:
           MAILCHIMP_LIST_ID: n-a
           ENABLE_SALESFORCE: 0
           SALESFORCE_INSTANCE_URL: n-a
+          SALESFORCE_HOST: n-a
           SALESFORCE_API_VERSION: n-a
           SALESFORCE_CLIENT_ID: n-a
           SALESFORCE_CLIENT_SECRET: n-a

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Salesforce::ApiClient do
   let(:salesforce_api_client) do
     Salesforce::ApiClient.new(
       instance_url: salesforce_instance_url,
+      host: salesforce_host,
       api_version: salesforce_api_version,
       client_id: salesforce_client_id,
       client_secret: salesforce_client_secret,
@@ -18,6 +19,7 @@ RSpec.describe Salesforce::ApiClient do
   end
 
   let(:salesforce_instance_url) { "https://test-salesforce.com/" }
+  let(:salesforce_host) { "test.salesforce.com" }
   let(:salesforce_api_version) { "60" }
   let(:salesforce_client_id) { "1234-09876-5432" }
   let(:salesforce_client_secret) { "8766-qwerty-54321" }
@@ -32,6 +34,7 @@ RSpec.describe Salesforce::ApiClient do
   before do
     allow(client_constructor).to receive(:new).with(
       instance_url: salesforce_instance_url,
+      host: salesforce_host,
       api_version: salesforce_api_version,
       client_id: salesforce_client_id,
       client_secret: salesforce_client_secret,


### PR DESCRIPTION
By default if a host is not specified, Restforce will use the production host (`login.salesforce.com`), for the sandbox we need to use `test.salesforce.com`. The changes in this PR will allow us to specify which host to use so we can set it for the sandbox environment.

