### PR TITLE
Install Scout APM gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "redis"
 gem "sidekiq", "~> 7.0"
 
 gem "airbrake", "~> 11.0.3"
+gem "scout_apm"
 
 gem "dalli", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scout_apm (5.3.8)
+      parser
     selenium-webdriver (4.12.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -630,6 +632,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0)
   rspec-retry
   sass-rails (~> 6.0)
+  scout_apm
   selenium-webdriver
   sidekiq (~> 7.0)
   simple_form (~> 5.0)


### PR DESCRIPTION
This will install Scout to hopefully help us troubleshoot the memory issues on Production.

From the [setup guide](https://scoutapm.com/docs/ruby/setup), no configuration should be necessary for Production or QA, since those environments already have the Scout add-on.

> Heroku Customers: We initially provision your application using environment variables instead of the `config/scout_apm.yml`. Configuration values set via env variables will take priority over those set via yaml.

I checked both QA and Production and I see ENV settings for `SCOUT_KEY`, `SCOUT_LOG_LEVEL`, and `SCOUT_MONITOR`, so I think adding the gem is all that we need.

There's also a section of the setup guide on how to use Scout locally, if we want to add/configure that later:
https://scoutapm.com/docs/ruby/setup#local
