### PR TITLE
Only update registration invite if an invite code exists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "redis"
 gem "sidekiq", "~> 7.0"
 
 gem "airbrake", "~> 11.0.3"
+gem "scout_apm"
 
 gem "dalli", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scout_apm (5.3.8)
+      parser
     selenium-webdriver (4.12.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -630,6 +632,7 @@ DEPENDENCIES
   rspec-rails (~> 5.0)
   rspec-retry
   sass-rails (~> 6.0)
+  scout_apm
   selenium-webdriver
   sidekiq (~> 7.0)
   simple_form (~> 5.0)

--- a/app/controllers/new_registration_controller.rb
+++ b/app/controllers/new_registration_controller.rb
@@ -153,9 +153,11 @@ class NewRegistrationController < ApplicationController
   end
 
   def update_registration_invite
-    UpdateRegistrationInviteJob.perform_later(
-      invite_code: params[:inviteCode],
-      account_id: @profile.account.id
-    )
+    if params[:inviteCode].present?
+      UpdateRegistrationInviteJob.perform_later(
+        invite_code: params[:inviteCode],
+        account_id: @profile.account.id
+      )
+    end
   end
 end


### PR DESCRIPTION
This simple update will make it so that the `UpdateRegistrationInviteJob` will only get called if an invite code exists. I think this should help with all the failed jobs that don't have an invite code.

Randomly, I had already made this change on Preview, but of course isn't on QA/Production, doh!

https://github.com/Iridescent-CM/technovation-app/blob/16846f1df092d60197600f75a0ef0466c9844ea6/app/controllers/new_registration_controller.rb#L161-L166



