### PR TITLE
Add text and date fields for Chapter program info

### DIFF
--- a/app/controllers/chapter_ambassador/chapter_program_information_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_program_information_controller.rb
@@ -1,0 +1,49 @@
+module ChapterAmbassador
+  class ChapterProgramInformationController < ChapterAmbassadorController
+    layout "chapter_ambassador_rebrand"
+
+    def new
+      @chapter_program_information = current_chapter.build_chapter_program_information
+    end
+
+    def create
+      @chapter_program_information = current_chapter.build_chapter_program_information(chapter_program_information_params)
+
+      if @chapter_program_information.save
+        redirect_to chapter_ambassador_chapter_program_information_path,
+                    success: "You updated your chapter program information!"
+      else
+        flash.now[:alert] = "Error updating chapter program information."
+        render :new
+      end
+    end
+
+    def edit
+      @chapter_program_information = current_chapter.chapter_program_information
+    end
+
+    def update
+      if current_chapter.chapter_program_information.update(chapter_program_information_params)
+        redirect_to chapter_ambassador_chapter_program_information_path,
+                    success: "You updated your chapter program information!"
+      else
+        flash.now[:alert] = "Error updating chapter program information."
+        render :edit
+      end
+    end
+
+    private
+
+    def chapter_program_information_params
+      params.require(:chapter_program_information).permit(
+        :child_safeguarding_policy_and_process,
+        :team_structure,
+        :external_partnerships,
+        :start_date,
+        :launch_date,
+        :program_model,
+        :number_of_low_income_or_underserved_calculation
+      )
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
       dashboards
       location_details
       profiles
-      program_information
+      chapter_program_information
       public_information
       training_completions
       mous

--- a/app/inputs/date_time_input.rb
+++ b/app/inputs/date_time_input.rb
@@ -1,0 +1,5 @@
+class DateTimeInput < SimpleForm::Inputs::DateTimeInput
+  def input(wrapper_options)
+    template.content_tag(:div, super, class: "custom-simpleform-date")
+  end
+end

--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -84,3 +84,7 @@ html {
   flex-basis: 33.333333%;
 }
 
+.custom-simpleform-date {
+  @apply flex flex-row justify-between items-center;
+}
+

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -7,6 +7,7 @@ class Chapter < ActiveRecord::Base
   has_many :chapter_links, class_name: "RegionalLink"
   has_many :student_profiles
   has_many :registration_invites, class_name: "UserInvitation"
+  has_one :chapter_program_information
 
   accepts_nested_attributes_for :chapter_links, reject_if: ->(attrs) {
     attrs.reject { |k, _| k.to_s == "custom_label" }.values.any?(&:blank?)

--- a/app/models/chapter_program_information.rb
+++ b/app/models/chapter_program_information.rb
@@ -1,0 +1,6 @@
+class ChapterProgramInformation < ActiveRecord::Base
+  self.table_name = "chapter_program_information"
+
+  belongs_to :chapter
+
+end

--- a/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
@@ -16,9 +16,9 @@
 
       <%= render "application/templates/completion_step",
         name: "Program Info",
-        url: chapter_ambassador_program_information_path,
+        url: chapter_ambassador_chapter_program_information_path,
         is_complete: false,
-        is_active_item: al(chapter_ambassador_program_information_path).present?
+        is_active_item: al(chapter_ambassador_chapter_program_information_path).present?
       %>
     </ol>
   </nav>

--- a/app/views/chapter_ambassador/chapter_program_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_program_information/_form.en.html.erb
@@ -1,0 +1,94 @@
+<%= simple_form_for @chapter_program_information,
+  url: chapter_ambassador_chapter_program_information_path do |f| %>
+
+  <p class="mb-4">
+    All this information is private and will not be publicly displayed. You are required to enter a
+    response now, but you can go back later and edit the information. This information helps our
+    team support your local chapter to the best of our ability.
+    <br>
+    <span class="text-red-600 mb-4">
+      Note: Your responses will not autosave. Please click "save" at the bottom of the form to
+      save responses before exiting the page.
+    </span>
+  </p>
+
+  <div class="mb-8">
+    <%= f.label :child_safeguarding_policy_and_process,
+                t("chapters.program_information.child_safeguarding_policy_and_process_question"),
+                for: :child_safeguarding_policy_and_process %>
+    <p class="text-base"><%= t("chapters.program_information.child_safeguarding_policy_and_process_description") %></p>
+
+    <%= f.input :child_safeguarding_policy_and_process,
+                label: false,
+                as: :text,
+                input_html: {
+                  rows: 3,
+                } %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.input :team_structure,
+                label: t("chapters.program_information.team_structure_question"),
+                as: :text,
+                input_html: {
+                  rows: 3,
+                } %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.input :external_partnerships,
+                label: t("chapters.program_information.external_partnerships_question"),
+                as: :text,
+                input_html: {
+                  rows: 3,
+                } %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.input :start_date,
+                label: t("chapters.program_information.start_date_question") %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.input :launch_date,
+                label: t("chapters.program_information.launch_date_question") %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.label :program_model,
+                t("chapters.program_information.program_model_question"),
+                for: :program_model %>
+    <p class="text-base"><%= t("chapters.program_information.program_model_description") %></p>
+
+    <%= f.input :program_model,
+                label: false,
+                as: :text,
+                input_html: {
+                  rows: 3,
+                } %>
+  </div>
+
+  <div class="mb-8">
+    <%= f.label :number_of_low_income_or_underserved_calculation,
+                t("chapters.program_information.number_of_low_income_or_underserved_calculation_question"),
+                for: :number_of_low_income_or_underserved_calculation %>
+    <p class="text-base"><%= t("chapters.program_information.number_of_low_income_or_underserved_calculation_description") %></p>
+
+    <%= f.input :number_of_low_income_or_underserved_calculation,
+                label: false,
+                as: :text,
+                input_html: {
+                  rows: 3,
+                } %>
+  </div>
+
+  <div class="mt-8 w-full flex mx-auto">
+    <p class="flex flex-row mx-auto space-x-4">
+      <%= f.submit "Save", class: "tw-green-btn cursor-pointer" %>
+      <span class="flex flex-col justify-center text-center">or</span>
+      <%= link_to "cancel",
+                  chapter_ambassador_chapter_program_information_path,
+                  class: "flex flex-col justify-center text-center" %>
+    </p>
+  </div >
+<% end %>

--- a/app/views/chapter_ambassador/chapter_program_information/_program_information.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_program_information/_program_information.en.html.erb
@@ -1,0 +1,50 @@
+<div class="overflow-y-auto h-full">
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.child_safeguarding_policy_and_process_description") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.child_safeguarding_policy_and_process.presence || raw('<span class="text-red-500">Missing</span>') %>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.team_structure_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.team_structure.presence || raw('<span class="text-red-500">Missing</span>') %>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.external_partnerships_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.external_partnerships.presence || raw('<span class="text-red-500">Missing</span>') %>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.start_date_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.start_date.presence || raw('<span class="text-red-500">Missing</span>') %>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.launch_date_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.launch_date.presence || raw('<span class="text-red-500">Missing</span>') %>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.program_model_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.program_model.presence || raw('<span class="text-red-500">Missing</span>')%>
+    </p>
+  </div>
+
+  <div class="mb-4">
+    <p class="font-semibold"><%= t("chapters.program_information.number_of_low_income_or_underserved_calculation_question") %></p>
+    <p>
+      <%= current_chapter.chapter_program_information.number_of_low_income_or_underserved_calculation.presence || raw('<span class="text-red-500">Missing</span>')%>
+    </p>
+  </div>
+</div>

--- a/app/views/chapter_ambassador/chapter_program_information/edit.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_program_information/edit.en.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Update Chapter Public Info" } do %>
+    <div>
+      <% if current_ambassador.chapter.present? %>
+        <%= render "chapter_ambassador/chapter_program_information/form"%>
+      <% else %>
+        <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/chapter_program_information/new.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_program_information/new.en.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Public Info" } do %>
+    <div>
+      <% if current_ambassador.chapter.present? %>
+        <%= render "chapter_ambassador/chapter_program_information/form"%>
+      <% else %>
+        <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/chapter_program_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_program_information/show.en.html.erb
@@ -1,0 +1,29 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Program Info" } do %>
+    <div>
+      <p class="mb-4">
+        All this information is private and will not be publicly displayed. You are required to enter a
+        response now, but you can go back later and edit the information. This information helps our
+        team support your local chapter to the best of our ability.
+      </p>
+
+      <% if current_chapter.chapter_program_information.present? %>
+        <%= render "chapter_ambassador/chapter_program_information/program_information"%>
+      <% end %>
+
+      <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
+        <% if current_chapter.chapter_program_information.present? %>
+          <%= link_to "Update chapter program info",
+                      edit_chapter_ambassador_chapter_program_information_path,
+                      class: "tw-green-btn mx-auto" %>
+        <% else %>
+          <%= link_to "Get started",
+                      new_chapter_ambassador_chapter_program_information_path,
+                      class: "tw-green-btn mx-auto" %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/views/chapters/en.yml
+++ b/config/locales/views/chapters/en.yml
@@ -1,0 +1,19 @@
+en:
+  chapters:
+    program_information:
+      organization_type_question: "Is your organization a:"
+      child_safeguarding_policy_and_process_question: What is your child safeguarding policy and process?
+      child_safeguarding_policy_and_process_description: Please describe if/how you conduct background checks, hold child protection trainings, safety reporting process, etc. If your policies are available online, please share the links.
+      team_structure_question: If you work with a team at your organization, please tell us about your team's structure and the roles they play in executing the Technovation program.
+      external_partnerships_question: What key external partnerships do you maintain to enhance your program implementation efforts? This may include collaborations with companies, schools, and government agencies.
+      start_date_question: When do you estimate will be the start of your Technovation Girls program this season?
+      launch_date_question: If you are planning a Launch Event or info session please share the date.
+      program_model_question: Tell us about your Technovation program model
+      program_model_description: For example, a 9-week summer camp in partnership with local schools to engage students. We host 3 to 4-hour workshops facilitated by teachers and corporate volunteers at Happiness University or other universities that provide space. Beverages and snacks are provided.
+      meeting_time_question: When do you plan to hold meetings for your participants?
+      program_length_question: How long are you planning to run your Technovation program?
+      meeting_facilitator_question: Who will facilitate the meetings for your students?
+      number_of_participants_question: How many participants do you anticipate serving with the program this year?
+      number_of_low_income_or_underserved_question: What percentage of the participants you plan to serve are low-income and/or under-resourced?
+      number_of_low_income_or_underserved_calculation_question: Please describe how you identified the percentage of low-income or under-resourced students for the previous question. Include any relevant information about your students' communities.
+      number_of_low_income_or_underserved_calculation_description: "Ex: Free/reduced lunch data, household income data, firsthand knowledge etc."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,8 @@ Rails.application.routes.draw do
     resource :chapter_profile, only: :show, controller: "chapter_profile"
     resource :public_information, only: [:show, :edit, :update], controller: "public_information"
     resource :chapter_location, only: [:show, :edit, :update]
-    resource :program_information, only: :show, controller: "program_information"
+    resource :chapter_program_information, only: [:show, :edit, :update, :new, :create], controller: "chapter_program_information"
+
 
     resource :introduction, only: [:edit, :update]
 

--- a/db/migrate/20240502005925_create_chapter_program_information.rb
+++ b/db/migrate/20240502005925_create_chapter_program_information.rb
@@ -1,0 +1,16 @@
+class CreateChapterProgramInformation < ActiveRecord::Migration[6.1]
+  def change
+    create_table :chapter_program_information do |t|
+      t.references :chapter, foreign_key: true
+      t.text :child_safeguarding_policy_and_process
+      t.text :team_structure
+      t.text :external_partnerships
+      t.date :start_date
+      t.date :launch_date
+      t.text :program_model
+      t.text :number_of_low_income_or_underserved_calculation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -392,6 +392,44 @@ ALTER SEQUENCE public.chapter_ambassador_profiles_id_seq OWNED BY public.chapter
 
 
 --
+-- Name: chapter_program_information; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.chapter_program_information (
+    id bigint NOT NULL,
+    chapter_id bigint,
+    child_safeguarding_policy_and_process text,
+    team_structure text,
+    external_partnerships text,
+    start_date date,
+    launch_date date,
+    program_model text,
+    number_of_low_income_or_underserved_calculation text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: chapter_program_information_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.chapter_program_information_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: chapter_program_information_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.chapter_program_information_id_seq OWNED BY public.chapter_program_information.id;
+
+
+--
 -- Name: chapters; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1864,6 +1902,13 @@ ALTER TABLE ONLY public.chapter_ambassador_profiles ALTER COLUMN id SET DEFAULT 
 
 
 --
+-- Name: chapter_program_information id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chapter_program_information ALTER COLUMN id SET DEFAULT nextval('public.chapter_program_information_id_seq'::regclass);
+
+
+--
 -- Name: chapters id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2170,6 +2215,14 @@ ALTER TABLE ONLY public.certificates
 
 ALTER TABLE ONLY public.chapter_ambassador_profiles
     ADD CONSTRAINT chapter_ambassador_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chapter_program_information chapter_program_information_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chapter_program_information
+    ADD CONSTRAINT chapter_program_information_pkey PRIMARY KEY (id);
 
 
 --
@@ -2591,6 +2644,13 @@ CREATE INDEX index_chapter_ambassador_profiles_on_chapter_id ON public.chapter_a
 --
 
 CREATE INDEX index_chapter_ambassador_profiles_on_status ON public.chapter_ambassador_profiles USING btree (status);
+
+
+--
+-- Name: index_chapter_program_information_on_chapter_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_chapter_program_information_on_chapter_id ON public.chapter_program_information USING btree (chapter_id);
 
 
 --
@@ -3241,6 +3301,14 @@ ALTER TABLE ONLY public.teams
 
 
 --
+-- Name: chapter_program_information fk_rails_ff5375610f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.chapter_program_information
+    ADD CONSTRAINT fk_rails_ff5375610f FOREIGN KEY (chapter_id) REFERENCES public.chapters(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -3495,6 +3563,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240417195826'),
 ('20240418152235'),
 ('20240424214507'),
-('20240425120120');
-
-
+('20240425120120'),
+('20240502005925');


### PR DESCRIPTION
Refs #4644 

Adds basic functionality for ChAs to create/edit their chapter program information needed for PT support. This only includes text and date fields. #4698 will add the other fields

![CleanShot 2024-05-03 at 11 06 37@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/105673c0-bf07-4cb3-a560-9fb8842b0dfb)

![CleanShot 2024-05-03 at 11 06 48@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/fc604f91-5c02-4603-804f-013476b5e547)

