### PR TITLE
Updates for completed, recused scores

### DIFF
--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -83,7 +83,7 @@ module Judge
       score = current_judge.submission_scores.find(params[:score_id])
 
       if score.update(score_params.merge({judge_recusal: true, completed_at: nil, approved_at: nil}))
-        flash[:success] = "You have been sucessfully recused from this submission"
+        flash[:success] = "You have been successfully recused from this submission"
       else
         flash[:error] = "There was a problem, please try again"
       end

--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -82,7 +82,7 @@ module Judge
     def judge_recusal
       score = current_judge.submission_scores.find(params[:score_id])
 
-      if score.update(score_params.merge({judge_recusal: true}))
+      if score.update(score_params.merge({judge_recusal: true, completed_at: nil, approved_at: nil}))
         flash[:success] = "You have been sucessfully recused from this submission"
       else
         flash[:error] = "There was a problem, please try again"

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -177,7 +177,7 @@ class SubmissionScore < ActiveRecord::Base
       ] => "recusal_scores_count"
     }
 
-  scope :complete, -> { where("submission_scores.completed_at IS NOT NULL") }
+  scope :complete, -> { where("submission_scores.completed_at IS NOT NULL AND submission_scores.judge_recusal = FALSE") }
   scope :incomplete, -> { where("submission_scores.completed_at IS NULL AND submission_scores.judge_recusal = FALSE") }
   scope :complete_and_incomplete_without_recused, -> { where("submission_scores.judge_recusal = FALSE") }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,15 +7316,10 @@ nan@^2.12.1, nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^3.1.28:
-  version "3.1.28"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.28.tgz#3c01bac14cb6c5680569014cc65a2f26424c6bd4"
-  integrity sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw==
-
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+nanoid@^3.1.28, nanoid@^3.3.4:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
Somehow its possible for a score to be both completed and recused. This will make two changes related to this:
- If a score is both recused and completed, that score will only get displayed under the recused section
- When a score is recused and it happens to be completed, the score will get marked as incomplete and unapproved
  - This will help prevent scores from getting into this state, I also think it would still be possible for a judge to recuse themselves and then we reassign them the same submission