### PR TITLE
Add legal agreement details to chapter's datagrid

### DIFF
--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -32,6 +32,18 @@ class ChaptersGrid
 
   filter(:visible_on_map, :xboolean)
 
+  column :legal_agreement_status do
+    if legal_document.present?
+      legal_document.signed? ? "Signed" : "Not signed"
+    else
+      "Not sent"
+    end
+  end
+
+  column :legal_agreement_valid_for do
+    legal_contact&.seasons_legal_agreement_is_valid_for&.join(", ")
+  end
+
   column :visible_on_map, header: "Visible on map"
 
   column :actions, mandatory: true, html: true do |chapter|

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -30,6 +30,19 @@ class ChaptersGrid
       "#{value}%")
   end
 
+  filter :legal_agreement_status,
+    :enum,
+    select: ["Signed", "Not signed", "Not sent"] do |value|
+      case value
+      when "Signed"
+        signed_legal_agreements
+      when "Not signed"
+        not_signed_legal_agreements
+      when "Not sent"
+        not_sent_legal_agreements
+      end
+    end
+
   filter(:visible_on_map, :xboolean)
 
   column :legal_agreement_status do

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -17,6 +17,22 @@ class Chapter < ActiveRecord::Base
 
   validates :summary, length: {maximum: 280}
 
+  scope :signed_legal_agreements, -> {
+    joins(legal_contact: :documents)
+      .where("documents.active = TRUE AND documents.signed_at IS NOT NULL")
+  }
+
+  scope :not_signed_legal_agreements, -> {
+    joins(legal_contact: :documents)
+      .where("documents.active = TRUE AND documents.signed_at IS NULL")
+  }
+
+  scope :not_sent_legal_agreements, -> {
+    left_joins(legal_contact: :documents)
+      .where("documents.active != TRUE OR documents.active IS NULL")
+      .where("documents.id IS NULL")
+  }
+
   delegate :seasons_legal_agreement_is_valid_for, to: :legal_contact
 
   def legal_document


### PR DESCRIPTION
For the chapter's datagrid, this will:

- Add these extra columns:
  - Legal agreement status
  - Legal agreement valid for

- Add a new filter:
  - Legal agreement status, with the following filterable options:
    - Signed
    - Not signed
    - Not sent