### PR TITLE
Add events to scored submissions datagrid

### DIFF
--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -66,15 +66,19 @@ class ScoredSubmissionsGrid
     end
   end
 
+  column :events do |submission|
+    submission.team.events.pluck(:name).join("; ")
+  end
+
   column :complete_scores, mandatory: true do |asset, grid|
     asset.public_send(
-      "complete_#{grid.round}_official_submission_scores_count"
+      :"complete_#{grid.round}_official_submission_scores_count"
     )
   end
 
   column :incomplete_scores, mandatory: true do |asset, grid|
     asset.public_send(
-      "pending_#{grid.round}_official_submission_scores_count"
+      :"pending_#{grid.round}_official_submission_scores_count"
     )
   end
 


### PR DESCRIPTION
This will add an additional column for Events on the scored submissions datagrid (on the Scores page).


