### PR TITLE
Saved search for scores export bug

### DIFF
--- a/app/controllers/concerns/saved_search_controller.rb
+++ b/app/controllers/concerns/saved_search_controller.rb
@@ -19,7 +19,9 @@ module SavedSearchController
       "#{current_scope}_team_submissions_path"
     when "judges_grid"
       "#{current_scope}_judges_path"
-    when "scores_grid", "scored_submissions_grid"
+    when "scores_grid"
+      "#{current_scope}_score_exports_path"
+    when "scored_submissions_grid"
       "#{current_scope}_scores_path"
     else
       raise "Param root #{@saved_search.param_root} not supported"

--- a/app/views/saved_searches/_saved_search.en.html.erb
+++ b/app/views/saved_searches/_saved_search.en.html.erb
@@ -6,5 +6,5 @@
 
 <%= content_tag :div, class: "saved-search", id: dom_id(saved_search) do %>
   <%= link_to saved_search.name, send("#{current_scope}_saved_search_path", saved_search), class: "badge #{active}" %>
-  <%= link_to web_icon('close', class: "icon-red"), send("#{current_scope}_saved_search_path", saved_search), method: :delete, remote: :true, class: "badge #{active}" %>
+  <%= link_to web_icon('close', class: "icon-red"), send("#{current_scope}_saved_search_path", saved_search), method: :delete, remote: :true %>
 <% end %>


### PR DESCRIPTION
A saved "scores export" would go to the scores page instead of the score exports page; this will fix that issue.

Saved searches are saved with the type of datagrid it is using:

- The "scores export" page uses the scores_grid
- The "scores" page uses the scored_submissions_grid

Both types of these saved searches were being associated to the "scores" page. The change here will make a saved "scores export" used the "scores export page".