### PR TITLE
Admin view for chapter ambassadoring onboarding

### DIFF
--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -1,43 +1,33 @@
 <div class="panel">
-  <dl>
-    <% unless profile.account.mentor_profile.present? %>
-      <dt>Browser / OS Info</dt>
-      <dd>
-        <%= [profile.browser_name,
-            profile.browser_version,
-            profile.os_name,
-            profile.os_version].compact.join(' - ') %>
-      </dd>
+  <%= render "chapter_ambassador_onboarding", chapter_ambassador: profile %>
 
-      <dt>
-        Background Check Invitation Status
-      </dt>
-      <dd>
-        <%= render 'admin/participants/background_check_invitation_status',
-                   profile: @account.chapter_ambassador_profile %>
-      </dd>
-
-      <dt>Background Check</dt>
-      <dd>
-        <%= render 'admin/participants/background_check_status',
-                   profile: @account.chapter_ambassador_profile %>
-      </dd>
-    <% end %>
-
-    <dt>Status</dt>
-
-    <dd>
-      <%= form_with model: profile,
-        url: admin_chapter_ambassador_status_path(profile),
-        local: true do |f| %>
-
-        <%= f.select :status,
-          ChapterAmbassadorProfile.statuses.keys.map { |k| [k.humanize, k] } %>
-
-        <p>
-          <%= f.submit "Change status", class: "button small" %>
-        </p>
+  <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <dl>
+      <% unless profile.account.mentor_profile.present? %>
+        <dt>Browser / OS Info</dt>
+        <dd>
+          <%= [profile.browser_name,
+              profile.browser_version,
+              profile.os_name,
+              profile.os_version].compact.join(' - ') %>
+        </dd>
       <% end %>
-    </dd>
-  </dl>
+
+      <dt>Status</dt>
+
+      <dd>
+        <%= form_with model: profile,
+          url: admin_chapter_ambassador_status_path(profile),
+          local: true do |f| %>
+
+          <%= f.select :status,
+            ChapterAmbassadorProfile.statuses.keys.map { |k| [k.humanize, k] } %>
+
+          <p>
+            <%= f.submit "Change status", class: "button small" %>
+          </p>
+        <% end %>
+      </dd>
+    </dl>
+  </div>
 </div>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -1,0 +1,90 @@
+  <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <h4 class="reset">Required onboarding steps:</h4>
+    <p class="hint">
+      Chapter Ambassasdors must complete these items to be considered onboarded:
+    </p>
+
+    <dl>
+      <dt>Complete Background Check</dt>
+      <dd>
+        <div style="display: flex;">
+          <% if chapter_ambassador.background_check.clear? %>
+            <%= web_icon("check-circle icon-green") %>
+            <div>Complete</div>
+          <% else %>
+            <%= web_icon("exclamation-circle icon-red") %>
+            <div>
+              Incomplete
+
+              <% if chapter_ambassador.background_check.invitation_status.present? && !chapter_ambassador.background_check.invitation_completed? %>
+                <p class="hint margin--b-none">
+                  Invitation status: <%= chapter_ambassador.background_check.invitation_status&.humanize %>
+                </p>
+
+                <% if chapter_ambassador.background_check.invitation_expired? %>
+                  <p class="hint margin--b-none">
+                    The background check invitation has expired. Participant must request a new invitation.
+                  </span>
+                <% end %>
+              <% else %>
+                <p class="hint margin--b-none">
+                  <% if chapter_ambassador.background_check.present? %>
+                    <% if chapter_ambassador.background_check.error? %>
+                      Error: <%= chapter_ambassador.background_check.error_message.presence || "No error message recorded" %>
+                    <% else %>
+                      <%= chapter_ambassador.background_check.status.humanize %>
+                    <% end %>
+                  <% else %>
+                    Not sent
+                  <% end %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </dd>
+
+      <dt>Take Training Quiz</dt>
+      <dd>
+        <%= web_icon("exclamation-circle icon-red", text: "Incomplete") %>
+      </dd>
+
+      <dt>Sign Legal Agreement</dt>
+      <dd>
+        <div style="display: flex;">
+          <% if chapter_ambassador.legal_document_signed? %>
+            <%= web_icon("check-circle icon-green") %>
+            <div>
+              Complete
+
+              <p class="hint margin--b-none">
+                Signed <%= chapter_ambassador.legal_document.signed_at.strftime("%b %d, %Y") %>
+              </p>
+            </div>
+          <% else %>
+            <%= web_icon("exclamation-circle icon-red") %>
+            <div>
+              Incomplete
+
+              <% if chapter_ambassador.legal_document.blank? %>
+                <p class="hint margin--b-none">
+                  Not sent
+                </p>
+              <% else %>
+                <p class="hint margin--b-none">
+                  Not signed
+                </p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </dd>
+
+      <dt>Review Community Page</dt>
+      <dd>
+        <%= web_icon("exclamation-circle icon-red", text: "Incomplete") %>
+      </dd>
+    </dl>
+
+    <hr style="height: 1px; width: 100%;">
+  </div>


### PR DESCRIPTION
This will add a new partial that will display the basics for chapter ambassador onboarding. The onboarding steps are:

- Complete Background Check
- Take Training Quiz
- Sign Legal Agreement
- Review Community Page

Only the background check and legal document are hooked up right now.

For the background check, right now in the admin area we track the status of the background invitation and the background check separately. But for chapter ambassador onboarding purposes the background check is either complete or incomplete. If it's incomplete, we'll display some additional information below the incomplete status; I tried to capture all the info that we were displaying before.


