### PR TITLE
Added ChA community connections placeholder page with text

### DIFF
--- a/app/controllers/chapter_ambassador/community_connections_controller.rb
+++ b/app/controllers/chapter_ambassador/community_connections_controller.rb
@@ -1,0 +1,5 @@
+module ChapterAmbassador
+  class CommunityConnectionsController < ChapterAmbassadorController
+    layout "chapter_ambassador_rebrand"
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,7 @@ module ApplicationHelper
       chapter_ambassador
       chapter_locations
       chapter_profile
+      community_connections
       dashboards
       location_details
       profiles

--- a/app/views/chapter_ambassador/community_connections/show.en.html.erb
+++ b/app/views/chapter_ambassador/community_connections/show.en.html.erb
@@ -1,0 +1,45 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Community Connections" } do %>
+    <div>
+      <p class="mb-4">
+        Check out all our resources for running the Technovation program on the
+        <%= link_to "Ambassador Resource Page",
+                    ENV.fetch("CHAPTER_AMBASSADOR_RESOURCE_PAGE_URL"),
+                    class: "tw-link" %>!
+      </p>
+
+      <p class="mb-4">
+        Join Technovation’s global community of ambassadors to stay connected and up-to-date with the
+        latest news and best practices.
+      </p>
+
+      <p class="mb-4">
+        We have added you to our email list to receive information about training, program deadlines,
+        and other relevant information to support leading a Technovation chapter.
+      </p>
+
+      <p>
+        You can also join our Global Community of Ambassadors by participating in the following groups:
+      </p>
+      <ul class="list-disc">
+        <li class="ml-8">
+          Join out global ambassador's
+          <%= link_to "LinkedIn Group",
+                      ENV.fetch("CHAPTER_AMBASSADOR_LINKEDIN_GROUP_URL"),
+                      class: "tw-link"%>!
+        </li>
+        <li class="ml-8">
+          Connect with other ambassadors and mentors on our
+          <%= link_to "Slack group",
+                      ENV.fetch("CHAPTER_AMBASSADOR_SLACK_URL"),
+                      class: "tw-link" %>!
+        </li>
+        <li class="ml-8">
+          Join our Whatsapp group and join a regional community (Coming soon)
+        </li>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -22,10 +22,10 @@
       %>
 
       <%= render "application/templates/completion_step",
-        name: "Program Profile",
-        url: "#",
+        name: "Community Connections",
+        url: chapter_ambassador_community_connections_path,
         is_complete: false,
-        is_active_item: false
+        is_active_item: al(chapter_ambassador_community_connections_path).present?
       %>
     </ol>
   </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
     resource :chapter_location, only: [:show, :edit, :update]
     resource :chapter_program_information, only: [:show, :edit, :update, :new, :create], controller: "chapter_program_information"
     resource :legal_agreement, only: :create
+    resource :community_connections, only: :show
 
     resource :introduction, only: [:edit, :update]
 


### PR DESCRIPTION
Refs #4740 

Added ChA community connections placeholder page with text

![CleanShot 2024-05-28 at 13 09 10@2x](https://github.com/Iridescent-CM/technovation-app/assets/29210380/972de999-afaf-4e13-a33a-029c4b136f1f)


Noting that I also added 3 new env variables that will need to be added to preview, QA & prod (later)
`CHAPTER_AMBASSADOR_RESOURCE_PAGE_URL`
`CHAPTER_AMBASSADOR_LINKEDIN_GROUP_URL`
`CHAPTER_AMBASSADOR_WHATSAPP_GROUP_URL`

The whatsapp group will be created at a later time
