### PR TITLE
Added viewing community connections as an onboarding step

### DIFF
--- a/app/controllers/chapter_ambassador/community_connections_controller.rb
+++ b/app/controllers/chapter_ambassador/community_connections_controller.rb
@@ -1,5 +1,13 @@
 module ChapterAmbassador
   class CommunityConnectionsController < ChapterAmbassadorController
     layout "chapter_ambassador_rebrand"
+
+    after_action :update_viewed_community_connections, only: :show
+
+    private
+
+    def update_viewed_community_connections
+      current_ambassador.update(viewed_community_connections: true)
+    end
   end
 end

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -108,6 +108,10 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     !bio.blank?
   end
 
+  def community_connections_viewed?
+    viewed_community_connections
+  end
+
   def legal_document_signed?
     legal_document&.signed?
   end

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -1,7 +1,7 @@
   <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
     <h4 class="reset">Required onboarding steps:</h4>
     <p class="hint">
-      Chapter Ambassasdors must complete these items to be considered onboarded:
+      Chapter Ambassadors must complete these items to be considered onboarded:
     </p>
 
     <dl>
@@ -24,7 +24,7 @@
                 <% if chapter_ambassador.background_check.invitation_expired? %>
                   <p class="hint margin--b-none">
                     The background check invitation has expired. Participant must request a new invitation.
-                  </span>
+                  </p>
                 <% end %>
               <% else %>
                 <p class="hint margin--b-none">
@@ -80,9 +80,19 @@
         </div>
       </dd>
 
-      <dt>Review Community Page</dt>
+      <dt>Viewed Community Connections Page</dt>
       <dd>
-        <%= web_icon("exclamation-circle icon-red", text: "Incomplete") %>
+        <% if chapter_ambassador.community_connections_viewed? %>
+          <div>
+            <%= web_icon("check-circle icon-green") %>
+            Viewed community connections
+          </div>
+        <% else %>
+          <div>
+            <%= web_icon("exclamation-circle icon-red") %>
+            Not viewed
+          </div>
+        <% end %>
       </dd>
     </dl>
 

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -24,7 +24,7 @@
       <%= render "application/templates/completion_step",
         name: "Community Connections",
         url: chapter_ambassador_community_connections_path,
-        is_complete: false,
+        is_complete: current_ambassador.community_connections_viewed?,
         is_active_item: al(chapter_ambassador_community_connections_path).present?
       %>
     </ol>

--- a/db/migrate/20240529011028_add_viewed_community_connections_to_chapter_ambassador_profiles.rb
+++ b/db/migrate/20240529011028_add_viewed_community_connections_to_chapter_ambassador_profiles.rb
@@ -1,0 +1,5 @@
+class AddViewedCommunityConnectionsToChapterAmbassadorProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :chapter_ambassador_profiles, :viewed_community_connections, :boolean, null: false, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -367,7 +367,8 @@ CREATE TABLE public.chapter_ambassador_profiles (
     program_name character varying,
     chapter_id bigint,
     organization_status public.chapter_ambassador_organization_status,
-    phone_number character varying
+    phone_number character varying,
+    viewed_community_connections boolean DEFAULT false NOT NULL
 );
 
 
@@ -4317,6 +4318,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240513150037'),
 ('20240513182351'),
 ('20240513182546'),
-('20240513182837');
+('20240513182837'),
+('20240529011028');
 
 


### PR DESCRIPTION
Refs #4751 

Added functionality when ChA views (clicks) the community connections page then this onboarding task will be considered completed.

This PR adds the following files:
- DB migration to add the `viewed_community_connections` field to chapter ambassador profiles table
- A new method (`update_viewed_community_connections`) to update this value once the ChA clicks the link in the side nav
- Updated the sidenav `is_complete` attribute so that the circle will be "checked" off once they click the link
- Added this onboarding step status to the admin portal in the ChA debugging section