### PR TITLE
Fix chapter link URLs

### DIFF
--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -36,7 +36,7 @@
                       <% if link.name == "email" %>
                         <%= mail_to link.value, web_icon(link.icon, text: link.value), style: "font-weight: lighter; color: black;" %>
                       <% else %>
-                        <%= link_to web_icon(link.icon, text: link.value), link.value, style: "font-weight: lighter; color: black;" %>
+                        <%= link_to web_icon(link.icon, text: link.value), link.url, style: "font-weight: lighter; color: black;" %>
                       <% end %>
                     </li>
                   <% end %>


### PR DESCRIPTION
Just a small update here, this will use the `url` value for the `href` links, which will make the links works correctly.



