### PR TITLE
Fix n+1 query on participants datagrid

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -313,7 +313,7 @@ class AccountsGrid
     if: ->(g) {
       (%w[judge chapter_ambassador] & (g.scope_names || [])).empty?
     } do |value, scope, grid|
-      scope.send(value)
+      scope.send(value).includes(:chapter_ambassador_profile)
     end
 
   filter :onboarded_students,


### PR DESCRIPTION
Selecting the "team matching" option on the participants datagrid is causing an n+1 query, this update will address that.

I found this using the [Bullet](https://github.com/flyerhzm/bullet) gem.