### PR TITLE
Add onboarded status to chapter ambassador datagrid

### DIFF
--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -37,6 +37,10 @@ class ChapterAmbassadorsGrid
     gender.presence || "-"
   end
 
+  column :onboarded do
+    chapter_ambassador_profile.onboarded? ? "yes" : "no"
+  end
+
   column :phone_number do
     chapter_ambassador_profile.phone_number.presence || "-"
   end


### PR DESCRIPTION
This will add a new onboarded filter and "additional column" to the chapter ambassador's datagrid in the admin section.

I also fixed an n+1 query issue for this datagrid.