### PR TITLE
Adds training module modals to the ChA training tab in onboarding

### DIFF
--- a/app/controllers/chapter_ambassador/training_completions_controller.rb
+++ b/app/controllers/chapter_ambassador/training_completions_controller.rb
@@ -6,7 +6,7 @@ module ChapterAmbassador
 
     def show
       current_ambassador.complete_training!
-      redirect_to chapter_ambassador_training_path,
+      redirect_to chapter_ambassador_trainings_path,
         success: "Thank you for completing the checkpoint!"
     end
 

--- a/app/helpers/external_resource_helper.rb
+++ b/app/helpers/external_resource_helper.rb
@@ -12,6 +12,6 @@ module ExternalResourceHelper
   end
 
   def external_chapter_ambassador_training_module_link(module_number)
-    ENV.fetch("CHAPTER_AMBASSADOR_TRAINING_SLIDES_MODULE_#{module_number}_URL", "")
+    ENV.fetch("CHAPTER_AMBASSADOR_TRAINING_MODULE_#{module_number}_URL", "")
   end
 end

--- a/app/helpers/external_resource_helper.rb
+++ b/app/helpers/external_resource_helper.rb
@@ -10,4 +10,8 @@ module ExternalResourceHelper
 
     "#{base_url}?#{params.to_query}"
   end
+
+  def external_chapter_ambassador_training_module_link(module_number)
+    ENV.fetch("CHAPTER_AMBASSADOR_TRAINING_SLIDES_MODULE_#{module_number}_URL", "")
+  end
 end

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -9,9 +9,9 @@
 
       <%= render "application/templates/completion_step",
         name: "Chapter Ambassador Training",
-        url: chapter_ambassador_training_path,
+        url: chapter_ambassador_trainings_path,
         is_complete: current_ambassador.training_completed?,
-        is_active_item: al(chapter_ambassador_training_completion_path).present?
+        is_active_item: al(chapter_ambassador_trainings_path).present?
       %>
 
       <%= render "application/templates/completion_step",

--- a/app/views/chapter_ambassador/trainings/_training_module.html.erb
+++ b/app/views/chapter_ambassador/trainings/_training_module.html.erb
@@ -1,0 +1,24 @@
+<li>
+  <%= link_to "Training Module #{module_number}: #{module_title}", '#',
+              data: {
+                opens_modal: "training-modal-#{module_number}",
+              }
+  %>
+</li>
+
+<%= content_tag :div,
+                class: "modal",
+                data: {
+                  heading: "Training Module #{module_number}: #{module_title}",
+                  module_number: module_number,
+                },
+                id: "training-modal-#{module_number}" do %>
+
+  <div class="modal-content">
+    <iframe class="w-full" height="315" src="<%= ENV.fetch("CHAPTER_AMBASSADOR_TRAINING_SLIDES_MODULE_#{module_number}_URL", "")%>"
+            title="YouTube video player" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>
+    </iframe>
+  </div>
+<% end %>

--- a/app/views/chapter_ambassador/trainings/_training_module.html.erb
+++ b/app/views/chapter_ambassador/trainings/_training_module.html.erb
@@ -15,7 +15,7 @@
                 id: "training-modal-#{module_number}" do %>
 
   <div class="modal-content">
-    <iframe class="w-full" height="315" src="<%= ENV.fetch("CHAPTER_AMBASSADOR_TRAINING_SLIDES_MODULE_#{module_number}_URL", "")%>"
+    <iframe class="w-full" height="315" src="<%= external_chapter_ambassador_training_module_link(module_number) %>"
             title="YouTube video player" frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>

--- a/app/views/chapter_ambassador/trainings/_training_module_list.html.erb
+++ b/app/views/chapter_ambassador/trainings/_training_module_list.html.erb
@@ -1,0 +1,32 @@
+<ul class="list list-disc ml-8 space-y-4">
+  <%= render partial: "chapter_ambassador/trainings/training_module",
+             locals: {
+               module_number: 0,
+               module_title: "What's New!"
+             } %>
+
+  <%= render partial: "chapter_ambassador/trainings/training_module",
+             locals: {
+               module_number: 1,
+               module_title: "Program Overview"
+             } %>
+
+  <%= render partial: "chapter_ambassador/trainings/training_module",
+             locals: {
+               module_number: 2,
+               module_title: "Curriculum"
+             } %>
+
+  <%= render partial: "chapter_ambassador/trainings/training_module",
+             locals: {
+               module_number: 3,
+               module_title: "Volunteer Management"
+             } %>
+
+  <%= render partial: "chapter_ambassador/trainings/training_module",
+             locals: {
+               module_number: 4,
+               module_title: "Community & Resources"
+             } %>
+
+</ul>

--- a/app/views/chapter_ambassador/trainings/_training_module_list.html.erb
+++ b/app/views/chapter_ambassador/trainings/_training_module_list.html.erb
@@ -1,31 +1,31 @@
 <ul class="list list-disc ml-8 space-y-4">
   <%= render partial: "chapter_ambassador/trainings/training_module",
              locals: {
-               module_number: 0,
+               module_number: 1,
                module_title: "What's New!"
              } %>
 
   <%= render partial: "chapter_ambassador/trainings/training_module",
              locals: {
-               module_number: 1,
+               module_number: 2,
                module_title: "Program Overview"
              } %>
 
   <%= render partial: "chapter_ambassador/trainings/training_module",
              locals: {
-               module_number: 2,
+               module_number: 3,
                module_title: "Curriculum"
              } %>
 
   <%= render partial: "chapter_ambassador/trainings/training_module",
              locals: {
-               module_number: 3,
+               module_number: 4,
                module_title: "Volunteer Management"
              } %>
 
   <%= render partial: "chapter_ambassador/trainings/training_module",
              locals: {
-               module_number: 4,
+               module_number: 5,
                module_title: "Community & Resources"
              } %>
 

--- a/app/views/chapter_ambassador/trainings/index.html.erb
+++ b/app/views/chapter_ambassador/trainings/index.html.erb
@@ -7,12 +7,15 @@
         Thank you for completing the checkpoint. You can view correct answers here.
       </p>
     <% else %>
-      <p>
-        Click the link below to proceed to the training checkpoint.
+      <p class="mb-4">
+        Please review the following training modules. This information will help you lead your chapter this season!
+        At the end of the training you will have access to the training checkpoint.
         Please take the checkpoint to complete this step of onboarding.
       </p>
 
-      <div class="flex flex-row">
+      <%= render "chapter_ambassador/trainings/training_module_list" %>
+
+      <div class="flex flex-row mt-8">
         <%= link_to "Training Checkpoint",
                     external_chapter_ambassador_training_checkpoint_link(current_account),
                     class: "tw-green-btn mx-auto", target: "_blank" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Rails.application.routes.draw do
     resources :background_checks, only: [:new, :create]
     post "/background_check_invitation", to: "background_checks#create_invitation"
 
-    resource :training, only: :show
+    resources :trainings, only: :index
     resource :training_completion, only: :show
 
     resource :mou, only: :show

--- a/spec/features/chapter_ambassador/training_spec.rb
+++ b/spec/features/chapter_ambassador/training_spec.rb
@@ -24,6 +24,6 @@ RSpec.feature "Chapter Ambassador Training" do
     visit chapter_ambassador_trainings_path
 
     expect(page).to have_text("Please review the following training modules.")
-    expect(page).to have_selector("a[href='#'][data-opens-modal='training-modal-1']", text: "Training Module 1: Program Overview")
+    expect(page).to have_selector("a[href='#'][data-opens-modal='training-modal-1']", text: "Training Module 1: What's New!")
   end
 end

--- a/spec/features/chapter_ambassador/training_spec.rb
+++ b/spec/features/chapter_ambassador/training_spec.rb
@@ -15,9 +15,15 @@ RSpec.feature "Chapter Ambassador Training" do
   end
 
   scenario "Visiting the training endpoint when training hasn't been completed displays a link to take the training" do
-    visit chapter_ambassador_training_path
-
-    expect(page).to have_text("Click the link below to proceed to the training checkpoint.")
+    visit chapter_ambassador_trainings_path
+    expect(page).to have_text("Please take the checkpoint to complete this step of onboarding.")
     expect(page).to have_link("Training Checkpoint", href: external_chapter_ambassador_training_checkpoint_link(chapter_ambassador.account))
+  end
+
+  scenario "Visiting the training endpoint when training hasn't been completed displays a link to view the training modal" do
+    visit chapter_ambassador_trainings_path
+
+    expect(page).to have_text("Please review the following training modules.")
+    expect(page).to have_selector("a[href='#'][data-opens-modal='training-modal-1']", text: "Training Module 1: Program Overview")
   end
 end


### PR DESCRIPTION
Refs #4792 

This PR adds the training module links & modals to the training & checkpoint tab for ChA onboarding. 

It would be nice if the training modules were more like a "checklist" and the quiz would only be available once all trainings were completed. Not a must-have but a nice to have! 

<img width="1571" alt="Screenshot 2024-06-20 at 1 58 02 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/2adc9ace-894a-424c-b4fc-d8072874e3ce">

<img width="1535" alt="Screenshot 2024-06-20 at 1 58 08 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/4bc11568-a694-4000-b646-e91bd3ac172f">
