### PR TITLE
Add all chapter program information to chapters grid 

### DIFF
--- a/app/controllers/concerns/saved_search_controller.rb
+++ b/app/controllers/concerns/saved_search_controller.rb
@@ -23,6 +23,10 @@ module SavedSearchController
       "#{current_scope}_score_exports_path"
     when "scored_submissions_grid"
       "#{current_scope}_scores_path"
+    when "chapters_grid"
+      "#{current_scope}_chapters_path"
+    when "chapter_ambassadors_grid"
+      "#{current_scope}_chapter_ambassadors_path"
     else
       raise "Param root #{@saved_search.param_root} not supported"
     end

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -20,6 +20,73 @@ class ChaptersGrid
 
   column :organization_name, header: "Organization", mandatory: true
 
+  column :organization_type, header: "Organization type" do
+    organization_types = chapter_program_information&.organization_types
+    if organization_types&.any?
+      organization_types.pluck(:name).join(", ")
+    else
+      "-"
+    end
+  end
+
+  column :child_safeguarding_policy_and_process do
+    chapter_program_information&.child_safeguarding_policy_and_process.presence || "-"
+  end
+
+  column :team_structure do
+    chapter_program_information&.team_structure.presence || "-"
+  end
+
+  column :external_partnerships do
+    chapter_program_information&.external_partnerships.presence || "-"
+  end
+
+  column :start_date, header: "Program start date" do
+    chapter_program_information&.start_date&.strftime("%m-%d-%Y").presence || "-"
+  end
+
+  column :launch_date do
+    chapter_program_information&.launch_date&.strftime("%m-%d-%Y").presence || "-"
+  end
+
+  column :program_model do
+    chapter_program_information&.program_model.presence || "-"
+  end
+
+  column :meeting_times do
+    meeting_times = chapter_program_information&.meeting_times
+    if meeting_times&.any?
+      meeting_times.pluck(:time).join(", ")
+    else
+      "-"
+    end
+  end
+
+  column :program_length do
+    chapter_program_information&.program_length&.length.presence || "-"
+  end
+
+  column :meeting_facilitators do
+    meeting_facilitators = chapter_program_information&.meeting_facilitators
+    if meeting_facilitators&.any?
+      meeting_facilitators.pluck(:name).join(", ")
+    else
+      "-"
+    end
+  end
+
+  column :participant_count_estimate, header: "Estimated participation" do
+    chapter_program_information&.participant_count_estimate&.range.presence || "-"
+  end
+
+  column :low_income_estimate, header: "Percent underresourced" do
+    chapter_program_information&.low_income_estimate&.percentage.presence || "-"
+  end
+
+  column :number_of_low_income_or_underserved_calculation do
+    chapter_program_information&.number_of_low_income_or_underserved_calculation.presence || "-"
+  end
+
   filter :program_name do |value|
     where("name ilike ?",
       "#{value}%")
@@ -45,6 +112,20 @@ class ChaptersGrid
 
   filter(:visible_on_map, :xboolean)
 
+  filter :organization_type,
+    :enum,
+    header: "Organization type",
+    select: proc { OrganizationType.all.map { |type| [type.name, type.id] } },
+    filter_group: "more-specific",
+    html: {
+      class: "and-or-field"
+    },
+    multiple: true do |values, scope|
+    scope.includes(chapter_program_information: {organization_types: :chapter_program_information_organization_types})
+      .references(:chapter_program_information_organization_types)
+      .where(chapter_program_information_organization_types: {organization_type_id: values})
+  end
+
   column :legal_agreement_status do
     if legal_document.present?
       legal_document.signed? ? "Signed" : "Not signed"
@@ -58,40 +139,6 @@ class ChaptersGrid
   end
 
   column :visible_on_map, header: "Visible on map"
-
-  column :start_date, header: "Program Start Date" do
-    chapter_program_information&.start_date&.strftime("%m-%d-%Y").presence || "-"
-  end
-
-  column :meeting_times do
-    meeting_times = chapter_program_information&.meeting_times
-    if meeting_times&.any?
-      meeting_times.pluck(:time).join(", ")
-    else
-      "-"
-    end
-  end
-
-  column :program_length do
-    chapter_program_information&.program_length&.length.presence || "-"
-  end
-
-  column :meeting_facilitators do
-    meeting_facilitators = chapter_program_information&.meeting_facilitators
-    if meeting_facilitators&.any?
-      meeting_facilitators.pluck(:name).join(", ")
-    else
-      "-"
-    end
-  end
-
-  column :participant_count_estimate, header: "Estimated Participation" do
-    chapter_program_information&.participant_count_estimate&.range.presence || "-"
-  end
-
-  column :low_income_estimate, header: "Percent Underresourced" do
-    chapter_program_information&.low_income_estimate&.percentage.presence || "-"
-  end
 
   column :actions, mandatory: true, html: true do |chapter|
     render "admin/chapters/actions", chapter: chapter


### PR DESCRIPTION
Refs #4774 & #4773 

This PR adds the following:
- all chapter program information responses as columns to the chapters grid 
- It also adds the organization type as a multi-select filter
- I ordered the columns to match the order of the questions/form 
- A small addition to the conditional logic that allows for saved searches. This was an issue where searches could not be saved for the Chapter Ambassadors grid and chapters grid

I am going to update/check this grid for n+1 queries as part of #4810 & once the bullet gem is added to this project structure (#4818)