### PR TITLE
Update rake task that converts ChAs to chapters

### DIFF
--- a/lib/tasks/convert_chapter_ambassadors_to_chapters.rake
+++ b/lib/tasks/convert_chapter_ambassadors_to_chapters.rake
@@ -1,11 +1,13 @@
 desc "Convert chapter ambassadors to chapters"
 task convert_chapter_ambassadors_to_chapters: :environment do |_, args|
   args.extras.each do |arg|
-    chapter_ambassador_id = arg.split(";").first
+    account_id = arg.split(";").first
     organization_name = arg.split(";").last
-    chapter_ambassador = ChapterAmbassadorProfile.find(chapter_ambassador_id)
+    chapter_ambassador = Account.find(account_id).chapter_ambassador_profile
 
-    if chapter_ambassador.chapter_id.present?
+    if chapter_ambassador.blank?
+      puts "Skipping account #{account_id}, this isn't a chapter ambassador account"
+    elsif chapter_ambassador.chapter_id.present?
       puts "Could not create chapter for #{chapter_ambassador.full_name}, they are already associated to #{chapter_ambassador.chapter.organization_name}"
     else
       chapter = Chapter.create(


### PR DESCRIPTION
This will update the rake task that is used to convert chapter ambassadors to chapters so that it accepts an `account_id` instead of a `chapter_ambassaador_id`.