### PR TITLE
Fix ChA registration bug

### DIFF
--- a/app/controllers/chapter_ambassador/location_details_controller.rb
+++ b/app/controllers/chapter_ambassador/location_details_controller.rb
@@ -1,5 +1,6 @@
 module ChapterAmbassador
   class LocationDetailsController < ChapterAmbassadorController
+    skip_before_action :require_chapter_and_chapter_ambassador_onboarded
     helper_method :current_profile
 
     layout "chapter_ambassador_rebrand"
@@ -15,3 +16,4 @@ module ChapterAmbassador
     end
   end
 end
+

--- a/app/controllers/chapter_ambassador/locations_controller.rb
+++ b/app/controllers/chapter_ambassador/locations_controller.rb
@@ -1,5 +1,7 @@
 module ChapterAmbassador
   class LocationsController < ChapterAmbassadorController
     include LocationController
+
+    skip_before_action :require_chapter_and_chapter_ambassador_onboarded
   end
 end


### PR DESCRIPTION
This will fix an issue where new chapter ambassadors can't enter their location after registering. The location controllers need to opt out of the chapter/chapter ambassador onboarded requirement.


