### PR TITLE
Add chapter affiliation agreement to chapter ambassador chapter onboarding tabs

### DIFF
--- a/app/controllers/chapter_ambassador/chapter_affiliation_agreements_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_affiliation_agreements_controller.rb
@@ -1,0 +1,8 @@
+module ChapterAmbassador
+  class ChapterAffiliationAgreementsController < ChapterAmbassadorController
+    skip_before_action :require_chapter_and_chapter_ambassador_onboarded
+
+    layout "chapter_ambassador_rebrand"
+
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,7 @@ module ApplicationHelper
     path = controller_path.split("/").second
     rebranded_chapter_ambassador_sections = %w[
       background_checks
+      chapter_affiliation_agreements
       chapter_ambassador
       chapter_locations
       chapter_profile

--- a/app/views/chapter_ambassador/chapter_affiliation_agreements/show.html.erb
+++ b/app/views/chapter_ambassador/chapter_affiliation_agreements/show.html.erb
@@ -1,0 +1,38 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Affiliation Agreement" } do %>
+    <% if current_chapter.present? %>
+      <% if current_chapter.legal_document_signed? %>
+        <p>
+          Your legal contact has signed the Chapter Affiliation Agreement!
+        </p>
+      <% else %>
+        <p class="mb-8">
+          <span class="italic"><%= current_chapter.organization_name %> </span>working with this chapter must sign a Chapter Affiliation Agreement before
+          Chapter Ambassadors are able to access administrative activity for the chapter.
+        </p>
+        <p>
+          <span class="font-medium">Legal Contact:</span>
+          <% if current_chapter.legal_contact.blank? %>
+            No legal contact has been setup yet
+          <% else %>
+            <%= current_chapter.legal_contact.full_name %>
+          <% end %>
+        </p>
+        <p>
+          <span class="font-medium">Chapter Affiliation Agreement Status:</span>
+          <% if current_chapter.legal_contact.blank? %>
+            Not sent (no legal contact has been setup yet)
+          <% elsif current_chapter.legal_document.blank? %>
+            Not sent
+          <% else %>
+            Not signed
+          <% end %>
+        </p>
+      <% end %>
+    <% else %>
+      <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
@@ -1,6 +1,13 @@
   <nav class="p-4" aria-label="Progress">
     <ol role="list" class="space-y-6 mb-6 overflow-hidden">
       <%= render "application/templates/completion_step",
+                 name: "Chapter Affiliation Agreement",
+                 url: chapter_ambassador_chapter_affiliation_agreement_path,
+                 is_complete: current_ambassador.chapter&.legal_document_signed?,
+                 is_active_item: al(chapter_ambassador_chapter_affiliation_agreement_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
         name: "Public Info",
         url: chapter_ambassador_public_information_path,
         is_complete: current_ambassador.chapter&.chapter_info_complete?,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
     resource :profile, only: [:show, :edit, :update]
 
     resource :chapter_profile, only: :show, controller: "chapter_profile"
+    resource :chapter_affiliation_agreement, only: :show
     resource :public_information, only: [:show, :edit, :update], controller: "public_information"
     resource :chapter_location, only: [:show, :edit, :update]
     resource :chapter_program_information, only: [:show, :edit, :update, :new, :create], controller: "chapter_program_information"

--- a/spec/features/chapter_ambassador/view_chapter_affiliation_agreement_spec.rb
+++ b/spec/features/chapter_ambassador/view_chapter_affiliation_agreement_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.feature "Chapter Ambassadors view the chapter affiliation agreement tab" do
+  let(:chapter) { FactoryBot.create(:chapter) }
+
+  scenario "A Chapter Ambassador assigned to a chapter with a signed chapter affiliation agreement" do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Chapter Affiliation Agreement"
+
+    expect(page).to have_content("Your legal contact has signed the Chapter Affiliation Agreement!")
+  end
+
+  scenario "A Chapter Ambassador assigned to a chapter with a sent (not signed) chapter affiliation agreement" do
+    chapter.legal_contact.legal_document.update(signed_at: nil)
+
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Chapter Affiliation Agreement"
+
+    expect(page).to have_content("#{chapter.organization_name} working with this chapter")
+    expect(page).to have_content("Legal Contact: #{chapter.legal_contact.full_name}")
+    expect(page).to have_content("Chapter Affiliation Agreement Status: Not signed")
+  end
+
+  scenario "A Chapter Ambassador assigned to a chapter with no legal contact" do
+    chapter.legal_contact.destroy
+    chapter.reload
+
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, chapter: chapter)
+
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Chapter Affiliation Agreement"
+
+    expect(page).to have_content("#{chapter.organization_name} working with this chapter")
+    expect(page).to have_content("Legal Contact: No legal contact has been setup yet")
+    expect(page).to have_content("Chapter Affiliation Agreement Status: Not sent (no legal contact has been setup yet)")
+  end
+
+  scenario "A Chapter Ambassador not assigned to a chapter" do
+    chapter_ambassador = FactoryBot.create(:chapter_ambassador, :not_assigned_to_chapter)
+
+    sign_in(chapter_ambassador)
+
+    click_link "Chapter Profile"
+    click_link "Chapter Affiliation Agreement"
+
+    expect(page).to have_content("You are not associated with a chapter. Please contact support@technovation.org for support.")
+  end
+
+end


### PR DESCRIPTION
Refs #4827 

This PR adds the chapter affiliation agreement information and tab to the Chapter ambassador chapter onboarding tasks

<img width="1522" alt="Screenshot 2024-07-01 at 6 56 17 PM" src="https://github.com/Iridescent-CM/technovation-app/assets/29210380/3ec2f489-9497-44e4-9bd9-ac5b22d5faf1">
