### PR TITLE
Added admin ability to exempt background checks for mentors (pt.1)

### DIFF
--- a/app/controllers/admin/background_check_exemptions_controller.rb
+++ b/app/controllers/admin/background_check_exemptions_controller.rb
@@ -1,0 +1,27 @@
+module Admin
+  class BackgroundCheckExemptionsController < AdminController
+    def grant
+      @account = Account.find(params[:participant_id])
+
+      if @account.grant_background_check_exemption!
+        redirect_to admin_participant_path(@account),
+          success: "Background check exemption granted"
+      else
+        redirect_to admin_participant_path(@account),
+          error: "Error granting background check exemption"
+      end
+    end
+
+    def revoke
+      @account = Account.find(params[:participant_id])
+
+      if @account.revoke_background_check_exemption!
+        redirect_to admin_participant_path(@account),
+          success: "Background check exemption revoked"
+      else
+        redirect_to admin_participant_path(@account),
+          error: "Error revoking background check exemption"
+      end
+    end
+  end
+end

--- a/app/controllers/admin/background_check_exemptions_controller.rb
+++ b/app/controllers/admin/background_check_exemptions_controller.rb
@@ -3,7 +3,7 @@ module Admin
     def grant
       @account = Account.find(params[:participant_id])
 
-      if @account.grant_background_check_exemption!
+      if @account.grant_background_check_exemption
         redirect_to admin_participant_path(@account),
           success: "Background check exemption granted"
       else
@@ -15,7 +15,7 @@ module Admin
     def revoke
       @account = Account.find(params[:participant_id])
 
-      if @account.revoke_background_check_exemption!
+      if @account.revoke_background_check_exemption
         redirect_to admin_participant_path(@account),
           success: "Background check exemption revoked"
       else

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -85,7 +85,14 @@ export default {
       "age",
       (age) => parseInt(age) >= 18
     );
-    return !isBackgroundCheckCountry || !isAgeAppropriate;
+
+    const isExempt = digStateAttributes(
+      state,
+      "currentAccount",
+      "backgroundCheckExemption"
+    );
+
+    return !isBackgroundCheckCountry || !isAgeAppropriate || isExempt;
   },
 
   isOnTeam(state) {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1012,11 +1012,11 @@ class Account < ActiveRecord::Base
     current_chapter.organization_name.presence || "Organization name not set"
   end
 
-  def grant_background_check_exemption!
+  def grant_background_check_exemption
     update(background_check_exemption: true)
   end
 
-  def revoke_background_check_exemption!
+  def revoke_background_check_exemption
     update(background_check_exemption: false)
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -260,6 +260,7 @@ class Account < ActiveRecord::Base
   after_create :create_account_created_activity
   before_update :update_division, if: -> { !is_a_judge? && !is_chapter_ambassador? }
   after_commit :update_email_list, on: :update
+  after_update :update_chapter_ambassador_onboarding_status
 
   after_commit -> {
     if saved_change_to_email_confirmed_at ||

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1012,6 +1012,20 @@ class Account < ActiveRecord::Base
     current_chapter.organization_name.presence || "Organization name not set"
   end
 
+  def grant_background_check_exemption!
+    update(background_check_exemption: true)
+  end
+
+  def revoke_background_check_exemption!
+    update(background_check_exemption: false)
+  end
+
+  def update_chapter_ambassador_onboarding_status
+    if chapter_ambassador_profile.present?
+      chapter_ambassador_profile.update_onboarding_status
+    end
+  end
+
   private
 
   def current_profile

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -83,12 +83,20 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     !intro_summary.blank?
   end
 
+  def background_check_exempt_or_complete?
+    background_check_exempt? || background_check_complete?
+  end
+
   def background_check_complete?
-    !!background_check && background_check.clear?
+    background_check.present? && background_check.clear?
+  end
+
+  def background_check_exempt?
+    account.background_check_exemption?
   end
 
   def requires_background_check?
-    !background_check_complete?
+    !background_check_exempt? && !background_check_complete?
   end
 
   def in_background_check_country?

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -297,7 +297,7 @@ class MentorProfile < ActiveRecord::Base
   def requires_background_check?
     (account.valid? && (account.date_of_birth.present? && account.age >= 18 || account.meets_minimum_age_requirement?)) &&
       in_background_check_country? &&
-      !(background_check.present? && background_check.clear?)
+      !(background_check.present? && background_check.clear? || account.background_check_exemption?)
   end
 
   def requires_background_check_invitation?

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -6,7 +6,7 @@ class AccountSerializer
 
   attributes :name, :email, :date_of_birth, :age, :city, :state, :country, :state_code,
     :country_code, :latitude, :longitude, :first_name, :last_name, :gender,
-    :referred_by, :referred_by_other, :avatar_url
+    :referred_by, :referred_by_other, :avatar_url, :background_check_exemption
 
   attribute(:api_root) do |account|
     "#{account.scope_name}"

--- a/app/views/admin/participants/_background_check_exemption.html.erb
+++ b/app/views/admin/participants/_background_check_exemption.html.erb
@@ -1,5 +1,4 @@
 <% if profile.requires_background_check? %>
-  <h6>Grant background check exemption</h6>
   <p>
     <%= profile.name %> is in a country that requires a background check. By clicking the button below, <%= profile.name %> will be exempt from the background check requirement.
   </p>
@@ -15,7 +14,6 @@
                 } %>
   </p>
 <% elsif profile.background_check_exemption? %>
-    <h6>Revoke background check exemption</h6>
     <p>
       <%= profile.name %> is in a country that requires a background check. They currently have a background check exemption. <br>
       By clicking the button below, you will revoke the background check exemption and they will be required to complete a background check.

--- a/app/views/admin/participants/_background_check_exemption.html.erb
+++ b/app/views/admin/participants/_background_check_exemption.html.erb
@@ -1,0 +1,34 @@
+<% if profile.requires_background_check? %>
+  <h6>Grant background check exemption</h6>
+  <p>
+    <%= profile.name %> is in a country that requires a background check. By clicking the button below, <%= profile.name %> will be exempt from the background check requirement.
+  </p>
+
+  <p>
+    <%= link_to "Exempt from background check requirement",
+                grant_admin_participant_background_check_exemption_path(profile.account),
+                class: 'button',
+                data: {
+                  method: :patch,
+                  confirm: "Exempt #{profile.name} from the background check requirement?" +
+                    "<p>Please document reason in your records.</p>"
+                } %>
+  </p>
+<% elsif profile.background_check_exemption? %>
+    <h6>Revoke background check exemption</h6>
+    <p>
+      <%= profile.name %> is in a country that requires a background check. They currently have a background check exemption. <br>
+      By clicking the button below, you will revoke the background check exemption and they will be required to complete a background check.
+    </p>
+
+    <p>
+      <%= link_to "Revoke background check exemption",
+                  revoke_admin_participant_background_check_exemption_path(profile.account),
+                  class: 'button',
+                  data: {
+                    method: :patch,
+                    confirm: "Revoke background check exemption for #{profile.name}?" +
+                      "<p>Please document reason in your records.</p>"
+                  } %>
+    </p>
+  <% end %>

--- a/app/views/admin/participants/_background_check_invitation_status.html.erb
+++ b/app/views/admin/participants/_background_check_invitation_status.html.erb
@@ -1,5 +1,10 @@
 <% if profile.in_background_check_invitation_country? %>
-  <% if profile.background_check.invitation_pending? %>
+  <% if profile.account.background_check_exemption? %>
+    <%= web_icon(
+          "check-circle icon-green",
+          text: "Background check exempt"
+        ) %>
+  <% elsif profile.background_check.invitation_pending? %>
     <%= web_icon(
           "exclamation-circle icon--orange",
           text:  profile.background_check.invitation_status.humanize

--- a/app/views/admin/participants/_background_check_status.html.erb
+++ b/app/views/admin/participants/_background_check_status.html.erb
@@ -1,5 +1,10 @@
 <% if profile.in_background_check_country? %>
-  <% if profile.background_check.clear? %>
+  <% if profile.account.background_check_exemption? %>
+    <%= web_icon(
+          "check-circle icon-green",
+          text: "Background check exempt"
+        ) %>
+  <% elsif profile.background_check.clear? %>
     <%= web_icon(
           "check-circle icon-green",
           text: profile.background_check.status.humanize

--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -2,6 +2,11 @@
   <%= render "chapter_ambassador_onboarding", chapter_ambassador: profile %>
 
   <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <% if current_account.is_admin? && (profile.requires_background_check? || profile.background_check_exemption?) %>
+      <%= render "admin/participants/background_check_exemption", profile: profile %>
+      <hr style="height: 1px; width: 100%;">
+    <% end %>
+
     <dl>
       <dt>Chapter Onboarding Status</dt>
       <dd>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -8,9 +8,9 @@
       <dt>Complete Background Check</dt>
       <dd>
         <div style="display: flex;">
-          <% if chapter_ambassador.background_check.clear? %>
+          <% if chapter_ambassador.background_check_exempt_or_complete? %>
             <%= web_icon("check-circle icon-green") %>
-            <div>Complete</div>
+            <div><%= chapter_ambassador.background_check_complete? ? "Complete" : "Background check exempt" %></div>
           <% else %>
             <%= web_icon("exclamation-circle icon-red") %>
             <div>

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -65,6 +65,12 @@
     </dd>
   </dl>
 
+  <% if current_account.is_admin? && (profile.requires_background_check? || profile.background_check_exemption?) %>
+    <hr>
+    <%= render 'admin/participants/background_check_exemption',
+               profile: @account.mentor_profile %>
+  <% end %>
+
   <% if ENV.fetch("CONVERT_MENTORS") { false } and profile.current_teams.none? %>
     <hr />
 

--- a/app/views/chapter_ambassador/background_checks/show.html.erb
+++ b/app/views/chapter_ambassador/background_checks/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
-  <% if current_ambassador.background_check.invitation_sent? %>
+  <% if current_ambassador.background_check.invitation_sent? && !current_ambassador.account.background_check_exemption?%>
     <%= render "background_checks/rebrand/show" %>
   <% else %>
     <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Background Check" } do %>

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -3,7 +3,7 @@
       <%= render "application/templates/completion_step",
         name: "Background Check",
         url: chapter_ambassador_background_check_path,
-        is_complete: current_ambassador.background_check_complete?,
+        is_complete: current_ambassador.background_check_exempt_or_complete?,
         is_active_item: al(chapter_ambassador_background_check_path).present?
       %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,10 @@ Rails.application.routes.draw do
 
     resources :participants do
       delete "permanently_delete"
+      resource :background_check_exemption, only: [] do
+        patch :grant
+        patch :revoke
+      end
     end
 
     resources :participant_sessions, only: [:show, :destroy]

--- a/db/migrate/20240708200855_add_background_check_exemption_to_accounts.rb
+++ b/db/migrate/20240708200855_add_background_check_exemption_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddBackgroundCheckExemptionToAccounts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :accounts, :background_check_exemption, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -133,7 +133,8 @@ CREATE TABLE public.accounts (
     parent_registered boolean DEFAULT false NOT NULL,
     learn_worlds_user_id character varying,
     salesforce_id character varying,
-    meets_minimum_age_requirement boolean
+    meets_minimum_age_requirement boolean,
+    background_check_exemption boolean DEFAULT false NOT NULL
 );
 
 
@@ -4523,6 +4524,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240614132749'),
 ('20240620151755'),
 ('20240625173653'),
-('20240702145233');
+('20240702145233'),
+('20240708200855');
 
 

--- a/spec/controllers/admin/background_check_exemptions_controller_spec.rb
+++ b/spec/controllers/admin/background_check_exemptions_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Admin::BackgroundCheckExemptionsController do
+  describe "PATCH #grant" do
+    let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+    let(:account) { chapter_ambassador.account }
+
+    before do
+      sign_in(:admin)
+
+      patch :grant, params: {participant_id: account.id}
+      account.reload
+    end
+
+    it "grants a background check exemption" do
+      expect(account.background_check_exemption).to eq(true)
+    end
+  end
+
+  describe "PATCH #revoke" do
+    let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+    let(:account) { chapter_ambassador.account }
+
+    before do
+      sign_in(:admin)
+
+      patch :revoke, params: {participant_id: account.id}
+      account.reload
+    end
+
+    it "revokes the background check exemption" do
+      expect(account.background_check_exemption).to eq(false)
+    end
+  end
+end

--- a/spec/features/admin/background_check_exemptions_spec.rb
+++ b/spec/features/admin/background_check_exemptions_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Background check exemptions" do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  %i[mentor chapter_ambassador].each do |scope|
+    scenario "Admin grants a background check exemption for a #{scope}" do
+      profile = FactoryBot.create(scope)
+      profile.background_check.destroy
+
+      sign_in(admin)
+      visit admin_participant_path(profile.account)
+
+      expect(page).to have_content("#{profile.account.full_name} is in a country that requires a background check")
+      click_link "Exempt from background check requirement"
+
+      profile.reload
+
+      expect(current_path).to eq(admin_participant_path(profile.account))
+      expect(page).to have_text("They currently have a background check exemption.")
+      expect(page).to have_link("Revoke background check exemption")
+    end
+
+    scenario "Admin grants a background check exemption for a #{scope}" do
+      profile = FactoryBot.create(scope)
+      profile.background_check.destroy
+
+      profile.account.update(background_check_exemption: true)
+
+      sign_in(admin)
+      visit admin_participant_path(profile.account)
+
+      expect(page).to have_text("They currently have a background check exemption.")
+      click_link "Revoke background check exemption"
+
+      profile.reload
+
+      expect(current_path).to eq(admin_participant_path(profile.account))
+      expect(page).to have_content("#{profile.account.full_name} is in a country that requires a background check")
+      expect(page).to have_link("Exempt from background check requirement")
+    end
+  end
+end

--- a/spec/javascript/mentor/store/getters.spec.js
+++ b/spec/javascript/mentor/store/getters.spec.js
@@ -11,6 +11,7 @@ describe("mentor/store/getters.js", () => {
             attributes: {
               countryCode: "BR",
               age: 18,
+              backgroundCheckExemption: false,
             },
           },
         },
@@ -22,13 +23,14 @@ describe("mentor/store/getters.js", () => {
       expect(getters.isBackgroundCheckWaived(state)).toBe(true);
     });
 
-    it("is false when currentAccount.countryCode is US", () => {
+    it("is false when currentAccount.countryCode is US and currentAccount.backgroundCheckExeption is false", () => {
       const state = {
         currentAccount: {
           data: {
             attributes: {
               countryCode: "US",
               age: 18,
+              backgroundCheckExemption: false,
             },
           },
         },
@@ -47,6 +49,26 @@ describe("mentor/store/getters.js", () => {
             attributes: {
               countryCode: "US",
               age: "17",
+              backgroundCheckExemption: false,
+            },
+          },
+        },
+        settings: {
+          backgroundCheckCountryCodes: backgroundCheckCountryCodes,
+        },
+      };
+
+      expect(getters.isBackgroundCheckWaived(state)).toBe(true);
+    });
+
+    it("is true when currentAccount.backgroundCheckExemption is true", () => {
+      const state = {
+        currentAccount: {
+          data: {
+            attributes: {
+              countryCode: "US",
+              age: "17",
+              backgroundCheckExemption: true,
             },
           },
         },

--- a/spec/models/chapter_ambassador_profile_spec.rb
+++ b/spec/models/chapter_ambassador_profile_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ChapterAmbassadorProfile do
             .and_return(legal_document)
         end
 
-        let(:account) { instance_double(Account, email_confirmed?: email_address_confirmed, marked_for_destruction?: false, valid?: true) }
+        let(:account) { instance_double(Account, email_confirmed?: email_address_confirmed, marked_for_destruction?: false, valid?: true,  background_check_exemption?: false) }
         let(:email_address_confirmed) { true }
         let(:background_check) { instance_double(BackgroundCheck, clear?: background_check_cleared) }
         let(:background_check_cleared) { true }


### PR DESCRIPTION
Refs #4843 

This PR will add ability for admin to exempt mentors from a background check. 

Added the following:
- New route/controller `BackgroundCheckExemptions`
- Migration to add `background_check_exemption` to the accounts table
- View/partial updates to accommodate for this new field (status displays & modal to grant or revoke a bg check exemption)