### PR TITLE
Added admin background check exemptions for ChAs (pt. 2)

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -260,6 +260,7 @@ class Account < ActiveRecord::Base
   after_create :create_account_created_activity
   before_update :update_division, if: -> { !is_a_judge? && !is_chapter_ambassador? }
   after_commit :update_email_list, on: :update
+  after_update :update_chapter_ambassador_onboarding_status
 
   after_commit -> {
     if saved_change_to_email_confirmed_at ||

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -84,11 +84,13 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
   end
 
   def background_check_complete?
-    !!background_check && background_check.clear?
+    return true unless requires_background_check?
+
+    background_check.present? && background_check.clear?
   end
 
   def requires_background_check?
-    !background_check_complete?
+    !(background_check.present? && background_check.clear? || account.background_check_exemption?)
   end
 
   def in_background_check_country?

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -83,14 +83,20 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     !intro_summary.blank?
   end
 
-  def background_check_complete?
-    return true unless requires_background_check?
+  def background_check_exempt_or_complete?
+    background_check_exempt? || background_check_complete?
+  end
 
+  def background_check_complete?
     background_check.present? && background_check.clear?
   end
 
+  def background_check_exempt?
+    account.background_check_exemption?
+  end
+
   def requires_background_check?
-    !(background_check.present? && background_check.clear? || account.background_check_exemption?)
+    !background_check_exempt? && !background_check_complete?
   end
 
   def in_background_check_country?

--- a/app/views/admin/participants/_background_check_exemption.html.erb
+++ b/app/views/admin/participants/_background_check_exemption.html.erb
@@ -1,5 +1,4 @@
 <% if profile.requires_background_check? %>
-  <h6>Grant background check exemption</h6>
   <p>
     <%= profile.name %> is in a country that requires a background check. By clicking the button below, <%= profile.name %> will be exempt from the background check requirement.
   </p>
@@ -15,7 +14,6 @@
                 } %>
   </p>
 <% elsif profile.background_check_exemption? %>
-    <h6>Revoke background check exemption</h6>
     <p>
       <%= profile.name %> is in a country that requires a background check. They currently have a background check exemption. <br>
       By clicking the button below, you will revoke the background check exemption and they will be required to complete a background check.

--- a/app/views/admin/participants/_background_check_invitation_status.html.erb
+++ b/app/views/admin/participants/_background_check_invitation_status.html.erb
@@ -1,5 +1,10 @@
 <% if profile.in_background_check_invitation_country? %>
-  <% if profile.background_check.invitation_pending? %>
+  <% if profile.account.background_check_exemption? %>
+    <%= web_icon(
+          "check-circle icon-green",
+          text: "Background check exempt"
+        ) %>
+  <% elsif profile.background_check.invitation_pending? %>
     <%= web_icon(
           "exclamation-circle icon--orange",
           text:  profile.background_check.invitation_status.humanize

--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -3,8 +3,7 @@
 
   <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
     <% if current_account.is_admin? && (profile.requires_background_check? || profile.background_check_exemption?) %>
-      <%= render 'admin/participants/background_check_exemption',
-                 profile: profile %>
+      <%= render "admin/participants/background_check_exemption", profile: profile %>
       <hr style="height: 1px; width: 100%;">
     <% end %>
 

--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -2,6 +2,12 @@
   <%= render "chapter_ambassador_onboarding", chapter_ambassador: profile %>
 
   <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <% if current_account.is_admin? && (profile.requires_background_check? || profile.background_check_exemption?) %>
+      <%= render 'admin/participants/background_check_exemption',
+                 profile: profile %>
+      <hr style="height: 1px; width: 100%;">
+    <% end %>
+
     <dl>
       <dt>Chapter Onboarding Status</dt>
       <dd>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -8,12 +8,9 @@
       <dt>Complete Background Check</dt>
       <dd>
         <div style="display: flex;">
-          <% if chapter_ambassador.account.background_check_exemption? %>
+          <% if chapter_ambassador.background_check_exempt_or_complete? %>
             <%= web_icon("check-circle icon-green") %>
-            <div>Background check exempt</div>
-          <% elsif chapter_ambassador.background_check.clear? %>
-            <%= web_icon("check-circle icon-green") %>
-            <div>Complete</div>
+            <div><%= chapter_ambassador.background_check_complete? ? "Complete" : "Background check exempt" %></div>
           <% else %>
             <%= web_icon("exclamation-circle icon-red") %>
             <div>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -8,7 +8,10 @@
       <dt>Complete Background Check</dt>
       <dd>
         <div style="display: flex;">
-          <% if chapter_ambassador.background_check.clear? %>
+          <% if chapter_ambassador.account.background_check_exemption? %>
+            <%= web_icon("check-circle icon-green") %>
+            <div>Background check exempt</div>
+          <% elsif chapter_ambassador.background_check.clear? %>
             <%= web_icon("check-circle icon-green") %>
             <div>Complete</div>
           <% else %>

--- a/app/views/chapter_ambassador/background_checks/show.html.erb
+++ b/app/views/chapter_ambassador/background_checks/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
-  <% if current_ambassador.background_check.invitation_sent? %>
+  <% if current_ambassador.background_check.invitation_sent? && !current_ambassador.account.background_check_exemption?%>
     <%= render "background_checks/rebrand/show" %>
   <% else %>
     <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Background Check" } do %>

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -3,7 +3,7 @@
       <%= render "application/templates/completion_step",
         name: "Background Check",
         url: chapter_ambassador_background_check_path,
-        is_complete: current_ambassador.background_check_complete?,
+        is_complete: current_ambassador.background_check_exempt_or_complete?,
         is_active_item: al(chapter_ambassador_background_check_path).present?
       %>
 

--- a/spec/controllers/admin/background_check_exemptions_controller_spec.rb
+++ b/spec/controllers/admin/background_check_exemptions_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Admin::BackgroundCheckExemptionsController do
+  describe "PATCH #grant" do
+    let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+    let(:account) { chapter_ambassador.account }
+
+    before do
+      sign_in(:admin)
+
+      patch :grant, params: {participant_id: account.id}
+      account.reload
+    end
+
+    it "grants a background check exemption" do
+      expect(account.background_check_exemption).to eq(true)
+    end
+  end
+
+  describe "PATCH #revoke" do
+    let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+    let(:account) { chapter_ambassador.account }
+
+    before do
+      sign_in(:admin)
+
+      patch :revoke, params: {participant_id: account.id}
+      account.reload
+    end
+
+    it "revokes the background check exemption" do
+      expect(account.background_check_exemption).to eq(false)
+    end
+  end
+end

--- a/spec/features/admin/background_check_exemptions_spec.rb
+++ b/spec/features/admin/background_check_exemptions_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.feature "Background check exemptions" do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  %i[mentor chapter_ambassador].each do |scope|
+    scenario "Admin grants a background check exemption for a #{scope}" do
+      profile = FactoryBot.create(scope)
+      profile.background_check.destroy
+
+      sign_in(admin)
+      visit admin_participant_path(profile.account)
+
+      expect(page).to have_content("#{profile.account.full_name} is in a country that requires a background check")
+      click_link "Exempt from background check requirement"
+
+      profile.reload
+
+      expect(current_path).to eq(admin_participant_path(profile.account))
+      expect(page).to have_text("They currently have a background check exemption.")
+      expect(page).to have_link("Revoke background check exemption")
+    end
+
+    scenario "Admin grants a background check exemption for a #{scope}" do
+      profile = FactoryBot.create(scope)
+      profile.background_check.destroy
+
+      profile.account.update(background_check_exemption: true)
+
+      sign_in(admin)
+      visit admin_participant_path(profile.account)
+
+      expect(page).to have_text("They currently have a background check exemption.")
+      click_link "Revoke background check exemption"
+
+      profile.reload
+
+      expect(current_path).to eq(admin_participant_path(profile.account))
+      expect(page).to have_content("#{profile.account.full_name} is in a country that requires a background check")
+      expect(page).to have_link("Exempt from background check requirement")
+    end
+  end
+end

--- a/spec/models/chapter_ambassador_profile_spec.rb
+++ b/spec/models/chapter_ambassador_profile_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ChapterAmbassadorProfile do
             .and_return(legal_document)
         end
 
-        let(:account) { instance_double(Account, email_confirmed?: email_address_confirmed, marked_for_destruction?: false, valid?: true) }
+        let(:account) { instance_double(Account, email_confirmed?: email_address_confirmed, marked_for_destruction?: false, valid?: true,  background_check_exemption?: false) }
         let(:email_address_confirmed) { true }
         let(:background_check) { instance_double(BackgroundCheck, clear?: background_check_cleared) }
         let(:background_check_cleared) { true }


### PR DESCRIPTION
Refs #4843 

This is part 2 of the bg check grant/revoke functionality. This PR adds the ability for admin to grant/revoke background check exemptions for ChAs. I am working on tests but wanted to get some eyes on the PR before your OOO time next week! 💯 🚀 