### PR TITLE
Updated technical additions section to account for removal of submission type

### DIFF
--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -1,6 +1,6 @@
 <% provide :title, "Technical Additions" %>
 
-<% if @team_submission.source_code_url_complete? %>
+  <% if @team_submission.source_code_url_complete? %>
     <div class="field-existing-value">
       Your team has previously uploaded
       <%= link_to @team_submission.source_code_filename,
@@ -8,14 +8,14 @@
     </div>
   <% end %>
 
-  <% if @team_submission.submission_type.blank? || (@team_submission.submission_type == "Mobile App" && @team_submission.development_platform.blank?) %>
+  <% if @team_submission.development_platform.blank? %>
     <%= render template: 'team_submissions/pieces/development_platform',
       locals: {
         submission: @team_submission,
         embedded: true,
       } %>
   <% else %>
-    <% if @team_submission.submission_type == "Mobile App" && @team_submission.developed_on?("Thunkable") %>
+    <% if @team_submission.developed_on?("Thunkable") %>
       <%= form_with model: @team_submission,
         url: send("#{current_scope}_team_submission_url", @team_submission),
         local: true do |f| %>
@@ -29,10 +29,18 @@
       </div>
 
       <% end %>
-    <% elsif @team_submission.submission_type == "Mobile App" %>
-      <p>Mobile App source code should be submitted depending on the language used:</p>
+    <% elsif @team_submission.developed_on?("App Inventor") ||  @team_submission.developed_on?("Other") %>
+      <p>Source code should be submitted depending on the language used:</p>
       <ul>
         <li><em>.aia</em> file (MIT App Inventor) OR <em>.zip</em> file (other languages)</li>
+      </ul>
+      <br>
+
+      <p>AI Projects should include 1 zip file that contains:</p>
+      <ul class="list-disc ml-8">
+        <li>Screenshot of dataset training (ML4Kids, TeachableMachine, App Inventor, etc.) or spreadsheet or link to images/sounds folder</li>
+        <li>Picture(s) of prototype (cardboard model, drawings, devices)</li>
+        <li>For online inventions - Any link with demo login information</li>
       </ul>
       <br>
 
@@ -46,26 +54,6 @@
         </div>
 
         <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
-      <% end %>
-    <% elsif @team_submission.submission_type == "AI Project" %>
-      <p>AI Projects should include 1 zip file that contains:</p>
-      <ul class="list-disc ml-8">
-        <li>Screenshot of dataset training (ML4Kids, TeachableMachine, App Inventor, etc.) or spreadsheet or link to images/sounds folder</li>
-        <li>Picture(s) of prototype (cardboard model, drawings, devices)</li>
-        <li>(For online inventions) Any link with demo login information</li>
-      </ul>
-      <br>
-
-      <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
-        <input type="hidden" name="utf8">
-        <%= f.label :file, "Upload your technical work" %>
-        <%= f.file_field :file, accept: ".zip", class: 'source-code-uploader__file' %>
-
-        <div class="flash flash--alert source-code-uploader__error hidden">
-          Sorry, you tried to upload an invalid file type.
-        </div>
-
-        <%= f.submit "Upload", class: "tw-green-btn source-code-uploader__submit-button" %>
       <% end %>
     <% end %>
 

--- a/spec/system/submissions/upload_source_code_spec.rb
+++ b/spec/system/submissions/upload_source_code_spec.rb
@@ -25,10 +25,14 @@ RSpec.describe "Uploading technical work to submissions", :js do
     end
 
     context "when development platform has been entered" do
-      ["Swift or XCode", "Thunkable Classic"].each do |platform|
+      ["App Inventor", "Other"].each do |platform|
         context "and development platform (#{platform}) is not Thunkable" do
           before do
-            TeamSubmission.last.update!(submission_type: 1, development_platform: platform)
+            if platform == "App Inventor"
+              TeamSubmission.last.update!(development_platform: platform, app_inventor_app_name: "Test")
+            else
+              TeamSubmission.last.update!(development_platform: platform)
+            end
           end
 
           context "and a valid file is uploaded" do
@@ -36,7 +40,7 @@ RSpec.describe "Uploading technical work to submissions", :js do
               click_link "Technical Additions"
               expect(page).to have_css("input[type=file]")
 
-              ["aia", "apk", "zip"].each do |good_file|
+              ["aia", "zip"].each do |good_file|
                 attach_file(
                   "file",
                   File.absolute_path("./spec/support/uploads/example.#{good_file}"),


### PR DESCRIPTION
Refs #4864 

This PR addresses the issue found with the technical additions section in the student submission process. As a student, you could not access the technical additions/uploader because the logic used the submission type. Since there is no longer a submission type, you could not access the page as intended. 

