### PR TITLE
Scratch & development platform/techincal additions cleanup

### DIFF
--- a/app/assets/javascripts/dropzones.js
+++ b/app/assets/javascripts/dropzones.js
@@ -40,7 +40,7 @@ Dropzone.options.teamSubmissionSourcecodeDropzone = $.extend(
   {
     method: "POST",
     paramName: "team_submission[source_code]",
-    acceptedFiles: ".aia,.zip",
+    acceptedFiles: ".aia,.zip,.sb3",
   }
 );
 

--- a/app/assets/javascripts/image-uploaders.js
+++ b/app/assets/javascripts/image-uploaders.js
@@ -97,7 +97,7 @@ function isValidSourceCodeFile () {
     'application/vnd.android.package-archive', //apk
   ];
 
-  var validFileExtensions = ['.aia', '.apk', '.zip'];
+  var validFileExtensions = ['.aia', '.apk', '.zip', '.sb3'];
 
   for (var i = 0; i < fileInput.files.length; i += 1) {
     var file = fileInput.files[i];

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -141,10 +141,7 @@ class SubmissionsGrid
   end
 
   column :development_platform do
-    if development_platform_text.present?
-      platform = development_platform_text
-      platform.downcase.starts_with?("mobile") ? platform : ""
-    end
+    development_platform_text.presence || "-"
   end
 
   column :state_province, header: "State" do

--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -74,4 +74,14 @@ module StudentHelper
       web_icon("circle-o", {class: "icon--orange", text: text})
     end
   end
+
+  def link_to_download_or_open_project(submission)
+    if submission.developed_on?("Thunkable")
+      submission.thunkable_project_url
+    elsif submission.developed_on?("Scratch")
+      submission.source_code.present? ? submission.source_code_url : submission.scratch_project_url
+    elsif submission.developed_on?("Other") || submission.developed_on?("App Inventor")
+      submission.source_code_url
+    end
+  end
 end

--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -40,48 +40,16 @@ module StudentHelper
     when :screenshots
       :complete if submission.screenshots.many?
     when :development_platform
-      if (
-            submission.development_platform == "App Inventor" &&
-            submission.app_inventor_app_name.present? &&
-            submission.errors.attribute_names.exclude?(:app_inventor_app_name) &&
-            (
-              submission.app_inventor_gmail.blank? ||
-              submission.errors.attribute_names.exclude?(:app_inventor_gmail)
-            )
-          ) ||
-          (
-
-            submission.development_platform == "Thunkable" &&
-            submission.thunkable_project_url.present? &&
-            submission.errors.attribute_names.exclude?(:thunkable_project_url) &&
-            (
-              submission.thunkable_account_email.blank? ||
-              submission.errors.attribute_names.exclude?(:thunkable_account_email)
-            )
-          ) ||
-          (
-
-            submission.development_platform == "Other"
-          )
-
+      if submission.app_inventor_fields_complete? ||
+          submission.thunkable_fields_complete? ||
+          submission.scratch_fields_complete? ||
+          submission.other_fields_complete?
         :complete
       end
     when :source_code, :source_code_url
-      if (submission.submission_type == "Mobile App" &&
-          submission.development_platform == "Thunkable" &&
-          submission.thunkable_project_url.present? &&
-          submission.errors.attribute_names.exclude?(:thunkable_project_url) &&
-          submission.source_code_external_url.present? &&
-          submission.errors.attribute_names.exclude?(:source_code_external_url)) &&
-          (
-            submission.thunkable_account_email.blank? ||
-            submission.errors.attribute_names.exclude?(:thunkable_account_email)
-          ) ||
-          (
-            submission.source_code_url.present? &&
-            submission.errors.attribute_names.exclude?(:source_code_url)
-          )
-
+      if submission.thunkable_source_code_fields_complete? ||
+          submission.scratch_source_code_fields_complete? ||
+          submission.source_code_url_complete?
         :complete
       end
     when :business_plan

--- a/app/models/submissions/required_fields.rb
+++ b/app/models/submissions/required_fields.rb
@@ -102,7 +102,7 @@ class RequiredSourceCodeField < RequiredField
   end
 
   def blank?
-    if submission.developed_on?("Thunkable")
+    if submission.developed_on?("Thunkable") || submission.developed_on?("Scratch")
       submission.source_code_external_url.blank?
     else
       value.blank?

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -597,6 +597,45 @@ class TeamSubmission < ActiveRecord::Base
     send(:Scratch?)
   end
 
+  def app_inventor_fields_complete?
+    developed_on?("App Inventor") &&
+      app_inventor_app_name.present? &&
+      errors.attribute_names.exclude?(:app_inventor_app_name) &&
+      (app_inventor_gmail.blank? || errors.attribute_names.exclude?(:app_inventor_gmail))
+  end
+
+  def thunkable_fields_complete?
+    developed_on?("Thunkable") &&
+      thunkable_project_url.present? &&
+      errors.attribute_names.exclude?(:thunkable_project_url) &&
+      (thunkable_account_email.blank? || errors.attribute_names.exclude?(:thunkable_account_email))
+  end
+
+  def scratch_fields_complete?
+    developed_on?("Scratch") &&
+      scratch_project_url.present? &&
+      errors.attribute_names.exclude?(:scratch_project_url)
+  end
+
+  def other_fields_complete?
+    developed_on?("Other")
+  end
+
+  def thunkable_source_code_fields_complete?
+    thunkable_fields_complete? &&
+      source_code_external_url_fields_complete?
+  end
+
+  def scratch_source_code_fields_complete?
+    scratch_fields_complete? &&
+      source_code_external_url_fields_complete?
+  end
+
+  def source_code_external_url_fields_complete?
+    source_code_external_url.present? &&
+      errors.attribute_names.exclude?(:source_code_external_url)
+  end
+
   def additional_questions?
     seasons.last >= 2021
   end

--- a/app/uploaders/file_processor.rb
+++ b/app/uploaders/file_processor.rb
@@ -10,6 +10,6 @@ class FileProcessor < CarrierWave::Uploader::Base
   end
 
   def extension_white_list
-    %w[aia apk zip csv pdf ppt pptx]
+    %w[aia apk zip csv pdf ppt pptx sb3]
   end
 end

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -7,7 +7,7 @@ class FileUploader < CarrierWave::Uploader::Base
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_white_list
-    %w[aia zip csv ppt pdf pptx]
+    %w[aia zip csv ppt pdf pptx sb3]
   end
 
   # Override the directory where uploaded files will be stored.

--- a/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
@@ -101,14 +101,14 @@
 
       <ul>
         <li>
-          <%= link_to submission.developed_on?("Thunkable") ? submission.thunkable_project_url : submission.source_code_url, class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :blank do %>
+          <%= link_to link_to_download_or_open_project(submission), class: "text-energetic-blue hover:text-energetic-blue text-lg", target: :blank do %>
             <div class="flex items-center">
               <svg class="mr-2 h-6 w-6 flex-shrink" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
 
               <div>
-                <%= submission.developed_on?("Thunkable") ? "View on Thunkable" : "Download the technical work" %>
+                <%= submission.source_code_url.present? ? "Download the technical work" : "Open project" %>
               </div>
 
               <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
+++ b/app/views/student/dashboards/completion_steps/rebrand/_view_completed_team_submission.html.erb
@@ -27,7 +27,6 @@
 
       <%=
         [
-          submission.submission_type,
           submission.development_platform,
           submission.development_platform_other
         ].delete_if(&:blank?).join(" - ")

--- a/app/views/team_submissions/pieces/source_code_pieces/_app_inventor_or_other.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_pieces/_app_inventor_or_other.en.html.erb
@@ -1,0 +1,25 @@
+<p>Source code should be submitted depending on the language used:</p>
+<ul>
+  <li><em>.aia</em> file (MIT App Inventor) OR <em>.zip</em> file (other languages)</li>
+</ul>
+<br>
+
+<p>AI Projects should include 1 zip file that contains:</p>
+<ul class="list-disc ml-8">
+  <li>Screenshot of dataset training (ML4Kids, TeachableMachine, App Inventor, etc.) or spreadsheet or link to images/sounds folder</li>
+  <li>Picture(s) of prototype (cardboard model, drawings, devices)</li>
+  <li>For online inventions - Any link with demo login information</li>
+</ul>
+<br>
+
+<%= direct_upload_form_for source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
+  <input type="hidden" name="utf8">
+  <%= f.label :file, "Upload your technical work" %>
+  <%= f.file_field :file, accept: ".aia,.zip", class: 'source-code-uploader__file' %>
+
+  <div class="flash flash--alert source-code-uploader__error hidden">
+    Sorry, you tried to upload an invalid file type.
+  </div>
+
+  <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
+<% end %>

--- a/app/views/team_submissions/pieces/source_code_pieces/_scratch.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_pieces/_scratch.en.html.erb
@@ -1,0 +1,34 @@
+<% if submission.source_code_external_url.present? %>
+  <%= form_with model: submission,
+                url: send("#{current_scope}_team_submission_url", submission),
+                local: true do |f| %>
+    <p>
+      <%= f.label :scratch_project_url %>
+      <%= f.text_field :scratch_project_url %>
+    </p>
+
+    <div class="flex flex-row justify-end">
+      <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
+    </div>
+
+  <% end %>
+<% else %>
+  <p>Source code should be submitted depending on the language used:</p>
+  <p>
+    If you used a Scratch environment other than the scratch.mit.edu website, you will
+    save your project to your computer, and then upload that file in this section.
+    The file will have a .sb3 file extension name.
+  </p>
+  <br>
+  <%= direct_upload_form_for source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
+    <input type="hidden" name="utf8">
+    <%= f.label :file, "Upload your technical work" %>
+    <%= f.file_field :file, accept: ".sb3", class: 'source-code-uploader__file' %>
+
+    <div class="flash flash--alert source-code-uploader__error hidden">
+      Sorry, you tried to upload an invalid file type.
+    </div>
+
+    <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
+  <% end %>
+<% end %>

--- a/app/views/team_submissions/pieces/source_code_pieces/_thunkable.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_pieces/_thunkable.en.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: submission,
+              url: send("#{current_scope}_team_submission_url", submission),
+              local: true do |f| %>
+  <p>
+    <%= f.label :thunkable_project_url %>
+    <%= f.text_field :thunkable_project_url %>
+  </p>
+
+  <div class="flex flex-row justify-end">
+    <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
+  </div>
+
+<% end %>

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -9,86 +9,22 @@
   <% end %>
 
   <% if @team_submission.development_platform.blank? %>
-    <%= render template: 'team_submissions/pieces/development_platform',
+    <%= render template: "team_submissions/pieces/development_platform",
       locals: {
         submission: @team_submission,
         embedded: true,
       } %>
   <% else %>
     <% if @team_submission.developed_on?("Thunkable") %>
-      <%= form_with model: @team_submission,
-        url: send("#{current_scope}_team_submission_url", @team_submission),
-        local: true do |f| %>
-        <p>
-          <%= f.label :source_code_external_url %>
-          <%= f.text_field :source_code_external_url %>
-        </p>
-
-      <div class="flex flex-row justify-end">
-        <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
-      </div>
-
-      <% end %>
+      <%= render "team_submissions/pieces/source_code_pieces/thunkable",
+        submission: @team_submission %>
     <% elsif @team_submission.developed_on?("App Inventor") ||  @team_submission.developed_on?("Other") %>
-      <p>Source code should be submitted depending on the language used:</p>
-      <ul>
-        <li><em>.aia</em> file (MIT App Inventor) OR <em>.zip</em> file (other languages)</li>
-      </ul>
-      <br>
-
-      <p>AI Projects should include 1 zip file that contains:</p>
-      <ul class="list-disc ml-8">
-        <li>Screenshot of dataset training (ML4Kids, TeachableMachine, App Inventor, etc.) or spreadsheet or link to images/sounds folder</li>
-        <li>Picture(s) of prototype (cardboard model, drawings, devices)</li>
-        <li>For online inventions - Any link with demo login information</li>
-      </ul>
-      <br>
-
-      <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
-        <input type="hidden" name="utf8">
-        <%= f.label :file, "Upload your technical work" %>
-        <%= f.file_field :file, accept: ".aia,.zip", class: 'source-code-uploader__file' %>
-
-        <div class="flash flash--alert source-code-uploader__error hidden">
-          Sorry, you tried to upload an invalid file type.
-        </div>
-
-        <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
-      <% end %>
+      <%= render "team_submissions/pieces/source_code_pieces/app_inventor_or_other",
+        source_code_uploader: @source_code_uploader %>
     <% elsif @team_submission.developed_on?("Scratch") %>
-      <% if @team_submission.source_code_external_url.present? %>
-        <%= form_with model: @team_submission,
-                      url: send("#{current_scope}_team_submission_url", @team_submission),
-                      local: true do |f| %>
-          <p>
-            <%= f.label :source_code_external_url %>
-            <%= f.text_field :source_code_external_url %>
-          </p>
-
-          <div class="flex flex-row justify-end">
-            <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
-          </div>
-        <% end %>
-      <% else %>
-        <p>Source code should be submitted depending on the language used:</p>
-        <p>
-          If you used a Scratch environment other than the scratch.mit.edu website, you will
-          save your project to your computer, and then upload that file in this section.
-          The file will have a .sb3 file extension name.
-        </p>
-        <br>
-        <%= direct_upload_form_for @source_code_uploader, html: { multipart: true, class: 'source-code-uploader' } do |f| %>
-          <input type="hidden" name="utf8">
-          <%= f.label :file, "Upload your technical work" %>
-          <%= f.file_field :file, accept: ".sb3", class: 'source-code-uploader__file' %>
-
-          <div class="flash flash--alert source-code-uploader__error hidden">
-            Sorry, you tried to upload an invalid file type.
-          </div>
-
-          <%= f.submit "Upload", class: "button source-code-uploader__submit-button" %>
-        <% end %>
-      <% end %>
+      <%= render "team_submissions/pieces/source_code_pieces/scratch",
+        submission: @team_submission,
+        source_code_uploader: @source_code_uploader %>
     <% end %>
 
     <p class="py-2">

--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -36,7 +36,7 @@
       <%= link_to @team_submission.thunkable_project_url,
       @team_submission.thunkable_project_url %>
     </p>
-  <% elsif @team_submission.developed_on?("Scratch") %>
+  <% elsif @team_submission.developed_on?("Scratch") && @team_submission.scratch_project_url.present? %>
     <p>
       Project url:
       <%= link_to @team_submission.scratch_project_url,

--- a/spec/system/submissions/upload_source_code_spec.rb
+++ b/spec/system/submissions/upload_source_code_spec.rb
@@ -88,6 +88,49 @@ RSpec.describe "Uploading technical work to submissions", :js do
           expect(page).to have_xpath("//input[@type='text' and @value='#{url}']")
         end
       end
+
+      context "and development platform is Scratch" do
+        context "and the scratch project url has been filled in" do
+          let(:url) { "https://scratch.mit.edu/projects/694700505" }
+
+          before do
+            TeamSubmission.last.update!({
+              development_platform: "Scratch",
+              scratch_project_url: url
+            })
+          end
+
+          it "displays a text field with the URL filled in" do
+            click_link "Technical Additions"
+            expect(page).not_to have_css("input[type=file]")
+            expect(page).to have_xpath("//input[@type='text' and @value='#{url}']")
+          end
+        end
+
+        context "and the scratch project url has not been filled in" do
+          before do
+            TeamSubmission.last.update!({
+              development_platform: "Scratch",
+              scratch_project_url: nil
+            })
+          end
+
+          it "allows an sb3 file to be uploaded" do
+            click_link "Technical Additions"
+            expect(page).to have_css("input[type=file]")
+
+            attach_file(
+              "file",
+              File.absolute_path("./spec/support/uploads/example.sb3"),
+              class: "source-code-uploader__file"
+            )
+
+            expect(page).to have_selector(".source-code-uploader__error", visible: false)
+            expect(page).to have_button("Upload", disabled: false)
+
+          end
+        end
+      end
     end
 
     context "when development platform has not been entered" do


### PR DESCRIPTION
Refs #4871 

This PR is general cleanup/fallout due to the addition of Scratch as a development platform option. It includes the following:
- Fixed weird behavior for thunkable & scratch selection - now when you update the project url through the technical additions, the project URL is saved correctly
- Refactored the logic for student sidenav development platform & technical additions checkmarks
- Update submission grid development platform column
- Allowed `sb3` file extension to be uploaded
- Multiple view updates 