### PR TITLE
Updated reset logic to address bugs when switching development platform

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -736,13 +736,19 @@ class TeamSubmission < ActiveRecord::Base
   def reset_development_platform_fields_for_app_inventor
     if development_platform == "App Inventor"
       self.development_platform_other = nil
+      self.thunkable_account_email = nil
+      self.thunkable_project_url = nil
+      self.scratch_project_url = nil
     end
   end
 
   def reset_development_platform_fields_for_thunkable
     if development_platform == "Thunkable"
+      self.remove_source_code! if source_code.present?
       self.development_platform_other = nil
       self.scratch_project_url = nil
+      self.app_inventor_app_name = nil
+      self.app_inventor_gmail = nil
     end
   end
 


### PR DESCRIPTION
Refs #2826 & #4170 

This update addresses 2 bugs

The 1st is very old (#2826). If you previously uploaded technical additions and then switched to a thunkable project, the upload was still part of the submission and would display in the technical additions detailed view

![CleanShot 2024-07-25 at 13 17 55@2x](https://github.com/user-attachments/assets/bb09702e-be59-40e1-b4e9-055fbaa81fde)

the 2nd bug (#4170) - You could not change between app inventor and thunkable 

This PR addresses these 2 bugs, however I think there is a better way to address resetting the platform fields when switching between development platform types. I added #4881 to capture this.
