### PR TITLE
Various ChA text updates 

### DIFF
--- a/app/views/application/templates/_sub_checklist_item.erb
+++ b/app/views/application/templates/_sub_checklist_item.erb
@@ -1,5 +1,7 @@
+<% new_tab ||= false %>
+
 <li>
-  <a href="<%= url  %>" class="group flex items-center hover:text-gray-900">
+  <a href="<%= url %>" class="group flex items-center hover:text-gray-900" target="<%= new_tab ? '_blank' : '_self' %>"  >
     <span class="flex items-center" aria-hidden="true">
       <% if is_complete %>
         <span class="flex h-6 w-6 items-center justify-center rounded-full bg-tg-green">

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -74,7 +74,7 @@
         Based on historical data,
         <%= link_to "Checkr reports",
         "http://checkr.com" %>
-        are usually completed within 4-7 business days.
+        are usually completed within 4-7 business days but may take longer depending on the country where you are located.
       </p>
 
       <p>
@@ -83,9 +83,10 @@
       </p>
 
       <p>
-        For example, Checkr has asked previous mentors to provide a scan
-        of their driver's licence. Technovation cannot offer help with this,
-        and you should consult the staff at Checkr.
+        For example, Checkr has asked previous
+        <%= current_scope == "mentor" ? "mentors" : "Chapter Ambassadors" %>
+        to provide a scan of their driver's license. Technovation cannot offer
+        help with this, and you should consult the staff at Checkr.
       </p>
 
       <p>

--- a/app/views/background_checks/rebrand/_background_check_invitation.html.erb
+++ b/app/views/background_checks/rebrand/_background_check_invitation.html.erb
@@ -8,8 +8,14 @@
                     rel: "noopener noreferrer",
                     target: "_blank", class: "tw-link"%>,
         a third-party screening service, to conduct our background checks.
-        We complete these checks for mentors as a safety measure before
-        they are able to match with a Technovation team.
+
+        <% if current_scope == "mentor" %>
+          We complete these checks for mentors as a safety measure before
+          they are able to match with a Technovation team.
+        <% elsif current_scope == "chapter_ambassador" %>
+          We complete these checks for Chapter Ambassadors before they are granted
+          access to the students’ data such as names and email addresses.
+        <% end %>
       </p>
 
       <p class="mb-4">
@@ -26,8 +32,13 @@
 
       <p>
         You will receive an email from us when your background check clears. Once your
-        background check has cleared, you will be able to match with an existing Technovation
-        team or create a new team.
+        background check has cleared,
+        <% if current_scope == "mentor" %>
+          you will be able to match with an existing Technovation team or create a new team.
+        <% elsif current_scope == "chapter_ambssador" %>
+          and you have completed the other onboarding steps, you will be able to access the administrative
+          information for your chapter.
+        <% end %>
       </p>
     </div>
 

--- a/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
@@ -2,5 +2,16 @@
   <%= render "chapter_ambassador/chapter_profile/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Profile" } do %>
+    <p class="mb-4">Welcome to the Chapter Profile section!</p>
+
+    <p class="mb-4">
+      Here, you'll provide important details about your Chapter to help us understand your local program better.
+      You must complete all four sections in order to access the administrative dashboard for your Chapter.
+      Remember, you can always come back and edit your Chapter Profile as needed.
+    </p>
+
+    <p>
+      Note that the information in the <span class="font-bold">Program Info section is not public.</span>
+    </p>
   <% end %>
 </div>

--- a/app/views/chapter_ambassador/dashboards/show.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show.en.html.erb
@@ -2,5 +2,10 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Ambassador Dashboard" } do %>
+    <p>
+      Welcome! Please review and complete the onboarding checklist items to officially become a Chapter Ambassador
+      for the upcoming season. Completing this process and the Chapter Profile information will grant you access to
+      the administrative dashboard for your Chapter.
+    </p>
   <% end %>
 </div>

--- a/app/views/completion_steps/rebrand/_mou.html.erb
+++ b/app/views/completion_steps/rebrand/_mou.html.erb
@@ -1,47 +1,48 @@
 <p class="mb-4">
-  The Memorandum of Understanding serves as the formal agreement between Technovation and you,
-  as the Chapter Ambassador representing a non-profit organization with whom Technovation is working.
+  The Chapter Volunteer Agreement serves as the formal agreement between
+  Technovation and you, as the Chapter Ambassador representing an
+  organization with whom Technovation is working.
 </p>
 
-<p class="mb-8">Please confirm that you have read each of these policies and then click the link
-  to sign the Memorandum of Understanding.
+<p class="mb-8">
+  Please confirm that you have read all guidelines and policies below,
+  and then click the link to sign the Chapter Volunteer Agreement.
 </p>
 
 <div class="ml-8 mb-8">
   <ol role="list" class="space-y-4">
     <%= render "application/templates/sub_checklist_item",
                name: "Non-Disclosure Agreement",
-               url: "#",
+               url: ENV.fetch("CHAPTER_AMBASSADOR_NON_DISCLOSURE_AGREEMENT_URL"),
+               new_tab: true,
                is_complete: false
     %>
 
     <%= render "application/templates/sub_checklist_item",
                name: "Brand Guidelines",
-               url: "#",
+               url: ENV.fetch("CHAPTER_AMBASSADOR_BRAND_GUIDELINES_URL"),
+               new_tab: true,
                is_complete: false
     %>
 
     <%= render "application/templates/sub_checklist_item",
-               name: "Social Media Admin Agreement",
-               url: "#",
+               name: "Social Media Guidelines",
+               url: ENV.fetch("CHAPTER_AMBASSADOR_SOCIAL_MEDIA_GUIDELINES_URL"),
+               new_tab: true,
                is_complete: false
     %>
 
     <%= render "application/templates/sub_checklist_item",
-               name: "Social Media Policy",
-               url: "#",
+               name: "Code of Conduct",
+               url: ENV.fetch("CHAPTER_AMBASSADOR_CODE_OF_CONDUCT_URL"),
+               new_tab: true,
                is_complete: false
     %>
 
     <%= render "application/templates/sub_checklist_item",
-               name: "Technovation Code of Conduct",
-               url: "#",
-               is_complete: true
-    %>
-
-    <%= render "application/templates/sub_checklist_item",
-               name: "Reviewed Safety Page",
-               url: "#",
+               name: "Safety Page",
+               url: ENV.fetch("CHAPTER_AMBASSADOR_SAFETY_PAGE_URL"),
+               new_tab: true,
                is_complete: false
     %>
   </ol>


### PR DESCRIPTION
Refs #4869 

This PR updates the text on the following ChA pages:
- ChA dashboard
- Chapter dashboard 
- Legal agreement page
- Background check page

I added the following ENV variables for the legal agreement page:
```
CHAPTER_AMBASSADOR_NON_DISCLOSURE_AGREEMENT_URL
CHAPTER_AMBASSADOR_BRAND_GUIDELINES_URL
CHAPTER_AMBASSADOR_SOCIAL_MEDIA_GUIDELINES_URL
CHAPTER_AMBASSADOR_CODE_OF_CONDUCT_URL
CHAPTER_AMBASSADOR_SAFETY_PAGE_URL
```

Should we also update the MOU text (at least on the front end) before the platform opens?