### PR TITLE
Updated chapter location page

### DIFF
--- a/app/views/chapter_ambassador/chapter_locations/_form.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/_form.en.html.erb
@@ -12,12 +12,6 @@
     </p>
   </div>
 
-  <div class="mb-4">
-    <%= f.label :country %>
-    <p class="text-base ml-3"><%= current_chapter.country %></p>
-    <p class="text-sm italic ml-3">Pre-set by Technovation HQ. Not editable.</p>
-  </div>
-
   <p class="mt-8">
     <%= f.submit "Save", class: "tw-green-btn" %>
       or

--- a/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
@@ -7,12 +7,6 @@
         <p class="mb-4">This information will be publicly visible to students, mentors, and visitors to the Technovation website.</p>
 
         <div class="ml-8">
-          <p class="font-semibold">Country</p>
-          <p class="mb-2">
-            <%= current_chapter.country.presence || "Not set" %>
-            <span class="text-sm italic">(pre-set by HQ)</span>
-          </p>
-
           <p class="font-semibold">Organization Headquarters Location</p>
           <p class="text-sm italic">
             The city entered for the organization headquarters will be used to map the location of your chapter.
@@ -21,29 +15,15 @@
 
           <p class="font-semibold">Location Served by Chapter</p>
           <p class="mb-2">
-            <% if current_chapter.country.present? %>
-              Your chapter's current location is set to <span class="font-semibold"><%= current_chapter.country %></span>.
-              <br>
-              When students from that country register,
-              they will see your chapter in the list of chapters available to them.
-              If you are working only in specific regions, please select those from the drop-down
-              list in order to provide a more accurate location. Your chapter will only be
-              displayed to students registering in those regions
-            <% else %>
-              Your chapter's location is not currently set.
-              Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.
-            <% end  %>
+              Your chapter is currently serving this location:
+              <span class="font-medium">
+                <%= "#{current_ambassador.state}, #{current_ambassador.country}" %>
+              </span>
           </p>
-
-          <p class="font-semibold">Selected Region</p>
-          <p class="mb-4"><%= current_chapter.state_province.presence || "Not set" %></p>
-
-          <p class="font-semibold">Selected City</p>
-          <p class="mb-4"><%= current_chapter.city.presence || "Not set" %></p>
         </div>
 
         <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
-          <%= link_to "Update chapter location",
+          <%= link_to "Update organization headquarters",
                       edit_chapter_ambassador_chapter_location_path,
                       class: "tw-green-btn mx-auto" %>
         </div>

--- a/spec/features/chapter_ambassador/edit_chapter_location_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_location_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Chapter ambassadors edit chapter location" do
   end
 
   scenario "Chapter ambassador edits organization headquarters location" do
-    click_link "Update chapter location"
+    click_link "Update organization headquarters"
 
     fill_in "chapter_organization_headquarters_location", with: "123 Main St, USA"
     click_button "Save"


### PR DESCRIPTION
Refs #4879 

This PR updates the Chapter location page - mostly removing location information that was not needed at this time.


<img width="1089" alt="Screenshot 2024-08-02 at 9 11 41 AM" src="https://github.com/user-attachments/assets/9f7617d9-4b37-4b60-ae1d-8bfc5fe38abb">

<img width="1109" alt="Screenshot 2024-08-02 at 9 12 26 AM" src="https://github.com/user-attachments/assets/9724b3a5-580d-4e7d-8ea8-48bb1cf9534d">

