### PR TITLE
Updated reset logic to address bugs when switching development platform

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -738,13 +738,19 @@ class TeamSubmission < ActiveRecord::Base
   def reset_development_platform_fields_for_app_inventor
     if development_platform == "App Inventor"
       self.development_platform_other = nil
+      self.thunkable_account_email = nil
+      self.thunkable_project_url = nil
+      self.scratch_project_url = nil
     end
   end
 
   def reset_development_platform_fields_for_thunkable
     if development_platform == "Thunkable"
+      self.remove_source_code! if source_code.present?
       self.development_platform_other = nil
       self.scratch_project_url = nil
+      self.app_inventor_app_name = nil
+      self.app_inventor_gmail = nil
     end
   end
 


### PR DESCRIPTION
This is a "duplicate" PR.
I did something strange with the merging of the [original](https://github.com/Iridescent-CM/technovation-app/pull/4882) PR into a different scratch branch. Somehow this work did not end up on QA and that is why the bug fix with switching between thunkable/app inventor was not working as intended. 

@shaun-technovation I am going to mark this as code review not required since you already reviewed this work. 