### PR TITLE
Added welcome message that includes incomplete cha and chapter onboarding tasks to cha dashboard and chapter tab

### DIFF
--- a/app/controllers/chapter_ambassador_controller.rb
+++ b/app/controllers/chapter_ambassador_controller.rb
@@ -54,7 +54,7 @@ class ChapterAmbassadorController < ApplicationController
   def require_chapter_and_chapter_ambassador_onboarded
     unless current_ambassador.chapter&.onboarded? && current_ambassador.onboarded?
       redirect_to chapter_ambassador_dashboard_path,
-        error: "You must complete all onboarding steps before accessing Chapter Admin Activity."
+        error: "You must complete all onboarding tasks before accessing Chapter Admin Activity."
     end
   end
 end

--- a/app/controllers/concerns/onboarding_tasks_concern.rb
+++ b/app/controllers/concerns/onboarding_tasks_concern.rb
@@ -1,0 +1,7 @@
+module OnboardingTasksConcern
+  extend ActiveSupport::Concern
+
+  def incomplete_onboarding_tasks
+    required_onboarding_tasks.reject { |_, completed| completed }.keys
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -2,7 +2,6 @@ class Chapter < ActiveRecord::Base
   include ActiveGeocoded
   include OnboardingTasksConcern
 
-
   belongs_to :primary_contact, class_name: "ChapterAmbassadorProfile", foreign_key: "primary_contact_id", optional: true
 
   has_one :legal_contact, dependent: :destroy

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,5 +1,7 @@
 class Chapter < ActiveRecord::Base
   include ActiveGeocoded
+  include OnboardingTasksConcern
+
 
   belongs_to :primary_contact, class_name: "ChapterAmbassadorProfile", foreign_key: "primary_contact_id", optional: true
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -74,4 +74,14 @@ class Chapter < ActiveRecord::Base
   def program_info_complete?
     chapter_program_information&.complete?
   end
+
+  def required_onboarding_tasks
+    {
+      "Chapter Affiliation Agreement" => legal_document_signed?,
+      "Public Info" => chapter_info_complete?,
+      "Chapter Location" => location_complete?,
+      "Program Info" => program_info_complete?
+    }
+  end
 end
+

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -1,4 +1,6 @@
 class ChapterAmbassadorProfile < ActiveRecord::Base
+  include OnboardingTasksConcern
+
   scope :onboarded, -> {
     approved.joins(:account)
       .where("accounts.email_confirmed_at IS NOT NULL")

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -131,6 +131,15 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     legal_document&.signed?
   end
 
+  def required_onboarding_tasks
+    {
+      "Background Check" => background_check_exempt_or_complete?,
+      "Chapter Ambassador Training" => training_completed?,
+      "Legal Agreement" => legal_document_signed?,
+      "Community Connections" => viewed_community_connections?
+    }
+  end
+
   def region_name
     return unless Country[country]
 

--- a/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
@@ -1,3 +1,7 @@
+<% if !current_ambassador.onboarded? || !current_chapter.onboarded? %>
+  <%= render "chapter_ambassador/profiles/welcome_message_with_required_steps" %>
+<% end %>
+
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/chapter_profile/side_nav" %>
 

--- a/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/show.en.html.erb
@@ -1,4 +1,5 @@
-<% if !current_ambassador.onboarded? || !current_chapter.onboarded? %>
+<% if current_chapter.present? &&
+  ( !current_ambassador.onboarded? || !current_chapter.onboarded? ) %>
   <%= render "chapter_ambassador/profiles/welcome_message_with_required_steps" %>
 <% end %>
 

--- a/app/views/chapter_ambassador/dashboards/show.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show.en.html.erb
@@ -1,4 +1,5 @@
-<% if !current_ambassador.onboarded? || !current_chapter.onboarded? %>
+<% if current_chapter.present? &&
+  ( current_ambassador.onboarded? || current_chapter.onboarded? ) %>
     <%= render "chapter_ambassador/profiles/welcome_message_with_required_steps" %>
 <% end %>
 

--- a/app/views/chapter_ambassador/dashboards/show.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show.en.html.erb
@@ -1,3 +1,7 @@
+<% if !current_ambassador.onboarded? || !current_chapter.onboarded? %>
+    <%= render "chapter_ambassador/profiles/welcome_message_with_required_steps" %>
+<% end %>
+
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 

--- a/app/views/chapter_ambassador/profiles/_welcome_message_with_required_steps.en.html.erb
+++ b/app/views/chapter_ambassador/profiles/_welcome_message_with_required_steps.en.html.erb
@@ -1,0 +1,21 @@
+<div class="container px-4 py-4 mx-auto mb-8 w-full lg:w-3/4 bg-blue-100 border-l-4 border-energetic-blue">
+  <h2 class="mb-4 text-gray-600">Welcome to Technovation Girls!</h2>
+
+  <p class="mb-3 text-base text-gray-500">
+    We're really happy you decided to join us for the <%= Season.current.year %> season!
+    To access participant data in the Chapter Admin Activity, please complete all Chapter Ambassador onboarding tasks and Chapter onboarding tasks.
+  </p>
+
+  <p class="mb-3 text-base text-gray-500">
+    The following tasks are incomplete: <br>
+  </p>
+
+  <ul class="mb-3 text-base text-gray-500 list-disc ml-8">
+    <li>
+      <%= chapter_ambassador.incomplete_onboarding_tasks.to_sentence %>
+    </li>
+    <li>
+      <%= current_chapter.incomplete_onboarding_tasks.to_sentence %>
+    </li>
+  </ul>
+</div>

--- a/spec/models/chapter_ambassador_profile_spec.rb
+++ b/spec/models/chapter_ambassador_profile_spec.rb
@@ -39,6 +39,61 @@ RSpec.describe ChapterAmbassadorProfile do
     end
   end
 
+  describe "#incomplete_onboarding_tasks" do
+    before do
+      allow(chapter_ambassador_profile).to receive(:background_check_exempt_or_complete?).and_return(true)
+      allow(chapter_ambassador_profile).to receive(:training_completed?).and_return(true)
+      allow(chapter_ambassador_profile).to receive(:legal_document_signed?).and_return(true)
+      allow(chapter_ambassador_profile).to receive(:viewed_community_connections?).and_return(true)
+    end
+
+    context "when all required onboarding tasks have been completed" do
+      it "returns returns an empty array" do
+        expect(chapter_ambassador_profile.incomplete_onboarding_tasks).to be_empty
+      end
+    end
+
+    context "when the background check is incomplete" do
+      before do
+        allow(chapter_ambassador_profile).to receive(:background_check_exempt_or_complete?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Background Check'" do
+        expect(chapter_ambassador_profile.incomplete_onboarding_tasks).to contain_exactly("Background Check")
+      end
+    end
+
+    context "when the training is incomplete" do
+      before do
+        allow(chapter_ambassador_profile).to receive(:training_completed?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Chapter Ambassador Training'" do
+        expect(chapter_ambassador_profile.incomplete_onboarding_tasks).to contain_exactly("Chapter Ambassador Training")
+      end
+    end
+
+    context "when the legal agreement has not been signed" do
+      before do
+        allow(chapter_ambassador_profile).to receive(:legal_document_signed?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Legal Agreement'" do
+        expect(chapter_ambassador_profile.incomplete_onboarding_tasks).to contain_exactly("Legal Agreement")
+      end
+    end
+
+    context "when the community connections page has not been viewed" do
+      before do
+        allow(chapter_ambassador_profile).to receive(:viewed_community_connections?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Community Connections'" do
+        expect(chapter_ambassador_profile.incomplete_onboarding_tasks).to contain_exactly("Community Connections")
+      end
+    end
+  end
+
   context "callbacks" do
     context "#after_update" do
       describe "updating the onboarded status" do

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -10,6 +10,61 @@ RSpec.describe Chapter do
     end
   end
 
+  describe "#incomplete_onboarding_tasks" do
+    before do
+      allow(chapter).to receive(:legal_document_signed?).and_return(true)
+      allow(chapter).to receive(:chapter_info_complete?).and_return(true)
+      allow(chapter).to receive(:location_complete?).and_return(true)
+      allow(chapter).to receive(:program_info_complete?).and_return(true)
+    end
+
+    context "when all required onboarding tasks have been completed" do
+      it "returns returns an empty array" do
+        expect(chapter.incomplete_onboarding_tasks).to be_empty
+      end
+    end
+
+    context "when the chapter affiliation has not been signed" do
+      before do
+        allow(chapter).to receive(:legal_document_signed?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Chapter Affiliation Agreement'" do
+        expect(chapter.incomplete_onboarding_tasks).to contain_exactly("Chapter Affiliation Agreement")
+      end
+    end
+
+    context "when the public info has not been completed" do
+      before do
+        allow(chapter).to receive(:chapter_info_complete?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Public Info'" do
+        expect(chapter.incomplete_onboarding_tasks).to contain_exactly("Public Info")
+      end
+    end
+
+    context "when chapter location is not complete" do
+      before do
+        allow(chapter).to receive(:location_complete?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Chapter Location'" do
+        expect(chapter.incomplete_onboarding_tasks).to contain_exactly("Chapter Location")
+      end
+    end
+
+    context "when program info is not complete" do
+      before do
+        allow(chapter).to receive(:program_info_complete?).and_return(false)
+      end
+
+      it "returns returns an array that contains 'Program Info'" do
+        expect(chapter.incomplete_onboarding_tasks).to contain_exactly("Program Info")
+      end
+    end
+  end
+
   context "callbacks" do
     context "#after_update" do
       describe "updating the onboarded status" do


### PR DESCRIPTION
Refs #4851 

This PR adds the following:
- `OnboardingTasksConcern`
- Logic to determine which chapter ambassador and chapter onboarding tasks are incomplete
- Welcome partial (similar to student experience) that displays incomplete tasks

<img width="1549" alt="Screenshot 2024-08-06 at 8 40 39 PM" src="https://github.com/user-attachments/assets/2ff56c42-bb10-4d7d-a5d8-58d695b53ae5">
