### PR TITLE
Added remaining onboarding tasks and completed onboarding tasks column to cha grid

### DIFF
--- a/app/controllers/concerns/onboarding_tasks_concern.rb
+++ b/app/controllers/concerns/onboarding_tasks_concern.rb
@@ -4,4 +4,8 @@ module OnboardingTasksConcern
   def incomplete_onboarding_tasks
     required_onboarding_tasks.reject { |_, completed| completed }.keys
   end
+
+  def complete_onboarding_tasks
+    required_onboarding_tasks.select { |_, completed| completed }.keys
+  end
 end

--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -80,6 +80,14 @@ class ChapterAmbassadorsGrid
     chapter_ambassador_profile.training_completed? ? "Yes" : "No"
   end
 
+  column :remaining_onboarding_tasks do
+    chapter_ambassador_profile.incomplete_onboarding_tasks.to_sentence
+  end
+
+  column :completed_onboarding_tasks do
+    chapter_ambassador_profile.complete_onboarding_tasks.to_sentence
+  end
+
   column :actions, mandatory: true, html: true do |account|
     link_to(
       "view",


### PR DESCRIPTION
Refs #4811 

This PR adds remaining onboarding tasks and completed onboarding tasks column to cha grid 

<img width="669" alt="Screenshot 2024-08-06 at 9 08 56 PM" src="https://github.com/user-attachments/assets/dd1f9ebc-fccd-49ef-973d-1da3af682c13">
