### PR TITLE
Salesforce updates

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -124,7 +124,12 @@ module Salesforce
         }
       when "mentor"
         {
-          Mentor_Type__c: account.mentor_profile.mentor_types.pluck(:name).join(";")
+          Mentor_Type__c: account
+            .mentor_profile
+            .mentor_types
+            .pluck(:name)
+            .delete_if { |mentor_type| mentor_type == "Club Ambassador" }
+            .join(";")
         }
       else
         {}
@@ -143,9 +148,13 @@ module Salesforce
           Team_Name__c: account.student_profile.team.name
         }
       when "mentor"
+        mentor_profile = account.mentor_profile
+
         initial_program_participant_info.merge(
           {
-            Mentor_Team_Status__c: account.mentor_profile.current_teams.present? ? "On Team" : "Not On Team"
+            Mentor_Team_Status__c: mentor_profile.current_teams.present? ? "On Team" : "Not On Team",
+            Mentor_Role__c: mentor_profile.mentor_types.pluck(:name).include?("Club Ambassador") ? "Club Ambassador" : ""
+
           }
         )
       else

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -249,11 +249,34 @@ RSpec.describe Salesforce::ApiClient do
               {
                 Id: program_participant_id,
                 Mentor_Type__c: mentor_profile.mentor_types.pluck(:name).join(";"),
+                Mentor_Role__c: "",
                 Mentor_Team_Status__c: "Not On Team"
               }
             )
 
             salesforce_api_client.update_program_info
+          end
+
+          context "when a mentor is a club ambassador" do
+            before do
+              mentor_profile.mentor_types = []
+              mentor_profile.mentor_types << FactoryBot.create(:mentor_type, name: "Club Ambassador")
+              mentor_profile.save
+            end
+
+            it "calls update! to update the 'program participant' info for the mentor, sets mentor role to club ambassador and does not include club ambassador as a mentor type" do
+              expect(salesforce_client).to receive(:update!).with(
+                "Program_Participant__c",
+                {
+                  Id: program_participant_id,
+                  Mentor_Type__c: "",
+                  Mentor_Role__c: "Club Ambassador",
+                  Mentor_Team_Status__c: "Not On Team"
+                }
+              )
+
+              salesforce_api_client.update_program_info
+            end
           end
         end
 


### PR DESCRIPTION
A few Salesforce updates here:

- Map email address to alternate email in Salesforce (`npe01__AlternateEmail__c`)
- Only send date of birth and parental/guardian info for students
- Send "Club Ambassador" as "Mentor Role"
- Remove "Club Ambassador" from "Mentor Types"

Addresses: #4904