### PR TITLE
Add preferred email address field to Salesforce

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -94,6 +94,7 @@ module Salesforce
           FirstName: account.first_name,
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
+          npe01__Preferred_Email__c: "Alternate",
           MailingCity: account.city,
           MailingState: account.state_province,
           MailingCountry: account.country

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Salesforce::ApiClient do
           FirstName: account.first_name,
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
+          npe01__Preferred_Email__c: "Alternate",
           Birthdate: account.date_of_birth,
           MailingCity: account.city,
           MailingState: account.state_province,
@@ -166,6 +167,7 @@ RSpec.describe Salesforce::ApiClient do
           FirstName: account.first_name,
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
+          npe01__Preferred_Email__c: "Alternate",
           MailingCity: account.city,
           MailingState: account.state_province,
           MailingCountry: account.country


### PR DESCRIPTION
This will fix an issue w/ Salesforce, since we're now sending email address as alternate email address, this seems to be causing an error where preferred email address needs to be provided/is required now. That's what this PR will do, it will make the "Alternate" email address the preferred email address in Salesforce.

Related to: #4904


