### PR TITLE
Update mentor info being sent to Salesforce

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -124,9 +124,14 @@ module Salesforce
           TG_Division__c: "#{account.division.name} Division"
         }
       when "mentor"
+        mentor_profile = account.mentor_profile
+
         {
-          Mentor_Type__c: account
-            .mentor_profile
+          Mentor_Role__c: mentor_profile
+            .mentor_types
+            .pluck(:name)
+            .include?("Club Ambassador") ? "Club Ambassador" : "",
+          Mentor_Type__c: mentor_profile
             .mentor_types
             .pluck(:name)
             .delete_if { |mentor_type| mentor_type == "Club Ambassador" }
@@ -149,13 +154,9 @@ module Salesforce
           Team_Name__c: account.student_profile.team.name
         }
       when "mentor"
-        mentor_profile = account.mentor_profile
-
         initial_program_participant_info.merge(
           {
-            Mentor_Team_Status__c: mentor_profile.current_teams.present? ? "On Team" : "Not On Team",
-            Mentor_Role__c: mentor_profile.mentor_types.pluck(:name).include?("Club Ambassador") ? "Club Ambassador" : ""
-
+            Mentor_Team_Status__c: account.mentor_profile.current_teams.present? ? "On Team" : "Not On Team"
           }
         )
       else

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Salesforce::ApiClient do
               Platform_Participant_Id__c: account.id,
               Year__c: Season.current.year,
               Type__c: profile_type,
+              Mentor_Role__c: "",
               Mentor_Type__c: mentor_profile.mentor_types.pluck(:name).join(";")
             }
           )


### PR DESCRIPTION
This will make "Mentor Role" be a part of the initial data being sent to Salesforce for the "Program Participant" record. Before this change, "Mentor Role" would only get sent when an update was triggered, but not for the initial insert.

Related to: #4904


