### PR TITLE
Various updates related to ChA testing feedback

### DIFF
--- a/app/models/submissions/required_fields.rb
+++ b/app/models/submissions/required_fields.rb
@@ -102,8 +102,10 @@ class RequiredSourceCodeField < RequiredField
   end
 
   def blank?
-    if submission.developed_on?("Thunkable") || submission.developed_on?("Scratch")
+    if submission.developed_on?("Thunkable")
       submission.source_code_external_url.blank?
+    elsif submission.developed_on?("Scratch")
+      submission.source_code_external_url.blank? && submission.source_code.blank?
     else
       value.blank?
     end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -741,6 +741,7 @@ class TeamSubmission < ActiveRecord::Base
       self.thunkable_account_email = nil
       self.thunkable_project_url = nil
       self.scratch_project_url = nil
+      self.remove_source_code! if source_code.present?
     end
   end
 

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -766,6 +766,7 @@ class TeamSubmission < ActiveRecord::Base
 
   def reset_development_platform_fields_for_scratch
     if development_platform == "Scratch"
+      self.remove_source_code! if source_code.present?
       self.thunkable_account_email = nil
       self.thunkable_project_url = nil
       self.app_inventor_app_name = nil

--- a/app/views/chapter_ambassador/community_connections/show.en.html.erb
+++ b/app/views/chapter_ambassador/community_connections/show.en.html.erb
@@ -37,6 +37,7 @@
                       ENV.fetch("CHAPTER_AMBASSADOR_SLACK_URL"),
                       class: "tw-link",
                       target: "_blank" %>!
+          If you're a new ambassador, look out for an email to join the group.
         </li>
         <li class="ml-8">
           Join our Whatsapp group and join a regional community (Coming soon)

--- a/app/views/student/team_submission_file_upload_confirmations/show.en.html.erb
+++ b/app/views/student/team_submission_file_upload_confirmations/show.en.html.erb
@@ -10,7 +10,7 @@
       </p>
 
       <p class="scent--strong">
-        If you used any format besides .zip, .aia, .ppt, .pptx, or .pdf, your file will NOT be linked!
+        If you used any format besides .zip, .aia, .sb3, .ppt, .pptx, or .pdf, your file will NOT be linked!
       </p>
 
       <center>

--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -60,7 +60,8 @@
       <%= link_to @team_submission.thunkable_project_url,
         @team_submission.thunkable_project_url %>
     </p>
-  <% elsif @team_submission.developed_on?("Scratch")%>
+  <% elsif @team_submission.developed_on?("Scratch") &&
+    @team_submission.scratch_project_url.present?%>
     <p>
       Project url:
       <%= link_to @team_submission.scratch_project_url,


### PR DESCRIPTION
Refs #4829 

-  If Scratch file uploaded and switch to App Inventor, the Scratch file remains
- Update text on Community Connections page in the Slack bullet to say: "Connect with other ambassadors and mentors on our Slack channel! If you're a new ambassador, look out for an email to join the group."
- Fix Scratch bug where when you upload an sb3 file, technical additions section showed a green checkmark (correct) and you can see the upload on the technical additions upload page, BUT the summary page did now show the file uploaded