### PR TITLE
Update affiliation agreement Docusign fields

### DIFF
--- a/app/services/docusign/api_client.rb
+++ b/app/services/docusign/api_client.rb
@@ -134,8 +134,11 @@ module Docusign
                   fontSize: "Size10",
                   italic: true,
                   underline: true,
+                  required: true,
+                  tabId: "location",
+                  tabLabel: "location",
                   value: truncate(chapter.location, length: 30),
-                  width: 150
+                  width: 165
                 },
                 {
                   anchorString: "Title:",
@@ -144,6 +147,8 @@ module Docusign
                   font: "Georgia",
                   fontSize: "Size12",
                   required: true,
+                  tabId: "title",
+                  tabLabel: "title",
                   value: legal_contact.job_title,
                   width: 155
                 }


### PR DESCRIPTION
This will update the location and title fields for the affiliation agreement.

Location:

- Making it required
- Adjusting the width
- Adding a label and id

Title:

- Adding a label and id

The ids are needed so they're treated as separate fields.

Related to: #4917, #4876


