### PR TITLE
Remove chapter summary character limit

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -18,8 +18,6 @@ class Chapter < ActiveRecord::Base
 
   after_update :update_onboarding_status
 
-  validates :summary, length: {maximum: 280}
-
   scope :signed_affiliation_agreements, -> {
     joins(legal_contact: :documents)
       .where("documents.active = TRUE AND documents.signed_at IS NOT NULL")

--- a/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
@@ -23,22 +23,6 @@ RSpec.feature "Chapter ambassadors edit public chapter information" do
     expect(page).to have_content "Hello this is our awesome chapter!"
   end
 
-  scenario "Chapter ambassador saves a chapter summary longer than 280 characters" do
-    click_link "Update chapter public info"
-
-    fill_in "chapter_summary",
-            with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
-              "Praesent luctus dapibus lacus vitae interdum. " +
-              "Praesent lacinia accumsan ligula, sit amet ultrices " +
-              "velit venenatis id. Duis ac nibh euismod, " +
-              "porta risus ut, molestie tortor. Nam quis nulla. Integer malesuada. " +
-              "In in enim a arcu imperdiet malesuada In in enim a arcu imperdiet malesuada."
-
-    click_button "Save"
-
-    expect(page).to have_css(".flash.flash--alert", text: "Error updating chapter details.")
-  end
-
   scenario "Chapter ambassador changes their public chapter visibility status to 'do not display'" do
     expect(page).to have_content "This chapter is displayed on the map of chapters on the Technovation website"
     click_link "Update chapter public info"


### PR DESCRIPTION
This will temporarily remove the chapter summary limit so we can convert more chapter ambassadors to chapters.

The chapter ambassador intro summary gets converted the chapter summary. Some chapter ambassadors we're converting have an intro summary that is more than 280 characters, which means they wouldn't get converted because the 280 character limit validation would fail for them.

Related to: #4652 #4933


