### PR TITLE
BUG: ChAs without a chapter can't click training link

### DIFF
--- a/app/helpers/external_resource_helper.rb
+++ b/app/helpers/external_resource_helper.rb
@@ -6,7 +6,7 @@ module ExternalResourceHelper
       uid_value: account.id,
       full_name_value: account.full_name,
       email_value: account.email,
-      organization_value: account.chapter_ambassador_profile.chapter.organization_name,
+      organization_value: account.chapter_ambassador_profile.chapter&.organization_name,
       city_value: account.city,
       state_province_value: account.state_province,
       country_value: account.country


### PR DESCRIPTION
If a chapter ambassador without a chapter clicks "Chapter Ambassador Training", it will cause an error. This will fix that.

Addresses: #4909


