### PR TITLE
Added a 1000 character limit for chapter summary - validation & front end changes

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -18,6 +18,8 @@ class Chapter < ActiveRecord::Base
 
   after_update :update_onboarding_status
 
+  validates :summary, length: {maximum: 1000}
+
   scope :signed_affiliation_agreements, -> {
     joins(legal_contact: :documents)
       .where("documents.active = TRUE AND documents.signed_at IS NOT NULL")

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -20,13 +20,13 @@
   <div class="flex flex-col lg:flex-row justify-between mb-4">
     <span class="text-sm italic">
       Give your participants a short introduction to your program.
-      Use up to 280 characters.
+      Use up to 1000 characters.
     </span>
 
     <%= content_tag :span,
                     data: {
                       keep_count_of: "#chapter_summary",
-                      down_from: 280,
+                      down_from: 1000,
                     } do %>
       <span><%= (f.object.summary || "").length %></span>
 

--- a/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_public_information_spec.rb
@@ -10,18 +10,32 @@ RSpec.feature "Chapter ambassadors edit public chapter information" do
     click_link "Public Info"
   end
 
-  scenario "Chapter ambassador edits chapter name and chapter summary" do
+  scenario "Chapter ambassador edits chapter name and adds a 680 character chapter summary" do
+    valid_length_text = "Hello this is our awesome chapter!" * 20
+
     click_link "Update chapter public info"
 
     expect(page).to have_checked_field("chapter_visible_on_map_true")
 
     fill_in "chapter_name", with: "Chapter Legoland"
-    fill_in "chapter_summary", with: "Hello this is our awesome chapter!"
+    fill_in "chapter_summary", with: valid_length_text
     click_button "Save"
 
     expect(page).to have_content "Chapter Legoland"
-    expect(page).to have_content "Hello this is our awesome chapter!"
+    expect(page).to have_content(valid_length_text)
   end
+
+  scenario "Chapter ambassador saves a chapter summary longer than 1000 characters" do
+    invalid_length_text = "Lorem ipsum dolor " * 90
+
+    click_link "Update chapter public info"
+
+    fill_in "chapter_summary", with: invalid_length_text
+    click_button "Save"
+
+    expect(page).to have_css(".flash.flash--alert", text: "Error updating chapter details.")
+  end
+
 
   scenario "Chapter ambassador changes their public chapter visibility status to 'do not display'" do
     expect(page).to have_content "This chapter is displayed on the map of chapters on the Technovation website"
@@ -30,6 +44,6 @@ RSpec.feature "Chapter ambassadors edit public chapter information" do
     choose("chapter_visible_on_map_false")
     click_button "Save"
 
-    expect(page).to have_content "This chapter is not displayed on the map of chapters on the Technovation website"
+    expect(page).to have_content("This chapter is not displayed on the map of chapters on the Technovation website")
   end
 end


### PR DESCRIPTION
Refs #4933 

This PR adds a 1000 character limit for chapter summary - validation & front end changes 