### PR TITLE
Updates the ChA Dashboard onboarding tabs so that they are only available if a chapter is present

### DIFF
--- a/app/controllers/chapter_ambassador/community_connections_controller.rb
+++ b/app/controllers/chapter_ambassador/community_connections_controller.rb
@@ -4,7 +4,9 @@ module ChapterAmbassador
 
     layout "chapter_ambassador_rebrand"
 
-    after_action :update_viewed_community_connections, only: :show
+    after_action :update_viewed_community_connections,
+      only: :show,
+      if: -> { current_ambassador.chapter.present? }
 
     def new
       @community_connection = current_ambassador.build_community_connection

--- a/app/controllers/chapter_ambassador/community_connections_controller.rb
+++ b/app/controllers/chapter_ambassador/community_connections_controller.rb
@@ -6,7 +6,7 @@ module ChapterAmbassador
 
     after_action :update_viewed_community_connections,
       only: :show,
-      if: -> { current_ambassador.chapter.present? }
+      if: -> { current_chapter.present? }
 
     def new
       @community_connection = current_ambassador.build_community_connection

--- a/app/views/chapter_ambassador/background_checks/show.html.erb
+++ b/app/views/chapter_ambassador/background_checks/show.html.erb
@@ -1,11 +1,16 @@
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
-
-  <% if current_ambassador.background_check.invitation_sent? && !current_ambassador.account.background_check_exemption?%>
-    <%= render "background_checks/rebrand/show" %>
+  <% if current_ambassador.chapter.present? %>
+    <% if current_ambassador.background_check.invitation_sent? && !current_ambassador.account.background_check_exemption?%>
+      <%= render "background_checks/rebrand/show" %>
+    <% else %>
+      <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Background Check" } do %>
+        <%= render "completion_steps/rebrand/background_check", profile: current_ambassador %>
+      <% end %>
+    <% end %>
   <% else %>
     <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Background Check" } do %>
-      <%= render "completion_steps/rebrand/background_check", profile: current_ambassador %>
+      <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/chapter_ambassador/background_checks/show.html.erb
+++ b/app/views/chapter_ambassador/background_checks/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
-  <% if current_ambassador.chapter.present? %>
+  <% if current_chapter.present? %>
     <% if current_ambassador.background_check.invitation_sent? && !current_ambassador.account.background_check_exemption?%>
       <%= render "background_checks/rebrand/show" %>
     <% else %>

--- a/app/views/chapter_ambassador/community_connections/show.en.html.erb
+++ b/app/views/chapter_ambassador/community_connections/show.en.html.erb
@@ -2,79 +2,10 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Community Connections" } do %>
-    <div>
-      <p class="mb-4">
-        Check out all our resources for running the Technovation program on the
-        <%= link_to "Ambassador Resource Page",
-                    ENV.fetch("CHAPTER_AMBASSADOR_RESOURCE_PAGE_URL"),
-                    class: "tw-link" %>!
-      </p>
-
-      <p class="mb-4">
-        Join Technovation’s global community of ambassadors to stay connected and up-to-date with the
-        latest news and best practices.
-      </p>
-
-      <p class="mb-4">
-        We have added you to our email list to receive information about training, program deadlines,
-        and other relevant information to support leading a Technovation chapter.
-      </p>
-
-      <p>
-        You can also join our Global Community of Ambassadors by participating in the following groups:
-      </p>
-      <ul class="list-disc mb-8">
-        <li class="ml-8">
-          Join out global ambassador's
-          <%= link_to "LinkedIn Group",
-                      ENV.fetch("CHAPTER_AMBASSADOR_LINKEDIN_GROUP_URL"),
-                      class: "tw-link",
-                      target: "_blank" %>!
-        </li>
-        <li class="ml-8">
-          Connect with other ambassadors and mentors on our
-          <%= link_to "Slack group",
-                      ENV.fetch("CHAPTER_AMBASSADOR_SLACK_URL"),
-                      class: "tw-link",
-                      target: "_blank" %>!
-          If you're a new ambassador, look out for an email to join the group.
-        </li>
-        <li class="ml-8">
-          Join our Whatsapp group and join a regional community (Coming soon)
-        </li>
-      </ul>
-
-      <p class="font-semibold">Please answer these questions so our team can better support you.</p>
-
-      <div class="my-4">
-        <p class="font-medium">Your selected availability to join councils, trainings, etc <span class="text-sm italic">(*optional)</span></p>
-        <% if current_ambassador.community_connection&.availability_slots&.any? %>
-          <ul class="list-disc ml-8">
-            <% current_ambassador.community_connection.availability_slots.each do |availability_slot| %>
-              <li><%= availability_slot.time %></li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="text-red-500 ml-8">None added</p>
-        <% end %>
-      </div>
-
-      <div class="my-4">
-        <p class="font-medium">Topics you are interested in sharing <span class="text-sm italic">(*optional)</span></p>
-        <p class="ml-8"><%= current_ambassador.community_connection&.topic_sharing_response.presence || raw('<span class="text-red-500">None added</span>')%></p>
-      </div>
-
-      <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
-        <% if current_ambassador.community_connection.present? %>
-          <%= link_to "Update community connections",
-                      edit_chapter_ambassador_community_connections_path,
-                      class: "tw-green-btn mx-auto" %>
-        <% else %>
-          <%= link_to "Add community connections",
-                      new_chapter_ambassador_community_connections_path,
-                      class: "tw-green-btn mx-auto" %>
-        <% end %>
-      </div>
-    </div>
+    <% if current_ambassador.chapter.present? %>
+      <%= render "completion_steps/rebrand/community_connections", profile: current_ambassador %>
+    <% else %>
+      <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/chapter_ambassador/community_connections/show.en.html.erb
+++ b/app/views/chapter_ambassador/community_connections/show.en.html.erb
@@ -2,7 +2,7 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Community Connections" } do %>
-    <% if current_ambassador.chapter.present? %>
+    <% if current_chapter.present? %>
       <%= render "completion_steps/rebrand/community_connections", profile: current_ambassador %>
     <% else %>
       <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>

--- a/app/views/chapter_ambassador/legal_agreements/show.html.erb
+++ b/app/views/chapter_ambassador/legal_agreements/show.html.erb
@@ -2,7 +2,7 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Legal Agreement" } do %>
-    <% if current_ambassador.chapter.present? %>
+    <% if current_chapter.present? %>
       <%= render "completion_steps/rebrand/legal_agreement", profile: current_ambassador %>
     <% else %>
       <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>

--- a/app/views/chapter_ambassador/legal_agreements/show.html.erb
+++ b/app/views/chapter_ambassador/legal_agreements/show.html.erb
@@ -2,6 +2,10 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Legal Agreement" } do %>
-    <%= render "completion_steps/rebrand/legal_agreement", profile: current_ambassador %>
+    <% if current_ambassador.chapter.present? %>
+      <%= render "completion_steps/rebrand/legal_agreement", profile: current_ambassador %>
+    <% else %>
+      <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/chapter_ambassador/trainings/index.html.erb
+++ b/app/views/chapter_ambassador/trainings/index.html.erb
@@ -2,7 +2,7 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Ambassador Training and Checkpoint" } do %>
-    <% if current_ambassador.chapter.present? %>
+    <% if current_chapter.present? %>
       <% if current_ambassador.training_completed? %>
         <p class="mb-4">
           Thank you for completing the checkpoint. You can view correct answers here.

--- a/app/views/chapter_ambassador/trainings/index.html.erb
+++ b/app/views/chapter_ambassador/trainings/index.html.erb
@@ -2,26 +2,30 @@
   <%= render "chapter_ambassador/dashboards/onboarding/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Ambassador Training and Checkpoint" } do %>
-    <% if current_ambassador.training_completed? %>
-      <p class="mb-4">
-        Thank you for completing the checkpoint. You can view correct answers here.
-      </p>
+    <% if current_ambassador.chapter.present? %>
+      <% if current_ambassador.training_completed? %>
+        <p class="mb-4">
+          Thank you for completing the checkpoint. You can view correct answers here.
+        </p>
 
-      <%= render "chapter_ambassador/trainings/training_module_list" %>
+        <%= render "chapter_ambassador/trainings/training_module_list" %>
+      <% else %>
+        <p class="mb-4">
+          Please review the following training modules. This information will help you lead your chapter this season!
+          At the end of the training you will have access to the training checkpoint.
+          Please take the checkpoint to complete this step of onboarding.
+        </p>
+
+        <%= render "chapter_ambassador/trainings/training_module_list" %>
+
+        <div class="flex flex-row mt-8">
+          <%= link_to "Training Checkpoint",
+                      external_chapter_ambassador_training_checkpoint_link(current_account),
+                      class: "tw-green-btn mx-auto", target: "_blank" %>
+        </div>
+      <% end %>
     <% else %>
-      <p class="mb-4">
-        Please review the following training modules. This information will help you lead your chapter this season!
-        At the end of the training you will have access to the training checkpoint.
-        Please take the checkpoint to complete this step of onboarding.
-      </p>
-
-      <%= render "chapter_ambassador/trainings/training_module_list" %>
-
-      <div class="flex flex-row mt-8">
-        <%= link_to "Training Checkpoint",
-                    external_chapter_ambassador_training_checkpoint_link(current_account),
-                    class: "tw-green-btn mx-auto", target: "_blank" %>
-      </div>
+      <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/completion_steps/rebrand/_community_connections.html.erb
+++ b/app/views/completion_steps/rebrand/_community_connections.html.erb
@@ -1,0 +1,74 @@
+<div>
+  <p class="mb-4">
+    Check out all our resources for running the Technovation program on the
+    <%= link_to "Ambassador Resource Page",
+                ENV.fetch("CHAPTER_AMBASSADOR_RESOURCE_PAGE_URL"),
+                class: "tw-link" %>!
+  </p>
+
+  <p class="mb-4">
+    Join Technovation’s global community of ambassadors to stay connected and up-to-date with the
+    latest news and best practices.
+  </p>
+
+  <p class="mb-4">
+    We have added you to our email list to receive information about training, program deadlines,
+    and other relevant information to support leading a Technovation chapter.
+  </p>
+
+  <p>
+    You can also join our Global Community of Ambassadors by participating in the following groups:
+  </p>
+  <ul class="list-disc mb-8">
+    <li class="ml-8">
+      Join out global ambassador's
+      <%= link_to "LinkedIn Group",
+                  ENV.fetch("CHAPTER_AMBASSADOR_LINKEDIN_GROUP_URL"),
+                  class: "tw-link",
+                  target: "_blank" %>!
+    </li>
+    <li class="ml-8">
+      Connect with other ambassadors and mentors on our
+      <%= link_to "Slack group",
+                  ENV.fetch("CHAPTER_AMBASSADOR_SLACK_URL"),
+                  class: "tw-link",
+                  target: "_blank" %>!
+      If you're a new ambassador, look out for an email to join the group.
+    </li>
+    <li class="ml-8">
+      Join our Whatsapp group and join a regional community (Coming soon)
+    </li>
+  </ul>
+
+  <p class="font-semibold">Please answer these questions so our team can better support you.</p>
+
+  <div class="my-4">
+    <p class="font-medium">Your selected availability to join councils, trainings, etc <span class="text-sm italic">(*optional)</span></p>
+    <% if current_ambassador.community_connection&.availability_slots&.any? %>
+      <ul class="list-disc ml-8">
+        <% current_ambassador.community_connection.availability_slots.each do |availability_slot| %>
+          <li><%= availability_slot.time %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-red-500 ml-8">None added</p>
+    <% end %>
+  </div>
+
+  <div class="my-4">
+    <p class="font-medium">Topics you are interested in sharing <span class="text-sm italic">(*optional)</span></p>
+    <p class="ml-8"><%= current_ambassador.community_connection&.topic_sharing_response.presence || raw('<span class="text-red-500">None added</span>')%></p>
+  </div>
+
+  <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
+    <% if current_ambassador.community_connection.present? %>
+      <%= link_to "Update community connections",
+                  edit_chapter_ambassador_community_connections_path,
+                  class: "tw-green-btn mx-auto" %>
+    <% else %>
+      <%= link_to "Add community connections",
+                  new_chapter_ambassador_community_connections_path,
+                  class: "tw-green-btn mx-auto" %>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/chapter_ambassador/view_chapter_ambassador_dashboard_spec.rb
+++ b/spec/features/chapter_ambassador/view_chapter_ambassador_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.feature "Chapter Ambassador Dashboard" do
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :not_assigned_to_chapter) }
+
+  before do
+    sign_in(chapter_ambassador)
+    click_link "Dashboard"
+  end
+
+  scenario "Viewing the Background Check tab, the Chapter Ambassador cannot complete background check onboarding task" do
+    click_link "Background Check"
+    expect(page).to have_content("You are not associated with a chapter.")
+  end
+
+  scenario "Viewing the Chapter Ambassador Training tab, the Chapter Ambassador cannot complete training onboarding task" do
+    click_link "Chapter Ambassador Training"
+    expect(page).to have_content("You are not associated with a chapter.")
+  end
+
+  scenario "Viewing the Legal Agreement tab, the Chapter Ambassador cannot complete legal agreement onboarding task" do
+    click_link "Legal Agreement"
+    expect(page).to have_content("You are not associated with a chapter.")
+  end
+
+  scenario "Viewing Community Connections tab, the Chapter Ambassador cannot complete community connections onboarding task" do
+    click_link "Community Connections"
+    expect(page).to have_content("You are not associated with a chapter.")
+  end
+end


### PR DESCRIPTION
Refs #4938 

This PR will make the ChA Dashboard onboarding tabs only available if a chapter is present. I also updated the after action callback for the Community Connections to only run if a chapter is present. Currently, just by clicking that link the task is marked as complete. This update will make it so that the task is only marked as complete if there is a chapter present. 