### PR TITLE
Rake task to make ChAs legal contacts

### DIFF
--- a/lib/tasks/set_chapter_ambassadors_as_legal_contacts.rake
+++ b/lib/tasks/set_chapter_ambassadors_as_legal_contacts.rake
@@ -1,0 +1,25 @@
+desc "Set chapter ambassadors as legal contacts"
+task set_chapter_ambassadors_as_legal_contacts: :environment do |_, args|
+  args.extras.each do |arg|
+    arg.split(",").each do |account_id|
+      account = Account.find(account_id)
+      chapter_ambassador = account&.chapter_ambassador_profile
+      chapter = chapter_ambassador&.chapter
+
+      if chapter_ambassador.blank?
+        puts "Skipping account #{account_id}, this isn't a chapter ambassador account"
+      elsif chapter.blank?
+        puts "Skipping account #{account_id}, this chapter ambassador doesn't belong to a chapter"
+      elsif chapter.legal_contact.present?
+        puts "Skipping account #{account_id}, a legal contact is already setup for this chapter"
+      else
+        chapter.create_legal_contact(
+          full_name: account.full_name,
+          email_address: account.email
+        )
+
+        puts "Made #{account.full_name} the legal contact for #{chapter.organization_name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task will make a chapter ambassador a legal contacts for their chapter.

This rake task needs a list of account ids, for each account id, if they are a chapter ambassador, they belong to a chapter, and a legal contact isn't already setup, it these conditions are met it will make the chapter ambassador the legal contact for the chapter.

The rake task is run with this command:

`bundle exec rake set_chapter_ambassadors_as_legal_contacts[account_ids]`

Addresses: #4934


