### PR TITLE
Only add Salesforce program participant record if upsert was successful

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -45,16 +45,18 @@ module Salesforce
         salesforce_contact_id = upsert_contact
       end
 
-      handle_request "Setting up account (#{account.id}) for current season" do
-        client.insert!(
-          "Program_Participant__c",
-          {
-            Contact__c: salesforce_contact_id,
-            Platform_Participant_Id__c: account.id,
-            Year__c: Season.current.year,
-            Type__c: profile_type
-          }.merge(initial_program_participant_info)
-        )
+      if salesforce_contact_id.present?
+        handle_request "Setting up account (#{account.id}) for current season" do
+          client.insert!(
+            "Program_Participant__c",
+            {
+              Contact__c: salesforce_contact_id,
+              Platform_Participant_Id__c: account.id,
+              Year__c: Season.current.year,
+              Type__c: profile_type
+            }.merge(initial_program_participant_info)
+          )
+        end
       end
     end
 


### PR DESCRIPTION
I mentioned on standup that the Salesforce errors are coming in pairs, the first error message is when the upsert fails:
`DUPLICATE_VALUE: duplicate value found: Platform_Participant_ID__c`

Which leads to this error (b/c we don't have a contact id which gets returned from the upsert):

`REQUIRED_FIELD_MISSING: Required fields are missing: [Contact__c]`

This PR addresses the second error message. It's basically a band-aid/hack fix where if the upsert to Salesforce fails, we won't try to add a program participant record because we won't have a contact id for them (which is needed to create the program participant record). A real fix is figuring out why the upsert can fail with the error message:

`DUPLICATE_VALUE: duplicate value found: Platform_Participant_ID__c`

Upsert should update or insert by the `Platform_Participant_Id__c`, there shouldn't be any duplicate ids in Salesforce because it's marked as distinct. I don't have a fix for this at the moment, so the "fix" here is to stop trying to create the program participant record if there isn't a contact id, which should stop these errors from coming in:

`REQUIRED_FIELD_MISSING: Required fields are missing: [Contact__c]`

Related to: #4904 #4913


