### PR TITLE
Make current season the default season for chapter ambassador datagrid

### DIFF
--- a/app/controllers/admin/chapter_ambassadors_controller.rb
+++ b/app/controllers/admin/chapter_ambassadors_controller.rb
@@ -20,7 +20,8 @@ module Admin
     def grid_params
       grid = params[:chapter_ambassadors_grid] ||= {}
       grid.merge(
-        column_names: detect_extra_columns(grid)
+        column_names: detect_extra_columns(grid),
+        season: params[:chapter_ambassadors_grid][:season] || Season.current.year
       )
     end
   end


### PR DESCRIPTION
This will make the current season the default season for the chapter ambassador's datagrid.

Addresses: #4909


