### PR TITLE
Salesforce duplicate error messages

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -120,18 +120,21 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
   end
 
   def setup_account_in_crm_for_current_season(record, profile_type)
-    if ENV.fetch("ACTIVE_JOB_BACKEND") == "inline"
-      CRM::SetupAccountForCurrentSeasonJob.perform_later(
-        account_id: record.id,
-        profile_type: profile_type.to_s
-      )
-    else
-      CRM::SetupAccountForCurrentSeasonJob.set(wait: @@crm_job_wait_time.seconds).perform_later(
-        account_id: record.id,
-        profile_type: profile_type.to_s
-      )
+    crm_job.perform_later(
+      account_id: record.id,
+      profile_type: profile_type.to_s
+    )
 
-      @@crm_job_wait_time += 30
+    @@crm_job_wait_time += 30
+  end
+
+  private
+
+  def crm_job
+    if ENV.fetch("ACTIVE_JOB_BACKEND", "inline") == "inline"
+      CRM::SetupAccountForCurrentSeasonJob
+    else
+      CRM::SetupAccountForCurrentSeasonJob.set(wait: @@crm_job_wait_time.seconds)
     end
   end
 end


### PR DESCRIPTION
In this PR, for any combo accounts (e.g. mentor/ChAs), we will space out their Salesforce calls by 30 seconds.

Duplicate error messages, according to this [document](https://help.salesforce.com/s/articleView?id=000383480&type=1) can be caused by:

> You are sending a duplicate record while the other is already present/being processed.

And a fix would be:

> it would be a good practice to program the requests in a way to have some milliseconds of time gap between two requests (if the same record is being sent multiple requests)

So that's what I'm trying here with the 30 second spacing.

In order to get the 30 second spacing to work locally I had to set this ENV:

`ACTIVE_JOB_BACKEND=async`

Refs: #4949


