### PR TITLE
Manually assign a ChA to a chapter (as an admin)

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1027,11 +1027,11 @@ class Account < ActiveRecord::Base
     end
   end
 
-  private
-
   def current_profile
     public_send(:"#{scope_name}_profile")
   end
+
+  private
 
   def self.survey_reminder_max_times
     2

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -71,8 +71,8 @@
       <% end %>
     <% end %>
 
-    <% if f.object.student_profile.present? %>
-      <%= f.fields_for :student_profile do |s| %>
+    <% if f.object.student_profile.present? || f.object.chapter_ambassador_profile.present? %>
+      <%= f.fields_for f.object.current_profile do |s| %>
         <p>
           <%= s.label :chapter_id, "Assign to Chapter", for: :chapter_id %>
 
@@ -81,15 +81,14 @@
                 Chapter.all.order(organization_name: :asc),
                 :id,
                 :organization_name,
-                include_blank: 'None',
-                selected: @account.student_profile.try(:chapter_id)
+                include_blank: 'None'
               ) %>
         </p>
       <% end %>
 
-      <% if f.object.student_profile.errors.present? %>
+      <% if f.object.current_profile.errors.present? %>
         <ul class="list--reset field_with_errors">
-          <% f.object.student_profile.errors.each do |error| %>
+          <% f.object.current_profile.errors.each do |error| %>
             <li class="error">
               <%= error.message %>
             </li>

--- a/spec/controllers/admin/participants_controller_spec.rb
+++ b/spec/controllers/admin/participants_controller_spec.rb
@@ -92,4 +92,25 @@ RSpec.describe Admin::ParticipantsController do
         .with(account_id: profile.account_id).at_least(:once)
     end
   end
+
+  %w[student chapter_ambassador].each do |scope|
+    it "updates the associated chapter for a #{scope} profile when a chapter is assigned" do
+      profile = FactoryBot.create(scope,
+        account: FactoryBot.create(
+          :account,
+          email: "#{scope}-testy-email@email.com"
+        ))
+
+      chapter = FactoryBot.create(:chapter)
+
+      patch :update, params: {
+        id: profile.account_id,
+        account: {
+          "#{scope}_profile": {chapter_id: chapter.id}
+        }
+      }
+
+      expect(profile.reload.chapter).to eq(chapter)
+    end
+  end
 end


### PR DESCRIPTION
Refs #4837 

This PR will allow admin to assign a ChA to a chapter. The same functionality still exists for students.

Noting that I discovered a bug (captured in #4951) that will affect this functionality for combo accounts.  