### PR TITLE
Update season value fuctionality for ChA datagrid

### DIFF
--- a/app/controllers/admin/chapter_ambassadors_controller.rb
+++ b/app/controllers/admin/chapter_ambassadors_controller.rb
@@ -21,7 +21,7 @@ module Admin
       grid = params[:chapter_ambassadors_grid] ||= {}
       grid.merge(
         column_names: detect_extra_columns(grid),
-        season: params[:chapter_ambassadors_grid][:season] || Season.current.year
+        season: params[:chapter_ambassadors_grid].present? ? params[:chapter_ambassadors_grid][:season] : Season.current.year
       )
     end
   end


### PR DESCRIPTION
A pretty simple update here for the season field on the chapter ambassador's datagrid:

- If `params[:chapter_ambassadors_grid]` aren't present, i.e. coming from another page
   - Use the current season

- If `params[:chapter_ambassadors_grid]` are present, i.e. submitting a request to the chapter ambassador datagrid
   - Use the season value that was selected

Related to: #4909


