### PR TITLE
Updated admin functionality for editing combo profile accounts

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -101,9 +101,9 @@ module Admin
         :profile_image,
         :profile_image_cache,
         :password,
-        mentor_profile: {},
+        mentor_profile_attributes: [:id, mentor_type_ids: []],
         student_profile: {},
-        judge_profile: {},
+        judge_profile_attributes: [:id, judge_type_ids: []],
         chapter_ambassador_profile: {}
       ).tap do |tapped|
         tapped[:skip_existing_password] = true

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -39,6 +39,7 @@ class Account < ActiveRecord::Base
   has_one :mentor_profile, dependent: :destroy
   has_one :judge_profile, dependent: :destroy
   has_one :chapter_ambassador_profile, dependent: :destroy
+  accepts_nested_attributes_for :mentor_profile, :judge_profile
 
   ChapterAmbassadorProfile.statuses.keys.each do |status|
     has_one :"#{status}_chapter_ambassador_profile",

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -44,6 +44,57 @@
       <%= f.select :gender,
         collection: Account.genders.keys %>
     </p>
+    <br>
+
+    <% if f.object.mentor_profile.present? %>
+      <%= f.fields_for :mentor_profile do |m| %>
+        <p>
+          <%= m.label :mentor_types %>
+          <%= m.collection_check_boxes :mentor_type_ids, MentorType.all, :id, :name,
+                                       checked: ->(value) { f.object.mentor_profile.mentor_types.include?(value) } do |b| %>
+            <%= b.check_box %>
+            <%= b.label %>
+            <br>
+          <% end %>
+        </p>
+
+        <% if f.object.mentor_profile.errors.present? %>
+          <ul class="list--reset field_with_errors">
+            <% f.object.mentor_profile.errors.each do |error| %>
+              <li class="error">
+                <%= error.message %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    <% end %>
+    <br>
+
+    <% if f.object.judge_profile.present? %>
+      <%= f.fields_for :judge_profile do |m| %>
+        <p>
+          <%= m.label :judge_types %>
+          <%= m.collection_check_boxes :judge_type_ids, JudgeType.all, :id, :name,
+                                       checked: ->(value) { f.object.judge_profile.judge_types.include?(value) } do |b| %>
+            <%= b.check_box %>
+            <%= b.label %>
+            <br>
+          <% end %>
+        </p>
+
+        <% if f.object.judge_profile.errors.present? %>
+          <ul class="list--reset field_with_errors">
+            <% f.object.judge_profile.errors.each do |error| %>
+              <li class="error">
+                <%= error.message %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
+    <% end %>
+    <br>
 
     <% if f.object.student_profile.present? || f.object.chapter_ambassador_profile.present? %>
       <%= f.fields_for f.object.current_profile do |s| %>

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -72,10 +72,10 @@
     <br>
 
     <% if f.object.judge_profile.present? %>
-      <%= f.fields_for :judge_profile do |m| %>
+      <%= f.fields_for :judge_profile do |j| %>
         <p>
-          <%= m.label :judge_types %>
-          <%= m.collection_check_boxes :judge_type_ids, JudgeType.all, :id, :name,
+          <%= j.label :judge_types %>
+          <%= j.collection_check_boxes :judge_type_ids, JudgeType.all, :id, :name,
                                        checked: ->(value) { f.object.judge_profile.judge_types.include?(value) } do |b| %>
             <%= b.check_box %>
             <%= b.label %>

--- a/spec/controllers/admin/participants_controller_spec.rb
+++ b/spec/controllers/admin/participants_controller_spec.rb
@@ -113,4 +113,50 @@ RSpec.describe Admin::ParticipantsController do
       expect(profile.reload.chapter).to eq(chapter)
     end
   end
+
+  it "updates the associated chapter for a combo chapter ambassador/judge account when a chapter is assigned" do
+    chapter_ambassador = FactoryBot.create(
+      :chapter_ambassador_profile,
+      :not_assigned_to_chapter,
+      :has_judge_profile,
+      account: FactoryBot.create(
+        :account,
+        email: "cha-judge@email.com"
+      )
+    )
+
+    chapter = FactoryBot.create(:chapter)
+
+    patch :update, params: {
+      id: chapter_ambassador.account_id,
+      account: {
+        chapter_ambassador_profile: {chapter_id: chapter.id}
+      }
+    }
+
+    expect(chapter_ambassador.reload.chapter).to eq(chapter)
+  end
+
+  it "updates the associated chapter for a combo chapter ambassador/mentor account when a chapter is assigned" do
+    chapter_ambassador = FactoryBot.create(
+      :chapter_ambassador_profile,
+      :not_assigned_to_chapter,
+      :has_mentor_profile,
+      account: FactoryBot.create(
+        :account,
+        email: "cha-mentor@email.com"
+      )
+    )
+
+    chapter = FactoryBot.create(:chapter)
+
+    patch :update, params: {
+      id: chapter_ambassador.account_id,
+      account: {
+        chapter_ambassador_profile: {chapter_id: chapter.id}
+      }
+    }
+
+    expect(chapter_ambassador.reload.chapter).to eq(chapter)
+  end
 end

--- a/spec/factories/ambassadors.rb
+++ b/spec/factories/ambassadors.rb
@@ -115,5 +115,11 @@ FactoryBot.define do
         CreateJudgeProfile.call(ambassador.account)
       end
     end
+
+    trait :has_mentor_profile do
+      after(:create) do |ambassador|
+        CreateMentorProfile.call(ambassador.account)
+      end
+    end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -128,7 +128,10 @@ RSpec.describe Account do
             email: "ccara55@example.com",
             password: "abc1239876",
             gender: "Non-binary",
-            judge_profile: JudgeProfile.new,
+            judge_profile: JudgeProfile.new(
+              job_title: "VIP",
+              company_name: "VIC"
+            ),
             meets_minimum_age_requirement: meets_minimum_age_requirement
           )
         }


### PR DESCRIPTION
Refs #4951 

This PR will allow admin to edit combo accounts (Cha-mentor, cha-judge, cha-mentor-judge, etc). In order to move forward with some of the manual chapter assignments, the mentor/judge type checkboxes in the admin participant edit form were moved in #4960. This PR also readds those options to the edit form. 