### PR TITLE
Removed mentor/judge types from admin edit participant form

### DIFF
--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -45,32 +45,6 @@
         collection: Account.genders.keys %>
     </p>
 
-    <% if f.object.mentor_profile.present? %>
-      <%= f.fields_for :mentor_profile do |m| %>
-        <p>
-          <%= m.label :mentor_types %>
-
-          <%= m.collection_check_boxes :mentor_type_ids, MentorType.all, :id, :name,
-            checked: ->(value) { f.object.mentor_profile.mentor_types.include?(value) } do |b| %>
-
-           <%= b.check_box %>
-           <%= b.label %>
-           <br>
-         <% end %>
-        </p>
-
-        <% if f.object.mentor_profile.errors.present? %>
-          <ul class="list--reset field_with_errors">
-            <% f.object.mentor_profile.errors.each do |error| %>
-              <li class="error">
-                <%= error.message %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-      <% end %>
-    <% end %>
-
     <% if f.object.student_profile.present? || f.object.chapter_ambassador_profile.present? %>
       <%= f.fields_for f.object.current_profile do |s| %>
         <p>
@@ -94,33 +68,6 @@
             </li>
           <% end %>
         </ul>
-      <% end %>
-    <% end %>
-    <br>
-
-    <% if f.object.judge_profile.present? %>
-      <%= f.fields_for :judge_profile do |m| %>
-        <p>
-          <%= m.label :judge_types %>
-
-          <%= m.collection_check_boxes :judge_type_ids, JudgeType.all, :id, :name,
-            checked: ->(value) { f.object.judge_profile.judge_types.include?(value) } do |b| %>
-
-           <%= b.check_box %>
-           <%= b.label %>
-           <br>
-         <% end %>
-        </p>
-
-        <% if f.object.judge_profile.errors.present? %>
-          <ul class="list--reset field_with_errors">
-            <% f.object.judge_profile.errors.each do |error| %>
-              <li class="error">
-                <%= error.message %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
       <% end %>
     <% end %>
     <br>


### PR DESCRIPTION
Refs #4951 

Currently, as an admin you cannot edit participant details for combo accounts due to the mentor and judge type checkbox selection. This PR removes mentor/judge type edit fields from the admin participant edit form so that combo ChA accounts can be assigned a chapter (work in #4837) and other participant account details can be edited. These fields will be added back to the edit form in [this PR](https://github.com/Iridescent-CM/technovation-app/pull/4958)

