### PR TITLE
Updated can be marked onboarded method to account for bg check exemptions

### DIFF
--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -161,7 +161,7 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
 
   def can_be_marked_onboarded?
     !!(account.email_confirmed? &&
-      background_check_complete? &&
+      background_check_exempt_or_complete? &&
       legal_agreement_signed? &&
       training_completed? &&
       viewed_community_connections?)


### PR DESCRIPTION
Currently, if you grant/revoke a background check exemption, the ChA onboarded status is not updated. This is an issue for ChAs with a bg check exemption. They cannot access the Chapter Ambassador Activity page since they are not considered onboarded, even though all onboarding steps are completed.

This PR updates the "can be marked onboarded" method to account for completed and exempt bg checks.