### PR TITLE
Search across seasons functionality for participants, teams, and submissions datagrid

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -73,7 +73,7 @@ module Admin
         admin: true,
         country: Array(params[:accounts_grid][:country]),
         state_province: Array(params[:accounts_grid][:state_province]),
-        season: params[:accounts_grid][:season] || Season.current.year,
+        season: params[:accounts_grid].present? ? params[:accounts_grid][:season] : Season.current.year,
         season_and_or: params[:accounts_grid][:season_and_or] ||
                          "match_any",
         mentor_types: params[:accounts_grid][:mentor_types]

--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -64,7 +64,7 @@ module Admin
         admin: true,
         country: Array(params[:submissions_grid][:country]),
         state_province: Array(params[:submissions_grid][:state_province]),
-        season: params[:submissions_grid][:season] || Season.current.year
+        season: params[:submissions_grid].present? ? params[:submissions_grid][:season] : Season.current.year
       )
 
       grid.merge(

--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -40,7 +40,7 @@ module Admin
         admin: true,
         country: Array(params[:teams_grid][:country]),
         state_province: Array(params[:teams_grid][:state_province]),
-        season: params[:teams_grid][:season] || Season.current.year
+        season: params[:teams_grid].present? ? params[:teams_grid][:season] : Season.current.year
       )
 
       grid.merge(


### PR DESCRIPTION
This will update the participants, teams, and submissions datagrid so that no season can be selected so that we can search across all seasons.

Addresses: #4954


