### PR TITLE
Fix bug when a ChA views their own profile

### DIFF
--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -48,22 +48,6 @@
               profile.os_version].compact.join(' - ') %>
         </dd>
       <% end %>
-
-      <dt>Status</dt>
-
-      <dd>
-        <%= form_with model: profile,
-          url: admin_chapter_ambassador_status_path(profile),
-          local: true do |f| %>
-
-          <%= f.select :status,
-            ChapterAmbassadorProfile.statuses.keys.map { |k| [k.humanize, k] } %>
-
-          <p>
-            <%= f.submit "Change status", class: "button small" %>
-          </p>
-        <% end %>
-      </dd>
     </dl>
   </div>
 </div>


### PR DESCRIPTION
This will hide chapter and chapter ambassador onboarding steps for chapter ambassadors (this was causing an error); this info will only be available to admins.

I also removed the status field (active, pending, etc) for chapter ambassadors since this isn't being used now.

Fixes: #4957