### PR TITLE
PT2 - Added uses gadget additional question frontend and other updates

### DIFF
--- a/app/assets/javascripts/submissions.js
+++ b/app/assets/javascripts/submissions.js
@@ -1,8 +1,8 @@
-$(document).on("click", "#team_submissions__menu a", function(e) {
+$(document).on("click", "#team_submissions__menu a", function (e) {
   e.preventDefault();
 
-  var anchor = "#" + $(this).attr('href').split("#")[1],
-      offset = 92;
+  var anchor = "#" + $(this).attr("href").split("#")[1],
+    offset = 92;
 
   $(anchor)[0].scrollIntoView();
   location.href = anchor;
@@ -10,19 +10,41 @@ $(document).on("click", "#team_submissions__menu a", function(e) {
   scrollBy(0, -offset);
 });
 
-$(document).on("change", ".provide-preview", function(e) {
+$(document).on("change", ".provide-preview", function (e) {
   var reader = new FileReader();
 
-  reader.onload = function(e) {
+  reader.onload = function (e) {
     var $img = $("<img>");
 
-    $img.prop('src', e.target.result)
-        .prop("width", 175);
+    $img.prop("src", e.target.result).prop("width", 175);
 
-    $(this).closest(".file-field")
-      .find(".img-preview")
-      .html($img);
+    $(this).closest(".file-field").find(".img-preview").html($img);
   }.bind(this);
 
-  reader.readAsDataURL($(this).prop('files')[0]);
+  reader.readAsDataURL($(this).prop("files")[0]);
+});
+
+document.addEventListener("turbolinks:load", function () {
+  const usesOtherGadgetTypeCheckbox = document.getElementById(
+    "team_submission_gadget_type_ids_4"
+  );
+  const usesGadgetsDescriptionDiv = document.getElementById(
+    "uses_gadgets_description"
+  );
+  const usesGadgetsDescription = document.getElementById(
+    "team_submission_uses_gadgets_description"
+  );
+
+  if (usesOtherGadgetTypeCheckbox.checked) {
+    usesGadgetsDescriptionDiv.style.display = "block";
+  }
+
+  usesOtherGadgetTypeCheckbox.addEventListener("change", function () {
+    if (this.checked) {
+      usesGadgetsDescriptionDiv.style.display = "block";
+    } else {
+      usesGadgetsDescriptionDiv.style.display = "none";
+      usesGadgetsDescription.value = "";
+    }
+  });
 });

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -140,6 +140,14 @@ class SubmissionsGrid
       .concat(description)
   end
 
+  column :uses_gadgets, header: "Uses Gadgets", if: ->(grid) { grid.admin } do
+    description = uses_gadgets? ? " - #{team_submission_gadget_types.joins(:gadget_type).pluck(:name).join(", ")}" : ""
+
+    ApplicationController.helpers
+      .humanize_boolean(uses_gadgets)
+      .concat(description)
+  end
+
   column :city, order: "teams.city" do
     team.city
   end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -63,11 +63,15 @@ class TeamSubmission < ActiveRecord::Base
     self.pitch_video_link = standardize_url(pitch_video_link)
   }
 
-  before_commit -> {
+  before_save -> {
     self.ai_description = "" if ai.blank?
     self.climate_change_description = "" if climate_change.blank?
     self.game_description = "" if game.blank?
-    self.gadget_types = [] unless uses_gadgets?
+    self.solves_education_description = "" if solves_education.blank?
+    if uses_gadgets.blank?
+      self.gadget_types = []
+      self.uses_gadgets_description = ""
+    end
   }
 
   after_commit :update_student_info_in_crm

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -267,6 +267,9 @@ class TeamSubmission < ActiveRecord::Base
   validates :solves_education_description, presence: true, max_word_count: true,
     if: ->(team_submission) { team_submission.solves_education? }
 
+  validates :gadget_type_ids, presence: {message: "At least one gadget type must be selected"},
+            if: ->(team_submission) { team_submission.uses_gadgets? }
+
   validates :pitch_video_link,
     format: {
       with: /[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,}(.[a-zA-Z]{2,63})?/

--- a/app/views/team_submissions/_app_details.en.html.erb
+++ b/app/views/team_submissions/_app_details.en.html.erb
@@ -43,4 +43,24 @@
       <%= simple_format(team_submission.solves_education_description) %>
     <% end %>
   </dd>
+
+  <dt><%= t("submissions.uses_gadgets_question") %></dt>
+  <dd>
+    <%= humanize_boolean(team_submission.uses_gadgets) %>
+
+    <% if team_submission.gadget_types.present? %>
+      <ul class="list-disc ml-8">
+        <% team_submission.gadget_types.each do |gadget_type| %>
+          <li>
+            <%= gadget_type.name %>
+            <% if gadget_type.name.downcase == "other" && team_submission.uses_gadgets_description.present? %>
+              <span class="italic">
+                - <%= team_submission.uses_gadgets_description %>
+              </span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  </dd>
 </dl>

--- a/app/views/team_submissions/pieces/app_details.en.html.erb
+++ b/app/views/team_submissions/pieces/app_details.en.html.erb
@@ -246,13 +246,13 @@
             </div>
           <% end %>
         </div>
-      </div>
 
-      <div id="uses_gadgets_description" class="mt-4" style="display: <%= @team_submission.uses_gadgets_description.present? ? 'block' : 'none' %>;">
-        <p class="tw-hint">Please specify other gadgets:</p>
+        <div id="uses_gadgets_description" class="mt-4" style="display: <%= @team_submission.uses_gadgets_description.present? ? 'block' : 'none' %>;">
+          <p class="tw-hint">Please specify other gadgets:</p>
 
-        <%= f.text_field :uses_gadgets_description,
-                        id: :team_submission_uses_gadgets_description %>
+          <%= f.text_field :uses_gadgets_description,
+                          id: :team_submission_uses_gadgets_description %>
+        </div>
       </div>
     </div>
 

--- a/app/views/team_submissions/pieces/app_details.en.html.erb
+++ b/app/views/team_submissions/pieces/app_details.en.html.erb
@@ -218,6 +218,44 @@
       </div>
     </div>
 
+    <div class="field mt-4">
+      <%= f.label :uses_gadgets,
+        t("submissions.uses_gadgets_question"),
+        for: :team_submission_uses_gadgets %>
+
+      <%= f.select :uses_gadgets,
+        [["Yes", true], ["No", false]],
+        { include_blank: true },
+        data: {
+          toggles: {
+            "true": "#uses_gadgets_checkboxes"
+          },
+        },
+        class: "w-full lg:w-1/5",
+        id: :team_submission_uses_gadgets %>
+
+      <div id="uses_gadgets_checkboxes" class="mt-4">
+        <%= f.label :gadget_type_ids,
+                    "Which of the following additional gadgets are used in your project?" %>
+
+        <div class="checkbox-group">
+          <%= f.collection_check_boxes :gadget_type_ids, GadgetType.all, :id, :name do |cb| %>
+            <div class="checkbox-item">
+              <%= cb.check_box %>
+              <%= cb.label %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div id="uses_gadgets_description" class="mt-4" style="display: <%= @team_submission.uses_gadgets_description.present? ? 'block' : 'none' %>;">
+        <p class="tw-hint">Please specify other gadgets:</p>
+
+        <%= f.text_field :uses_gadgets_description,
+                        id: :team_submission_uses_gadgets_description %>
+      </div>
+    </div>
+
     <div class="actions mt-8 submission-actions">
       <p class="btn-wrapper">
         <%= f.submit "Save my responses", class: "tw-green-btn cursor-pointer" %>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -7,3 +7,4 @@ en:
     solves_hunger_or_food_waste_question: Does your submission help reduce hunger or food insecurity in some way?
     uses_open_ai_question: "Did you use AI assistance such as ChatGPT at any point when working on your project?"
     solves_education_question: Does your submission address a problem in education?
+    uses_gadgets_question: Does your submission use additional gadgets?


### PR DESCRIPTION
Refs #4896 

This is part 2. This PR adds the frontend work for the `uses gadgets` additional question. 
The following was added
- JS to show/hide other gadget description text box
- gadget types to the submission grid
- Updated the submission form to include the uses gadget question in addition to the yes/no dropdown
- Updated the additional question section overview to display uses gadget details 
- Validation for at least 1 gadget type being selected if user selects "yes"
- Updated the `before_commit` callback to `before_save`. I will leave my notes in a comment

https://github.com/user-attachments/assets/303bd444-fe76-4a7b-af61-25a77b750873



