### PR TITLE
Update ChA mentor mode functionality

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -577,7 +577,7 @@ class Account < ActiveRecord::Base
     if student_profile
       student_profile.school_name
     elsif chapter_ambassador_profile
-      chapter_ambassador_profile.organization_company_name
+      chapter_ambassador_profile.organization_company_name.presence || chapter_ambassador_profile.chapter&.organization_name
     elsif mentor_profile
       mentor_profile.school_company_name
     elsif judge_profile

--- a/app/technovation/create_mentor_profile.rb
+++ b/app/technovation/create_mentor_profile.rb
@@ -17,7 +17,7 @@ module CreateMentorProfile
     if account.chapter_ambassador_profile.present?
       {
         school_company_name: account.chapter_ambassador_profile
-          .organization_company_name,
+          .organization_company_name.presence || account.chapter_ambassador_profile.chapter.organization_name,
         job_title: account.chapter_ambassador_profile.job_title,
         mentor_type_ids: [MentorType.find_by(name: "Industry professional")&.id]
       }


### PR DESCRIPTION
When a chapter ambassador clicks the "mentor mode" button for the first time a new mentor profile will get created for them.

`school_company_name` is a required field for mentor profiles, this validation was failing for newer chapter ambassadors who belong to a chapter, to address this:

- for chapter ambassadors who belong to a chapter, we'll use the chapter's organization name for the mentor's school/company name
- for chapter ambassadors who do not belong to a chapter, we'll use organization/company field from the chapter ambassador's profile (this is existing behavior)

Fixes: #4969


