### PR TITLE
Search improvements for chapter name and organization name

### DIFF
--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -8,13 +8,17 @@ class ChaptersGrid
   end
 
   filter :program_name do |value|
-    where("name ilike ?",
-      "#{value}%")
+    sanitized = sanitize_sql_like(value)
+    processed_value = I18n.transliterate(sanitized.strip.downcase).gsub(/['\s]+/, "%")
+
+    where("lower(unaccent(name)) ILIKE ?", "%#{processed_value}%")
   end
 
-  filter :organization_name do |value|
-    where("organization_name ilike ?",
-      "#{value}%")
+  filter :organization_name, header: "Organization" do |value|
+    value = sanitize_sql_like(value)
+    processed_value = I18n.transliterate(value.strip.downcase).gsub(/['\s]+/, "%")
+
+    where("lower(unaccent(organization_name)) ILIKE ?", "%#{processed_value}%")
   end
 
   filter(:onboarded,


### PR DESCRIPTION
Refs #4953 

This PR improves the search filter for program and organization names on the chapter datagrid.
This update accounts for accented characters, partial matching, spaces, and trailing whitespace. The `unaccent` function is also used in the search query which follows other patterns in the platform for searching. 
