### PR TITLE
Add name/email fuzzy search to paper parental consents

### DIFF
--- a/app/controllers/concerns/saved_search_controller.rb
+++ b/app/controllers/concerns/saved_search_controller.rb
@@ -29,6 +29,8 @@ module SavedSearchController
       "#{current_scope}_chapters_path"
     when "chapter_ambassadors_grid"
       "#{current_scope}_chapter_ambassadors_path"
+    when "parental_consents_grid"
+      "#{current_scope}_paper_parental_consents_path"
     else
       raise "Param root #{@saved_search.param_root} not supported"
     end

--- a/app/data_grids/parental_consents_grid.rb
+++ b/app/data_grids/parental_consents_grid.rb
@@ -54,6 +54,22 @@ class ParentalConsentsGrid
     render "admin/paper_parental_consents/actions", parental_consent: parental_consent
   end
 
+  filter :name_email,
+    header: "Name or Email",
+    filter_group: "common" do |value, scope, grid|
+    names = value.strip.downcase.split(" ").map { |n|
+      I18n.transliterate(n).gsub("'", "''")
+    }
+
+    scope.fuzzy_search({
+      accounts: {
+        first_name: names.first,
+        last_name: names.last || names.first,
+        email: names.first
+      }
+    }, false).left_outer_joins(student_profile: :account)
+  end
+
   filter :upload_approval_status,
     :enum,
     header: "Status",


### PR DESCRIPTION
Refs #4985 

This PR adds the name/email fuzzy search to the paper parental consents datagrid. Uses the same approach/logic as all of the other datagrids. I also added the condition to the saved search method so that saved searches can be used on the this datagrid. 