### PR TITLE
Off-platform Chapter Affiliation Agreements

### DIFF
--- a/app/controllers/admin/chapters/off_platform_chapter_affiliation_agreement_controller.rb
+++ b/app/controllers/admin/chapters/off_platform_chapter_affiliation_agreement_controller.rb
@@ -1,0 +1,24 @@
+module Admin::Chapters
+  class OffPlatformChapterAffiliationAgreementController < AdminController
+    def create
+      @chapter = Chapter.find(params[:chapter_id])
+
+      if @chapter.affiliation_agreement.present?
+        redirect_to admin_chapter_path(@chapter),
+          error: "This chapter already has an active affiliation agreement."
+      else
+        @chapter.legal_contact.documents.create(
+          full_name: @chapter.legal_contact.full_name,
+          email_address: @chapter.legal_contact.email_address,
+          active: true,
+          season_signed: Season.current.year,
+          season_expires: Season.current.year + params[:seasons_valid].to_i - 1,
+          status: "off-platform"
+        )
+
+        redirect_to admin_chapter_path(@chapter),
+          success: "Successfully created an off-platform legal agreement this chapter"
+      end
+    end
+  end
+end

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -133,9 +133,17 @@ class ChaptersGrid
 
   column :affiliation_agreement_status, preload: [:legal_contact, legal_contact: :chapter_affiliation_agreement] do
     if affiliation_agreement.present?
-      affiliation_agreement_signed? ? "Signed" : "Not signed"
-    else
-      "Not sent"
+      if affiliation_agreement_complete?
+        if affiliation_agreement.signed?
+          "Signed"
+        elsif affiliation_agreement.off_platform?
+          "Off-platform"
+        else
+          "Not signed"
+        end
+      else
+        "Not sent"
+      end
     end
   end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -22,7 +22,7 @@ class Chapter < ActiveRecord::Base
 
   scope :signed_affiliation_agreements, -> {
     joins(legal_contact: :documents)
-      .where("documents.active = TRUE AND documents.signed_at IS NOT NULL")
+      .where("documents.active = TRUE AND documents.status = 'signed' OR documents.status = 'off-platform'")
   }
 
   scope :not_signed_affiliation_agreements, -> {
@@ -43,7 +43,7 @@ class Chapter < ActiveRecord::Base
   end
 
   def can_be_marked_onboarded?
-    !!(affiliation_agreement_signed? &&
+    !!(affiliation_agreement_complete? &&
       chapter_info_complete? &&
       location_complete? &&
       program_info_complete?)
@@ -53,8 +53,8 @@ class Chapter < ActiveRecord::Base
     update_column(:onboarded, can_be_marked_onboarded?)
   end
 
-  def affiliation_agreement_signed?
-    !!affiliation_agreement&.signed?
+  def affiliation_agreement_complete?
+    !!affiliation_agreement&.complete?
   end
 
   def chapter_info_complete?
@@ -76,7 +76,7 @@ class Chapter < ActiveRecord::Base
 
   def required_onboarding_tasks
     {
-      "Chapter Affiliation Agreement" => affiliation_agreement_signed?,
+      "Chapter Affiliation Agreement" => affiliation_agreement_complete?,
       "Public Info" => chapter_info_complete?,
       "Chapter Location" => location_complete?,
       "Program Info" => program_info_complete?

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,10 +4,19 @@ class Document < ActiveRecord::Base
   before_save :set_status
   after_update -> { signer.update_onboarding_status }
 
-  enum status: {sent: "sent", signed: "signed", voided: "voided"}
+  enum status: {
+    sent: "sent",
+    signed: "signed",
+    "off-platform": "off-platform",
+    voided: "voided"
+  }
 
   def sent?
     sent_at.present?
+  end
+
+  def complete?
+    signed? || off_platform?
   end
 
   private

--- a/app/views/admin/chapters/_chapter_onboarding.html.erb
+++ b/app/views/admin/chapters/_chapter_onboarding.html.erb
@@ -9,14 +9,20 @@
         <dt>Sign Chapter Affiliation Agreement</dt>
         <dd>
           <div style="display: flex;">
-            <% if chapter.affiliation_agreement_signed? %>
+            <% if chapter.affiliation_agreement_complete? %>
               <%= web_icon("check-circle icon-green") %>
               <div>
                 Complete
 
-                <p class="hint margin--b-none">
-                  Signed <%= chapter.affiliation_agreement.signed_at.strftime("%b %d, %Y") %>
-                </p>
+                <% if chapter.affiliation_agreement.signed? %>
+                  <p class="hint margin--b-none">
+                    Signed <%= chapter.affiliation_agreement.signed_at.strftime("%b %d, %Y") %>
+                  </p>
+                <% elsif chapter.affiliation_agreement.off_platform? %>
+                  <p class="hint margin--b-none">
+                    Completed Off-platform
+                  </p>
+                <% end %>
               </div>
             <% else %>
               <%= web_icon("exclamation-circle icon-red") %>

--- a/app/views/admin/chapters/_legal_contact.html.erb
+++ b/app/views/admin/chapters/_legal_contact.html.erb
@@ -36,7 +36,8 @@
                 class: "button",
                 onclick: "this.disabled=true; this.form.submit();"
               %>
-            <% elsif !@chapter.affiliation_agreement_signed? %>
+
+            <% elsif !@chapter.affiliation_agreement.signed? && !@chapter.affiliation_agreement.off_platform? %>
               <%= button_to "Void Chapter Affiliation Agreement",
                 void_admin_chapter_affiliation_agreement_path(@chapter),
                 method: "patch",
@@ -46,6 +47,26 @@
             <% end %>
           <% end %>
         </div>
+
+        <% if @chapter.affiliation_agreement.blank? && params[:affiliation_agreement_job_scheduled].blank? %>
+          <h4 class="margin--t-xxlarge">Create Off-platform Affiliation Agreement</h4>
+          <%= form_with url: admin_chapter_off_platform_affiliation_agreement_path(@chapter), method: :post do %>
+
+            <%= select_tag :seasons_valid,
+              options_for_select({
+                "Valid for 1 season": "1",
+                "Valid for 2 seasons": "2",
+                "Valid for 3 seasons": "3"
+              })
+            %>
+
+          <%= submit_tag "Submit",
+            method: "post",
+            class: "button",
+            onclick: "this.disabled=true; this.form.submit();"
+          %>
+      <% end %>
+    <% end %>
       <% else %>
         <%= render "admin/chapters/legal_contacts/form", chapter: @chapter, legal_contact: @chapter.build_legal_contact %>
       <% end %>

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -59,13 +59,20 @@
         </div>
 
         <div class="grid__col-6">
+          <h3>Chapter Affiliation Agreement</h3>
+
           <dl>
-            <dt>Chapter Affiliation Agreement</dt>
+            <dt>Status</dt>
             <dd>
               <% if @chapter.legal_contact.present? %>
                 <% if @chapter.affiliation_agreement.present? %>
-                  <% if @chapter.affiliation_agreement_signed? %>
-                    Signed <%= @chapter.affiliation_agreement.signed_at.strftime("%b %d, %Y") %>
+                  <% if @chapter.affiliation_agreement_complete? %>
+                    <% if @chapter.affiliation_agreement.signed? %>
+                      Signed <%= @chapter.affiliation_agreement.signed_at.strftime("%b %d, %Y") %>
+                  <% elsif @chapter.affiliation_agreement.off_platform? %>
+                      Completed off-platform
+
+                  <% end %>
                   <% else %>
                     Not signed
                   <% end %>
@@ -77,17 +84,17 @@
               <% end %>
             </dd>
 
-            <dt>Season Affiliation Agreement Signed</dt>
+            <dt>Season Signed</dt>
             <dd>
               <%= @chapter.affiliation_agreement&.season_signed.presence || "-" %>
             </dd>
 
-            <dt>Season Affiliation Agreement Expires</dt>
+            <dt>Season Expires</dt>
             <dd>
               <%= @chapter.affiliation_agreement&.season_expires.presence || "-" %>
             </dd>
 
-            <dt>Seasons Affiliation Agreement Valid For</dt>
+            <dt>Seasons Valid For</dt>
             <dd>
               <% if @chapter.affiliation_agreement.present? && @chapter.seasons_chapter_affiliation_agreement_is_valid_for.present? %>
                 <%= @chapter.seasons_chapter_affiliation_agreement_is_valid_for.to_sentence %>

--- a/app/views/chapter_ambassador/chapter_affiliation_agreements/show.html.erb
+++ b/app/views/chapter_ambassador/chapter_affiliation_agreements/show.html.erb
@@ -3,7 +3,7 @@
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Chapter Affiliation Agreement" } do %>
     <% if current_chapter.present? %>
-      <% if current_chapter.affiliation_agreement_signed? %>
+      <% if current_chapter.affiliation_agreement_complete? %>
         <p>
           Your legal contact has signed the Chapter Affiliation Agreement!
         </p>

--- a/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/chapter_profile/_side_nav_content.html.erb
@@ -3,7 +3,7 @@
       <%= render "application/templates/completion_step",
                  name: "Chapter Affiliation Agreement",
                  url: chapter_ambassador_chapter_affiliation_agreement_path,
-                 is_complete: current_ambassador.chapter&.affiliation_agreement_signed?,
+                 is_complete: current_ambassador.chapter&.affiliation_agreement_complete?,
                  is_active_item: al(chapter_ambassador_chapter_affiliation_agreement_path).present?
       %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,9 @@ Rails.application.routes.draw do
       resource :affiliation_agreement, only: :create, controller: "chapter_affiliation_agreement" do
         patch :void
       end
+      resource :off_platform_affiliation_agreement,
+        only: :create,
+        controller: "chapters/off_platform_chapter_affiliation_agreement"
       resources :invites, only: :create, controller: "chapter_invites"
       resource :chapter_program_information, only: :show, controller: "chapters/chapter_program_information"
     end

--- a/db/migrate/20240829193423_add_off_platform_status_to_documents.rb
+++ b/db/migrate/20240829193423_add_off_platform_status_to_documents.rb
@@ -1,0 +1,11 @@
+class AddOffPlatformStatusToDocuments < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      ALTER TYPE document_status ADD VALUE 'off-platform' BEFORE 'voided'
+    SQL
+  end
+
+  def down
+    # NOOP
+  end
+end

--- a/db/migrate/20240830132508_remove_not_null_constraint_from_documents.rb
+++ b/db/migrate/20240830132508_remove_not_null_constraint_from_documents.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromDocuments < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :documents, :docusign_envelope_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -82,6 +82,7 @@ CREATE TYPE public.chapter_ambassador_organization_status AS ENUM (
 CREATE TYPE public.document_status AS ENUM (
     'sent',
     'signed',
+    'off-platform',
     'voided'
 );
 
@@ -813,7 +814,7 @@ CREATE TABLE public.documents (
     active boolean,
     signed_at timestamp without time zone,
     season_signed smallint,
-    docusign_envelope_id character varying NOT NULL,
+    docusign_envelope_id character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     voided_at timestamp without time zone,
@@ -4689,10 +4690,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240723134706'),
 ('20240806155230'),
 ('20240806155409'),
-('20240806155409'),
 ('20240819184734'),
 ('20240819184824'),
 ('20240819191052'),
 ('20240822181726'),
-('20240827125548');
+('20240827125548'),
+('20240829193423'),
+('20240830132508');
+
 

--- a/spec/controllers/admin/chapters/off_platform_chapter_affiliation_agreement_controller_spec.rb
+++ b/spec/controllers/admin/chapters/off_platform_chapter_affiliation_agreement_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Admin::Chapters::OffPlatformChapterAffiliationAgreementController do
+  describe "POST #create" do
+    let(:chapter) { FactoryBot.create(:chapter) }
+
+    before do
+      chapter.affiliation_agreement.delete
+
+      sign_in(:admin)
+      post :create, params: {chapter_id: chapter.id, seasons_valid: 1}
+
+      chapter.reload
+    end
+
+    it "creates an off-platform affiliation agreement for the chapter" do
+      expect(chapter.affiliation_agreement).to be_present
+      expect(chapter.affiliation_agreement.status).to eq("off-platform")
+    end
+  end
+end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Chapter do
 
   describe "#incomplete_onboarding_tasks" do
     before do
-      allow(chapter).to receive(:affiliation_agreement_signed?).and_return(true)
+      allow(chapter).to receive(:affiliation_agreement_complete?).and_return(true)
       allow(chapter).to receive(:chapter_info_complete?).and_return(true)
       allow(chapter).to receive(:location_complete?).and_return(true)
       allow(chapter).to receive(:program_info_complete?).and_return(true)
@@ -26,7 +26,7 @@ RSpec.describe Chapter do
 
     context "when the chapter affiliation has not been signed" do
       before do
-        allow(chapter).to receive(:affiliation_agreement_signed?).and_return(false)
+        allow(chapter).to receive(:affiliation_agreement_complete?).and_return(false)
       end
 
       it "returns returns an array that contains 'Chapter Affiliation Agreement'" do
@@ -78,13 +78,13 @@ RSpec.describe Chapter do
             .and_return(chapter_program_information)
         end
 
-        let(:affiliation_agreement) { instance_double(Document, signed?: affiliation_agreement_signed) }
-        let(:affiliation_agreement_signed) { true }
+        let(:affiliation_agreement) { instance_double(Document, complete?: affiliation_agreement_complete) }
+        let(:affiliation_agreement_complete) { true }
         let(:chapter_program_information) { instance_double(ChapterProgramInformation, complete?: program_info_complete) }
         let(:program_info_complete) { true }
 
         context "when all onboarding steps have been completed" do
-          let(:affiliation_agreement_signed) { true }
+          let(:affiliation_agreement_complete) { true }
           let(:program_info_complete) { true }
 
           before do
@@ -97,7 +97,7 @@ RSpec.describe Chapter do
         end
 
         context "when the affiliation agreement has not been signed" do
-          let(:affiliation_agreement_signed) { false }
+          let(:affiliation_agreement_complete) { false }
 
           before do
             chapter.save
@@ -163,25 +163,25 @@ RSpec.describe Chapter do
     end
   end
 
-  describe "#affiliation_agreement_signed?" do
+  describe "#affiliation_agreement_complete?" do
     context "when an affiliation agreement exists" do
       before do
-        allow(chapter).to receive_message_chain(:affiliation_agreement, :signed?).and_return(affiliation_agreement_signed)
+        allow(chapter).to receive_message_chain(:affiliation_agreement, :complete?).and_return(affiliation_agreement_complete)
       end
 
       context "when the affiliation agreement has been signed" do
-        let(:affiliation_agreement_signed) { true }
+        let(:affiliation_agreement_complete) { true }
 
         it "returns true" do
-          expect(chapter.affiliation_agreement_signed?).to eq(true)
+          expect(chapter.affiliation_agreement_complete?).to eq(true)
         end
       end
 
       context "when the affiliation agreement has not been signed" do
-        let(:affiliation_agreement_signed) { false }
+        let(:affiliation_agreement_complete) { false }
 
         it "returns false" do
-          expect(chapter.affiliation_agreement_signed?).to eq(false)
+          expect(chapter.affiliation_agreement_complete?).to eq(false)
         end
       end
     end
@@ -192,7 +192,7 @@ RSpec.describe Chapter do
       end
 
       it "returns false" do
-        expect(chapter.affiliation_agreement_signed?).to eq(false)
+        expect(chapter.affiliation_agreement_complete?).to eq(false)
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,23 +1,31 @@
 require "rails_helper"
 
 RSpec.describe Document do
-  let(:document) { Document.new(sent_at: sent_at) }
-  let(:sent_at) { Time.now }
+  let(:document) { Document.new(status: document_status) }
+  let(:document_status) { "void" }
 
-  describe "#sent?" do
-    context "when the document has a sent_at timestamp" do
-      let(:sent_at) { 1.day.ago }
+  describe "#complete?" do
+    context "when the document has been signed" do
+      let(:document_status) { "signed" }
 
       it "returns true" do
-        expect(document.sent?).to eq(true)
+        expect(document.complete?).to eq(true)
       end
     end
 
-    context "when the document does not have a sent_at timestamp" do
-      let(:sent_at) { nil }
+    context "when it's an off-platform document" do
+      let(:document_status) { "off-platform" }
+
+      it "returns true" do
+        expect(document.complete?).to eq(true)
+      end
+    end
+
+    context "when the document hasn't been signed and it's not an off-platform document" do
+      let(:document_status) { "sent" }
 
       it "returns false" do
-        expect(document.sent?).to eq(false)
+        expect(document.complete?).to eq(false)
       end
     end
   end

--- a/spec/system/admin/chapters/affiliation_agreement_buttons_spec.rb
+++ b/spec/system/admin/chapters/affiliation_agreement_buttons_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe "Admin 'Chapter Affiliation Agreement' buttons" do
 
         expect(page).to have_button("Send Chapter Affiliation Agreement")
       end
+
+      it "displays the section to create an off-platform affiliation agreeemnt" do
+        visit admin_chapter_path(chapter)
+
+        expect(page).to have_content("Create Off-platform Affiliation Agreement")
+        expect(page).to have_select(
+          nil,
+          with_options: [
+            "Valid for 1 season",
+            "Valid for 2 seasons",
+            "Valid for 3 seasons"
+          ]
+        )
+        expect(page).to have_button("Submit")
+      end
     end
 
     context "when the legal contact's chapter affiliation agreement has not been signed" do


### PR DESCRIPTION
This will add basic functionality to allow admins to create an off-platform chapter affiliation agreement.

An affiliation agreement is now considered complete (for onboarding purposes) if it's either signed or off-platform.


