### PR TITLE
Added email confirmed status to mentor and Cha debugging

### DIFF
--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -5,6 +5,8 @@
     </p>
 
     <dl>
+      <%= render "admin/participants/email_confirmed_status", account: chapter_ambassador.account %>
+
       <dt>Complete Background Check</dt>
       <dd>
         <div style="display: flex;">

--- a/app/views/admin/participants/_email_confirmed_status.en.html.erb
+++ b/app/views/admin/participants/_email_confirmed_status.en.html.erb
@@ -1,0 +1,10 @@
+<dt>Email Confirmed</dt>
+<dd>
+  <% if account.email_confirmed? %>
+    <%= web_icon("check-circle icon-green") %>
+    Confirmed
+  <% else %>
+    <%= web_icon("exclamation-circle icon-red") %>
+    Not confirmed. Please contact the dev team.
+  <% end %>
+</dd>

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -11,6 +11,8 @@
   </p>
 
   <dl>
+    <%= render "admin/participants/email_confirmed_status", account: profile.account %>
+
     <dt>Mentor training</dt>
     <dd class="mentor-training">
       <% if profile.training_complete? %>


### PR DESCRIPTION
Refs #5014 

We have had quite a few instances where program support does not why a profile may not be considered onboarded when all onboarding steps have been completed. This is sometimes due to the participant updating their email on the platform. When an email address is updated an automated email is sent and they must click "confirm" to confirm their updated email. This PR adds the email confirmation status to the admin debugging/onboarding section for additional context. We also discussed removing this as a requirement from "onboarding." 

<img width="614" alt="Screenshot 2024-09-12 at 1 31 29 PM" src="https://github.com/user-attachments/assets/8d4f0ca0-6ec1-499f-b173-28662ea048b2">
