### PR TITLE
Fixed chapter onboarding flag bug

### DIFF
--- a/app/models/chapter_program_information.rb
+++ b/app/models/chapter_program_information.rb
@@ -15,7 +15,7 @@ class ChapterProgramInformation < ActiveRecord::Base
   has_many :chapter_program_information_meeting_facilitators, dependent: :destroy
   has_many :meeting_facilitators, through: :chapter_program_information_meeting_facilitators
 
-  after_update -> { chapter.update_onboarding_status }
+  after_save -> { chapter.update_onboarding_status }
 
   def complete?
     [


### PR DESCRIPTION
Refs #5001 

This PR addresses an issue where the chapter onboarded flag sometimes remained false even when all chapter onboarding steps were completed. I've changed the `after_update` callback to `after_save` for updating the onboarding status.

This ensures that `update_onboarding_status` is called for both new and updated records, which should resolve the inconsistent behavior we have seen for a Chapter's onboarding status. I tried multiple scenarios and sequences of onboarding tasks and was only able to recreate this issue when chapter program information was filled out. 

