### PR TITLE
Added specific chrome version to circle ci config due to breaking changes in newest chrome v 129

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -122,6 +122,8 @@ jobs:
 
     steps:
       - checkout
+      - browser-tools/install-browser-tools:
+          chrome-version: 128.0.6613.84 # TODO: remove when chromedriver downloads are fixed
 
       - restore_cache:
           name: Restore cached gems


### PR DESCRIPTION
Refs #5033 

This PR adds a specific chrome version to circle ci config due to breaking changes in newest chrome v 129

On September 17th, our CircleCI builds began failing, specifically the RSpec tests. Initially, we thought this was due to a recent deprecation of old CircleCI images. Shaun noticed that only JS tests were failing. This was confirmed by adding the `--tag ~js` option to the CircleCI RSpec step, which excluded all JS tests and allowed the build to pass.

Upon further investigation, we determined that the issue was likely Chrome-related. Shaun discovered this [bug report](https://github.com/SeleniumHQ/selenium/issues/14514). This led me to a potential [solution](https://stackoverflow.com/questions/79006406/chrome-browser-latest-version-129-in-headless-mode-produces-a-blank-white-wind/79006697#79006697) found on Stack Overflow

The issue has been logged in the Chromium [issue tracker](https://issues.chromium.org/issues/367755364). However, its status is currently "Won't fix (Infeasible)". We may need to monitor future Chrome releases or explore alternative solutions.