### PR TITLE
Updated accounts and teams datagrid so ChAs can add participant and team id as an additional column

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -9,7 +9,7 @@ class AccountsGrid
     Account.not_admin
   end
 
-  column :id, header: "Participant ID", if: ->(g) { g.admin }
+  column :id, header: "Participant ID"
 
   column :profile_type do
     scope_name

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -9,7 +9,7 @@ class TeamsGrid
     Team
   end
 
-  column :id, header: "Team ID", if: ->(g) { g.admin }
+  column :id, header: "Team ID"
 
   column :name, mandatory: true
 


### PR DESCRIPTION
Refs #5037 

Updated accounts and teams datagrid so ChAs can add participant and team id as an additional column