### PR TITLE
Added phone number validation to only allow +, -, numbers, and spaces

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -19,6 +19,10 @@ class AccountsGrid
   column :last_name, mandatory: true
   column :email, mandatory: true
 
+  column :phone_number do |account|
+    account.phone_number.presence || "-"
+  end
+
   column :gender, header: "Gender Identity" do |account|
     account.gender.present? ? account.gender : "-"
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -550,6 +550,10 @@ class Account < ActiveRecord::Base
     presence: true,
     format: {with: /\A[^.-].*/, message: "must start with an alphabetical character"}
 
+  validates :phone_number,
+    allow_blank: true,
+    format: {with: /\A[0-9+\-\s]+\z/, message: "can only contain numbers, dashes, and +"}
+
   validates :date_of_birth, presence: true, if: -> { !is_a_judge? && !is_chapter_ambassador? }
   validates :meets_minimum_age_requirement, inclusion: [true], if: -> { (is_a_judge? || is_chapter_ambassador?) && new_record? }
   validates :gender, presence: true, if: -> { not_student? }

--- a/app/views/admin/participants/edit.html.erb
+++ b/app/views/admin/participants/edit.html.erb
@@ -39,10 +39,10 @@
 
     <% if !f.object.student_profile.present? %>
       <p>
-        <%=  f.label :phone_number  %>
+        <%= f.label :phone_number %>
         <%= f.text_field :phone_number %>
       </p>
-    <%  end %>
+    <% end %>
 
     <p>
       <%= f.label :gender,
@@ -64,16 +64,6 @@
             <br>
           <% end %>
         </p>
-
-        <% if f.object.mentor_profile.errors.present? %>
-          <ul class="list--reset field_with_errors">
-            <% f.object.mentor_profile.errors.each do |error| %>
-              <li class="error">
-                <%= error.message %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
       <% end %>
     <% end %>
     <br>
@@ -89,16 +79,6 @@
             <br>
           <% end %>
         </p>
-
-        <% if f.object.judge_profile.errors.present? %>
-          <ul class="list--reset field_with_errors">
-            <% f.object.judge_profile.errors.each do |error| %>
-              <li class="error">
-                <%= error.message %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
       <% end %>
     <% end %>
     <br>
@@ -116,16 +96,6 @@
                 include_blank: 'None'
               ) %>
         </p>
-      <% end %>
-
-      <% if f.object.current_profile.errors.present? %>
-        <ul class="list--reset field_with_errors">
-          <% f.object.current_profile.errors.each do |error| %>
-            <li class="error">
-              <%= error.message %>
-            </li>
-          <% end %>
-        </ul>
       <% end %>
     <% end %>
     <br>

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe Account do
         expect(account).to be_valid
       end
 
-      it "allows phone numbers with invalid characters" do
+      it "does not allow phone numbers with invalid characters" do
         account = FactoryBot.create(:account)
         account.phone_number = "+123-AAA-CCC"
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -281,6 +281,22 @@ RSpec.describe Account do
         end
       end
     end
+
+    describe "phone number" do
+      it "allows phone numbers with valid characters" do
+        account = FactoryBot.create(:account)
+        account.phone_number = "+1123-456-7890"
+
+        expect(account).to be_valid
+      end
+
+      it "allows phone numbers with invalid characters" do
+        account = FactoryBot.create(:account)
+        account.phone_number = "+123-AAA-CCC"
+
+        expect(account).not_to be_valid
+      end
+    end
   end
 
   it "formats the country as a short code before validating" do


### PR DESCRIPTION
Refs #5036 

This PR adds basic phone number validation to only allow +, -, numbers, and spaces.

I checked prod DB and found the following variations of phone numbers
- +11234516791
- +1 1234516791
- 1234516791
- 123 4516791
- 123-451-6791

Some had country code, a country code with leading + sign, no country code, dashes, no dashes, and spaces. I thought allowing + sign, dashes, and numbers fit the variety best. I also researched a phone number [validator/formator](https://github.com/daddyz/phonelib) gem that could be helpful for this functionality. Especially given the variety of formats we already have. I did mock it out, and it seems like it would integrate nicely. 

I also added the phone number field to the participants datagrid so it can be exported. 

