### PR TITLE
Update onboarding status for off-platform documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,7 +2,7 @@ class Document < ActiveRecord::Base
   belongs_to :signer, polymorphic: true
 
   before_save :set_status
-  after_update -> { signer.update_onboarding_status }
+  after_save -> { signer.update_onboarding_status }
 
   enum status: {
     sent: "sent",

--- a/app/models/legal_contact.rb
+++ b/app/models/legal_contact.rb
@@ -18,6 +18,6 @@ class LegalContact < ActiveRecord::Base
   end
 
   def update_onboarding_status
-    chapter.update_onboarding_status
+    chapter&.update_onboarding_status
   end
 end

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
 
     association :legal_contact
 
+    after(:build) do |chapter|
+      build(:chapter_program_information,
+        chapter: chapter)
+    end
+
     after(:create) do |chapter|
       create(:chapter_program_information,
         chapter: chapter)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Document do
         signed_at: signed_at,
         voided_at: voided_at)
     end
-    let(:signer) { FactoryBot.create(:chapter_ambassador) }
+    let(:signer) { FactoryBot.create(:chapter_ambassador, :not_assigned_to_chapter) }
     let(:sent_at) { nil }
     let(:signed_at) { nil }
     let(:voided_at) { nil }
@@ -71,9 +71,22 @@ RSpec.describe Document do
       end
     end
 
-    context "#after_update" do
+    context "#after_save" do
+      let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :not_assigned_to_chapter) }
+
+      it "makes a call to update the signer's onboarding status when an off-platform document is created" do
+        expect(chapter_ambassador).to receive(:update_onboarding_status)
+
+        Document.create(
+          signer: chapter_ambassador,
+          full_name: chapter_ambassador.full_name,
+          email_address: chapter_ambassador.email,
+          status: "off-platform"
+        )
+      end
+
       it "makes a call to update the signer's onboarding status when the document is updated" do
-        expect(signer).to receive(:update_onboarding_status)
+        expect(signer).to receive(:update_onboarding_status).at_least(:once)
 
         document.update(signed_at: Time.now)
       end

--- a/spec/models/legal_contact_spec.rb
+++ b/spec/models/legal_contact_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe LegalContact do
   end
 
   describe "#update_onboarding_status" do
-    let(:legal_contact) { FactoryBot.create(:legal_contact) }
+    let(:chapter) { FactoryBot.create(:chapter) }
+    let(:legal_contact) { FactoryBot.create(:legal_contact, chapter: chapter) }
 
     it "calls #update_onboarding_status on the legal contact's chapter" do
       expect(legal_contact.chapter).to receive(:update_onboarding_status)

--- a/spec/system/registration/invites_spec.rb
+++ b/spec/system/registration/invites_spec.rb
@@ -64,8 +64,10 @@ RSpec.describe "Using registration invite codes", :js do
       let(:register_at_any_time) { false }
 
       after :each do
-        UserInvitation.delete_all
         ChapterAmbassadorProfile.update_all(chapter_id: nil)
+        UserInvitation.destroy_all
+        LegalContact.destroy_all
+        ChapterProgramInformation.destroy_all
         Chapter.destroy_all
       end
 


### PR DESCRIPTION
An off-platform document is "created" which isn't triggering the `after_update` onboarding status update. 

A simple change here that will change the `after_update` hook to `after_save` which will cover both creating and updating. And a few other changes to support this change.


