### PR TITLE
Update CircleCi configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -125,11 +125,15 @@ jobs:
       - browser-tools/install-browser-tools:
           chrome-version: 128.0.6613.84 # TODO: remove when chromedriver downloads are fixed
 
+      - run:
+          name: Install libc6
+          command: sudo apt install libc6
+
       - restore_cache:
           name: Restore cached gems
           keys:
-            - v2-gem-cache-{{ checksum "Gemfile.lock" }}
-            - v2-gem-cache-
+            - v3-gem-cache-{{ checksum "Gemfile.lock" }}
+            - v3-gem-cache-
 
       - restore_cache:
           name: Restore cached node packages
@@ -165,7 +169,7 @@ jobs:
 
       - save_cache:
           name: Cache gems
-          key: v2-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v3-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 


### PR DESCRIPTION
Some updates here to address the Puma and bootsnap gem updates. The build started failing b/c of a missing dependency, this will address that.

----

This will install libc6, which is needed for bootsnap which will address this error message:

> /home/circleci/technovation-girls/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require': [1m/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /home/circleci/technovation-girls/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.18.4/lib/bootsnap/bootsnap.so) - /home/circleci/technovation-girls/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.18.4/lib/bootsnap/bootsnap.so

https://stackoverflow.com/a/75219857

I also forced gems to be reinstalled and cached.


