### PR TITLE
Pre populate email address in the registration form when participant is invited 

### DIFF
--- a/app/controllers/api/registration/user_invitation_emails_controller.rb
+++ b/app/controllers/api/registration/user_invitation_emails_controller.rb
@@ -1,0 +1,11 @@
+module Api::Registration
+  class UserInvitationEmailsController < ActionController::API
+    def show
+      invite = UserInvitation.find_by(admin_permission_token: params[:invite_code])
+
+      render json: {
+        email: invite.email
+      }
+    end
+  end
+end

--- a/app/javascript/new_registration/components/StepFour.vue
+++ b/app/javascript/new_registration/components/StepFour.vue
@@ -3,26 +3,52 @@
     <ContainerHeader header-text="Set your email and password" />
 
     <div id="email-password" class="form-wrapper">
-      <h1 class="text-tg-green text-2xl text-left mb-6" v-if="formValues.profileType === 'mentor'">This is an account for a mentor</h1>
-      <h1 class="text-tg-green text-2xl text-left mb-6" v-else-if="formValues.profileType === 'judge'">This is an account for a judge</h1>
+      <h1
+        class="text-tg-green text-2xl text-left mb-6"
+        v-if="formValues.profileType === 'mentor'"
+      >
+        This is an account for a mentor
+      </h1>
+      <h1
+        class="text-tg-green text-2xl text-left mb-6"
+        v-else-if="formValues.profileType === 'judge'"
+      >
+        This is an account for a judge
+      </h1>
 
       <FormulateInput
         name="email"
         id="email"
         type="email"
-        :label="formValues.profileType === 'parent' ? 'Parent Email Address' : 'Email Address'"
+        :label="
+          formValues.profileType === 'parent'
+            ? 'Parent Email Address'
+            : 'Email Address'
+        "
         placeholder="Email address"
         :validation="emailValidation"
         validation-name="Email address"
         @keyup="checkValidation"
         @blur="checkValidation"
         class="flex-grow"
-        v-model="setAccountEmailForParentProfile"
-        :disabled="formValues.profileType === 'parent'"
+        v-model="setAccountEmailForParentOrChapterAmbassadorProfile"
+        :disabled="
+          formValues.profileType === 'parent' ||
+          formValues.profileType === 'chapter_ambassador'
+        "
       />
 
-      <p class="text-left text-sm mb-12" v-if="formValues.profileType === 'judge'">Please use your company email if you want your employer to know you volunteered with Technovation.</p>
-      <p class="text-left text-sm mb-12" v-else >Please choose a personal, permanent email. A school or company email might block us from sending important messages to you.</p>
+      <p
+        class="text-left text-sm mb-12"
+        v-if="formValues.profileType === 'judge'"
+      >
+        Please use your company email if you want your employer to know you
+        volunteered with Technovation.
+      </p>
+      <p class="text-left text-sm mb-12" v-else>
+        Please choose a personal, permanent email. A school or company email
+        might block us from sending important messages to you.
+      </p>
 
       <div class="double-wide">
         <FormulateInput
@@ -62,58 +88,63 @@ export default {
   name: "StepFour",
   components: {
     ContainerHeader,
-    PreviousButton
+    PreviousButton,
   },
-  data () {
+  data() {
     return {
-      hasValidationErrors: true
-    }
+      hasValidationErrors: true,
+    };
   },
   methods: {
     checkValidation() {
       const validationErrorMessages = Array.from(
-        document.getElementsByClassName('validation-error-message')
-      ).map(element => element.innerText)
+        document.getElementsByClassName("validation-error-message")
+      ).map((element) => element.innerText);
 
-      if (document.getElementById('email').value.length === 0 ||
-        document.getElementById('password').value.length < 8 ||
+      if (
+        document.getElementById("email").value.length === 0 ||
+        document.getElementById("password").value.length < 8 ||
         validationErrorMessages.some((message) => {
-          return (message.indexOf('is not a valid email address') >= 0 ||
-            message.indexOf('Password must be at least') >= 0)
-        })) {
-
-        this.hasValidationErrors = true
+          return (
+            message.indexOf("is not a valid email address") >= 0 ||
+            message.indexOf("Password must be at least") >= 0
+          );
+        })
+      ) {
+        this.hasValidationErrors = true;
       } else {
-        this.hasValidationErrors = false
+        this.hasValidationErrors = false;
       }
-    }
+    },
   },
   props: {
     formValues: {
       type: Object,
-      required: true
+      required: true,
     },
     isLoading: {
       type: Boolean,
-      required: true
-    }
+      required: true,
+    },
   },
-  computed:{
-    setAccountEmailForParentProfile: {
-      get(){
+  computed: {
+    setAccountEmailForParentOrChapterAmbassadorProfile: {
+      get() {
         if (this.formValues.profileType === "parent") {
-          return this.formValues.studentParentGuardianEmail
+          return this.formValues.studentParentGuardianEmail;
+        } else if (this.formValues.profileType === "chapter_ambassador") {
+          return this.formValues.email;
         } else {
-          return  this.formValues.email
+          return this.formValues.email;
         }
       },
-      set(accountEmailVal){
-        this.formValues.email = accountEmailVal
-      }
+      set(accountEmailVal) {
+        this.formValues.email = accountEmailVal;
+      },
     },
     emailValidation() {
-        return 'required|email'
-    }
-  }
-}
+      return "required|email";
+    },
+  },
+};
 </script>

--- a/app/javascript/new_registration/components/StepOne.vue
+++ b/app/javascript/new_registration/components/StepOne.vue
@@ -10,12 +10,15 @@
         </div>
       </div>
 
-      <div v-if="(this.inviteCode != null || this.teamInviteCode != null) && this.successMessage.length > 0">
-        <h2 class="registration-title">
-          Welcome to Technovation Girls!
-        </h2>
+      <div
+        v-if="
+          (this.inviteCode != null || this.teamInviteCode != null) &&
+          this.successMessage.length > 0
+        "
+      >
+        <h2 class="registration-title">Welcome to Technovation Girls!</h2>
 
-        <div class=" border-l-2 border-energetic-blue bg-blue-50 p-2 mb-8">
+        <div class="border-l-2 border-energetic-blue bg-blue-50 p-2 mb-8">
           <p class="text-left">
             {{ this.successMessage }}
           </p>
@@ -25,7 +28,10 @@
       <div v-else>
         <h2 class="registration-title">
           Technovation Girls is a free program that empowers
-          <a href="https://www.technovation.org/diversity-equity-inclusion-statement/" target="_blank">
+          <a
+            href="https://www.technovation.org/diversity-equity-inclusion-statement/"
+            target="_blank"
+          >
             <em>girls</em>
           </a>
           to be leaders. How will you participate?
@@ -43,9 +49,9 @@
       />
 
       <p v-if="displayDivisionCutoffDescription()" class="italic text-sm">
-        *As of <strong>{{ divisionCutoffDate }}</strong>.
-        For example, if you turn 13 on {{ exampleStudentBirthday }}, you will need to select
-        “I am registering myself and am 13-18 years old.”
+        *As of <strong>{{ divisionCutoffDate }}</strong
+        >. For example, if you turn 13 on {{ exampleStudentBirthday }}, you will
+        need to select “I am registering myself and am 13-18 years old.”
       </p>
     </div>
 
@@ -54,17 +60,17 @@
 </template>
 
 <script>
-import axios from 'axios'
+import axios from "axios";
 
-import { airbrake } from 'utilities/utilities'
-import ContainerHeader from './ContainerHeader'
-import NextButton from './NextButton'
-import { divisionCutoffDateFormatted } from '../../utilities/technovation-dates.js'
-import { exampleStudentBirthday } from '../../utilities/age-helpers.js'
+import { airbrake } from "utilities/utilities";
+import ContainerHeader from "./ContainerHeader";
+import NextButton from "./NextButton";
+import { divisionCutoffDateFormatted } from "../../utilities/technovation-dates.js";
+import { exampleStudentBirthday } from "../../utilities/age-helpers.js";
 
 export default {
-  name: 'StepOne',
-  components: {ContainerHeader, NextButton},
+  name: "StepOne",
+  components: { ContainerHeader, NextButton },
   data() {
     return {
       values: {},
@@ -74,138 +80,172 @@ export default {
       isMentorRegistrationOpen: false,
       isJudgeRegistrationOpen: false,
       isChapterAmbassadorRegistrationOpen: false,
-      invitedRegistrationProfileType: '',
-      successMessage: '',
-      errorMessage: '',
-      inviteCode:  new URLSearchParams(document.location.search).get('invite_code'),
-      teamInviteCode: new URLSearchParams(document.location.search).get('team_invite_code'),
-      hasValidationErrors: true
-    }
+      invitedRegistrationProfileType: "",
+      successMessage: "",
+      errorMessage: "",
+      inviteCode: new URLSearchParams(document.location.search).get(
+        "invite_code"
+      ),
+      teamInviteCode: new URLSearchParams(document.location.search).get(
+        "team_invite_code"
+      ),
+      hasValidationErrors: true,
+    };
   },
   methods: {
     async getRegistrationSettings() {
       try {
-        const response = await axios.get('/api/registration/settings', {
-          params: { invite_code: this.inviteCode, team_invite_code: this.teamInviteCode }
-        })
+        const response = await axios.get("/api/registration/settings", {
+          params: {
+            invite_code: this.inviteCode,
+            team_invite_code: this.teamInviteCode,
+          },
+        });
 
-        this.isStudentRegistrationOpen = response.data.isStudentRegistrationOpen
-        this.isParentRegistrationOpen = response.data.isParentRegistrationOpen
-        this.isMentorRegistrationOpen = response.data.isMentorRegistrationOpen
-        this.isJudgeRegistrationOpen = response.data.isJudgeRegistrationOpen
-        this.isChapterAmbassadorRegistrationOpen = response.data.isChapterAmbassadorRegistrationOpen
-        this.invitedRegistrationProfileType = response.data.invitedRegistrationProfileType
-        this.successMessage = response.data.successMessage
-        this.errorMessage = response.data.errorMessage
-      }
-      catch(error) {
+        this.isStudentRegistrationOpen =
+          response.data.isStudentRegistrationOpen;
+        this.isParentRegistrationOpen = response.data.isParentRegistrationOpen;
+        this.isMentorRegistrationOpen = response.data.isMentorRegistrationOpen;
+        this.isJudgeRegistrationOpen = response.data.isJudgeRegistrationOpen;
+        this.isChapterAmbassadorRegistrationOpen =
+          response.data.isChapterAmbassadorRegistrationOpen;
+        this.invitedRegistrationProfileType =
+          response.data.invitedRegistrationProfileType;
+        this.successMessage = response.data.successMessage;
+        this.errorMessage = response.data.errorMessage;
+      } catch (error) {
         airbrake.notify({
-          error: `[REGISTRATION] Error getting registration settings - ${error.response.data}`
-        })
+          error: `[REGISTRATION] Error getting registration settings - ${error.response.data}`,
+        });
       }
     },
     setupProfileTypes() {
       if (this.isStudentRegistrationOpen) {
-        this.profileTypes.push(this.studentProfileType())
+        this.profileTypes.push(this.studentProfileType());
       }
 
       if (this.isParentRegistrationOpen) {
-        this.profileTypes.push(this.parentProfileType())
+        this.profileTypes.push(this.parentProfileType());
       }
 
       if (this.isMentorRegistrationOpen) {
-        this.profileTypes.push(this.mentorProfileType())
+        this.profileTypes.push(this.mentorProfileType());
       }
 
       if (this.isJudgeRegistrationOpen) {
-        this.profileTypes.push(this.judgeProfileType())
+        this.profileTypes.push(this.judgeProfileType());
       }
 
       if (this.isChapterAmbassadorRegistrationOpen) {
-        this.profileTypes.push(this.chapterAmbassadorProfileType())
+        this.profileTypes.push(this.chapterAmbassadorProfileType());
       }
     },
     preSelectInvitedProfileType() {
-      document.getElementById(`${this.invitedRegistrationProfileType}`).click()
-      document.getElementById(`${this.invitedRegistrationProfileType}`).checked = true
+      console.log(this.invitedRegistrationProfileType);
+      document.getElementById(`${this.invitedRegistrationProfileType}`).click();
+      document.getElementById(
+        `${this.invitedRegistrationProfileType}`
+      ).checked = true;
 
-      this.hasValidationErrors = false
+      this.hasValidationErrors = false;
     },
     disableNonInvitedProfileTypes() {
-      const profileTypeRadioButtons = document.querySelectorAll(`#profile-type input[type="radio"]:not(#${this.invitedRegistrationProfileType}`)
-      const profileTypeImages = document.querySelectorAll(`#profile-type img:not(.${this.invitedRegistrationProfileType})`)
-      const profileTypeText = document.querySelectorAll(`#profile-type span:not(.${this.invitedRegistrationProfileType})`)
+      const profileTypeRadioButtons = document.querySelectorAll(
+        `#profile-type input[type="radio"]:not(#${this.invitedRegistrationProfileType}`
+      );
+      const profileTypeImages = document.querySelectorAll(
+        `#profile-type img:not(.${this.invitedRegistrationProfileType})`
+      );
+      const profileTypeText = document.querySelectorAll(
+        `#profile-type span:not(.${this.invitedRegistrationProfileType})`
+      );
 
-      profileTypeRadioButtons.forEach(profileType => {
-        profileType.disabled = true
-        profileType.classList.add("disabled")
+      profileTypeRadioButtons.forEach((profileType) => {
+        profileType.disabled = true;
+        profileType.classList.add("disabled");
       });
 
-      profileTypeImages.forEach(profileType => {
-        profileType.classList.add("disabled")
-      })
+      profileTypeImages.forEach((profileType) => {
+        profileType.classList.add("disabled");
+      });
 
-      profileTypeText.forEach(profileType => {
-        profileType.classList.add("disabled")
-      })
+      profileTypeText.forEach((profileType) => {
+        profileType.classList.add("disabled");
+      });
+    },
+    async getUserInvitationEmail() {
+      try {
+        const response = await axios.get(
+          "/api/registration/user_invitation_email",
+          {
+            params: { invite_code: this.inviteCode },
+          }
+        );
+        this.formValues.email = response.data.email;
+      } catch (error) {
+        airbrake.notify({
+          error: `[REGISTRATION] Error getting user invitation email - ${error.response.data}`,
+        });
+      }
     },
     studentProfileType() {
       return {
-        label: `<img src="${require('signup/student.png')}" alt="" class="student mb-2"> <span class="student s1-label-text">I am registering myself and am 13-18 years old*</span>`,
-        value: 'student',
-        id: 'student'
-      }
+        label: `<img src="${require("signup/student.png")}" alt="" class="student mb-2"> <span class="student s1-label-text">I am registering myself and am 13-18 years old*</span>`,
+        value: "student",
+        id: "student",
+      };
     },
     parentProfileType() {
       return {
-        label: `<img src="${require('signup/parent.png')}" alt="" class="parent mb-2"> <span class="parent s1-label-text">I am registering my 8-12 year old* daughter</span>`,
-        value: 'parent',
-        id: 'parent'
-      }
+        label: `<img src="${require("signup/parent.png")}" alt="" class="parent mb-2"> <span class="parent s1-label-text">I am registering my 8-12 year old* daughter</span>`,
+        value: "parent",
+        id: "parent",
+      };
     },
     mentorProfileType() {
       return {
-        label: `<img src="${require('signup/mentor.png')}" alt="" class="mentor mb-2"> <span class="mentor s1-label-text">I am over 18 years old and will guide a team</span>`,
-        value: 'mentor',
-        id: 'mentor'
-      }
+        label: `<img src="${require("signup/mentor.png")}" alt="" class="mentor mb-2"> <span class="mentor s1-label-text">I am over 18 years old and will guide a team</span>`,
+        value: "mentor",
+        id: "mentor",
+      };
     },
     judgeProfileType() {
       return {
-        label: `<img src="${require('signup/judge.png')}" alt="" class="judge mb-2"> <span class="judge s1-label-text">I am over 18 years old and will <span class="judge font-bold">judge submissions</span>`,
-        value: 'judge',
-        id: 'judge'
-      }
+        label: `<img src="${require("signup/judge.png")}" alt="" class="judge mb-2"> <span class="judge s1-label-text">I am over 18 years old and will <span class="judge font-bold">judge submissions</span>`,
+        value: "judge",
+        id: "judge",
+      };
     },
     chapterAmbassadorProfileType() {
       return {
-        label: `<img src="${require('signup/chapter-ambassador.png')}" alt="" class="chapter_ambassador mb-2"> <span class="chapter_ambassador s1-label-text">Chapter Ambassador</span>`,
-        value: 'chapter_ambassador',
-        id: 'chapter_ambassador'
-      }
+        label: `<img src="${require("signup/chapter-ambassador.png")}" alt="" class="chapter_ambassador mb-2"> <span class="chapter_ambassador s1-label-text">Chapter Ambassador</span>`,
+        value: "chapter_ambassador",
+        id: "chapter_ambassador",
+      };
     },
     displayDivisionCutoffDescription() {
-      return (this.isStudentRegistrationOpen)
-    }
+      return this.isStudentRegistrationOpen;
+    },
   },
   computed: {
     divisionCutoffDate: divisionCutoffDateFormatted,
-    exampleStudentBirthday
+    exampleStudentBirthday,
   },
   props: {
     formValues: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   async created() {
-    await this.getRegistrationSettings()
-    await this.setupProfileTypes()
+    await this.getRegistrationSettings();
+    await this.setupProfileTypes();
 
     if (this.invitedRegistrationProfileType.length > 0) {
-      this.preSelectInvitedProfileType()
-      this.disableNonInvitedProfileTypes()
+      this.preSelectInvitedProfileType();
+      this.disableNonInvitedProfileTypes();
+      await this.getUserInvitationEmail();
     }
-  }
-}
+  },
+};
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -373,6 +373,7 @@ Rails.application.routes.draw do
       resources :judge_types, only: :index
 
       resource :chapter_organization_name, only: :show
+      resource :user_invitation_email, only: :show
     end
 
     namespace :regional_pitch_events do

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Chapter ambassadors registering", :js do
-  let(:chapter_ambassado_registration_invite) {
+  let(:chapter_ambassador_registration_invite) {
     UserInvitation.create!(
       profile_type: :chapter_ambassador,
       email: "chapter_ambassador_invite@example.com",
@@ -15,7 +15,7 @@ RSpec.feature "Chapter ambassadors registering", :js do
   before do
     SeasonToggles.registration_open!
 
-    visit signup_path(invite_code: chapter_ambassado_registration_invite.admin_permission_token)
+    visit signup_path(invite_code: chapter_ambassador_registration_invite.admin_permission_token)
   end
 
   scenario "Chapter ambassador registration steps and fields" do
@@ -40,7 +40,6 @@ RSpec.feature "Chapter ambassadors registering", :js do
 
     expect(page).to have_content("Set your email and password")
 
-    fill_in "Email Address", with: "hopeful.heart@test.com"
     fill_in "Password", with: "secret12345"
     click_button "Submit this form"
   end

--- a/spec/requests/api/registration/user_invitation_emails_controller_spec.rb
+++ b/spec/requests/api/registration/user_invitation_emails_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "User Invitation Emails API", type: :request do
+  describe "GET /api/registration/user_invitation_email" do
+    let(:registration_invite) {
+      UserInvitation.create!(
+        profile_type: :chapter_ambassador,
+        email: "chapter_ambassador_invite@example.com",
+        chapter_id: chapter.id
+      )
+    }
+    let(:chapter) { FactoryBot.create(:chapter) }
+
+    context "when the invite_code is valid" do
+      before do
+        get "/api/registration/user_invitation_email", params: {
+          invite_code: registration_invite.admin_permission_token
+        }
+      end
+
+      it "returns the email associated with the invitation" do
+        json = JSON.parse(response.body)
+        expect(json["email"]).to eq("chapter_ambassador_invite@example.com")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refs #4201 

This PR adds functionality to pre-populate the registration form's email address when a participant is invited. This will apply to any invited user, however, the email field will only be disabled for an invited chapter ambassador (the other profile types can still edit the field).

Main changes

- Added `UserInvitationEmailsController which follows the `ChapterOrganizationNamesController` pattern. 
- Added `getUserInvitationEmail()` method
- Disabled the email form field for chapter ambassador profile type
- Added test




 

