### PR TITLE
Off-platform Chapter Volunteer Agreements

### DIFF
--- a/app/controllers/admin/chapter_ambassadors/off_platform_chapter_volunteer_agreement_controller.rb
+++ b/app/controllers/admin/chapter_ambassadors/off_platform_chapter_volunteer_agreement_controller.rb
@@ -1,0 +1,24 @@
+module Admin::ChapterAmbassadors
+  class OffPlatformChapterVolunteerAgreementController < AdminController
+    def create
+      @chapter_ambassador = ChapterAmbassadorProfile.find(params[:chapter_ambassador_id])
+
+      if @chapter_ambassador.chapter_volunteer_agreement.present?
+        redirect_to admin_participant_path(@chapter_ambassador.account),
+          error: "This chapter ambassador already has an active chapter volunteer agreement"
+      else
+        @chapter_ambassador.documents.create(
+          full_name: @chapter_ambassador.full_name,
+          email_address: @chapter_ambassador.email,
+          active: true,
+          season_signed: Season.current.year,
+          season_expires: Season.current.year + 1,
+          status: "off-platform"
+        )
+
+        redirect_to admin_participant_path(@chapter_ambassador.account),
+          success: "Successfully created an off-platform chapter volunteer agreement this chapter ambassador"
+      end
+    end
+  end
+end

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -127,15 +127,15 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
     viewed_community_connections
   end
 
-  def chapter_volunteer_agreement_signed?
-    chapter_volunteer_agreement&.signed?
+  def chapter_volunteer_agreement_complete?
+    !!chapter_volunteer_agreement&.complete?
   end
 
   def required_onboarding_tasks
     {
       "Background Check" => background_check_exempt_or_complete?,
       "Chapter Ambassador Training" => training_completed?,
-      "Chapter Volunteer Agreement" => chapter_volunteer_agreement_signed?,
+      "Chapter Volunteer Agreement" => chapter_volunteer_agreement_complete?,
       "Community Connections" => viewed_community_connections?
     }
   end
@@ -162,7 +162,7 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
   def can_be_marked_onboarded?
     !!(account.email_confirmed? &&
       background_check_exempt_or_complete? &&
-      chapter_volunteer_agreement_signed? &&
+      chapter_volunteer_agreement_complete? &&
       training_completed? &&
       viewed_community_connections?)
   end

--- a/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_debugging.html.erb
@@ -8,6 +8,11 @@
         <hr style="height: 1px; width: 100%;">
       <% end %>
 
+      <% if current_account.is_admin? && !profile.chapter_volunteer_agreement_complete? %>
+        <%= render "admin/participants/off_platform_chapter_volunteer_agreement", profile: profile %>
+        <hr style="height: 1px; width: 100%;">
+      <% end %>
+
       <dl>
         <dt>Chapter Onboarding Status</dt>
         <dd>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -64,13 +64,17 @@
       <dt>Sign Chapter Volunteer Agreement</dt>
       <dd>
         <div style="display: flex;">
-          <% if chapter_ambassador.chapter_volunteer_agreement_signed? %>
+          <% if chapter_ambassador.chapter_volunteer_agreement_complete? %>
             <%= web_icon("check-circle icon-green") %>
             <div>
               Complete
 
               <p class="hint margin--b-none">
-                Signed <%= chapter_ambassador.chapter_volunteer_agreement.signed_at.strftime("%b %d, %Y") %>
+                <% if chapter_ambassador.chapter_volunteer_agreement.signed? %>
+                  Signed <%= chapter_ambassador.chapter_volunteer_agreement.signed_at.strftime("%b %d, %Y") %>
+                <% elsif chapter_ambassador.chapter_volunteer_agreement.off_platform? %>
+                  Completed Off-platform
+                <% end %>
               </p>
             </div>
           <% else %>

--- a/app/views/admin/participants/_off_platform_chapter_volunteer_agreement.en.html.erb
+++ b/app/views/admin/participants/_off_platform_chapter_volunteer_agreement.en.html.erb
@@ -1,0 +1,25 @@
+<h5>Create Off-platform Chapter Volunteer Agreement</h5>
+
+<% if profile.chapter_volunteer_agreement.present? %>
+  <p>
+    A Chapter Volunteer Agreement already exists for this chapter ambassador.
+    The existing agreement will need to be voided before an off-platform one can be created.
+  </p>
+
+  <p>
+    Chapter Volunteer Agreement Status: <strong><%= profile.chapter_volunteer_agreement.status.humanize %></strong>
+  </p>
+<% else %>
+  <p>
+    Click the button below to create an off-platform Chapter Volunteer Agreement for <%= profile.full_name %> that will be valid for one year.
+  </p>
+
+  <%= form_with url: admin_chapter_ambassador_off_platform_chapter_volunteer_agreement_path(profile), method: :post do %>
+    <%= submit_tag "Create an off-platform Chapter Volunteer Agreement",
+      method: "post",
+      class: "button",
+      style: "margin: 8px 0;",
+      onclick: "this.disabled=true; this.form.submit();"
+    %>
+  <% end %>
+<% end %>

--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -17,7 +17,7 @@
       <%= render "application/templates/completion_step",
         name: "Chapter Volunteer Agreement",
         url: chapter_ambassador_chapter_volunteer_agreement_path,
-        is_complete: current_ambassador.chapter_volunteer_agreement_signed?,
+        is_complete: current_ambassador.chapter_volunteer_agreement_complete?,
         is_active_item: al(chapter_ambassador_chapter_volunteer_agreement_path).present?
       %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,7 +284,11 @@ Rails.application.routes.draw do
       resource :location, only: :edit, controller: "chapters/locations"
     end
 
-    resources :chapter_ambassadors, only: :index
+    resources :chapter_ambassadors, only: :index do
+      resource :off_platform_chapter_volunteer_agreement,
+        only: :create,
+        controller: "chapter_ambassadors/off_platform_chapter_volunteer_agreement"
+    end
 
     resources :chapter_ambassador_status, only: :update
 

--- a/spec/models/chapter_ambassador_profile_spec.rb
+++ b/spec/models/chapter_ambassador_profile_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe ChapterAmbassadorProfile do
     end
   end
 
-  describe "#chapter_volunteer_agreement_signed?" do
+  describe "#chapter_volunteer_agreement_complete?" do
     before do
-      allow(chapter_ambassador_profile).to receive_message_chain(:chapter_volunteer_agreement, :signed?).and_return(document_signed)
+      allow(chapter_ambassador_profile).to receive_message_chain(:chapter_volunteer_agreement, :complete?).and_return(document_completed)
     end
 
     context "when the legal document has been signed" do
-      let(:document_signed) { true }
+      let(:document_completed) { true }
 
       it "returns true" do
-        expect(chapter_ambassador_profile.chapter_volunteer_agreement_signed?).to eq(true)
+        expect(chapter_ambassador_profile.chapter_volunteer_agreement_complete?).to eq(true)
       end
     end
 
     context "when the legal document has not been signed" do
-      let(:document_signed) { false }
+      let(:document_completed) { false }
 
       it "returns false" do
-        expect(chapter_ambassador_profile.chapter_volunteer_agreement_signed?).to eq(false)
+        expect(chapter_ambassador_profile.chapter_volunteer_agreement_complete?).to eq(false)
       end
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe ChapterAmbassadorProfile do
     before do
       allow(chapter_ambassador_profile).to receive(:background_check_exempt_or_complete?).and_return(true)
       allow(chapter_ambassador_profile).to receive(:training_completed?).and_return(true)
-      allow(chapter_ambassador_profile).to receive(:chapter_volunteer_agreement_signed?).and_return(true)
+      allow(chapter_ambassador_profile).to receive(:chapter_volunteer_agreement_complete?).and_return(true)
       allow(chapter_ambassador_profile).to receive(:viewed_community_connections?).and_return(true)
     end
 
@@ -75,7 +75,7 @@ RSpec.describe ChapterAmbassadorProfile do
 
     context "when the Chapter Volunteer Agreement has not been signed" do
       before do
-        allow(chapter_ambassador_profile).to receive(:chapter_volunteer_agreement_signed?).and_return(false)
+        allow(chapter_ambassador_profile).to receive(:chapter_volunteer_agreement_complete?).and_return(false)
       end
 
       it "returns returns an array that contains 'Chapter Volunteer Agreement'" do
@@ -112,13 +112,13 @@ RSpec.describe ChapterAmbassadorProfile do
         let(:email_address_confirmed) { true }
         let(:background_check) { instance_double(BackgroundCheck, clear?: background_check_cleared) }
         let(:background_check_cleared) { true }
-        let(:chapter_volunteer_agreement) { instance_double(Document, signed?: chapter_volunteer_agreement_signed) }
-        let(:chapter_volunteer_agreement_signed) { true }
+        let(:chapter_volunteer_agreement) { instance_double(Document, complete?: chapter_volunteer_agreement_complete) }
+        let(:chapter_volunteer_agreement_complete) { true }
 
         context "when all onboarding steps have been completed" do
           let(:email_address_confirmed) { true }
           let(:background_check_cleared) { true }
-          let(:chapter_volunteer_agreement_signed) { true }
+          let(:chapter_volunteer_agreement_complete) { true }
 
           before do
             chapter_ambassador_profile.update(viewed_community_connections: true)
@@ -142,7 +142,7 @@ RSpec.describe ChapterAmbassadorProfile do
         end
 
         context "when the legal document has not been signed" do
-          let(:chapter_volunteer_agreement_signed) { false }
+          let(:chapter_volunteer_agreement_complete) { false }
 
           before do
             chapter_ambassador_profile.save

--- a/spec/system/admin/chapter_ambassadors/create_off_platform_chapter_volunteer_agreement_spec.rb
+++ b/spec/system/admin/chapter_ambassadors/create_off_platform_chapter_volunteer_agreement_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Admin creating an off-platform Chapter Volunteer Agreement for a chapter ambassador" do
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+
+  context "when the chapter ambassador does not already have a Chapter Volunteer Agreement" do
+    before do
+      chapter_ambassador.chapter_volunteer_agreement.delete
+    end
+
+    it "creates an off-platform Chapter Volunteer Agreement" do
+      sign_in(:admin)
+      visit admin_participant_path(chapter_ambassador.account)
+
+      click_button "Create an off-platform Chapter Volunteer Agreement"
+
+      chapter_ambassador.reload
+      expect(chapter_ambassador.chapter_volunteer_agreement.status).to eq("off-platform")
+    end
+  end
+end


### PR DESCRIPTION
This will add functionality that will admins to create off-platform Chapter Volunteer Agreements for chapter ambassadors. This functionality will only be available if the chapter ambassador doesn't already have a Chapter Volunteer Agreement.


