### PR TITLE
Update mentor background check to use invitation flow

### DIFF
--- a/app/models/background_check.rb
+++ b/app/models/background_check.rb
@@ -18,6 +18,12 @@ class BackgroundCheck < ActiveRecord::Base
     pending?
   end
 
+  def complete_with_concerns?
+    consider? ||
+      suspended? ||
+      canceled?
+  end
+
   class << self
     def get(resource, id)
       Checkr.request(:get, "/v1/#{resource}/#{id}")

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -295,6 +295,12 @@ class MentorProfile < ActiveRecord::Base
       background_check.clear?
   end
 
+  def background_check_flagged?
+    background_check.consider? ||
+      background_check.suspended? ||
+      background_check.suspended?
+  end
+
   def requires_background_check?
     (account.valid? && (account.date_of_birth.present? && account.age >= 18 || account.meets_minimum_age_requirement?)) &&
       in_background_check_country? &&

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -295,12 +295,6 @@ class MentorProfile < ActiveRecord::Base
       background_check.clear?
   end
 
-  def background_check_flagged?
-    background_check.consider? ||
-      background_check.suspended? ||
-      background_check.canceled?
-  end
-
   def requires_background_check?
     (account.valid? && (account.date_of_birth.present? && account.age >= 18 || account.meets_minimum_age_requirement?)) &&
       in_background_check_country? &&

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -319,7 +319,6 @@ class MentorProfile < ActiveRecord::Base
 
   def in_background_check_invitation_country?
     country_codes = ENV.fetch("BACKGROUND_CHECK_COUNTRY_CODES", "").split(",")
-    country_codes.delete("US")
     country_codes.include?(account.country_code)
   end
 

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -298,7 +298,7 @@ class MentorProfile < ActiveRecord::Base
   def background_check_flagged?
     background_check.consider? ||
       background_check.suspended? ||
-      background_check.suspended?
+      background_check.canceled?
   end
 
   def requires_background_check?

--- a/app/null_objects/null_background_check.rb
+++ b/app/null_objects/null_background_check.rb
@@ -43,6 +43,10 @@ class NullBackgroundCheck < NullObject
     false
   end
 
+  def complete_with_concerns?
+    false
+  end
+
   def paranoid?
     false
   end

--- a/app/null_objects/null_background_check.rb
+++ b/app/null_objects/null_background_check.rb
@@ -39,6 +39,10 @@ class NullBackgroundCheck < NullObject
     false
   end
 
+  def canceled?
+    false
+  end
+
   def paranoid?
     false
   end

--- a/app/views/admin/participants/_background_check_invitation_status.html.erb
+++ b/app/views/admin/participants/_background_check_invitation_status.html.erb
@@ -1,47 +1,23 @@
-<% if profile.in_background_check_invitation_country? %>
-  <% if profile.account.background_check_exemption? %>
-    <%= web_icon(
-          "check-circle icon-green",
-          text: "Background check exempt"
-        ) %>
-  <% elsif profile.background_check.invitation_pending? %>
-    <%= web_icon(
-          "exclamation-circle icon--orange",
-          text:  profile.background_check.invitation_status.humanize
-        ) %>
- <% elsif profile.background_check.invitation_completed? %>
-    <%= web_icon(
-          "check-circle icon-green",
-          text: profile.background_check.invitation_status.humanize
-        ) %>
-  <% elsif profile.background_check.invitation_expired? %>
-    <%= web_icon(
-          "exclamation-circle icon-red",
-          text: profile.background_check.invitation_status.humanize
-        ) %>
-    <br>
-    <span class="hint">
+<% if profile.background_check.invitation_status.present? && !profile.background_check.invitation_completed? %>
+  <p class="hint margin--b-none">
+    Invitation status: <%= profile.background_check.invitation_status&.humanize %>
+  </p>
+
+  <% if profile.background_check.invitation_expired? %>
+    <p class="hint margin--b-none">
       The background check invitation has expired. Participant must request a new invitation.
-    </span>
-  <% elsif profile.background_check.error? %>
-    <%= web_icon(
-          "exclamation-circle icon-red",
-          text: profile.background_check.error_message.present? ? "Error from Checkr: #{profile.background_check.error_message}" : "No error message recorded. Review Checkr logs."
-        ) %>
-  <% elsif profile.background_check.blank?  %>
-    <%= web_icon(
-          "exclamation-circle icon--orange",
-          text: "Background check invitation not yet requested"
-        ) %>
-  <% else %>
-    <%= web_icon(
-          "exclamation-circle icon--orange",
-          text:  "Error - please contact the dev team"
-        ) %>
+    </p>
   <% end %>
 <% else %>
-  <%= web_icon(
-        "check-circle",
-        text: "Background check invitation not required in this country"
-      ) %>
+  <p class="hint margin--b-none">
+    <% if profile.background_check.present? %>
+      <% if profile.background_check.error? %>
+        Error: <%= profile.background_check.error_message.presence || "No error message recorded" %>
+      <% else %>
+        <%= profile.background_check.status.humanize %>
+      <% end %>
+    <% else %>
+      Invitation not sent
+    <% end %>
+  </p>
 <% end %>

--- a/app/views/admin/participants/_background_check_status.html.erb
+++ b/app/views/admin/participants/_background_check_status.html.erb
@@ -10,7 +10,7 @@
               "check-circle icon-green",
               text: profile.background_check.status.humanize
             ) %>
-    <% elsif profile.background_check.pending? || profile.background_check_flagged? %>
+    <% elsif profile.background_check.pending? || profile.background_check.complete_with_concerns? %>
         <%= web_icon(
               "exclamation-circle icon--orange",
               text: profile.background_check.status.humanize

--- a/app/views/admin/participants/_background_check_status.html.erb
+++ b/app/views/admin/participants/_background_check_status.html.erb
@@ -1,28 +1,34 @@
-<% if profile.in_background_check_country? %>
-  <% if profile.account.background_check_exemption? %>
-    <%= web_icon(
-          "check-circle icon-green",
-          text: "Background check exempt"
-        ) %>
-  <% elsif profile.background_check.clear? %>
-    <%= web_icon(
-          "check-circle icon-green",
-          text: profile.background_check.status.humanize
-        ) %>
-  <% elsif profile.background_check.present? %>
-    <%= web_icon(
-          "exclamation-circle icon-red",
-          text: profile.background_check.status.humanize
-        ) %>
+<div style="display: flex;">
+  <% if profile.in_background_check_country? %>
+    <% if profile.account.background_check_exemption? %>
+      <%= web_icon(
+            "check-circle icon-green",
+            text: "Background check exempt"
+          ) %>
+    <% elsif profile.background_check.clear? %>
+        <%= web_icon(
+              "check-circle icon-green",
+              text: profile.background_check.status.humanize
+            ) %>
+    <% elsif profile.background_check.pending? || profile.background_check_flagged? %>
+        <%= web_icon(
+              "exclamation-circle icon--orange",
+              text: profile.background_check.status.humanize
+            ) %>
+    <% else %>
+      <%= web_icon(
+            "exclamation-circle icon-red"
+          ) %>
+      <div>
+        Incomplete
+        <%= render 'admin/participants/background_check_invitation_status',
+          profile: profile %>
+      </div>
+    <% end %>
   <% else %>
     <%= web_icon(
-          "exclamation-circle icon-red",
-          text: "Not submitted"
+          "check-circle",
+          text: "Background check not required in this country"
         ) %>
   <% end %>
-<% else %>
-  <%= web_icon(
-        "check-circle",
-        text: "Background check not required in this country"
-      ) %>
-<% end %>
+</div>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -17,30 +17,8 @@
             <%= web_icon("exclamation-circle icon-red") %>
             <div>
               Incomplete
-
-              <% if chapter_ambassador.background_check.invitation_status.present? && !chapter_ambassador.background_check.invitation_completed? %>
-                <p class="hint margin--b-none">
-                  Invitation status: <%= chapter_ambassador.background_check.invitation_status&.humanize %>
-                </p>
-
-                <% if chapter_ambassador.background_check.invitation_expired? %>
-                  <p class="hint margin--b-none">
-                    The background check invitation has expired. Participant must request a new invitation.
-                  </p>
-                <% end %>
-              <% else %>
-                <p class="hint margin--b-none">
-                  <% if chapter_ambassador.background_check.present? %>
-                    <% if chapter_ambassador.background_check.error? %>
-                      Error: <%= chapter_ambassador.background_check.error_message.presence || "No error message recorded" %>
-                    <% else %>
-                      <%= chapter_ambassador.background_check.status.humanize %>
-                    <% end %>
-                  <% else %>
-                    Not sent
-                  <% end %>
-                </p>
-              <% end %>
+              <%= render 'admin/participants/background_check_invitation_status',
+                profile: chapter_ambassador %>
             </div>
           <% end %>
         </div>

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -34,14 +34,6 @@
       <% end %>
     </dd>
 
-    <dt>
-      Background Check Invitation Status
-    </dt>
-    <dd>
-      <%= render 'admin/participants/background_check_invitation_status',
-                 profile: @account.mentor_profile %>
-    </dd>
-
     <dt>Background Check</dt>
     <dd>
       <%= render 'admin/participants/background_check_status',

--- a/app/views/background_checks/_new.html.erb
+++ b/app/views/background_checks/_new.html.erb
@@ -1,5 +1,1 @@
-<% if current_account.country_code == "US" %>
-  <%= render "background_checks/us_background_check", url: url %>
-<% else %>
-  <%= render "background_checks/background_check_invitation" %>
-<% end %>
+<%= render "background_checks/background_check_invitation" %>

--- a/app/views/background_checks/_show.html.erb
+++ b/app/views/background_checks/_show.html.erb
@@ -40,10 +40,9 @@
 
       <h5>Possible status values:</h5>
 
-      <dl>
+      <dl class="padding--l-large">
         <dt>Invitation Required</dt>
         <dd>
-          You are an international candidate.
           An invitation was sent to your email.
           Please accept the invitation and complete the background check through the Checkr portal.
         </dd>
@@ -68,7 +67,7 @@
         </dd>
       </dl>
 
-      <h5>While your background check is being processed:</h5>
+      <h5 class="margin--t-xxlarge">While your background check is being processed:</h5>
 
       <p>
         Based on historical data,
@@ -98,7 +97,7 @@
         and to download a copy when it's complete.
       </p>
 
-      <h5>After your background check is complete:</h5>
+      <h5 class="margin--t-xxlarge">After your background check is complete:</h5>
 
       <p>
         You will receive an <strong>email from us</strong>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -188,7 +188,7 @@ en:
             text: "Check Invitation status"
           background_check_submitted:
             prefix: "Your background check is being processed. You will get an email in 4-7 business days if it clears."
-            text: "Check Submission Status"
+            text: "Check Background Check Status"
           fill_bg_check_form:
             prefix: "You must submit and clear a background check to gain access to the platform."
             text: "Submit Background Check"

--- a/spec/cassettes/background_check_invitation/Request_a_background_check_invitation_as_a_mentor_in_the_United_States.yml
+++ b/spec/cassettes/background_check_invitation/Request_a_background_check_invitation_as_a_mentor_in_the_United_States.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.checkr.com/v1/candidates
+    body:
+      encoding: UTF-8
+      string: '{"email":"engineering+factorymentorusa@technovation.org","first_name":"Mentor","last_name":"FactoryBot","work_locations":[{"country":"US"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.5.2
+      Authorization:
+      - Basic MzdlY2E4ZmRmNDAxNGM0N2Y5MzUzNGNhMWZkODYzNTY3ZGFjNTMzMTo=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 08 Oct 2024 17:31:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '630'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 8cf7dd0c0fe0c309-IAH
+      Cf-Cache-Status:
+      - DYNAMIC
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Origin, Accept-Encoding
+      Ratelimit-Limit:
+      - '1200'
+      Ratelimit-Remaining:
+      - '1199'
+      Ratelimit-Reset:
+      - '45'
+      X-Checkr-Region:
+      - us-east-1
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '1200'
+      X-Ratelimit-Remaining:
+      - '1199'
+      X-Ratelimit-Reset:
+      - '2024-10-08T17:32:00Z'
+      X-Request-Id:
+      - 34610354-72b7-9a2c-a072-8a37110adffb
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"id":"19152f75446aea8b543fd14e","uri":"/v1/candidates/19152f75446aea8b543fd14e","created_at":"2024-10-08T17:31:15Z","first_name":"Mentor","last_name":"Factorybot","middle_name":null,"mother_maiden_name":null,"dob":null,"ssn":null,"email":"engineering+factorymentorusa@technovation.org","zipcode":null,"phone":null,"driver_license_state":null,"driver_license_number":null,"copy_requested":false,"previous_driver_license_state":null,"previous_driver_license_number":null,"adjudication":null,"custom_id":null,"no_middle_name":false,"updated_at":"2024-10-08T17:31:15Z","locale":null,"object":"candidate","report_ids":[],"geo_ids":[]}'
+  recorded_at: Tue, 08 Oct 2024 17:31:15 GMT
+- request:
+    method: post
+    uri: https://api.checkr.com/v1/invitations
+    body:
+      encoding: UTF-8
+      string: '{"package":"tasker_standard","candidate_id":"19152f75446aea8b543fd14e","work_locations":[{"country":"US"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.5.2
+      Authorization:
+      - Basic MzdlY2E4ZmRmNDAxNGM0N2Y5MzUzNGNhMWZkODYzNTY3ZGFjNTMzMTo=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 08 Oct 2024 17:31:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '487'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 8cf7dd106b3a486d-DFW
+      Cf-Cache-Status:
+      - DYNAMIC
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Origin, Accept-Encoding
+      Ratelimit-Limit:
+      - '1200'
+      Ratelimit-Remaining:
+      - '1198'
+      Ratelimit-Reset:
+      - '44'
+      X-Checkr-Region:
+      - us-east-1
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '1200'
+      X-Ratelimit-Remaining:
+      - '1198'
+      X-Ratelimit-Reset:
+      - '2024-10-08T17:32:00Z'
+      X-Request-Id:
+      - eaf5e11b-3b66-9a83-8019-d38ba92d66fa
+      Server:
+      - cloudflare
+    body:
+      encoding: UTF-8
+      string: '{"id":"4e987a175af77e16ec3cfe68","status":"pending","uri":"/v1/invitations/4e987a175af77e16ec3cfe68","invitation_url":"https://apply.checkrhq-staging.net/invite/technovation/e3b72976d8385be0f23798c92ba96146","completed_at":null,"deleted_at":null,"package":"tasker_standard","created_at":"2024-10-08T17:31:16Z","expires_at":"2024-10-16T06:59:59Z","tags":[],"locale":null,"archived":false,"archived_info":{},"object":"invitation","candidate_id":"19152f75446aea8b543fd14e","report_id":null}'
+  recorded_at: Tue, 08 Oct 2024 17:31:16 GMT
+recorded_with: VCR 6.1.0

--- a/spec/features/admin/profile_debugging_spec.rb
+++ b/spec/features/admin/profile_debugging_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "When an admin is debugging a profile" do
-  scenario "they view the background check status in the mentor debugging section a mentor based in the US" do
+  scenario "they view the background check status in the mentor debugging section of an onboarded mentor based in the US" do
     mentor = FactoryBot.create(
       :mentor,
       :los_angeles,
@@ -16,11 +16,10 @@ RSpec.feature "When an admin is debugging a profile" do
       click_link "view"
     end
 
-    expect(page).to have_content("Background check invitation not required in this country")
     expect(page).to have_css(".web-icon-text", text: "Clear")
   end
 
-  scenario "they view the background check status in the mentor debugging section of mentor based in India" do
+  scenario "they view the background check status of a mentor based in India who has not completed their background check invitation" do
     mentor = FactoryBot.create(
       :mentor,
       :india,
@@ -47,11 +46,10 @@ RSpec.feature "When an admin is debugging a profile" do
       click_link "view"
     end
 
-    expect(page).to have_content("Pending")
-    expect(page).to have_css(".web-icon-text", text: "Invitation required")
+    expect(page).to have_content("Invitation status: Pending")
   end
 
-  scenario "they view the background check status in the mentor debugging section of a mentor not in a background check country" do
+  scenario "they view the background check status of a mentor not in a background check country" do
     mentor = FactoryBot.create(
       :mentor,
       :brazil,
@@ -66,17 +64,17 @@ RSpec.feature "When an admin is debugging a profile" do
       click_link "view"
     end
 
-    expect(page).to have_content("Background check invitation not required in this country")
     expect(page).to have_content("Background check not required in this country")
   end
 
-  scenario "they view the background check invitation status in the mentor debugging section of a mentor based in India who has not requested a background check invitation" do
+  scenario "they view the background check invitation status of a mentor based in India who has not requested a background check invitation" do
     mentor = FactoryBot.create(
       :mentor,
       :india
     )
 
     mentor.background_check.destroy
+    mentor.reload
 
     sign_in(:admin)
 
@@ -86,7 +84,7 @@ RSpec.feature "When an admin is debugging a profile" do
       click_link "view"
     end
 
-    expect(page).to have_content("Background check invitation not yet requested")
-    expect(page).to have_css(".web-icon-text", text: "Not submitted")
+    expect(page).to have_content("Incomplete")
+    expect(page).to have_content("Invitation not sent")
   end
 end

--- a/spec/features/background_check_invitation_spec.rb
+++ b/spec/features/background_check_invitation_spec.rb
@@ -18,6 +18,24 @@ RSpec.feature "background check invitation" do
     expect(mentor.reload.background_check).to be_present
   end
 
+  scenario "Request a background check invitation as a mentor in the United States", :vcr do
+    mentor = FactoryBot.create(
+      :mentor,
+      :los_angeles,
+      account: FactoryBot.create(:account, email: "engineering+factorymentorusa@technovation.org")
+    )
+    mentor.background_check.destroy
+
+    sign_in(mentor)
+    click_link "Submit Background Check"
+
+    expect(page).to have_link("Request background check invitation")
+    click_link "Request background check invitation"
+
+    expect(mentor.reload.background_check).to be_present
+  end
+
+
   scenario "Request a background check invitation as a chapter ambassador", :vcr do
     chapter_ambassador = FactoryBot.create(
       :chapter_ambassador,

--- a/spec/features/background_check_spec.rb
+++ b/spec/features/background_check_spec.rb
@@ -1,20 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "background checks" do
-  scenario "Complete a mentor background check", :vcr do
-    mentor = FactoryBot.create(:mentor, :geocoded)
-    mentor.background_check.destroy
-    sign_in(mentor)
-    click_link "Submit Background Check"
-
-    fill_in "Zipcode", with: 60622
-    fill_in "Ssn", with: "111-11-2001"
-    fill_in "Driver license state", with: "CA"
-    click_button "Submit"
-
-    expect(mentor.reload.background_check).to be_present
-  end
-
   scenario "mentors not located in the US, India, or Canada do not see a link to submit a background check" do
     mentor = FactoryBot.create(
       :mentor,


### PR DESCRIPTION
Refs #5056 
This PR updates the mentor background check flow to use the checkr invitation system similar to international participants and ChAs.

Main changes:
- Removed "US" conditional that separated the 2 tracks
- Extracted the invitation status code from ChA debugging into a separate partial
- Update the mentor debugging section to use the invitation status partial (now used for ChAs and Mentors - so they match)
- Updated/added tests

Also created #5073 to complete any cleanup.