### PR TITLE
Update student to mentor conversion functionality

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -8,7 +8,9 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
 
     update_season_data_with_resets(record)
 
-    if is_student?(record) && !is_mentor?(record)
+    if is_student?(record) &&
+        !is_mentor?(record) &&
+        record.age_by_cutoff <= 18
       prepare_student_for_current_season(record)
     end
 

--- a/app/services/student_to_mentor_converter.rb
+++ b/app/services/student_to_mentor_converter.rb
@@ -10,7 +10,7 @@ class StudentToMentorConverter
       delete_team_memberships
       delete_student_profile
 
-      setup_mentor_profile_in_crm
+      register_mentor_to_current_season
 
       Result.new(success?: true, message: {success: "#{account.name} has been successfully converted to a mentor"})
     else
@@ -49,10 +49,7 @@ class StudentToMentorConverter
     account.student_profile&.delete
   end
 
-  def setup_mentor_profile_in_crm
-    CRM::SetupAccountForCurrentSeasonJob.perform_later(
-      account_id: account.id,
-      profile_type: "mentor"
-    )
+  def register_mentor_to_current_season
+    RegisterToCurrentSeasonJob.perform_later(account)
   end
 end

--- a/spec/services/student_to_mentor_converter_spec.rb
+++ b/spec/services/student_to_mentor_converter_spec.rb
@@ -15,7 +15,7 @@ describe StudentToMentorConverter do
     allow(student_profile).to receive_message_chain(:join_requests, :pending, :delete_all)
     allow(student_profile).to receive_message_chain(:memberships, :delete_all)
 
-    allow(CRM::SetupAccountForCurrentSeasonJob).to receive(:perform_later)
+    allow(RegisterToCurrentSeasonJob).to receive(:perform_later)
   end
 
   it "creates a mentor profile (that's marked as being a former student)" do
@@ -57,12 +57,9 @@ describe StudentToMentorConverter do
     student_to_mentor_converter.call
   end
 
-  it "calls the job that will setup the new mentor profile in the CRM" do
-    expect(CRM::SetupAccountForCurrentSeasonJob).to receive(:perform_later)
-      .with(
-        account_id: account.id,
-        profile_type: "mentor"
-      )
+  it "registers the mentor to the current season" do
+    expect(RegisterToCurrentSeasonJob).to receive(:perform_later)
+      .with(account)
 
     student_to_mentor_converter.call
   end


### PR DESCRIPTION
For when a student who will be over 18 years old by the cutoff date signs-in to a new season:

- They won't get registered to the current season as a student
- If they choose to become a mentor, they will get registered to the current season as a mentor (including receive the mentor welcome email), this is new functionality



