### PR TITLE
Update seasons filter for ChA's participants datagrid

### DIFF
--- a/app/views/datagrid/_datagrid.en.html.erb
+++ b/app/views/datagrid/_datagrid.en.html.erb
@@ -9,7 +9,7 @@
     url: form_url %>
 
   <h6>
-    <%= number_with_delimiter(grid.assets.count) %>
+    <%= number_with_delimiter(grid.assets.length) %>
     <%= model_name.humanize.downcase.pluralize(grid.assets.count) %>
     <%= verb %>
   </h6>


### PR DESCRIPTION
This will add a new "season" filter for chapter ambassadors to make it so that the filter will only return participants who were a part of their chapter for a given season.

The admins will use the existing/original "season" filter.


