### PR TITLE
Legal documents datagrid and void functionality

### DIFF
--- a/app/controllers/admin/legal_documents_controller.rb
+++ b/app/controllers/admin/legal_documents_controller.rb
@@ -1,0 +1,26 @@
+module Admin
+  class LegalDocumentsController < AdminController
+    include DatagridController
+
+    use_datagrid with: LegalDocumentsGrid
+
+    def void
+      document = Document.find(params.fetch(:legal_document_id))
+
+      VoidDocumentJob.perform_later(document_id: document.id)
+
+      redirect_to admin_legal_documents_path,
+        success: "Successfully scheduled a job to void the #{document.document_type} for #{document.full_name}. Please wait about a minute to see the changes reflected here."
+    end
+
+    private
+
+    def grid_params
+      grid = params[:legal_documents_grid] ||= {}
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
+    end
+  end
+end

--- a/app/controllers/concerns/saved_search_controller.rb
+++ b/app/controllers/concerns/saved_search_controller.rb
@@ -31,6 +31,8 @@ module SavedSearchController
       "#{current_scope}_chapter_ambassadors_path"
     when "parental_consents_grid"
       "#{current_scope}_paper_parental_consents_path"
+    when "legal_documents_grid"
+      "admin_legal_documents_path"
     else
       raise "Param root #{@saved_search.param_root} not supported"
     end

--- a/app/data_grids/legal_documents_grid.rb
+++ b/app/data_grids/legal_documents_grid.rb
@@ -1,0 +1,42 @@
+class LegalDocumentsGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Document.order(created_at: :desc)
+  end
+
+  column :full_name, header: "Name", mandatory: true
+  column :email_address, mandatory: true
+  column :document_type, header: "Document", mandatory: true
+
+  column :status, mandatory: true do |document|
+    document.status&.capitalize
+  end
+
+  column :actions, mandatory: true, html: true do |document|
+    render "admin/legal_documents/actions", document: document
+  end
+
+  filter :full_name,
+    header: "Name",
+    filter_group: "common" do |value|
+      where("full_name LIKE '%#{value}%'")
+    end
+
+  filter :email_address,
+    filter_group: "common" do |value|
+      where("email_address LIKE '%#{value}%'")
+    end
+
+  filter :status,
+    :enum,
+    select: Document.statuses.transform_keys(&:capitalize),
+    filter_group: "common",
+    html: {
+      class: "and-or-field"
+    } do |value|
+    where(status: value)
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,12 +11,21 @@ class Document < ActiveRecord::Base
     voided: "voided"
   }
 
-  def sent?
-    sent_at.present?
+  def unsigned?
+    sent? && signed_at.blank?
   end
 
   def complete?
     signed? || off_platform?
+  end
+
+  def document_type
+    case signer_type
+    when "LegalContact"
+      "Chapter Affiliation Agreement"
+    when "ChapterAmbassadorProfile"
+      "Chapter Volunteer Agreement"
+    end
   end
 
   private

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -74,6 +74,10 @@
       admin_background_checks_path,
       class: al(admin_background_checks_path) %>
 
+    <%= link_to "Legal Documents",
+      admin_legal_documents_path,
+      class: al(admin_legal_documents_path) %>
+
     <%= link_to "Admins",
       admin_admins_path,
       class: al(admin_admins_path) %>

--- a/app/views/admin/legal_documents/_actions.html.erb
+++ b/app/views/admin/legal_documents/_actions.html.erb
@@ -1,0 +1,11 @@
+<% if document.unsigned? %>
+  <%= link_to(
+    "Void",
+    admin_legal_document_void_path(document),
+    class: "button small",
+    data: {
+      method: :patch,
+      confirm: "You are about to void this legal document"
+    }
+  ) %>
+<% end %>

--- a/app/views/admin/legal_documents/index.html.erb
+++ b/app/views/admin/legal_documents/index.html.erb
@@ -1,0 +1,7 @@
+<% provide :title, "Admin • Legal Documents" %>
+
+<%= render 'datagrid/datagrid',
+  grid: @legal_documents_grid,
+  form_url: admin_legal_documents_path,
+  model_name: "documents",
+  scope: :admin %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,6 +315,10 @@ Rails.application.routes.draw do
     resources :background_check_sweeps, only: :create
     resources :background_check_syncs, only: :create
 
+    resources :legal_documents, only: :index do
+      patch :void
+    end
+
     resources :events,
       controller: :regional_pitch_events,
       only: [:index, :show, :edit, :update]

--- a/spec/controllers/admin/legal_documents_controller_spec.rb
+++ b/spec/controllers/admin/legal_documents_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Admin::LegalDocumentsController do
+  describe "PATCH #void" do
+    let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+    let(:document) { FactoryBot.create(:document, signer: chapter_ambassador) }
+
+    before do
+      sign_in(:admin)
+
+      allow(Document).to receive(:find).and_return(document)
+      allow(VoidDocumentJob).to receive(:perform_later)
+    end
+
+    it "makes a call to find the document" do
+      expect(Document).to receive(:find).with(document.id.to_s)
+
+      patch :void, params: {legal_document_id: document.id}
+    end
+
+    it "makes a call to void the document" do
+      expect(VoidDocumentJob).to receive(:perform_later).with(document_id: document.id)
+
+      patch :void, params: {legal_document_id: document.id}
+    end
+
+    it "redirects to the admin legal documents datagrid" do
+      patch :void, params: {legal_document_id: document.id}
+
+      expect(response).to redirect_to(admin_legal_documents_path)
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,8 +1,36 @@
 require "rails_helper"
 
 RSpec.describe Document do
-  let(:document) { Document.new(status: document_status) }
-  let(:document_status) { "void" }
+  let(:document) do
+    Document.new(
+      status: document_status,
+      signed_at: document_signed_at,
+      signer_type: document_signer_type
+    )
+  end
+
+  let(:document_status) { "voided" }
+  let(:document_signer_type) { "LegalContact" }
+  let(:document_signed_at) { nil }
+
+  describe "#unsigned?" do
+    context "when the document has been sent but not signed" do
+      let(:document_status) { "sent" }
+      let(:document_signed_at) { nil }
+
+      it "returns true" do
+        expect(document.unsigned?).to eq(true)
+      end
+    end
+
+    context "when the document has been signed" do
+      let(:document_status) { "signed" }
+
+      it "returns false" do
+        expect(document.unsigned?).to eq(false)
+      end
+    end
+  end
 
   describe "#complete?" do
     context "when the document has been signed" do
@@ -26,6 +54,24 @@ RSpec.describe Document do
 
       it "returns false" do
         expect(document.complete?).to eq(false)
+      end
+    end
+
+    describe "#document_type" do
+      context "when the signer type is a legal contact" do
+        let(:document_signer_type) { "LegalContact" }
+
+        it "returns 'Chapter Affiliation Agreement'" do
+          expect(document.document_type).to eq("Chapter Affiliation Agreement")
+        end
+      end
+
+      context "when the signer type is a chapter ambassador" do
+        let(:document_signer_type) { "ChapterAmbassadorProfile" }
+
+        it "returns 'Chapter Volunteer Agreement'" do
+          expect(document.document_type).to eq("Chapter Volunteer Agreement")
+        end
       end
     end
   end


### PR DESCRIPTION
This will add a basic datagrid for legal documents (chapter affiliation agreements and chapter volunteer agreements). It will also add functionality to void a sent/unsigned document.


