### PR TITLE
Cookie opt-out functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 
 gem "rexml", "~> 3.3.6"
+gem "immosquare-cookies"
 
 group :development do
   gem "pp_sql", "~> 0.2", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
       glob
       i18n
     i18n_data (0.7.0)
+    immosquare-cookies (0.1.6)
     indefinite_article (0.2.4)
       activesupport
     ipaddress (0.8.3)
@@ -600,6 +601,7 @@ DEPENDENCIES
   geocoder (~> 1.6.0)
   hiredis (~> 0.6)
   i18n-js (~> 4.0)
+  immosquare-cookies
   indefinite_article (~> 0.2)
   jquery-rails (~> 4.3)
   jquery-ui-rails (~> 7.0)!

--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -5,8 +5,8 @@
 
 // FIXES VENDOR BUG:
 // https://github.com/tsechingho/chosen-rails/issues/97#issuecomment-365472872
-$chosen-sprite: image-url('chosen-sprite.png');
-$chosen-sprite-retina: image-url('chosen-sprite@2x.png');
+$chosen-sprite: image-url("chosen-sprite.png");
+$chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 
 @import "chosen";
 @import "sweetalert2";
@@ -40,6 +40,9 @@ $chosen-sprite-retina: image-url('chosen-sprite@2x.png');
 
 // animation/transitions
 @import "transitions";
+
+@import "immosquare-cookies";
+@import "cookies_banner";
 
 #site-footer {
   font-size: 0.9rem;

--- a/app/assets/stylesheets/_cookies_banner.scss
+++ b/app/assets/stylesheets/_cookies_banner.scss
@@ -1,0 +1,49 @@
+#immosquare-cookies-container {
+  background-color: #f1f5f9;
+  height: 9rem;
+  min-height: 8rem;
+  padding: 0.75rem 3rem;
+  border-top: 1px solid #334155;
+
+  span {
+    font-size: 0.875rem;
+  }
+
+  #immosquare-cookies-title {
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-bottom: 0.05rem;
+  }
+
+  #immosquare-cookies-actions {
+    margin: 0.5rem 0;
+  }
+
+  #immosquare-cookies-accept,
+  #immosquare-cookies-refuse {
+    border-radius: 0.375rem;
+    background-color: #ffffff;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: #1f2937;
+    text-decoration: none;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0), 0 0 0 1px rgba(209, 213, 219, 1),
+      0 0 0 0 rgba(0, 0, 0, 0);
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0),
+      0 0 0 calc(1px + 0) rgba(209, 213, 219, 1), 0 0 0 0 rgba(0, 0, 0, 0);
+    box-shadow: inset 0 0 0 0 rgba(0, 0, 0, 0),
+      0 0 0 calc(1px + 0) rgba(209, 213, 219, 1), 0 0 0 0 rgba(0, 0, 0, 0);
+    box-shadow: inset 0 0 0 0 rgba(0, 0, 0, 0),
+      0 0 0 calc(1px + 0) rgba(209, 213, 219, 1), 0 0 0 0 rgba(0, 0, 0, 0);
+
+    &:hover {
+      animation: none;
+      background-color: #dbeafe;
+    }
+  }
+}

--- a/app/constants/cookie_names.rb
+++ b/app/constants/cookie_names.rb
@@ -1,4 +1,5 @@
 module CookieNames
+  CONSENTED_TO_ALL_COOKIES = "consented_to_all_cookies"
   AUTH_TOKEN = [ENV.fetch("COOKIES_AUTH_TOKEN"), Season.current.year].join("_")
   LAST_PROFILE_USED = ENV.fetch("COOKIES_LAST_PROFILE_USED")
   LAST_VISITED_SUBMISSION_SECTION = ENV.fetch("COOKIES_LAST_VISITED_SUBMISSION_SECTION")

--- a/app/javascript/mentor/index.js
+++ b/app/javascript/mentor/index.js
@@ -39,14 +39,6 @@ document.addEventListener('turbolinks:load', () => {
           this.$el.classList.remove('hidden')
         },
       })
-
-      ga('set', 'page', router.currentRoute.path);
-      ga('send', 'pageview');
-
-      router.afterEach(( to, from ) => {
-        ga('set', 'page', to.path);
-        ga('send', 'pageview');
-      });
     })
   }
 })

--- a/app/javascript/registration/index.js
+++ b/app/javascript/registration/index.js
@@ -34,14 +34,6 @@ document.addEventListener('turbolinks:load', () => {
           App,
         },
       })
-
-      ga('set', 'page', router.currentRoute.path);
-      ga('send', 'pageview');
-
-      router.afterEach(( to, from ) => {
-        ga('set', 'page', to.path);
-        ga('send', 'pageview');
-      });
     })
   }
 })

--- a/app/javascript/student/index.js
+++ b/app/javascript/student/index.js
@@ -41,14 +41,6 @@ document.addEventListener('turbolinks:load', () => {
           this.$el.classList.remove('hidden')
         },
       })
-
-      ga('set', 'page', router.currentRoute.path);
-      ga('send', 'pageview');
-
-      router.afterEach(( to, from ) => {
-        ga('set', 'page', to.path);
-        ga('send', 'pageview');
-      });
     })
   }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
       <%= render 'application/footer' %>
     </div>
 
-    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
+    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/application_rebrand.html.erb
+++ b/app/views/layouts/application_rebrand.html.erb
@@ -54,7 +54,16 @@
      <%= render 'application_rebrand/footer' %>
     </div>
 
-    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
+    <%= render(
+      "immosquare-cookies/consent_banner",
+      key: CookieNames::CONSENTED_TO_ALL_COOKIES,
+      document_name: t("cookies_banner.header"),
+      refuse: t("cookies_banner.refuse"),
+      accept: t("cookies_banner.accept"),
+      text: t("cookies_banner.body")
+    ) %>
+
+    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/chapter_ambassador.html.erb
+++ b/app/views/layouts/chapter_ambassador.html.erb
@@ -57,7 +57,7 @@
 
     <%= render 'application/queued_jobs' %>
 
-    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
+    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/new_registration.html.erb
+++ b/app/views/layouts/new_registration.html.erb
@@ -30,7 +30,7 @@
   <body>
     <%= yield %>
 
-    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
+    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
               (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/public_team_submissions.html.erb
+++ b/app/views/layouts/public_team_submissions.html.erb
@@ -41,7 +41,7 @@
 
     <%= javascript_include_tag 'application' %>
 
-    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? %>
+    <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/config/locales/views/cookies_banner.en.yml
+++ b/config/locales/views/cookies_banner.en.yml
@@ -1,0 +1,6 @@
+en:
+  cookies_banner:
+    header: Cookie Preferences
+    body: By clicking “Accept All Cookies”, you agree to the storing of cookies on your device that will allow us to analyze site usage and assist in our marketing efforts.
+    accept: Accept All Cookies
+    refuse: Essential Cookies Only


### PR DESCRIPTION
This will lay the groundwork to opt-out of non-essential cookies.

This will present a banner to either "Accept All Cookies" or "Essential Cookies Only". Google Analytics will only load if someone selects "Accept all Cookies".

I also added translations and styles for this new cookies banner.

And I removed some Google Analytics settings from a few Vue.js files:

- app/javascript/student/index.js
- app/javascript/mentor/index.js
- app/javascript/registration/index.js


