### PR TITLE
Security: Update Elliptic node module

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4377,9 +4377,9 @@ electron-to-chromium@^1.4.147:
   integrity sha512-/Wj5NC7E0wHaMCdqxWz9B0lv7CcycDTiHyXCtbbu3pXM9TV2AOp8BtMqkVuqvJNdEvltBG6LxT2Q+BxY4LUCIA==
 
 elliptic@^6.0.0, elliptic@^6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
+  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
A simple update here to update the Elliptic node module, which should address these security vulnerabilities:

- https://github.com/Iridescent-CM/technovation-app/security/dependabot/223
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/218
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/207
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/206
- https://github.com/Iridescent-CM/technovation-app/security/dependabot/205

