### PR TITLE
Update onboarding status for off-platform legal docs

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -42,7 +42,7 @@ class Chapter < ActiveRecord::Base
   delegate :seasons_chapter_affiliation_agreement_is_valid_for, to: :legal_contact
 
   def affiliation_agreement
-    legal_contact&.chapter_affiliation_agreement
+    legal_contact&.reload&.chapter_affiliation_agreement
   end
 
   def can_be_marked_onboarded?

--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -128,6 +128,8 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
   end
 
   def chapter_volunteer_agreement_complete?
+    reload
+
     !!chapter_volunteer_agreement&.complete?
   end
 


### PR DESCRIPTION
A very simple fix for a very annoying bug, this will address an issue where the chapter and chapter ambassador's onboarding statuses weren't getting updated for an off-platform legal agreement. The onboarding check was basically using a stale copy of the legal agreements. Using `reload` will cause the legal agreements to be refreshed to ensure the onboarding check is using the updated version.


