### PR TITLE
Update no chapter selected for unaffiliated participants

### DIFF
--- a/app/controllers/admin/chapter_account_assignments_controller.rb
+++ b/app/controllers/admin/chapter_account_assignments_controller.rb
@@ -43,6 +43,7 @@ module Admin
         )
       else
         chapter_account_assignment.delete
+        account.update(no_chapter_selected: true)
       end
 
       redirect_to admin_participant_path(account),

--- a/app/controllers/admin/chapter_account_assignments_controller.rb
+++ b/app/controllers/admin/chapter_account_assignments_controller.rb
@@ -43,7 +43,10 @@ module Admin
         )
       else
         chapter_account_assignment.delete
-        account.update(no_chapter_selected: true)
+
+        if account.is_a_mentor? || account.is_a_student?
+          account.update(no_chapter_selected: true)
+        end
       end
 
       redirect_to admin_participant_path(account),

--- a/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
+++ b/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
@@ -7,6 +7,7 @@ module ChapterAmbassador
       html_scope: ->(scope, user, params) {
         scope = scope
           .left_outer_joins(:student_profile, :mentor_profile)
+          .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
 
         scope = if user.account.current_chapter&.country.present?
           scope.where(country: user.account.current_chapter.country_code)
@@ -18,7 +19,8 @@ module ChapterAmbassador
       },
 
       csv_scope: "->(scope, user, params) { " +
-        "scope = scope.left_outer_joins(:student_profile, :mentor_profile); " +
+        "scope = scope.left_outer_joins(:student_profile, :mentor_profile)" +
+        ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
         "scope = if user.account.current_chapter&.country.present?; " +
         "scope.where(country: user.account.current_chapter.country_code); " +
         "else; scope.in_region(user); end; " +

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -752,6 +752,10 @@ class Account < ActiveRecord::Base
     mentor_profile.present?
   end
 
+  def is_a_student?
+    student_profile.present?
+  end
+
   def is_an_ambassador?
     chapter_ambassador_profile.present?
   end


### PR DESCRIPTION
Refs #4824 and [this comment](https://github.com/Iridescent-CM/technovation-app/issues/4824#issuecomment-2436105061)

> On the admin page for a mentor assigned to a chapter (/admin/participants/1498#/), I changed the chapter assignment to "none."
I then confirmed their location was in a country where we had active chapters.
I logged in as the ChA for a chapter in that country (/admin/participants/1577#/) and went to the unaffiliated page. I did not see the mentor's name.

This PR will address the issues when a participant is assigned to "none". If that happens then the `no_chapter_selected` field will be set to true and they will show up on the unaffiliated list. 