### PR TITLE
Added ability for ChAs to update their chapter location 

### DIFF
--- a/app/controllers/chapter_ambassador/chapter_current_locations_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_current_locations_controller.rb
@@ -1,0 +1,21 @@
+module ChapterAmbassador
+  class ChapterCurrentLocationsController < ChapterAmbassadorController
+    def show
+      state = FriendlySubregion.call(current_account.current_chapter, prefix: false)
+      state_code = FriendlySubregion.call(current_account.current_chapter, {
+        prefix: false,
+        short_code: true
+      })
+
+      friendly_country = FriendlyCountry.new(current_account.current_chapter)
+
+      render json: {
+        city: current_account.current_chapter.city,
+        state: state,
+        state_code: state_code,
+        country: friendly_country.country_name,
+        country_code: friendly_country.as_short_code
+      }
+    end
+  end
+end

--- a/app/controllers/chapter_ambassador/chapter_locations_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_locations_controller.rb
@@ -1,26 +1,17 @@
 module ChapterAmbassador
   class ChapterLocationsController < ChapterAmbassadorController
+    include LocationController
+
     skip_before_action :require_chapter_and_chapter_ambassador_onboarded
 
     layout "chapter_ambassador_rebrand"
 
-    def update
-      @chapter = current_ambassador.chapter
-      if @chapter.update(chapter_location_params)
-        redirect_to chapter_ambassador_chapter_location_path,
-          success: "You updated your chapter location details!"
-      else
-        flash.now[:alert] = "Error updating chapter location details."
-        render :edit
-      end
-    end
-
     private
 
-    def chapter_location_params
-      params.require(:chapter).permit(
-        :organization_headquarters_location
-      )
+    def db_record
+      @db_record ||= if params.has_key?(:chapter_id)
+        Chapter.find(params.fetch(:chapter_id))
+      end
     end
   end
 end

--- a/app/controllers/chapter_ambassador/chapter_organization_headquarters_locations_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_organization_headquarters_locations_controller.rb
@@ -6,18 +6,18 @@ module ChapterAmbassador
 
     def update
       @chapter = current_ambassador.chapter
-      if @chapter.update(chapter_location_params)
+      if @chapter.update(chapter_organization_headquarters_location_params)
         redirect_to chapter_ambassador_chapter_location_path,
-          success: "You updated your chapter location details!"
+          success: "You updated your chapter organization headquarters location details!"
       else
-        flash.now[:alert] = "Error updating chapter location details."
+        flash.now[:alert] = "Error updating chapter organization headquarters location details."
         render :edit
       end
     end
 
     private
 
-    def chapter_location_params
+    def chapter_organization_headquarters_location_params
       params.require(:chapter).permit(
         :organization_headquarters_location
       )

--- a/app/controllers/chapter_ambassador/chapter_organization_headquarters_locations_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_organization_headquarters_locations_controller.rb
@@ -1,0 +1,26 @@
+module ChapterAmbassador
+  class ChapterOrganizationHeadquartersLocationsController < ChapterAmbassadorController
+    skip_before_action :require_chapter_and_chapter_ambassador_onboarded
+
+    layout "chapter_ambassador_rebrand"
+
+    def update
+      @chapter = current_ambassador.chapter
+      if @chapter.update(chapter_location_params)
+        redirect_to chapter_ambassador_chapter_location_path,
+          success: "You updated your chapter location details!"
+      else
+        flash.now[:alert] = "Error updating chapter location details."
+        render :edit
+      end
+    end
+
+    private
+
+    def chapter_location_params
+      params.require(:chapter).permit(
+        :organization_headquarters_location
+      )
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,7 @@ module ApplicationHelper
       chapter_affiliation_agreements
       chapter_ambassador
       chapter_locations
+      chapter_organization_headquarters_locations
       chapter_profile
       chapter_program_information
       chapter_volunteer_agreements

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -199,6 +199,7 @@
 <script>
 import LocationResult from "../models/LocationResult";
 import HttpStatusCodes from "../../constants/HttpStatusCodes";
+import Swal from "sweetalert2";
 
 export default {
   data() {
@@ -286,6 +287,14 @@ export default {
         this.state = data.state;
         this.country = data.country;
       });
+    }
+  },
+
+  mounted() {
+    if (
+      window.location.pathname === "/chapter_ambassador/chapter_location/edit"
+    ) {
+      this.openAlertMessage();
     }
   },
 
@@ -595,6 +604,24 @@ export default {
       } else {
         return endpointRoot;
       }
+    },
+
+    openAlertMessage() {
+      Swal.fire({
+        html: `
+        <p>
+          The chapter location determines which users see your chapter as a suggested chapter when they register.
+          Students and mentors see a list of chapters in their local area or their country.
+        </p>
+
+        <p class="mt-8">By editing your location, you understand that it may change which users can join your chapter when they register.</p>
+
+        <p class="mt-8">Please contact <a href=mailto:"${process.env.HELP_EMAIL}" class="tw-link">${process.env.HELP_EMAIL}</a> with any questions.</p>
+        `,
+        confirmButtonText: "OK",
+        confirmButtonColor: "#3FA428",
+        width: "50%",
+      });
     },
   },
 };

--- a/app/javascript/location/components/LocationForm.vue
+++ b/app/javascript/location/components/LocationForm.vue
@@ -335,6 +335,8 @@ export default {
         return "this person's";
       } else if (this.teamId) {
         return "this team's";
+      } else if (this.chapterId) {
+        return "this chapter's";
       } else {
         return "your";
       }
@@ -576,7 +578,13 @@ export default {
     },
 
     _getEndpoint(pathPart) {
-      const endpointRoot = `/${this.scopeName}/${pathPart}`;
+      let endpointRoot;
+
+      if (this.scopeName === "chapter_ambassador" && this.chapterId) {
+        endpointRoot = `/chapter_ambassador/chapter_${pathPart}`;
+      } else {
+        endpointRoot = `/${this.scopeName}/${pathPart}`;
+      }
 
       if (this.accountId) {
         return `${endpointRoot}?account_id=${this.accountId}`;

--- a/app/views/chapter_ambassador/chapter_locations/edit.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/edit.en.html.erb
@@ -1,13 +1,17 @@
-<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
-  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
-
-  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Update Chapter Location" } do %>
+<% if current_chapter.present? %>
+  <div class="mx-auto w-full lg:w-1/2">
     <div>
-      <% if current_chapter.present? %>
-        <%= render "chapter_ambassador/chapter_locations/form"%>
-      <% else %>
-        <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
-      <% end %>
+      <%= render "signups/location_fields", chapter_id: current_chapter.id%>
     </div>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+    <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+    <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Update Chapter Location" } do %>
+      <div>
+          <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/chapter_ambassador/chapter_locations/edit.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/edit.en.html.erb
@@ -1,7 +1,7 @@
 <% if current_chapter.present? %>
   <div class="mx-auto w-full lg:w-1/2">
     <div>
-      <%= render "signups/location_fields", chapter_id: current_chapter.id%>
+      <%= render "signups/location_fields", chapter_id: current_chapter.id %>
     </div>
   </div>
 <% else %>

--- a/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
@@ -37,9 +37,6 @@
             </div>
           </div>
         </div>
-
-
-
       <% else %>
         <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
       <% end %>

--- a/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_locations/show.en.html.erb
@@ -13,20 +13,32 @@
           </p>
           <p class="mb-4"><%= current_chapter.organization_headquarters_location.presence || "Not set" %></p>
 
-          <p class="font-semibold">Location Served by Chapter</p>
-          <p class="mb-2">
-              Your chapter is currently serving this location:
-              <span class="font-medium">
-                <%= "#{current_ambassador.state}, #{current_ambassador.country}" %>
-              </span>
-          </p>
+          <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
+            <%= link_to "Update organization headquarters",
+                        edit_chapter_ambassador_chapter_organization_headquarters_location_path,
+                        class: "tw-green-btn mx-auto text-center" %>
+          </div>
+
+          <div class="pt-16">
+            <p class="font-semibold">Location Served by Chapter</p>
+            <p class="mb-2">
+                Your chapter is currently serving this location:
+                <span class="font-medium">
+                  <%= "#{current_chapter.address_details}" %>
+                </span>
+            </p>
+
+            <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
+              <%= link_to "Update chapter location",
+                edit_chapter_ambassador_chapter_location_path(
+                  return_to: chapter_ambassador_chapter_location_path
+                ),
+                class: "tw-green-btn mx-auto text-center" %>
+            </div>
+          </div>
         </div>
 
-        <div class="w-full lg:w-1/3 flex mt-8 mx-auto">
-          <%= link_to "Update organization headquarters",
-                      edit_chapter_ambassador_chapter_location_path,
-                      class: "tw-green-btn mx-auto" %>
-        </div>
+
 
       <% else %>
         <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>

--- a/app/views/chapter_ambassador/chapter_organization_headquarters_locations/_form.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_organization_headquarters_locations/_form.en.html.erb
@@ -1,0 +1,20 @@
+<%= simple_form_for current_chapter,
+  url: chapter_ambassador_chapter_organization_headquarters_location_path do |f| %>
+
+  <div class="mb-4">
+    <%= f.label :organization_headquarters_location, "Organization Headquarters Location" %>
+    <%= f.text_field :organization_headquarters_location,
+                     placeholder: "Full address OR city, state, country",
+                     class: "mb-0"
+    %>
+    <p class="text-sm italic">
+      The city entered for the organization headquarters will be used to map the location of your chapter.
+    </p>
+  </div>
+
+  <p class="mt-8">
+    <%= f.submit "Save", class: "tw-green-btn" %>
+      or
+    <%= link_to "cancel", chapter_ambassador_chapter_location_path %>
+  </p>
+<% end %>

--- a/app/views/chapter_ambassador/chapter_organization_headquarters_locations/edit.en.html.erb
+++ b/app/views/chapter_ambassador/chapter_organization_headquarters_locations/edit.en.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "chapter_ambassador/chapter_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Update Chapter Location" } do %>
+    <div>
+      <% if current_chapter.present? %>
+        <%= render "chapter_ambassador/chapter_organization_headquarters_locations/form" %>
+      <% else %>
+        <p>You are not associated with a chapter. Please contact <%= mail_to ENV.fetch("HELP_EMAIL") %> for support.</p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,10 @@ Rails.application.routes.draw do
     resource :chapter_profile, only: :show, controller: "chapter_profile"
     resource :chapter_affiliation_agreement, only: :show
     resource :public_information, only: [:show, :edit, :update], controller: "public_information"
-    resource :chapter_location, only: [:show, :edit, :update]
+    resource :chapter_organization_headquarters_location, only: [:edit, :update]
+    resource :chapter_location, only: [:show, :edit, :update, :create], controller: "chapter_locations"
+    resource :chapter_current_location, only: :show
+
     resource :chapter_program_information, only: [:show, :edit, :update, :new, :create], controller: "chapter_program_information"
     resource :chapter_volunteer_agreement, only: [:show, :create]
     resource :community_connections, only: [:show, :new, :create, :edit, :update]

--- a/spec/features/chapter_ambassador/edit_chapter_location_spec.rb
+++ b/spec/features/chapter_ambassador/edit_chapter_location_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Chapter ambassadors edit chapter location" do
     fill_in "chapter_organization_headquarters_location", with: "123 Main St, USA"
     click_button "Save"
 
-    expect(page).to have_css(".flash.flash--success", text: "You updated your chapter location details!")
+    expect(page).to have_css(".flash.flash--success", text: "You updated your chapter organization headquarters location details!")
     expect(page).to have_content "123 Main St, USA"
   end
 end


### PR DESCRIPTION
Refs #4684 

This PR adds the ability for ChAs to update their chapter location.

Main Changes
- Moved organization headquarters functionality to new route/controller -`organzation_headquarters_location`
- Added routes and controllers for current chapter location and chapter location
- Updated logic to determine endpoint in location component 
- Added sweet alert for ChAs when changing chapter location

![CleanShot 2024-10-30 at 09 06 41](https://github.com/user-attachments/assets/a72979f8-364f-4076-9ca6-fbb5829cc7ef)
