### PR TITLE
Update student -> mentor conversion functionality

### DIFF
--- a/app/services/student_to_mentor_converter.rb
+++ b/app/services/student_to_mentor_converter.rb
@@ -50,6 +50,12 @@ class StudentToMentorConverter
   end
 
   def register_mentor_to_current_season
-    RegisterToCurrentSeasonJob.perform_later(account)
+    if ENV.fetch("ACTIVE_JOB_BACKEND", "inline") == "inline"
+      RegisterToCurrentSeasonJob.perform_later(account)
+    else
+      RegisterToCurrentSeasonJob
+        .set(wait: 1.minute)
+        .perform_later(account)
+    end
   end
 end

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -13,7 +13,9 @@ module SignIn
       permanent: options[:permanent]
     )
 
-    RegisterToCurrentSeasonJob.perform_later(signin)
+    unless signin.student? && signin.age_by_cutoff > 18
+      RegisterToCurrentSeasonJob.perform_later(signin)
+    end
 
     RecordBrowserDetailsJob.perform_later(
       signin.id,


### PR DESCRIPTION
There is issue where two `RegisterToCurrentSeasonJob` could get called when students are converted to mentors. One when they initially sign in for the first time during a season, and another one after the mentor profile is created. I *think these two jobs were creating duplicate participant records in Salesforce. There is also an issue where the `prepare_mentor_for_current_season` functionality was not being called for the new mentor profile.

The changes here will make it so that:

- If a student is over 18 by the cutoff date, the `RegisterToCurrentSeasonJob` will not be called when they sign in, making it so this job will only get scheduled once

- Adding a 1 minute delay to the `RegisterToCurrentSeasonJob` to better ensure the mentor conversion process has finished before the job runs

