### PR TITLE
Added unaffiliated participants grid for admin

### DIFF
--- a/app/controllers/admin/unaffiliated_participants_controller.rb
+++ b/app/controllers/admin/unaffiliated_participants_controller.rb
@@ -1,0 +1,35 @@
+module Admin
+  class UnaffiliatedParticipantsController < AdminController
+    include DatagridController
+
+    use_datagrid with: UnaffiliatedParticipantsGrid,
+      html_scope: ->(scope, user, params) {
+        scope
+          .current
+          .left_outer_joins(:student_profile, :mentor_profile)
+          .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
+          .where(no_chapter_selected: true).page(params[:page])
+      },
+
+      csv_scope: "->(scope, user, params) { " +
+        "scope.current.left_outer_joins(:student_profile, :mentor_profile)" +
+        ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
+        "scope.where(no_chapter_selected: true) " +
+        "}"
+
+    private
+
+    def grid_params
+      grid = (params[:unaffiliated_participants_grid] ||= {}).merge(
+        admin: true,
+        allow_state_search: true,
+        country: Array(params[:unaffiliated_participants_grid][:country]),
+        state_province: Array(params[:unaffiliated_participants_grid][:state_province])
+      )
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
+    end
+  end
+end

--- a/app/controllers/admin/unaffiliated_participants_controller.rb
+++ b/app/controllers/admin/unaffiliated_participants_controller.rb
@@ -6,13 +6,15 @@ module Admin
       html_scope: ->(scope, user, params) {
         scope
           .current
+          .includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)
           .left_outer_joins(:student_profile, :mentor_profile)
           .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
           .where(no_chapter_selected: true).page(params[:page])
       },
 
       csv_scope: "->(scope, user, params) { " +
-        "scope.current.left_outer_joins(:student_profile, :mentor_profile)" +
+        "scope.current.includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)" +
+        ".left_outer_joins(:student_profile, :mentor_profile)" +
         ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
         "scope.where(no_chapter_selected: true) " +
         "}"

--- a/app/controllers/admin/unaffiliated_participants_controller.rb
+++ b/app/controllers/admin/unaffiliated_participants_controller.rb
@@ -6,14 +6,13 @@ module Admin
       html_scope: ->(scope, user, params) {
         scope
           .current
-          .includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)
           .left_outer_joins(:student_profile, :mentor_profile)
           .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
           .where(no_chapter_selected: true).page(params[:page])
       },
 
       csv_scope: "->(scope, user, params) { " +
-        "scope.current.includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)" +
+        "scope.current" +
         ".left_outer_joins(:student_profile, :mentor_profile)" +
         ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
         "scope.where(no_chapter_selected: true) " +

--- a/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
+++ b/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
@@ -7,6 +7,7 @@ module ChapterAmbassador
       html_scope: ->(scope, user, params) {
         scope = scope
           .current
+          .includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)
           .left_outer_joins(:student_profile, :mentor_profile)
           .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
 
@@ -20,7 +21,8 @@ module ChapterAmbassador
       },
 
       csv_scope: "->(scope, user, params) { " +
-        "scope = scope.current.left_outer_joins(:student_profile, :mentor_profile)" +
+        "scope = scope.current.includes(:student_profile, :mentor_profile, :chapter_ambassador_profile))" +
+        ".left_outer_joins(:student_profile, :mentor_profile)" +
         ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
         "scope = if user.account.current_chapter&.country.present?; " +
         "scope.where(country: user.account.current_chapter.country_code); " +

--- a/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
+++ b/app/controllers/chapter_ambassador/unaffiliated_participants_controller.rb
@@ -7,7 +7,6 @@ module ChapterAmbassador
       html_scope: ->(scope, user, params) {
         scope = scope
           .current
-          .includes(:student_profile, :mentor_profile, :chapter_ambassador_profile)
           .left_outer_joins(:student_profile, :mentor_profile)
           .where("student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL")
 
@@ -21,7 +20,7 @@ module ChapterAmbassador
       },
 
       csv_scope: "->(scope, user, params) { " +
-        "scope = scope.current.includes(:student_profile, :mentor_profile, :chapter_ambassador_profile))" +
+        "scope = scope.current" +
         ".left_outer_joins(:student_profile, :mentor_profile)" +
         ".where('student_profiles.id IS NOT NULL OR mentor_profiles.id IS NOT NULL'); " +
         "scope = if user.account.current_chapter&.country.present?; " +

--- a/app/data_grids/unaffiliated_participants_grid.rb
+++ b/app/data_grids/unaffiliated_participants_grid.rb
@@ -9,11 +9,14 @@ class UnaffiliatedParticipantsGrid
     Account
   end
 
-  column :id, header: "Participant ID"
+  column :id, header: "Participant ID", if: ->(g) { g.admin }
 
   column :first_name, mandatory: true
   column :last_name, mandatory: true
   column :email, mandatory: true
+  column :profile_type do
+    scope_name
+  end
 
   column :city, mandatory: true
 
@@ -26,16 +29,31 @@ class UnaffiliatedParticipantsGrid
   end
 
   column :actions, mandatory: true, html: true do |account, grid|
-    link_to "Add to your chapter",
-      chapter_ambassador_account_chapter_account_assignments_path(
-        account_id: account.id,
-        chapter_account_assignment: {chapter_id: grid.chapter_id}
-      ),
-      class: "button button--remove-bg",
-      data: {
-        method: :post,
-        confirm: "You are adding #{account.full_name} to your chapter!",
-      }
+    if grid.admin
+      html = link_to(
+        "View",
+        admin_participant_path(account),
+        data: {turbolinks: false}
+      )
+      html += " | "
+
+      html += link_to(
+        "Assign to a chapter",
+        new_admin_account_chapter_account_assignment_path(account),
+        data: {turbolinks: false}
+      )
+    else
+      link_to "Add to your chapter",
+        chapter_ambassador_account_chapter_account_assignments_path(
+          account_id: account.id,
+          chapter_account_assignment: {chapter_id: grid.chapter_id}
+        ),
+        class: "button button--remove-bg",
+        data: {
+          method: :post,
+          confirm: "You are adding #{account.full_name} to your chapter!"
+        }
+    end
   end
 
   filter :name_email,

--- a/app/data_grids/unaffiliated_participants_grid.rb
+++ b/app/data_grids/unaffiliated_participants_grid.rb
@@ -14,7 +14,7 @@ class UnaffiliatedParticipantsGrid
   column :first_name, mandatory: true
   column :last_name, mandatory: true
   column :email, mandatory: true
-  column :profile_type do
+  column :profile_type, preload: [:student_profile, :mentor_profile, :chapter_ambassador_profile] do
     scope_name
   end
 

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -15,6 +15,11 @@
       data: { turbolinks: false },
       class: al(admin_participants_path) %>
 
+    <%= link_to "Unaffiliated Participants",
+      admin_unaffiliated_participants_path,
+      data: { turbolinks: false },
+      class: al(admin_unaffiliated_participants_path) %>
+
     <%= link_to "Teams",
       admin_teams_path,
       data: { turbolinks: false },

--- a/app/views/admin/unaffiliated_participants/index.html.erb
+++ b/app/views/admin/unaffiliated_participants/index.html.erb
@@ -1,0 +1,7 @@
+<% provide :title, "Admin Data • Unaffiliated Participants" %>
+
+<%= render 'datagrid/datagrid',
+  grid: @unaffiliated_participants_grid,
+  form_url: admin_unaffiliated_participants_path,
+  model_name: "account",
+  scope: :admin %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,6 +270,7 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :unaffiliated_participants, only: [:index]
     resources :participant_sessions, only: [:show, :destroy]
     resources :user_invitations, only: [:new, :create, :index, :destroy]
     resources :user_invitation_emails, only: :create

--- a/spec/features/admin/view_unaffiliated_participants_spec.rb
+++ b/spec/features/admin/view_unaffiliated_participants_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature "Admin viewing unaffiliated participants" do
   let(:admin) { FactoryBot.create(:admin) }
 
   scenario "displays unaffiliated students and mentors in any country" do
-    unaffiliated_student = FactoryBot.create(:student, :chicago, :unaffiliated)
-    unaffiliated_mentor = FactoryBot.create(:mentor, :brazil, :unaffiliated)
+    unaffiliated_student = FactoryBot.create(:student, :chicago, :unaffiliated_chapter)
+    unaffiliated_mentor = FactoryBot.create(:mentor, :brazil, :unaffiliated_chapter)
 
     sign_in(admin)
     visit(admin_unaffiliated_participants_path)

--- a/spec/features/admin/view_unaffiliated_participants_spec.rb
+++ b/spec/features/admin/view_unaffiliated_participants_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "Admin viewing unaffiliated participants" do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  scenario "displays unaffiliated students and mentors in any country" do
+    unaffiliated_student = FactoryBot.create(:student, :chicago, :unaffiliated)
+    unaffiliated_mentor = FactoryBot.create(:mentor, :brazil, :unaffiliated)
+
+    sign_in(admin)
+    visit(admin_unaffiliated_participants_path)
+
+    expect(page).to have_content(unaffiliated_student.account.country)
+    expect(page).to have_content(unaffiliated_mentor.account.country)
+  end
+
+  scenario "does not display students or mentors assigned to a chapter" do
+    chapter = FactoryBot.create(:chapter, :chicago, :onboarded)
+
+    affiliated_student = FactoryBot.create(:student, :chicago)
+    affiliated_student.chapter_assignments.create(
+      account: affiliated_student.account,
+      chapter: chapter,
+      season: Season.current.year
+    )
+
+    affiliated_mentor = FactoryBot.create(:mentor, :chicago)
+    affiliated_mentor.chapter_assignments.create(
+      account: affiliated_mentor.account,
+      chapter: chapter,
+      season: Season.current.year
+    )
+
+    sign_in(admin)
+    visit(admin_unaffiliated_participants_path)
+
+    expect(page).not_to have_content(affiliated_student.account.email)
+    expect(page).not_to have_content(affiliated_mentor.account.email)
+  end
+end


### PR DESCRIPTION
Refs #5094 

This PR adds the unaffiliated participants grid for admin

Main changes for admin
- Admin can view participant id
- Admin can view all unaffiliated participants and search by country/state
- Admin have a link to view the participant profile and a link to assign the participant to any chapter
- Added profile type as a column for both admin and chas

