### PR TITLE
Update admin student-chapter assignment functionality

### DIFF
--- a/app/controllers/admin/chapter_account_assignments_controller.rb
+++ b/app/controllers/admin/chapter_account_assignments_controller.rb
@@ -45,6 +45,8 @@ module Admin
         chapter_account_assignment.update(
           chapter_id: chapter_account_assignment_params.fetch(:chapter_id)
         )
+
+        account.update(no_chapter_selected: nil)
       else
         chapter_account_assignment.delete
 


### PR DESCRIPTION
A small update here that will make it so that when an admin updates a student-chapter assignment it will now remove them from the unaffiliated list, which will trigger the "assigned to chapter" email.


