### PR TITLE
Add Heroku release phase tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+release: bundle exec rails db:migrate tmp:cache:clear assets:clean
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -v -e $RACK_ENV -c $SIDEKIQ_SERVER_LIMIT -q default -q mailers
 console: bundle exec bin/rails console


### PR DESCRIPTION
This will add release phase tasks for Heroku (moving them from `DEPLOY_TASKS` to Heroku's `Procfile`).

We're currently using an outdated, no-longer-supported plugin for this: https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks

This outdated way^ relies on an ENV named `RELEASE_TASKS`. I copied the `RELEASE_TASKS` from the Heroku ENV setting and moved them to the Heroku `Profile`.

More info about the Heroku release phase being used: https://devcenter.heroku.com/articles/procfile#the-release-process-type
