### PR TITLE
Added admin club management (Add, edit, view a club & club datagrid)

### DIFF
--- a/app/controllers/admin/clubs_controller.rb
+++ b/app/controllers/admin/clubs_controller.rb
@@ -1,0 +1,56 @@
+module Admin
+  class ClubsController < AdminController
+    include DatagridController
+    use_datagrid with: ClubsGrid
+
+    def show
+      @club = Club.find(params[:id])
+    end
+
+    def new
+      @club = Club.new
+    end
+
+    def create
+      club = Club.new(club_params)
+
+      if club.save
+        redirect_to admin_club_path(club), success: "#{club.name} was added as a new club."
+      else
+        render :new
+      end
+    end
+
+    def edit
+      @club = Club.find(params.fetch(:id))
+    end
+
+    def update
+      @club = Club.find(params.fetch(:id))
+
+      if @club.update(club_params)
+        redirect_to admin_club_path(@club), success: "Club updated successfully."
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def club_params
+      params.require(:club).permit(
+        :id,
+        :name,
+        :summary
+      )
+    end
+
+    def grid_params
+      grid = params[:clubs_grid] ||= {}
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
+    end
+  end
+end

--- a/app/data_grids/clubs_grid.rb
+++ b/app/data_grids/clubs_grid.rb
@@ -1,0 +1,31 @@
+class ClubsGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Club.order(id: :desc)
+  end
+
+  filter :name do |value|
+    sanitized = sanitize_sql_like(value)
+    processed_value = I18n.transliterate(sanitized.strip.downcase).gsub(/['\s]+/, "%")
+
+    where("lower(unaccent(name)) ILIKE ?", "%#{processed_value}%")
+  end
+
+  column :name, header: "Name", mandatory: true
+
+  column :actions, mandatory: true, html: true do |club|
+    link_to("View",
+      admin_club_path(club),
+      class: "button small gray",
+      data: {turbolinks: false})
+  end
+
+  column_names_filter(
+    header: "More columns",
+    filter_group: "more-columns",
+    multiple: true
+  )
+end

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -1,0 +1,7 @@
+class Club < ActiveRecord::Base
+
+  belongs_to :primary_contact, class_name: "Account", foreign_key: "primary_account_id", optional: true
+
+  validates :name, presence: true
+  validates :summary, length: {maximum: 1000}
+end

--- a/app/null_objects/null_club.rb
+++ b/app/null_objects/null_club.rb
@@ -1,0 +1,10 @@
+class NullClub < NullObject
+  def name
+    nil
+  end
+
+  def summary
+    nil
+  end
+
+end

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -95,6 +95,10 @@
                 admin_chapter_ambassadors_path,
       class: al(admin_chapter_ambassadors_path) %>
 
+    <%= link_to "Clubs",
+                admin_clubs_path,
+                class: al(admin_clubs_path) %>
+
     <%= link_to "Background jobs",
       "/sidekiq",
       target: :_blank,

--- a/app/views/admin/clubs/_form.html.erb
+++ b/app/views/admin/clubs/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: @club, url: admin_clubs_path, local: true do |f| %>
+  <%= render 'errors', record: @club %>
+
+  <p>
+    <%= f.label :name, for: :name %>
+    <%= f.text_field :name, id: :name, required: true  %>
+  </p>
+
+  <%= f.submit "Add", class: "button" %> or <%= link_to 'cancel', admin_clubs_path %>
+
+<% end %>

--- a/app/views/admin/clubs/edit.html.erb
+++ b/app/views/admin/clubs/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="grid">
+  <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <h1>
+      Edit Club
+    </h1>
+
+    <div class="panel">
+      <%= simple_form_for @club, url: admin_club_path(@club) do |f| %>
+        <%= f.input :name, label: "Club Name" %>
+        <%= f.input :summary, label: "Club Summary" %>
+
+        <br>
+        <%= f.submit "Update", class: "button" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/clubs/index.html.erb
+++ b/app/views/admin/clubs/index.html.erb
@@ -1,0 +1,15 @@
+<div class="grid margin--t-xlarge">
+  <div class="grid__col-auto grid__col--bleed-y">
+    <h3>View Clubs</h3>
+
+    <div class="panel">
+      <p><%= link_to "Setup a new club", new_admin_club_path, class: "button" %></p>
+    </div>
+
+    <%= render 'datagrid/datagrid',
+               grid: @clubs_grid,
+               form_url: admin_clubs_path,
+               model_name: "club",
+               scope: :admin %>
+  </div>
+</div>

--- a/app/views/admin/clubs/new.html.erb
+++ b/app/views/admin/clubs/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Add a club</h1>
+
+<%= render 'form', club: @club %>

--- a/app/views/admin/clubs/show.html.erb
+++ b/app/views/admin/clubs/show.html.erb
@@ -1,0 +1,34 @@
+<div class="grid grid--justify-center">
+  <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+    <div class="panel">
+      <div class="grid">
+        <div class="grid__col-12">
+          <h3><%= @club.name %></h3>
+        </div>
+
+        <div class="grid__col-6">
+          <dl>
+            <dt>Name</dt>
+            <dd><%= @club.name %></dd>
+
+            <dt>Primary Contact</dt>
+            <dd>
+              <%= @club.primary_contact.present? ? (link_to @club.primary_contact.full_name, admin_participant_path(@club.primary_contact)) : "Not Set" %>
+            </dd>
+
+            <dt>Summary</dt>
+            <dd>
+              <%= simple_format h(@club.summary.presence || "-") %>
+            </dd>
+          </dl>
+        </div>
+      </div>
+
+      <%= button_to "Edit Club",
+        edit_admin_club_path(@club),
+        method: "get",
+        class: "button"
+      %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,8 @@ Rails.application.routes.draw do
       resource :location, only: :edit, controller: "chapters/locations"
     end
 
+    resources :clubs
+
     resources :chapter_ambassadors, only: :index do
       resource :off_platform_chapter_volunteer_agreement,
         only: :create,

--- a/spec/controllers/admin/clubs_controller_spec.rb
+++ b/spec/controllers/admin/clubs_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Admin::ClubsController do
+  before do
+    sign_in(:admin)
+  end
+  describe "POST #create" do
+    context "with valid attributes" do
+      it "creates a new club" do
+        expect {
+          post :create, params: {
+            club: {name: "Hello World"}
+          }
+        }.to change { Club.count }.by(1)
+      end
+
+      it "redirects to the created club" do
+        post :create, params: {
+          club: {name: "Hello World Again"}
+        }
+        expect(response).to redirect_to(admin_club_path(Club.last))
+      end
+    end
+
+    context "with invalid attributes" do
+      it "does not create a new club" do
+        expect {
+          post :create, params: {
+            club: {name: ""}
+          }
+        }.not_to change { Club.count }
+      end
+
+    end
+  end
+end

--- a/spec/factories/clubs.rb
+++ b/spec/factories/clubs.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :club do
+    sequence(:name) { |n| "FactoryBot Program #{n}" }
+    sequence(:summary) { |n| "FactoryBot Summary #{n}" }
+
+    trait :chicago do
+      city { "Chicago" }
+      state_province { "IL" }
+      country { "US" }
+    end
+
+    trait :los_angeles do
+      city { "Los Angeles" }
+      state_province { "CA" }
+      country { "US" }
+    end
+
+    trait :brazil do
+      city { "Salvador" }
+      state_province { "Bahia" }
+      country { "BR" }
+    end
+  end
+end

--- a/spec/features/admin/manage_clubs_spec.rb
+++ b/spec/features/admin/manage_clubs_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.feature "Admins managing clubs", :js do
+  before do
+    sign_in(:admin)
+
+    Club.destroy_all
+  end
+
+  scenario "Admin add a club" do
+    visit admin_clubs_path
+    click_link "Setup a new club"
+
+    fill_in "name", with: "Hello World"
+    expect(page).to have_field("name", with: "Hello World")
+
+    click_button "Add"
+
+    expect(page).to have_content("Hello World")
+    expect(Club.count).to eq(1)
+  end
+
+  scenario "Admin view all clubs" do
+    clubs = FactoryBot.create_list(:club, 2)
+    visit admin_clubs_path
+
+    clubs.each do |club|
+      expect(page).to have_selector("tr#club_#{club.id}")
+      within("tr#club_#{club.id}") do
+        expect(page).to have_link("View", href: admin_club_path(club))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refs #5170 & #5172

This PR adds the basic foundation of admin club management. 
Admin can
- Add a club (only the name is required), view a club, edit a club
- View all clubs on the Clubs datagrid

This PR also adds
- basic specs, clubs factory
- clubs model & basic validation for name and summary length
- null club 

PS - specs are currently failing because the migration is in [this PR](https://github.com/Iridescent-CM/technovation-app/pull/5188)