### PR TITLE
Support request: added "inaccurate data" note to main cha admin activity page and additional chapter columns

### DIFF
--- a/app/controllers/chapter_ambassador/chapter_admin_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_admin_controller.rb
@@ -36,6 +36,8 @@ module ChapterAmbassador
         .not_staff
         .inactive
         .limit(3)
+
+      flash.now[:alert] = "Note: This page may not show accurate data. We're working on updating it, please refer to the participants page for accurate numbers."
     end
   end
 end

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -66,15 +66,11 @@ class ChaptersGrid
     )
   end
 
-  column :name, header: "Chapters (Program Name)", html: false do |chapter|
+  column :name, header: "Chapter (Program Name)", html: false do |chapter|
     chapter.name.presence || "-"
   end
 
   column :organization_name, header: "Organization", mandatory: true
-
-  column :actions, mandatory: true, html: true do |chapter|
-    render "admin/chapters/actions", chapter: chapter
-  end
 
   column :organization_type, header: "Organization type" do
     organization_types = chapter_program_information&.organization_types
@@ -84,6 +80,10 @@ class ChaptersGrid
       "-"
     end
   end
+
+  column :summary
+
+  column :organization_headquarters_location
 
   column :onboarded do
     onboarded? ? "yes" : "no"
@@ -171,6 +171,28 @@ class ChaptersGrid
     legal_contact&.email_address.presence || "-"
   end
 
+  column :primary_contact_name, preload: [:primary_contact] do
+    primary_contact&.full_name.presence || "-"
+  end
+
+  column :primary_contact_email_address, preload: [:primary_contact] do
+    primary_contact&.email.presence || "-"
+  end
+
+  column :updated_at, header: "Last updated at" do
+    updated_at&.strftime("%Y-%m-%d %H:%M %Z").presence || "-"
+  end
+
+  column :city
+
+  column :state_province, header: "State" do
+    FriendlySubregion.call(self, prefix: false)
+  end
+
+  column :country do
+    FriendlyCountry.new(self).country_name
+  end
+
   column :visible_on_map, header: "Visible on map"
 
   column :child_safeguarding_policy_and_process, preload: :chapter_program_information do
@@ -230,6 +252,11 @@ class ChaptersGrid
   column :number_of_low_income_or_underserved_calculation, preload: :chapter_program_information do
     chapter_program_information&.number_of_low_income_or_underserved_calculation.presence || "-"
   end
+
+  column :actions, mandatory: true, html: true do |chapter|
+    render "admin/chapters/actions", chapter: chapter
+  end
+
 
   column_names_filter(
     header: "More columns",

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -257,7 +257,6 @@ class ChaptersGrid
     render "admin/chapters/actions", chapter: chapter
   end
 
-
   column_names_filter(
     header: "More columns",
     filter_group: "more-columns",


### PR DESCRIPTION
Refs #5184 

This PR adds an "inaccurate data" note to main cha admin activity page and additional columns to the chapter datagrid