### PR TITLE
Rake task to assign students to chapters

### DIFF
--- a/lib/tasks/assign_students_to_chapters.rake
+++ b/lib/tasks/assign_students_to_chapters.rake
@@ -1,0 +1,26 @@
+desc "Assign students to chapters"
+task assign_students_to_chapters: :environment do |task, args|
+  chapter = Chapter.find(args.extras.last)
+
+  puts "Assigning accounts to chapter #{chapter.name} (Chapter ID #{chapter.id})"
+  args.extras[0..-2].each do |email_address|
+    account = Account.find_by(email: email_address)
+
+    if account.present? && account.student_profile.present?
+      if account.chapter_assignments.empty?
+        account.student_profile.chapter_assignments.create(
+          account: account,
+          chapter: chapter,
+          season: Season.current.year,
+          primary: true
+        )
+
+        puts "Assigned #{email_address} to #{chapter.name}"
+      else
+        puts "#{email_address} is already assigned to a chapter"
+      end
+    else
+      puts "#{email_address} could not be found or is not a student"
+    end
+  end
+end


### PR DESCRIPTION
This rake task will add a list of email addresses to a chapter.

It can be run like this:

```
bundle exec rails assign_students_to_chapters[email_address1,email_address2,email_address3,chapter_id]
```

The last argument is the chapter id.
