### PR TITLE
Admin can invite club ambassadors to register

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -81,13 +81,20 @@ document.addEventListener("turbolinks:load", function () {
         "user_invitation_register_at_any_time"
       );
       const chapterSelect = document.getElementById("chapter");
+      const clubSelect = document.getElementById("club");
 
       if (invitationProfileType.value == "chapter_ambassador") {
         chapterSelect.style.display = "block";
         registerAtAnyTime.checked = true;
         registerAtAnyTime.disabled = true;
-      } else {
+      } else if (invitationProfileType.value == "club_ambassador") {
+        clubSelect.style.display = "block";
+        registerAtAnyTime.checked = true;
+        registerAtAnyTime.disabled = true;
+      }
+      else {
         chapterSelect.style.display = "none";
+        clubSelect.style.display = "none";
         registerAtAnyTime.checked = false;
         registerAtAnyTime.disabled = false;
       }

--- a/app/controllers/admin/user_invitations_controller.rb
+++ b/app/controllers/admin/user_invitations_controller.rb
@@ -67,7 +67,8 @@ module Admin
         :name,
         :email,
         :register_at_any_time,
-        :chapter_id
+        :chapter_id,
+        :club_id
       )
     end
   end

--- a/app/data_grids/user_invitations_grid.rb
+++ b/app/data_grids/user_invitations_grid.rb
@@ -2,7 +2,7 @@ class UserInvitationsGrid
   include Datagrid
 
   scope do
-    UserInvitation.order(created_at: :desc)
+    UserInvitation.includes(:account, :invited_by).order(created_at: :desc)
   end
 
   column :profile_type, header: "Registration Type", mandatory: true do |registration_invite|
@@ -72,11 +72,22 @@ class UserInvitationsGrid
     end
   end
 
-  column :chapter, html: true do |registration_invite|
+  column :chapter, preload: [:chapter], html: true do |registration_invite|
     if registration_invite.chapter.present?
       link_to(
         registration_invite.chapter.organization_name,
         admin_chapter_path(registration_invite.chapter)
+      )
+    else
+      "-"
+    end
+  end
+
+  column :club, preload: [:club], html: true do |registration_invite|
+    if registration_invite.club.present?
+      link_to(
+        registration_invite.club.name,
+        admin_club_path(registration_invite.club)
       )
     else
       "-"

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -39,6 +39,7 @@ class Account < ActiveRecord::Base
   has_one :mentor_profile, dependent: :destroy
   has_one :judge_profile, dependent: :destroy
   has_one :chapter_ambassador_profile, dependent: :destroy
+  has_one :club_ambassador_profile, dependent: :destroy
   accepts_nested_attributes_for :mentor_profile, :judge_profile
 
   ChapterAmbassadorProfile.statuses.keys.each do |status|

--- a/app/models/club_ambassador_profile.rb
+++ b/app/models/club_ambassador_profile.rb
@@ -5,8 +5,7 @@ class ClubAmbassadorProfile < ActiveRecord::Base
 
   belongs_to :current_account, -> { current },
     class_name: "Account",
-    foreign_key: "account_id",
-    required: false
+    foreign_key: "account_id"
 
   validates :job_title, presence: true
 

--- a/app/models/club_ambassador_profile.rb
+++ b/app/models/club_ambassador_profile.rb
@@ -1,0 +1,39 @@
+class ClubAmbassadorProfile < ActiveRecord::Base
+  belongs_to :account
+  accepts_nested_attributes_for :account
+  validates_associated :account
+
+  belongs_to :current_account, -> { current },
+    class_name: "Account",
+    foreign_key: "account_id",
+    required: false
+
+  validates :job_title, presence: true
+
+  def method_missing(method_name, *args) # standard:disable all
+    account.public_send(method_name, *args) # standard:disable all
+  rescue
+    raise NoMethodError,
+      "undefined method `#{method_name}' not found for #{self}"
+  end
+
+  def full_name
+    account.full_name
+  end
+
+  def email_address
+    account.email
+  end
+
+  def rebranded?
+    true
+  end
+
+  def authenticated?
+    true
+  end
+
+  def scope_name
+    "club_ambassador"
+  end
+end

--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -22,7 +22,12 @@
 
   <div id="chapter" class="field margin--b-large" style="display: none;">
     <%= f.label :chapter_id, "Chapter", for: :chapter_id %>
-    <%= f.collection_select(:chapter_id, Chapter.all.order(organization_name: :asc), :id, :organization_name) %>
+    <%= f.collection_select(:chapter_id, Chapter.all.order(organization_name: :asc), :id, :organization_name, include_blank: true) %>
+  </div>
+
+  <div id="club" class="field margin--b-large" style="display: none;">
+    <%= f.label :club_id, "Club", for: :club_id %>
+    <%= f.collection_select(:club_id, Club.all.order(name: :asc), :id, :name, include_blank: true) %>
   </div>
 
   <div class="field">

--- a/db/migrate/20241203191721_add_clubs_to_user_invitations.rb
+++ b/db/migrate/20241203191721_add_clubs_to_user_invitations.rb
@@ -1,0 +1,5 @@
+class AddClubsToUserInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :user_invitations, :club, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2483,7 +2483,8 @@ CREATE TABLE public.user_invitations (
     name character varying,
     register_at_any_time boolean,
     invited_by_id integer,
-    chapter_id bigint
+    chapter_id bigint,
+    club_id bigint
 );
 
 
@@ -4066,6 +4067,13 @@ CREATE INDEX index_user_invitations_on_chapter_id ON public.user_invitations USI
 
 
 --
+-- Name: index_user_invitations_on_club_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_invitations_on_club_id ON public.user_invitations USING btree (club_id);
+
+
+--
 -- Name: meeting_facilitator_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4507,6 +4515,14 @@ ALTER TABLE ONLY public.chapter_links
 
 
 --
+-- Name: user_invitations fk_rails_bb8dd2eee8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_invitations
+    ADD CONSTRAINT fk_rails_bb8dd2eee8 FOREIGN KEY (club_id) REFERENCES public.clubs(id);
+
+
+--
 -- Name: mentor_profiles fk_rails_beb02031d5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4940,9 +4956,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241118204108'),
 ('20241122025956'),
 ('20241202210231'),
+('20241203191721'),
 ('20241204142027'),
 ('20241211141114'),
 ('20241211222824'),
 ('20241211230435');
-
-

--- a/spec/factories/club_ambassadors.rb
+++ b/spec/factories/club_ambassadors.rb
@@ -1,0 +1,72 @@
+FactoryBot.define do
+  factory :club_ambassador_profile, aliases: [
+    :club_ambassador,
+    :club_ambassador_account
+  ] do
+    job_title { "Engineer" }
+
+    account { association :account, meets_minimum_age_requirement: true }
+
+    transient do
+      city { "Chicago" }
+      state_province { "IL" }
+      country { "US" }
+      sequence(:email) { |n| "factory-club-ambassador-#{n}@example.com" }
+      password { nil }
+      first_name { "Club Ambassador" }
+    end
+
+    trait :chicago do
+      city { "Chicago" }
+      state_province { "IL" }
+      country { "US" }
+    end
+
+    trait :los_angeles do
+      city { "Los Angeles" }
+      state_province { "CA" }
+      country { "US" }
+    end
+
+    trait :brazil do
+      city { "Salvador" }
+      state_province { "Bahia" }
+      country { "BR" }
+    end
+
+    trait :geocoded do
+      after(:create) do |r, _|
+        Geocoding.perform(r.account).with_save
+      end
+    end
+
+    before(:create) do |r, e|
+      {
+        city: e.city,
+        state_province: e.state_province,
+        country: e.country,
+        first_name: e.first_name,
+        skip_existing_password: true,
+        meets_minimum_age_requirement: true
+      }.each do |k, v|
+        r.account.send(:"#{k}=", v)
+      end
+    end
+
+    after(:create) do |r, e|
+      ProfileCreating.execute(r, FakeController.new)
+    end
+
+    trait :has_judge_profile do
+      after(:create) do |club_ambassador|
+        CreateJudgeProfile.call(club_ambassador.account)
+      end
+    end
+
+    trait :has_mentor_profile do
+      after(:create) do |club_ambassador|
+        CreateMentorProfile.call(club_ambassador.account)
+      end
+    end
+  end
+end

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe UserInvitation do
 
   it "validates the email against an existing club ambassador" do
     club_ambassador = FactoryBot.create(:club_ambassador)
-    club_ambassador.account.create_mentor_profile!(
-      FactoryBot.attributes_for(:mentor)
-        .merge({mentor_type_ids: [MentorType.first.id]})
-    )
 
     invite = UserInvitation.new(
       profile_type: :club_ambassador,

--- a/spec/models/user_invitation_spec.rb
+++ b/spec/models/user_invitation_spec.rb
@@ -36,6 +36,24 @@ RSpec.describe UserInvitation do
     )
   end
 
+  it "validates the email against an existing club ambassador" do
+    club_ambassador = FactoryBot.create(:club_ambassador)
+    club_ambassador.account.create_mentor_profile!(
+      FactoryBot.attributes_for(:mentor)
+        .merge({mentor_type_ids: [MentorType.first.id]})
+    )
+
+    invite = UserInvitation.new(
+      profile_type: :club_ambassador,
+      email: club_ambassador.email
+    )
+
+    expect(invite).not_to be_valid
+    expect(invite.errors[:email]).to include(
+      "An account already exists with that email"
+    )
+  end
+
   %i[student mentor judge].each do |type|
     it "validates email against existing mentor if the type is #{type}" do
       mentor = FactoryBot.create(:mentor, :onboarded)

--- a/spec/system/admin/registration_invites_spec.rb
+++ b/spec/system/admin/registration_invites_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Registration invites", :js do
   let(:admin) { FactoryBot.create(:admin) }
   let!(:chapter) { FactoryBot.create(:chapter) }
+  let!(:club) { FactoryBot.create(:club) }
 
   before do
     sign_in(admin)
@@ -33,6 +34,11 @@ RSpec.describe "Registration invites", :js do
       invite_profile_type: "chapter_ambassador",
       friendly_profile_type: "chapter ambassador",
       select_option: "Chapter Ambassador"
+    },
+    {
+      invite_profile_type: "club_ambassador",
+      friendly_profile_type: "club ambassador",
+      select_option: "Club Ambassador"
     }
   ].each do |item|
     let(:name) { "Devin #{item[:friendly_profile_type]}" }
@@ -46,6 +52,12 @@ RSpec.describe "Registration invites", :js do
           select item[:select_option], from: "Registration Type"
           fill_in "Name", with: name
           fill_in "Email", with: email_address
+
+          if item[:friendly_profile_type] === "chapter ambassador"
+            find("#user_invitation_chapter_id").select(chapter.organization_name)
+          elsif item[:friendly_profile_type] === "club ambassador"
+            find("#user_invitation_club_id").select(club.name)
+          end
 
           click_button "Send invitation"
         }.to change {


### PR DESCRIPTION
Refs #5169 
This PR adds the following:
- Overall functionality: Admin can invite club ambassadors to register to the platform. This PR only sends the invite (does not update the registration flow)
- Updates `admin.js` so that when a club ambassador is selected as the profile type, then the list of clubs is displayed
- Updates the user invitiations datagrid: Addresses n+1 bullet warnings and adds clubs as a column
- Adds the club ambassador profile model with basic relationship to account following the chapter ambassador profile pattern
- Adds validation for checking the club ambassador invitation email against other profile types (follows cha approach)
- Updates the chapter and club select dropdowns to include a `blank` to prevent the 1st item in the list being auto-selected when sending an invite
- Add club to user invitations table
- Update tests