### PR TITLE
Add "unaffiliated type" to unaffiliated participants datagrid

### DIFF
--- a/app/data_grids/unaffiliated_participants_grid.rb
+++ b/app/data_grids/unaffiliated_participants_grid.rb
@@ -28,6 +28,14 @@ class UnaffiliatedParticipantsGrid
     FriendlyCountry.new(account).country_name
   end
 
+  column :unaffilated_type, if: ->(g) { g.admin } do |account, _grid|
+    if account.no_chapter_selected?
+      "No chapter selected"
+    elsif account.no_chapters_available?
+      "No chapters available"
+    end
+  end
+
   column :actions, mandatory: true, html: true do |account, grid|
     if grid.admin
       html = link_to(


### PR DESCRIPTION
This will add a new column for "unaffiliated type" to the participants datagrid for admins only.


