### PR TITLE
Added admin club ambassador datagrid

### DIFF
--- a/app/controllers/admin/club_ambassadors_controller.rb
+++ b/app/controllers/admin/club_ambassadors_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class ClubAmbassadorsController < AdminController
+    include DatagridController
+
+    use_datagrid with: ClubAmbassadorsGrid
+
+    def grid_params
+      grid = params[:club_ambassadors_grid] ||= {}
+      grid.merge(
+        column_names: detect_extra_columns(grid),
+        season: params[:club_ambassadors_grid].present? ? params[:club_ambassadors_grid][:season] : Season.current.year
+      )
+    end
+  end
+end

--- a/app/data_grids/club_ambassadors_grid.rb
+++ b/app/data_grids/club_ambassadors_grid.rb
@@ -1,0 +1,108 @@
+class ClubAmbassadorsGrid
+  include Datagrid
+
+  self.batch_size = 10
+
+  scope do
+    Account
+      .includes(:club_ambassador_profile, :chapterable_assignments, :clubs)
+      .where.not(club_ambassador_profiles: {id: nil})
+      .order(id: :desc)
+  end
+
+  column :name, header: "Club Name", mandatory: true do |account|
+    if account.assigned_to_club?
+      format(account.name) do
+        link_to(
+          account.current_primary_club || "-",
+          admin_club_path(account.current_primary_club)
+        )
+      end
+    else
+      "No club"
+    end
+  end
+
+  column :first_name, mandatory: true
+  column :last_name, mandatory: true
+  column :email, mandatory: true
+  column :id, header: "Participant ID"
+
+  column :gender, header: "Gender Identity" do
+    gender.presence || "-"
+  end
+
+  column :phone_number do
+    club_ambassador_profile.phone_number.presence || "-"
+  end
+
+  column :city
+
+  column :state_province, header: "State" do
+    FriendlySubregion.call(self, prefix: false)
+  end
+
+  column :country do
+    FriendlyCountry.new(self).country_name
+  end
+
+  column :actions, mandatory: true, html: true do |account|
+    link_to(
+      "view",
+      send(:"#{current_scope}_participant_path", account),
+      data: {turbolinks: false}
+    )
+  end
+
+  filter :assigned_to_club,
+    :enum,
+    select: [
+      ["Yes", "yes"],
+      ["No", "no"]
+    ],
+    filter_group: "common" do |value, scope, grid|
+      if value == "yes"
+        scope.joins(:chapterable_assignments)
+      else
+        scope.left_outer_joins(:chapterable_assignments)
+          .where(chapterable_assignments: {id: nil})
+      end
+    end
+
+  filter :season,
+    :enum,
+    select: (2025..Season.current.year).to_a.reverse,
+    html: {
+      class: "and-or-field"
+    },
+    multiple: true do |value, scope, grid|
+    scope.by_season(value)
+  end
+
+  filter :name_email,
+    header: "Name or Email",
+    filter_group: "common" do |value, scope, grid|
+      names = value.strip.downcase.split(" ").map { |n|
+        I18n.transliterate(n).gsub("'", "''")
+      }
+      scope.fuzzy_search({
+        first_name: names.first,
+        last_name: names.last || names.first,
+        email: names.first
+      }, false)
+        .left_outer_joins(:club_ambassador_profile)
+    end
+
+  filter :club_name do |value, scope|
+    scope
+      .left_outer_joins(:club_ambassador_profile)
+      .left_outer_joins(club_ambassador_profile: :club)
+      .where("club.name ilike ?", "#{value}%")
+  end
+
+  column_names_filter(
+    header: "More columns",
+    filter_group: "more-columns",
+    multiple: true
+  )
+end

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -99,6 +99,10 @@
                 admin_clubs_path,
                 class: al(admin_clubs_path) %>
 
+    <%= link_to "Club Ambassadors",
+                admin_club_ambassadors_path,
+                class: al(admin_club_ambassadors_path) %>
+
     <%= link_to "Background jobs",
       "/sidekiq",
       target: :_blank,

--- a/app/views/admin/club_ambassadors/index.html.erb
+++ b/app/views/admin/club_ambassadors/index.html.erb
@@ -1,0 +1,7 @@
+<% provide :title, "Admin Data • Club Ambassadors" %>
+
+<%= render 'datagrid/datagrid',
+  grid: @club_ambassadors_grid,
+  form_url: admin_club_ambassadors_path,
+  model_name: "account",
+  scope: :admin %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,6 +298,8 @@ Rails.application.routes.draw do
       resource :location, only: :edit, controller: "clubs/locations"
     end
 
+    resources :club_ambassadors, only: :index
+
     resources :chapter_ambassadors, only: :index do
       resource :off_platform_chapter_volunteer_agreement,
         only: :create,


### PR DESCRIPTION
Refs #5250 

Added admin club ambassador datagrid. Since Admin can now invite ClAs to the platform I thought the admin ClA datagrid would be helpful for testing. Just the basic columns/filters for now!