### PR TITLE
Update clubs header

### DIFF
--- a/app/views/chapterable_account_assignments/_additional_clubs.en.html.erb
+++ b/app/views/chapterable_account_assignments/_additional_clubs.en.html.erb
@@ -16,12 +16,6 @@
   </div>
 
   <div id="additional-clubs" class="hidden">
-    <% if @primary_clubs.empty? %>
-      <h2 style="font-size: 1.875rem; font-weight: 600; color: #1f2937; margin-top: 0;">
-        Clubs
-      </h2>
-    <% end %>
-
     <% @additional_clubs.each do |club| %>
       <%= render "chapterable", chapterable: club %>
     <% end %>

--- a/app/views/chapterable_account_assignments/new.en.html.erb
+++ b/app/views/chapterable_account_assignments/new.en.html.erb
@@ -38,9 +38,16 @@
                     <% @primary_clubs.each do |club| %>
                       <%= render "chapterable", chapterable: club %>
                     <% end %>
+
+                    <%= render "additional_clubs" %>
+                  <% else %>
+                    <h2 style="font-size: 1.875rem; font-weight: 600; color: #1f2937; margin-top: 0;">
+                      Clubs
+                    </h2>
+
+                    <%= render "additional_clubs" %>
                   <% end %>
 
-                  <%= render "additional_clubs" %>
                 <% else %>
                   <% if @additional_chapters.present? %>
                     <h2 style="font-size: 1.875rem; font-weight: 600; color: #1f2937; margin-top: 0;">


### PR DESCRIPTION
This should address the issue of the "Club" header being displayed twice.

This change will make it so that if there aren't any clubs in someone's state/province, but there are clubs in someone's country, the "Club" header will be displayed along with the "Show All Clubs in my country" button (instead of displaying the header after the button was clicked).


