### PR TITLE
Update mentor meet your Ambassador section to account for chapters, clubs, & unaffiliated chapterable assignments 

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -106,6 +106,7 @@ $chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 }
 
 h1.page-heading .chapter-ambassador-intro,
+.ambassador-intro,
 .chapter-ambassador-intro {
   color: #333;
   font-family: "Source Sans Pro", sans-serif;

--- a/app/javascript/components/DashboardHeader.vue
+++ b/app/javascript/components/DashboardHeader.vue
@@ -1,23 +1,23 @@
 <template>
   <div class="grid dashboard-notices">
     <div class="grid__col-sm-6 grid__col--bleed-y">
-      <div v-if="assignedToChapter" class="grid__cell">
+      <div v-if="assignedToChapterable" class="grid__cell">
         <h1 class="page-heading">
           <img
-            :src="getChapterAmbassadorAvatarUrl()"
+            :src="getChapterableAmbassadorAvatarUrl()"
             class="profile-image"
             width="40"
             height="40"
           />
-          {{ getChapterName() }}
+          {{ getChapterableName() }}
 
           <small v-if="surveyLink">
             <a :href="surveyLink" target="_blank">{{ surveyLinkText }}</a>
           </small>
 
           <small>
-            <drop-down label="Meet your Chapter Ambassador">
-              <slot name="chapter-ambassador-intro" />
+            <drop-down label="Meet your Ambassador">
+              <slot name="ambassador-intro" />
             </drop-down>
           </small>
         </h1>
@@ -33,7 +33,7 @@
 
           <small>
             <drop-down label="More Details">
-              <slot name="chapter-ambassador-intro" />
+              <slot name="ambassador-intro" />
             </drop-down>
           </small>
         </h1>
@@ -102,11 +102,9 @@ export default {
     ...mapGetters([
       "currentAccountName",
       "currentAccountAvatarUrl",
-      "regionalProgramName",
-      "chapterAmbassadorAvatarUrl",
-      "chapterAmbassadorHasProvidedIntro",
-      "assignedToChapter",
-      "chapterName",
+      "assignedToChapterable",
+      "chapterableName",
+      "chapterableAmbassadorAvatarUrl"
     ]),
 
     surveyLink() {
@@ -126,20 +124,20 @@ export default {
   },
 
   methods: {
-    getChapterAmbassadorAvatarUrl() {
+    getChapterableAmbassadorAvatarUrl() {
       if (
-        this.chapterAmbassadorAvatarUrl === "placeholders/avatars/1.svg" ||
-        !this.chapterAmbassadorAvatarUrl
+        this.chapterableAmbassadorAvatarUrl === "placeholders/avatars/1.svg" ||
+        !this.chapterableAmbassadorAvatarUrl
       ) {
         return `${require("placeholders/avatars/1.svg")}`;
       } else {
-        return this.chapterAmbassadorAvatarUrl;
+        return this.chapterableAmbassadorAvatarUrl;
       }
     },
 
-    getChapterName() {
-      if (this.chapterName) {
-        return this.chapterName;
+    getChapterableName() {
+      if (this.chapterableName) {
+        return this.chapterableName;
       } else {
         return "Technovation Girls";
       }

--- a/app/javascript/mentor/App.vue
+++ b/app/javascript/mentor/App.vue
@@ -9,8 +9,8 @@
         <small><slot name="judge-switch-link" /></small>
       </div>
 
-      <div slot="chapter-ambassador-intro">
-        <slot name="chapter-ambassador-intro" />
+      <div slot="ambassador-intro">
+        <slot name="ambassador-intro" />
       </div>
     </dashboard-header>
 

--- a/app/javascript/mentor/store/getters.js
+++ b/app/javascript/mentor/store/getters.js
@@ -13,20 +13,16 @@ export default {
     return digStateAttributes(state, "chapterAmbassador", "name");
   },
 
-  assignedToChapter(state) {
-    return digStateAttributes(state, "currentAccount", "assignedToChapter");
+  assignedToChapterable(state) {
+    return digStateAttributes(state, "currentAccount", "assignedToChapterable");
   },
 
-  chapterName(state) {
-    return digStateAttributes(state, "currentAccount", "chapterName");
+  chapterableName(state) {
+    return digStateAttributes(state, "currentAccount", "chapterableName");
   },
 
-  chapterAmbassadorAvatarUrl(state) {
-    return digStateAttributes(state, "chapterAmbassador", "avatarUrl");
-  },
-
-  chapterAmbassadorHasProvidedIntro(state) {
-    return digStateAttributes(state, "chapterAmbassador", "hasProvidedIntro");
+  chapterableAmbassadorAvatarUrl(state) {
+    return digStateAttributes(state, "chapterableAmbassador", "avatarUrl");
   },
 
   canJoinTeams(state) {

--- a/app/javascript/mentor/store/mutations.js
+++ b/app/javascript/mentor/store/mutations.js
@@ -3,6 +3,7 @@ import Vue from 'vue'
 export default {
   htmlDataset (state, dataset) {
     [
+      'chapterableAmbassador',
       'chapterAmbassador',
       'currentAccount',
       'currentMentor',

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1063,7 +1063,7 @@ class Account < ActiveRecord::Base
   end
 
   def current_primary_chapterable_assignment
-    current_chapterable_assignments.find_by(primary: true)
+    current_chapterable_assignments.find_by(primary: true) || ::NullChapterableAccountAssignment.new
   end
 
   def chapter_program_name

--- a/app/null_objects/null_chapterable.rb
+++ b/app/null_objects/null_chapterable.rb
@@ -1,0 +1,5 @@
+class NullChapterable < NullObject
+  def primary_contact
+    nil
+  end
+end

--- a/app/null_objects/null_chapterable_account_asignment.rb
+++ b/app/null_objects/null_chapterable_account_asignment.rb
@@ -1,0 +1,5 @@
+class NullChapterableAccountAssignment < NullObject
+  def chapterable
+    NullChapterable.new
+  end
+end

--- a/app/serializers/account_serializer.rb
+++ b/app/serializers/account_serializer.rb
@@ -71,13 +71,13 @@ class AccountSerializer
     end
   end
 
-  attribute(:assigned_to_chapter) do |account|
-    account.assigned_to_chapter?
+  attribute(:assigned_to_chapterable) do |account|
+    account.assigned_to_chapterable?
   end
 
-  attribute(:chapter_name) do |account|
-    if account.assigned_to_chapter?
-      account.current_chapter.name.presence
+  attribute(:chapterable_name) do |account|
+    if account.assigned_to_chapterable?
+      account.current_chapterable_assignment.chapterable.name.presence
     end
   end
 end

--- a/app/serializers/chapterable_ambassador_serializer.rb
+++ b/app/serializers/chapterable_ambassador_serializer.rb
@@ -1,0 +1,16 @@
+class ChapterableAmbassadorSerializer
+  include FastJsonapi::ObjectSerializer
+  set_key_transform :camel_lower
+
+  set_id :random_id
+
+  attributes :name
+
+  attribute(:api_root) do |account|
+    "#{account.scope_name}"
+  end
+
+  attribute(:avatar_url) do |account|
+    account.profile_image_url
+  end
+end

--- a/app/views/dashboards/_chapter_ambassador_chapter_intro.en.html.erb
+++ b/app/views/dashboards/_chapter_ambassador_chapter_intro.en.html.erb
@@ -1,52 +1,34 @@
 <div class="chapter-ambassador-intro">
-  <% if chapter.present? %>
-    <p>
-      Welcome to Technovation Girls!
-      <% if chapter.name.present? %>
-        You are connected with <span><%= chapter.name.titleize %></span>.
-      <% end %>
-      Please check out the following info about the Chapter.
-    </p>
-
-    <p><%= chapter.name&.titleize.presence || "Chapter name coming soon" %></p>
-
-    <% if chapter.primary_contact.present? %>
-      <p><%= chapter.primary_contact.full_name.presence %></p>
-      <p><%= chapter.primary_contact.email.presence %></p>
+  <p>
+    Welcome to Technovation Girls!
+    <% if chapter.name.present? %>
+      You are connected with <span><%= chapter.name.titleize %></span>.
     <% end %>
+    Please check out the following info about the Chapter.
+  </p>
 
-    <p><%= chapter.summary.presence || "Your Chapter Ambassador will be adding more information about the Chapter soon." %></p>
+  <p><%= chapter.name&.titleize.presence || "Chapter name coming soon" %></p>
 
-    <% if chapter.chapter_links.any? %>
-      <div>
-        <% chapter.chapter_links.each do |link| %>
-        <span>
-          <% if link.name == "email" %>
-            <%= mail_to link.value, web_icon("envelope-o", text: link.value) %>
-          <% else %>
-            <%= link_to web_icon(link.icon, text: link.display_text), link.url %>
-          <% end %>
-        </span>
-        <% end %>
-      </div>
-    <% end %>
-  <% else %>
-    <p>
-      Welcome to Technovation Girls! Currently, you are not affiliated with a Chapter.
-    </p>
-    <p>
-      Please check out our
-      <%= link_to "curriculum",
-        "https://technovationchallenge.org/curriculum-intro/registered/new/",
-        target: "_blank"
-      %>
-      and review the
-      <%= link_to "Pre-Season Checklist",
-        "https://technovationchallenge.org/courses/mentor-training/lessons/mentor-training-pre-season-checklist/",
-        target: "_blank"
-      %>
-      for support as you work on your Technovation Girls project.
-    </p>
+  <% if chapter.primary_contact.present? %>
+    <p><%= chapter.primary_contact.full_name.presence %></p>
+    <p><%= chapter.primary_contact.email.presence %></p>
   <% end %>
+
+  <p><%= chapter.summary.presence || "Your Chapter Ambassador will be adding more information about the Chapter soon." %></p>
+
+  <% if chapter.chapter_links.any? %>
+    <div>
+      <% chapter.chapter_links.each do |link| %>
+      <span>
+        <% if link.name == "email" %>
+          <%= mail_to link.value, web_icon("envelope-o", text: link.value) %>
+        <% else %>
+          <%= link_to web_icon(link.icon, text: link.display_text), link.url %>
+        <% end %>
+      </span>
+      <% end %>
+    </div>
+  <% end %>
+
   <p>Please email <%= mail_to ENV.fetch("HELP_EMAIL") %> if you need to change your Chapter.</p>
 </div>

--- a/app/views/dashboards/_chapterable_ambassador_intro.en.html.erb
+++ b/app/views/dashboards/_chapterable_ambassador_intro.en.html.erb
@@ -1,0 +1,13 @@
+<div class="ambassador-intro">
+  <% if current_account.assigned_to_chapterable? %>
+    <% if current_account.assigned_to_chapter? %>
+      <%= render partial: 'dashboards/chapter_ambassador_chapter_intro',
+        locals: { chapter: current_account.current_primary_chapter } %>
+    <% elsif current_account.assigned_to_club? %>
+      <%= render partial: 'dashboards/club_ambassador_club_intro',
+        locals: { club: current_account.current_primary_club } %>
+    <% end %>
+  <% else %>
+    <%= render partial: 'dashboards/unaffiliated_to_chapterable' %>
+  <% end %>
+</div>

--- a/app/views/dashboards/_club_ambassador_club_intro.en.html.erb
+++ b/app/views/dashboards/_club_ambassador_club_intro.en.html.erb
@@ -1,0 +1,20 @@
+<div class="club-ambassador-intro">
+  <p>
+    Welcome to Technovation Girls!
+    <% if club.name.present? %>
+      You are connected with <span><%= club.name.titleize %></span>.
+    <% end %>
+    Please check out the following info about the Club.
+  </p>
+
+  <p><%= club.name&.titleize.presence || "Club name coming soon" %></p>
+
+  <% if club.primary_contact.present? %>
+    <p><%= club.primary_contact.full_name.presence %></p>
+    <p><%= club.primary_contact.email.presence %></p>
+  <% end %>
+
+  <p><%= club.summary.presence || "Your Club Ambassador will be adding more information about the Club soon." %></p>
+
+  <p>Please email <%= mail_to ENV.fetch("HELP_EMAIL") %> if you need to change your Club.</p>
+</div>

--- a/app/views/dashboards/_unaffiliated_to_chapterable.en.html.erb
+++ b/app/views/dashboards/_unaffiliated_to_chapterable.en.html.erb
@@ -1,0 +1,17 @@
+<p>
+  Welcome to Technovation Girls! Currently, you are not affiliated with a Chapter or Club.
+</p>
+<p>
+  Please check out our
+  <%= link_to "curriculum",
+              "https://technovationchallenge.org/curriculum-intro/registered/new/",
+              target: "_blank"
+  %>
+  and review the
+  <%= link_to "Pre-Season Checklist",
+              "https://technovationchallenge.org/courses/mentor-training/lessons/mentor-training-pre-season-checklist/",
+              target: "_blank"
+  %>
+  for support as you work on your Technovation Girls project.
+</p>
+<p>Please email <%= mail_to ENV.fetch("HELP_EMAIL") %> if you need to change your Chapter or Club.</p>

--- a/app/views/mentor/dashboards/_header.en.html.erb
+++ b/app/views/mentor/dashboards/_header.en.html.erb
@@ -1,7 +1,5 @@
-<div slot="chapter-ambassador-intro">
-  <%= render partial: 'dashboards/chapter_ambassador_chapter_intro',
-    locals: { chapter: current_account.current_chapter }
-  %>
+<div slot="ambassador-intro">
+  <%= render partial: 'dashboards/chapterable_ambassador_intro' %>
 </div>
 
 <% if SeasonToggles.survey_link_available?(current_scope, current_account) %>

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -3,6 +3,7 @@
     nil,
     id: "vue-data-registration",
     data: {
+      chapterable_ambassador: ChapterableAmbassadorSerializer.new(current_account.current_primary_chapterable_assignment.chapterable.primary_contact).serialized_json,
       chapter_ambassador: ChapterAmbassadorSerializer.new(current_account.current_chapter.primary_contact&.chapter_ambassador_profile).serialized_json,
       current_account: AccountSerializer.new(current_account).serialized_json,
       current_mentor: MentorProfileSerializer.new(current_mentor).serialized_json,

--- a/spec/javascript/mentor/DashboardHeader.spec.js
+++ b/spec/javascript/mentor/DashboardHeader.spec.js
@@ -96,17 +96,17 @@ describe("mentor/DashboardHeader.vue", () => {
     });
   });
 
-  describe("when the mentor is assigned to a chapter ", () => {
+  describe("when the mentor is assigned to a chapterable ", () => {
     beforeEach(() => {
       defaultWrapper.vm.$store.commit("authenticated/htmlDataset", {
         currentAccount:
-          '{"data":{"attributes":{"chapterName":"Technovation[MN]","assignedToChapter":"true"}}}',
-        chapterAmbassador:
+          '{"data":{"attributes":{"chapterableName":"Technovation[MN]","assignedToChapterable":"true"}}}',
+        chapterableAmbassador:
           '{"data":{"attributes":{"avatarUrl":"https://cdn.filestackcontent.com/MeWCyN4LQzWrojqPwYDX}"}}}',
       });
     });
 
-    it("displays the chapter ambassador intro header", () => {
+    it("displays the ambassador's intro header", () => {
       const text = defaultWrapper
         .find(".dashboard-notices .grid__col-sm-6:first-child")
         .text();


### PR DESCRIPTION
Refs #5248 

Update mentor meet your Ambassador section to account for chapters, clubs, & unaffiliated chapterable assignments 

This PR addresses the shift from Chapter to Chapterable (chapter, club, unaffiliated mentors). I tried to remove chapter specific references in favor of "ambassador" references and then more specifically chapter and club when needed. I cleaned up the header just a bit and followed the same approach a the header for students. I don't want to spend too much extra time here since this is a vue app and we will be ripping it out eventually! I was hesitant to remove all references to chapter ambassador (for ex the serializer) since I am unsure if this will break other parts of the mentor experience. I don't think it will, but with the holiday time coming up, I feel it is better to be cautious. 