### PR TITLE
Add clubs to admin participants datagrid

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -319,6 +319,20 @@ class AccountsGrid
     by_chapter(value)
   end
 
+  filter :club,
+    :enum,
+    header: "Club (students, mentors and ChAs only)",
+    select: Club.all.order(name: :asc).map { |c| [c.name, c.id] },
+    filter_group: "common",
+    if: ->(g) {
+      g.admin
+    },
+    html: {
+      class: "and-or-field"
+    } do |value|
+    by_club(value)
+  end
+
   filter :division,
     :enum,
     header: "Division (students only)",

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -513,6 +513,12 @@ class Account < ActiveRecord::Base
       .where("chapterable_account_assignments.chapterable_id = ?", chapter_id)
   }
 
+  scope :by_club, ->(club_id) {
+    left_outer_joins(:chapterable_assignments)
+      .where("chapterable_account_assignments.chapterable_type = 'Club'")
+      .where("chapterable_account_assignments.chapterable_id = ?", club_id)
+  }
+
   scope :by_division, ->(division) {
     left_outer_joins(:division, :student_profile)
       .where("student_profiles.id IS NOT NULL")

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -359,6 +359,40 @@ RSpec.describe Account do
         expect(Account.by_chapter(chapter.id)).not_to include(student_in_another_chapter.account)
       end
     end
+
+    describe ".by_club" do
+      let!(:club) { FactoryBot.create(:club) }
+      let!(:student1) { FactoryBot.create(:student) }
+      let!(:student2) { FactoryBot.create(:student) }
+
+      let!(:another_club) { FactoryBot.create(:club) }
+      let!(:student_in_another_club) { FactoryBot.create(:student) }
+
+      before do
+        student1.chapterable_assignments.create(
+          account: student1.account,
+          chapterable: club
+        )
+
+        student2.chapterable_assignments.create(
+          account: student2.account,
+          chapterable: club
+        )
+
+        student_in_another_club.chapterable_assignments.create(
+          account: student_in_another_club.account,
+          chapterable: another_club
+        )
+      end
+
+      it "returns accounts belonging to the specified club" do
+        expect(Account.by_club(club.id)).to include(student1.account, student2.account)
+      end
+
+      it "does not return accounts belonging to a different club" do
+        expect(Account.by_club(club.id)).not_to include(student_in_another_club.account)
+      end
+    end
   end
 
   it "formats the country as a short code before validating" do


### PR DESCRIPTION
This will add a column and filter for clubs on the admin's participants datagrid.