### PR TITLE
Send separate parent/guardian first and last names to Salesforce

### DIFF
--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -141,6 +141,14 @@ class StudentProfile < ActiveRecord::Base
     end
   end
 
+  def parent_guardian_first_name
+    parent_guardian_name.split(/\s+/, 2).first
+  end
+
+  def parent_guardian_last_name
+    parent_guardian_name.split(/\s+/, 2).last
+  end
+
   def self.exists_on_team?(email)
     if record = joins(:account).find_by("accounts.email = ?", email)
       record.is_on_team?

--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -134,6 +134,8 @@ module Salesforce
         {
           Birthdate: account.date_of_birth,
           Parent__c: student_profile.parent_guardian_name,
+          Parent_First_Name__c: student_profile.parent_guardian_first_name,
+          Parent_Last_Name__c: student_profile.parent_guardian_last_name,
           Parent_Guardian_Email__c: student_profile.parent_guardian_email
         }
       else

--- a/spec/models/student_profile_spec.rb
+++ b/spec/models/student_profile_spec.rb
@@ -145,6 +145,25 @@ RSpec.describe StudentProfile do
     end
   end
 
+  describe "parent/guardian first and last name" do
+    let(:student_profile) do
+      FactoryBot.build(:student_profile,
+        parent_guardian_name: "Pandy Paws the Cat")
+    end
+
+    describe "#parent_guardian_first_name" do
+      it "returns the first part (separated by whitespace) as the first name" do
+        expect(student_profile.parent_guardian_first_name).to eq("Pandy")
+      end
+    end
+
+    describe "#parent_guardian_last_name" do
+      it "return the remaining parts (separated by whitespace) as the last name" do
+        expect(student_profile.parent_guardian_last_name).to eq("Paws the Cat")
+      end
+    end
+  end
+
   it "allows ON FILE as the email ONLY by admin action" do
     profile = FactoryBot.build(:student_profile, parent_guardian_email: "ON FILE")
     expect(profile).not_to be_valid

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -151,6 +151,8 @@ RSpec.describe Salesforce::ApiClient do
           MailingState: account.state_province,
           MailingCountry: account.country,
           Parent__c: account.student_profile.parent_guardian_name,
+          Parent_First_Name__c: student_profile.parent_guardian_first_name,
+          Parent_Last_Name__c: student_profile.parent_guardian_last_name,
           Parent_Guardian_Email__c: account.student_profile.parent_guardian_email
         )
 


### PR DESCRIPTION
This will split up the parent/guardian name into two parts before sending it to Salesforce, one part (the first part separated by whitespace) will be sent as the first name, and the remaining part will be sent as the last name.

And then in Salesforce the first and last name can be combined to form the full name like it is on the platform.


