### PR TITLE
Added club ambassador club profile tab

### DIFF
--- a/app/controllers/club_ambassador/club_profile_controller.rb
+++ b/app/controllers/club_ambassador/club_profile_controller.rb
@@ -1,0 +1,4 @@
+module ClubAmbassador
+  class ClubProfileController < ClubAmbassadorController
+  end
+end

--- a/app/views/club_ambassador/club_profile/_side_nav.html.erb
+++ b/app/views/club_ambassador/club_profile/_side_nav.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: "Club Details"} do %>
+  <div class="p-4" id="tab-wrapper">
+    <%= render "club_ambassador/club_profile/side_nav_content" %>
+  </div>
+<% end %>

--- a/app/views/club_ambassador/club_profile/_side_nav_content.html.erb
+++ b/app/views/club_ambassador/club_profile/_side_nav_content.html.erb
@@ -1,17 +1,17 @@
   <nav class="p-4" aria-label="Progress">
     <ol role="list" class="space-y-6 mb-6 overflow-hidden">
       <%= render "application/templates/completion_step",
-                 name: "Public info",
-                 url: club_ambassador_profile_path,
-                 is_complete: false,
-                 is_active_item: al(club_ambassador_profile_path).present?
+        name: "Public info",
+        url: club_ambassador_profile_path,
+        is_complete: false,
+        is_active_item: al(club_ambassador_profile_path).present?
       %>
 
       <%= render "application/templates/completion_step",
-                 name: "Club location",
-                 url: club_ambassador_profile_path,
-                 is_complete: false,
-                 is_active_item: al(club_ambassador_profile_path).present?
+        name: "Club location",
+        url: club_ambassador_profile_path,
+        is_complete: false,
+        is_active_item: al(club_ambassador_profile_path).present?
       %>
     </ol>
   </nav>

--- a/app/views/club_ambassador/club_profile/_side_nav_content.html.erb
+++ b/app/views/club_ambassador/club_profile/_side_nav_content.html.erb
@@ -1,0 +1,17 @@
+  <nav class="p-4" aria-label="Progress">
+    <ol role="list" class="space-y-6 mb-6 overflow-hidden">
+      <%= render "application/templates/completion_step",
+                 name: "Public info",
+                 url: club_ambassador_profile_path,
+                 is_complete: false,
+                 is_active_item: al(club_ambassador_profile_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
+                 name: "Club location",
+                 url: club_ambassador_profile_path,
+                 is_complete: false,
+                 is_active_item: al(club_ambassador_profile_path).present?
+      %>
+    </ol>
+  </nav>

--- a/app/views/club_ambassador/club_profile/show.en.html.erb
+++ b/app/views/club_ambassador/club_profile/show.en.html.erb
@@ -1,0 +1,11 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "club_ambassador/club_profile/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Club Profile" } do %>
+    <p class="mb-4">Welcome to the Club Profile section!</p>
+
+    <p class="mb-4">
+      Here, you'll provide important details about your Club to help us understand your local program better.
+    </p>
+  <% end %>
+</div>

--- a/app/views/club_ambassador/navigation/_tg_sub_nav.html.erb
+++ b/app/views/club_ambassador/navigation/_tg_sub_nav.html.erb
@@ -4,6 +4,10 @@
                 club_ambassador_dashboard_path,
                 class: al(club_ambassador_dashboard_path) + " sub-nav-item"%>
 
+    <%= link_to t("views.club_ambassador.navigation.club_profile"),
+                club_ambassador_club_profile_path,
+                class: al(club_ambassador_club_profile_path) + " sub-nav-item"%>
+
     <%= link_to t("views.club_ambassador.navigation.my_profile"),
                 club_ambassador_profile_path,
                 class: al(club_ambassador_profile_path) + " sub-nav-item"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,6 +218,7 @@ Rails.application.routes.draw do
   namespace :club_ambassador do
     resource :dashboard, only: :show
     resource :profile, only: [:show, :edit, :update]
+    resource :club_profile, only: :show, controller: "club_profile"
   end
 
   namespace :judge do


### PR DESCRIPTION
Ref #5211 

This PR adds the foundation for the club ambassador club profile tab. The navigation will need to be updated to account for the club public info and club location work completed in [this PR ](https://github.com/Iridescent-CM/technovation-app/pull/5275).