### PR TITLE
Restrict team submissions grid to only display submissions from students/teams affiliated with current chapter

### DIFF
--- a/app/controllers/chapter_ambassador/team_submissions_controller.rb
+++ b/app/controllers/chapter_ambassador/team_submissions_controller.rb
@@ -5,10 +5,17 @@ module ChapterAmbassador
     use_datagrid with: SubmissionsGrid,
 
       html_scope: ->(scope, user, params) {
-        scope.in_region(user).page(params[:page])
+        scope
+          .by_chapterable("Chapter", user.current_chapter.id)
+          .distinct
+          .page(params[:page])
       },
 
-      csv_scope: "->(scope, user, params) { scope.in_region(user) }"
+      csv_scope: "->(scope, user, params) {
+        scope
+          .by_chapterable('Chapter', user.current_chapter.id)
+          .distinct
+      }"
 
     def show
       @team_submission = TeamSubmission.friendly.find(params[:id])

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -6,7 +6,7 @@ class SubmissionsGrid
   self.batch_size = 10
 
   scope do
-    TeamSubmission.includes(:team).references(:teams)
+    TeamSubmission.includes(:screenshots, team: :division).references(:teams)
   end
 
   column :submission_id, header: "Submission ID", if: ->(grid) { grid.admin } do

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -136,6 +136,11 @@ class TeamSubmission < ActiveRecord::Base
       .where("regional_pitch_events.id IS NULL")
   }
 
+  scope :by_chapterable, ->(chapterable_type, chapterable_id) do
+    joins(team: {students: {account: :chapterable_assignments}})
+      .where(chapterable_assignments: {chapterable_type: chapterable_type, chapterable_id: chapterable_id})
+  end
+
   belongs_to :team, touch: true
   has_many :screenshots, -> { order(:sort_position) },
     dependent: :destroy,

--- a/spec/features/chapter_ambassador/view_team_submissions_spec.rb
+++ b/spec/features/chapter_ambassador/view_team_submissions_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.feature "Chapter Ambassador viewing their team submissions" do
+  let(:chapter) { FactoryBot.create(:chapter, :chicago, :onboarded) }
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :not_assigned_to_chapter) }
+
+  before do
+    chapter_ambassador.chapterable_assignments.create(
+      account: chapter_ambassador.account,
+      chapterable: chapter,
+      season: Season.current.year,
+      primary: true
+    )
+  end
+
+  scenario "displays team submissions of students assigned to their chapter" do
+    affiliated_student = FactoryBot.create(:student, :chicago)
+    affiliated_student.chapterable_assignments.create(
+      account: affiliated_student.account,
+      chapterable: chapter,
+      season: Season.current.year,
+      primary: true
+    )
+
+    team = FactoryBot.create(:team)
+    TeamRosterManaging.add(team, affiliated_student)
+
+    submission = FactoryBot.create(:team_submission,
+      app_name: "hello",
+      team: team)
+
+    affiliated_student_2 = FactoryBot.create(:student, :chicago)
+    affiliated_student_2.chapterable_assignments.create(
+      account: affiliated_student_2.account,
+      chapterable: chapter,
+      season: Season.current.year,
+      primary: true
+    )
+
+    team_2 = FactoryBot.create(:team)
+    TeamRosterManaging.add(team_2, affiliated_student_2)
+
+    submission_2 = FactoryBot.create(:team_submission,
+      app_name: "hello 2",
+      team: team_2)
+
+    sign_in(chapter_ambassador)
+    visit(chapter_ambassador_team_submissions_path)
+
+    expect(page).to have_content(submission.app_name)
+    expect(page).to have_content(submission_2.app_name)
+  end
+
+  scenario "does not display team submissions of students not assigned to their chapter" do
+    affiliated_student = FactoryBot.create(:student, :brazil)
+    team = FactoryBot.create(:team)
+    TeamRosterManaging.add(team, affiliated_student)
+
+    submission = FactoryBot.create(:team_submission,
+      app_name: "hello brazil",
+      team: team)
+
+    sign_in(chapter_ambassador)
+    visit(chapter_ambassador_teams_path)
+
+    expect(page).not_to have_content(submission.app_name)
+  end
+end


### PR DESCRIPTION
Refs #5164 

This PR restricts the team submissions grid to only display submissions from students/teams affiliated with current chapter.

Main changes 
- Created a `by_chapterable` scope on the `team_submission` model. I made this dynamic to handle chapters and clubs
- Added tests
- Fixed n+1 bullet warning

I also added #5283 - Add a counter cache for screenshot count. There was one additional bullet warning
```
Need Counter Cache with Active Record size
  TeamSubmission => [:screenshots]
```
I'm not sure if this is something we should investigate/add!
