### PR TITLE
Updated chapter dropdown to include country name

### DIFF
--- a/app/controllers/admin/chapter_account_assignments_controller.rb
+++ b/app/controllers/admin/chapter_account_assignments_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class ChapterAccountAssignmentsController < AdminController
     def new
       @account = Account.find(params.fetch(:account_id))
-      @chapters = Chapter.all.order(organization_name: :asc)
+      @chapters = Chapter.all.order(:country, :organization_name)
       @chapterable_account_assignment = ChapterableAccountAssignment.new
     end
 
@@ -35,7 +35,7 @@ module Admin
 
     def edit
       @account = Account.find(params.fetch(:account_id))
-      @chapters = Chapter.all.order(organization_name: :asc)
+      @chapters = Chapter.all.order(:country, :organization_name)
       @chapterable_account_assignment = @account.current_chapterable_assignment
     end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -46,10 +46,6 @@ class Chapter < ActiveRecord::Base
 
   delegate :seasons_chapter_affiliation_agreement_is_valid_for, to: :legal_contact
 
-  def organization_name_with_country
-    country.present? ? "#{organization_name} - #{country}" : "#{organization_name} - No Country"
-  end
-
   def affiliation_agreement
     legal_contact&.reload&.chapter_affiliation_agreement
   end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -46,6 +46,10 @@ class Chapter < ActiveRecord::Base
 
   delegate :seasons_chapter_affiliation_agreement_is_valid_for, to: :legal_contact
 
+  def organization_name_with_country
+    country.present? ? "#{organization_name} - #{country}" : "#{organization_name} - No Country"
+  end
+
   def affiliation_agreement
     legal_contact&.reload&.chapter_affiliation_agreement
   end

--- a/app/views/admin/chapter_account_assignments/_form.en.html.erb
+++ b/app/views/admin/chapter_account_assignments/_form.en.html.erb
@@ -11,7 +11,7 @@
     <%= form.collection_select :chapter_id,
       @chapters,
       :id,
-      :organization_name,
+      :organization_name_with_country,
       include_blank: "None",
       selected: @account.current_chapter&.id %>
   </div>

--- a/app/views/admin/chapter_account_assignments/_form.en.html.erb
+++ b/app/views/admin/chapter_account_assignments/_form.en.html.erb
@@ -11,7 +11,7 @@
     <%= form.collection_select :chapter_id,
       @chapters,
       :id,
-      :organization_name_with_country,
+      ->(chapter) { "#{chapter.organization_name} - #{chapter.country.presence || 'No Country'}" },
       include_blank: "None",
       selected: @account.current_chapter&.id %>
   </div>


### PR DESCRIPTION
Refs #5289 

This PR appends the chapter's country name to the chapter organization name in the dropdown where admin assign participant to chapters. One thing to note, is that the dropdown will be grouped by country and then within the country groups, organization names will be alpha ordered. 

We discussed adding a more robust set of tools in the future, such as filters and search options, but for this ticket decided to go with this approach for now.