### PR TITLE
Update Spain text on chapter selection screen

### DIFF
--- a/app/views/chapterable_account_assignments/additional_info/_spain.en.html.erb
+++ b/app/views/chapterable_account_assignments/additional_info/_spain.en.html.erb
@@ -1,11 +1,13 @@
 <div class="p-2 border mb-8" style="background-color: #f0f9ff;">
   <p class="my-0">Catalonia Chapters cover:</p>
   <ul>
-    <li class="my-0 text-sm">Catalonia, Baleares</li>
+    <li class="my-0 text-sm">Catalonia</li>
+    <li class="my-0 text-sm">Baleares</li>
   </ul>
 
   <p class="mt-3 mb-0">Madrid Chapters cover:</p>
   <ul>
+    <li class="my-0 text-sm">Comunidad de Madrid</li>
     <li class="my-0 text-sm">Andalucía (except Málaga, Almería, and Jaén)</li>
     <li class="my-0 text-sm">Aragón</li>
     <li class="my-0 text-sm">Principado de Asturias</li>
@@ -15,7 +17,6 @@
     <li class="my-0 text-sm">Castilla-La Mancha (except Cuenca and Albacete)</li>
     <li class="my-0 text-sm">Extremadura</li>
     <li class="my-0 text-sm">Galicia</li>
-    <li class="my-0 text-sm">Comunidad de Madrid</li>
     <li class="my-0 text-sm">Comunidad de Navarra</li>
     <li class="my-0 text-sm">País Vasco, La Rioja</li>
     <li class="my-0 text-sm">Ceuta</li>


### PR DESCRIPTION
Two updates:

- For Catalonia, could you put the two options on separate lines so it matches the other chapters?
- For Madrid, the ChAs would like Comunidad de Madrid to be listed first.


