### PR TITLE
Club ambassador testing feedback updates

### DIFF
--- a/app/data_grids/club_ambassadors_grid.rb
+++ b/app/data_grids/club_ambassadors_grid.rb
@@ -94,10 +94,12 @@ class ClubAmbassadorsGrid
     end
 
   filter :club_name do |value, scope|
+    processed_value = I18n.transliterate(value.strip.downcase).gsub(/['\s]+/, "%")
     scope
       .left_outer_joins(:club_ambassador_profile)
-      .left_outer_joins(club_ambassador_profile: :club)
-      .where("club.name ilike ?", "#{value}%")
+      .left_outer_joins(:chapterable_assignments)
+      .left_outer_joins(:clubs)
+      .where("lower(unaccent(clubs.name)) ILIKE ?", "%#{processed_value}%")
   end
 
   column_names_filter(

--- a/app/data_grids/club_ambassadors_grid.rb
+++ b/app/data_grids/club_ambassadors_grid.rb
@@ -12,7 +12,7 @@ class ClubAmbassadorsGrid
 
   column :name, header: "Club Name", mandatory: true do |account|
     if account.assigned_to_club?
-      format(account.name) do
+      format(account.current_primary_club.name) do
         link_to(
           account.current_primary_club.name || "-",
           admin_club_path(account.current_primary_club)

--- a/app/data_grids/clubs_grid.rb
+++ b/app/data_grids/clubs_grid.rb
@@ -16,11 +16,36 @@ class ClubsGrid
 
   column :name, header: "Name", mandatory: true
 
+  column :city
+
+  column :state_province, header: "State" do
+    FriendlySubregion.call(self, prefix: false)
+  end
+
+  column :country do
+    FriendlyCountry.new(self).country_name
+  end
+
   column :actions, mandatory: true, html: true do |club|
     link_to("View",
       admin_club_path(club),
       class: "button small gray",
       data: {turbolinks: false})
+  end
+
+  filter :country,
+    :enum,
+    header: "Country",
+    select: ->(g) {
+      CountryStateSelect.countries_collection
+    },
+    filter_group: "more-specific",
+    multiple: true,
+    data: {
+      placeholder: "Select or start typing..."
+    } do |values|
+    clauses = values.flatten.map { |v| "clubs.country = '#{v}'" }
+    where(clauses.join(" OR "))
   end
 
   column_names_filter(


### PR DESCRIPTION
Refs #5309 


This PR addresses the following

- Searching by club name on the club ambassador data grid (/admin/club_ambassadors#/) results in the error page. This is true if it is the only filter used or if it is combined with other filters.
-  When exporting from the club ambassador admin page (/admin/club_ambassadors#/), the club name column is a combination of the person's first and last name (not the club name) unless the person is not assigned to a club in which case it says "no club"
- Add country as an additional column and filter on the clubs admin page (/admin/clubs#/)


I updated the club names search with the same functionality as the chapter ambassador name search so that partial matches and accented names would still be returned. Also noting that this may need to be updated with the refactoring work. 