### PR TITLE
Address Salesforce duplicate records issue

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -136,7 +136,7 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
       profile_type: profile_type.to_s
     )
 
-    @@crm_job_wait_time += 30
+    @@crm_job_wait_time += 45
   end
 
   private

--- a/app/services/chapter_ambassador_profile_addition.rb
+++ b/app/services/chapter_ambassador_profile_addition.rb
@@ -32,9 +32,18 @@ class ChapterAmbassadorProfileAddition
   end
 
   def setup_chapter_ambassador_profile_in_crm
-    CRM::SetupAccountForCurrentSeasonJob.perform_later(
-      account_id: account.id,
-      profile_type: "chapter ambassador"
-    )
+    if ENV.fetch("ACTIVE_JOB_BACKEND", "inline") == "inline"
+      CRM::SetupAccountForCurrentSeasonJob.perform_later(
+        account_id: account.id,
+        profile_type: "chapter ambassador"
+      )
+    else
+      CRM::SetupAccountForCurrentSeasonJob
+        .set(wait: 4.minutes)
+        .perform_later(
+          account_id: account.id,
+          profile_type: "chapter ambassador"
+        )
+    end
   end
 end

--- a/app/services/club_ambassador_profile_addition.rb
+++ b/app/services/club_ambassador_profile_addition.rb
@@ -30,9 +30,18 @@ class ClubAmbassadorProfileAddition
   end
 
   def setup_club_ambassador_profile_in_crm
-    CRM::SetupAccountForCurrentSeasonJob.perform_later(
-      account_id: account.id,
-      profile_type: "club ambassador"
-    )
+    if ENV.fetch("ACTIVE_JOB_BACKEND", "inline") == "inline"
+      CRM::SetupAccountForCurrentSeasonJob.perform_later(
+        account_id: account.id,
+        profile_type: "club ambassador"
+      )
+    else
+      CRM::SetupAccountForCurrentSeasonJob
+        .set(wait: 6.minutes)
+        .perform_later(
+          account_id: account.id,
+          profile_type: "club ambassador"
+        )
+    end
   end
 end

--- a/app/services/student_to_mentor_converter.rb
+++ b/app/services/student_to_mentor_converter.rb
@@ -54,7 +54,7 @@ class StudentToMentorConverter
       RegisterToCurrentSeasonJob.perform_later(account)
     else
       RegisterToCurrentSeasonJob
-        .set(wait: 1.minute)
+        .set(wait: 8.minutes)
         .perform_later(account)
     end
   end


### PR DESCRIPTION
Salesforce gets updated via scheduled jobs. A job can get scheduled for various reasons (not an inclusive list):

- when someone logs in for the first time during a new season
- when someone gets converted from a student to a mentor
- when a chapter ambassador profile is adding to a mentor
- when a club ambassador profile is adding to a mentor

If two of these actions are done back-to-back it can cause duplicate records in Salesforce.

I added some arbitrary pauses/delays in between each of these jobs that will space them out more which will hopefully help with this issue.

