### PR TITLE
Admin can assign a club ambassador to a club + groundwork for refactoring the admin chapterable assignment flow

### DIFF
--- a/app/controllers/admin/chapterable_account_assignments_controller.rb
+++ b/app/controllers/admin/chapterable_account_assignments_controller.rb
@@ -1,0 +1,75 @@
+module Admin
+  class ChapterableAccountAssignmentsController < AdminController
+    def new
+      @account = Account.find(params.fetch(:account_id))
+      @chapterables = Club.all.order(:country, :name)
+      @chapterable_account_assignment = ChapterableAccountAssignment.new
+    end
+
+    def create
+      account = Account.find(params.fetch(:account_id))
+      chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
+
+      account
+        .current_chapterable_assignments
+        .where(primary: true)
+        .delete_all
+
+      if chapterable_account_assignment_params.fetch(:chapterable_id).present?
+        account.chapterable_assignments.create(
+          profile: account.chapter_ambassador_profile.presence ||
+            account.club_ambassador_profile.presence ||
+            account.mentor_profile.presence ||
+            account.student_profile,
+          chapterable_id: chapterable_account_assignment_params.fetch(:chapterable_id),
+          chapterable_type: chapterable_type,
+          season: Season.current.year,
+          primary: true
+        )
+
+        account.update(no_chapterable_selected: nil)
+        account.update(no_chapterables_available: nil)
+      end
+
+      redirect_to admin_participant_path(account),
+        success: "Successfully assigned #{account.full_name} to a new #{chapterable_type}"
+    end
+
+    def edit
+      @account = Account.find(params.fetch(:account_id))
+      @chapterables = Club.all.order(:country, :name)
+      @chapterable_account_assignment = @account.current_chapterable_assignment
+    end
+
+    def update
+      account = Account.find(params.fetch(:account_id))
+      chapterable_account_assignment = ChapterableAccountAssignment.find(params.fetch(:id))
+      chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
+
+
+      if chapterable_account_assignment_params.fetch(:chapterable_id).present?
+        chapterable_account_assignment.update(
+          chapterable_id: chapterable_account_assignment_params.fetch(:chapterable_id),
+          chapterable_type: chapterable_type
+        )
+
+        account.update(no_chapterable_selected: nil)
+      else
+        chapterable_account_assignment.delete
+
+        if account.is_a_mentor? || account.is_a_student?
+          account.update(no_chapterable_selected: true)
+        end
+      end
+
+      redirect_to admin_participant_path(account),
+        success: "Successfully updated #{account.full_name}'s #{chapterable_type} assignment"
+    end
+
+    private
+
+    def chapterable_account_assignment_params
+      params.require(:chapterable_account_assignment).permit(:chapterable_id, :chapterable_type)
+    end
+  end
+end

--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -63,12 +63,14 @@ class AccountMailer < ApplicationMailer
     end
   end
 
-  def chapter_assigned(account)
+  def chapterable_assigned(account)
     @first_name = account.first_name
-    @chapter_name = account.current_chapter.name
+    @chapterable_name = account.current_chapterable_assignment.chapterable.name
+    @assigned_to_chapter = account.assigned_to_chapter?
 
     I18n.with_locale(account.locale) do
-      mail to: account.email
+      mail to: account.email,
+        subject: "#{account.assigned_to_chapter? ? "Chapter" : "Club"} assignment"
     end
   end
 end

--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -65,12 +65,14 @@ class AccountMailer < ApplicationMailer
 
   def chapterable_assigned(account)
     @first_name = account.first_name
-    @chapterable_name = account.current_chapterable_assignment.chapterable.name
+    @chapterable_assignment = account.current_chapterable_assignment
+    @chapterable_name = @chapterable_assignment.chapterable.name.presence ||
+      "a #{@chapterable_assignment.chapterable_type}"
     @assigned_to_chapter = account.assigned_to_chapter?
 
     I18n.with_locale(account.locale) do
       mail to: account.email,
-        subject: "#{account.assigned_to_chapter? ? "Chapter" : "Club"} assignment"
+        subject: "#{@chapterable_assignment.chapterable_type} assignment"
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -286,7 +286,7 @@ class Account < ActiveRecord::Base
   before_update :update_division, if: -> { !is_a_judge? && !is_chapter_ambassador? }
   after_commit :update_crm_contact_info, on: :update
   after_update :update_chapter_ambassador_onboarding_status
-  after_update :send_assigned_to_chapter_email
+  after_update :send_assigned_to_chapterable_email
 
   after_commit -> {
     if saved_change_to_email_confirmed_at ||
@@ -1226,11 +1226,11 @@ class Account < ActiveRecord::Base
     end
   end
 
-  def send_assigned_to_chapter_email
+  def send_assigned_to_chapterable_email
     if (student_profile.present? || mentor_profile.present?) &&
         saved_change_to_no_chapterable_selected? && !no_chapterable_selected?
 
-      AccountMailer.chapter_assigned(self).deliver_later
+      AccountMailer.chapterable_assigned(self).deliver_later
     end
   end
 end

--- a/app/views/account_mailer/chapterable_assigned.en.html.erb
+++ b/app/views/account_mailer/chapterable_assigned.en.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="content-wrap">
-    <meta itemprop="name" content="Assigned to a chapter notification">
+    <meta itemprop="name" content="Assigned to a chapter or club notification">
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td class="content-block">
@@ -11,18 +11,20 @@
       <tr>
         <td class="content-block">
           Thank you for being part of the Technovation Girls program. Based on
-          your location, you have been assigned to <%= @chapter_name %>.
+          your location, you have been assigned to <%= @chapterable_name %>.
         </td>
       </tr>
 
-      <tr>
-        <td class="content-block">
-          Technovation Chapters are partner organizations that run the
-          Technovation program in a local community or region. The
-          Chapter Ambassador is the leader of a Chapter and can help
-          guide you through the Technovation program.
-        </td>
-      </tr>
+      <% if @assigned_to_chapter %>
+        <tr>
+          <td class="content-block">
+            Technovation Chapters are partner organizations that run the
+            Technovation program in a local community or region. The
+            Chapter Ambassador is the leader of a Chapter and can help
+            guide you through the Technovation program.
+          </td>
+        </tr>
+      <% end %>
 
       <tr>
         <td class="content-block">

--- a/app/views/admin/chapterable_account_assignments/_form.en.html.erb
+++ b/app/views/admin/chapterable_account_assignments/_form.en.html.erb
@@ -1,0 +1,23 @@
+<%= form_with model: @chapterable_account_assignment,
+  url: (
+    @chapterable_account_assignment.new_record? ?
+    admin_account_chapterable_account_assignments_path(@account) :
+    admin_account_chapterable_account_assignment_path(@account, @chapterable_account_assignment)
+  ),
+  local: true do |form| %>
+
+  <div>
+    <%= form.label :chapterable_id, "Select Club" %>
+    <%= form.collection_select :chapterable_id,
+      @chapterables,
+      :id,
+      ->(club) { "#{club.name} - #{club.country.presence || 'No Country'}" },
+      include_blank: "None",
+      selected: @account.current_club&.id %>
+    <%= form.hidden_field :chapterable_type, value: "Club" %>
+  </div>
+
+  <div style="margin-top: 16px;">
+    <%= form.submit "Save", class: "button" %>
+  </div>
+<% end %>

--- a/app/views/admin/chapterable_account_assignments/edit.en.html.erb
+++ b/app/views/admin/chapterable_account_assignments/edit.en.html.erb
@@ -1,0 +1,3 @@
+<div class="panel">
+  <%= render "form" %>
+</div>

--- a/app/views/admin/chapterable_account_assignments/new.en.html.erb
+++ b/app/views/admin/chapterable_account_assignments/new.en.html.erb
@@ -1,0 +1,3 @@
+<div class="panel">
+  <%= render "form" %>
+</div>

--- a/app/views/admin/participants/_assigned_to_chapterable.en.html.erb
+++ b/app/views/admin/participants/_assigned_to_chapterable.en.html.erb
@@ -1,0 +1,43 @@
+<% if @account.assigned_to_chapter? %>
+  <dt>Chapter (Program name)</dt>
+  <dd>
+    <%= link_to(@account.friendly_chapter_program_name,
+      admin_chapter_path(@account.current_chapter)) %>
+  </dd>
+
+  <dt>Chapter Organization</dt>
+  <dd>
+    <%= @account.friendly_chapter_organization_name %>
+  </dd>
+
+  <p>
+    <% case @account.current_primary_chapterable_assignment.profile_type %>
+    <% when "StudentProfile" %>
+      <% link_text = "Edit chapter" %>
+    <% when "MentorProfile" %>
+      <% link_text = "Edit chapter for mentor" %>
+    <% else %>
+      <% link_text = "Edit chapter for ChA" %>
+    <% end %>
+
+    <%= link_to link_text,
+      edit_admin_account_chapter_account_assignment_path(
+        @account,
+        @account.current_primary_chapterable_assignment
+      ),
+      class: "button secondary small" %>
+  </p>
+<% elsif @account.assigned_to_club? %>
+  <dt>Club</dt>
+  <dd>
+    <%= link_to(@account.current_club.name.presence,
+      admin_club_path(@account.current_club)) %>
+  </dd>
+
+  <%= link_to "Edit club",
+    edit_admin_account_chapterable_account_assignment_path(
+      @account,
+      @account.current_primary_chapterable_assignment
+    ),
+    class: "button secondary small" %>
+<% end %>

--- a/app/views/admin/participants/_not_assigned_to_chapterable.en.html.erb
+++ b/app/views/admin/participants/_not_assigned_to_chapterable.en.html.erb
@@ -1,0 +1,21 @@
+<% if @account.is_a_club_ambassador? %>
+  <dt>Club</dt>
+  <dd>Not assigned to a club</dd>
+  <p>
+    <%= link_to "Assign to club",
+      new_admin_account_chapterable_account_assignment_path(
+        @account
+      ),
+      class: "button secondary small" %>
+  </p>
+<% else %>
+  <dt>Chapter</dt>
+  <dd>Not assigned to a chapter</dd>
+  <p>
+    <%= link_to "Assign #{(@account.is_an_ambassador? && @account.is_a_mentor?) ? 'ChA' : ''} to a chapter",
+      new_admin_account_chapter_account_assignment_path(
+        @account
+      ),
+      class: "button secondary small" %>
+  </p>
+<% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -83,58 +83,17 @@
 
           <% if @account.student_profile.present? ||
             @account.is_a_mentor? ||
-            @account.is_an_ambassador?
+            @account.is_an_ambassador? ||
+            @account.is_a_club_ambassador?
           %>
 
-            <dl class="chapter-info">
+            <dl class="chapterable-info">
               <% if @account.assigned_to_chapterable? %>
-                <% if @account.assigned_to_chapter? %>
-                  <dt>Chapter (Program name)</dt>
-                  <dd>
-                    <%= link_to(@account.friendly_chapter_program_name,
-                      admin_chapter_path(@account.current_chapter)) %>
-                  </dd>
-
-                  <dt>Chapter Organization</dt>
-                  <dd>
-                    <%= @account.friendly_chapter_organization_name %>
-                  </dd>
-
-                  <p>
-                    <% case @account.current_primary_chapterable_assignment.profile_type %>
-                    <% when "StudentProfile" %>
-                      <% link_text = "Edit chapter" %>
-                    <% when "MentorProfile" %>
-                      <% link_text = "Edit chapter for mentor" %>
-                    <% else %>
-                      <% link_text = "Edit chapter for ChA" %>
-                    <% end %>
-
-                    <%= link_to link_text,
-                      edit_admin_account_chapter_account_assignment_path(
-                      @account,
-                      @account.current_primary_chapterable_assignment
-                    ),
-                    class: "button secondary small" %>
-                  </p>
-                <% elsif @account.assigned_to_club? %>
-                  <dt>Club</dt>
-                  <dd>
-                    <%= link_to(@account.current_club.name.presence,
-                      admin_club_path(@account.current_club)) %>
-                  </dd>
-                <% end %>
+                <%= render "admin/participants/assigned_to_chapterable",
+                  account: @account %>
               <% else %>
-                <dt>Chapter</dt>
-                <dd>Not assigned to a chapter</dd>
-
-                <p>
-                  <%= link_to "Assign #{(@account.is_an_ambassador? && @account.is_a_mentor?) ? 'ChA' : ''} to a chapter",
-                    new_admin_account_chapter_account_assignment_path(
-                      @account
-                    ),
-                    class: "button secondary small" %>
-                </p>
+                <%= render "admin/participants/not_assigned_to_chapterable",
+                  account: @account %>
               <% end %>
             </dl>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,7 @@ Rails.application.routes.draw do
 
     resources :accounts, only: [] do
       resources :chapter_account_assignments, only: [:new, :create, :edit, :update]
+      resources :chapterable_account_assignments, only: [:new, :create, :edit, :update]
     end
     resources :chapters do
       resource :legal_contact, only: [:new, :create, :edit, :update], controller: "chapters/legal_contacts"

--- a/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
+++ b/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Admin::ChapterableAccountAssignmentsController do
+  let(:club_ambassador) { FactoryBot.create(:club_ambassador) }
+  let(:club) { FactoryBot.create(:club) }
+
+  before do
+    sign_in(:admin)
+  end
+
+  describe "POST #create" do
+    context "when assigning a chapterable to an account" do
+      it "sets 'no chapterable selected' to nil for the account" do
+        post :create, params: {
+          account_id: club_ambassador.account.id,
+          chapterable_account_assignment: {
+            chapterable_id: club.id,
+            chapterable_type: "Club"
+          }
+        }
+
+        expect(club_ambassador.account.reload.no_chapterable_selected).to be_nil
+      end
+
+      it "creates a chapterable assignment for this account" do
+        post :create, params: {
+          account_id: club_ambassador.account.id,
+          chapterable_account_assignment: {
+            chapterable_id: club.id,
+            chapterable_type: "Club"
+          }
+        }
+
+        expect(club_ambassador.account.reload.current_club).to eq(club)
+      end
+    end
+
+    context "when no chapterable is selected" do
+      it "does not create a chapterable assignment" do
+        post :create, params: {
+          account_id: club_ambassador.account.id,
+          chapterable_account_assignment: {
+            chapterable_id: nil,
+            chapterable_type: "Club"
+          }
+        }
+
+        expect(club_ambassador.account.reload.current_club).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/chapter_ambassador/chapter_account_assignments_controller_spec.rb
+++ b/spec/controllers/chapter_ambassador/chapter_account_assignments_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ChapterAmbassador::ChapterAccountAssignmentsController do
   let(:student_profile) { FactoryBot.create(:student_profile, :unaffiliated_chapter) }
 
   before do
-    allow(AccountMailer).to receive_message_chain(:chapter_assigned, :deliver_later)
+    allow(AccountMailer).to receive_message_chain(:chapterable_assigned, :deliver_later)
 
     sign_in(chapter_ambassador)
   end
@@ -36,7 +36,7 @@ RSpec.describe ChapterAmbassador::ChapterAccountAssignmentsController do
       end
 
       it "makes a call to send the chapter assigned email to the student" do
-        expect(AccountMailer).to receive_message_chain(:chapter_assigned, :deliver_later)
+        expect(AccountMailer).to receive_message_chain(:chapterable_assigned, :deliver_later)
 
         post :create, params: {
           account_id: student_profile.account.id,

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Account do
           let(:student) { FactoryBot.create(:student, :unaffiliated_chapter) }
 
           it "makes a call to send the chapter assigned email to the student when they're assigned to a chapter" do
-            expect(AccountMailer).to receive_message_chain(:chapter_assigned, :deliver_later)
+            expect(AccountMailer).to receive_message_chain(:chapterable_assigned, :deliver_later)
 
             student.account.update(no_chapterable_selected: false)
           end
@@ -316,7 +316,7 @@ RSpec.describe Account do
           let(:mentor) { FactoryBot.create(:mentor, :unaffiliated_chapter) }
 
           it "makes a call to send the chapter assigned email to the mentor when they're assigned to a chapter" do
-            expect(AccountMailer).to receive_message_chain(:chapter_assigned, :deliver_later)
+            expect(AccountMailer).to receive_message_chain(:chapterable_assigned, :deliver_later)
 
             mentor.account.update(no_chapterable_selected: false)
           end


### PR DESCRIPTION
Refs #5311 
I originally planned to complete the refactor with the understanding that we would be able to deploy clubs with what we currently have, followed up by a quick 2nd deployment with the club assignment. This shifted at this week's dev priorities. I consider this PR a sort of intermediate step to unblock deployment. This PR allows admin to assign club ambassadors to a club. I added #5324 to complete the refactor to include chapter assignment. This is the bare minimum to get club assignment available but I tried to keep things more neutral and dynamic so that chapters can be easily included. Most of the flow is duplicated but altered in some ways for clubs. Anything hardcoded for clubs will be updated in #5324 (which also has a few additional checklist items). 