### PR TITLE
Add force location screen for club ambassadors

### DIFF
--- a/app/controllers/club_ambassador/current_locations_controller.rb
+++ b/app/controllers/club_ambassador/current_locations_controller.rb
@@ -1,0 +1,21 @@
+module ClubAmbassador
+  class CurrentLocationsController < ClubAmbassadorController
+    def show
+      state = FriendlySubregion.call(current_account, prefix: false)
+      state_code = FriendlySubregion.call(current_account, {
+        prefix: false,
+        short_code: true
+      })
+
+      friendly_country = FriendlyCountry.new(current_account)
+
+      render json: {
+        city: current_account.city,
+        state: state,
+        state_code: state_code,
+        country: friendly_country.country_name,
+        country_code: friendly_country.as_short_code
+      }
+    end
+  end
+end

--- a/app/controllers/club_ambassador/location_details_controller.rb
+++ b/app/controllers/club_ambassador/location_details_controller.rb
@@ -1,0 +1,17 @@
+module ClubAmbassador
+  class LocationDetailsController < ClubAmbassadorController
+    helper_method :current_profile
+
+    layout "club_ambassador"
+
+    def show
+      render template: "location_details/show"
+    end
+
+    private
+
+    def current_profile
+      current_ambassador
+    end
+  end
+end

--- a/app/controllers/club_ambassador/locations_controller.rb
+++ b/app/controllers/club_ambassador/locations_controller.rb
@@ -1,0 +1,5 @@
+module ClubAmbassador
+  class LocationsController < ClubAmbassadorController
+    include LocationController
+  end
+end

--- a/app/controllers/concerns/force_location.rb
+++ b/app/controllers/concerns/force_location.rb
@@ -10,8 +10,7 @@ module ForceLocation
   def require_location
     return if request.xhr?
 
-    # todo: force location screen for club ambassadors
-    return if current_scope == "admin" || current_scope == "club_ambassador"
+    return if current_scope == "admin"
 
     if logged_in_and_has_profile && !valid_location && !on_location_form
       redirect_to send(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,10 @@ Rails.application.routes.draw do
     resource :dashboard, only: :show
     resource :profile, only: [:show, :edit, :update]
 
+    resource :current_location, only: :show
+    resource :location, only: [:update, :create]
+    resource :location_details, only: :show
+
     resource :club_profile, only: :show, controller: "club_profile"
     resource :club_headquarters_location, only: [:edit, :update]
     resource :club_location, only: [:show, :edit, :update, :create], controller: "club_locations"


### PR DESCRIPTION
This will add the force location screen for club ambassadors making it so that they will have to add their location before they can access their dashboard.
