### PR TITLE
Refactor admin chapterable assignment flow to allow for chapter and club assignments 

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -91,14 +91,48 @@ document.addEventListener("turbolinks:load", function () {
         clubSelect.style.display = "block";
         registerAtAnyTime.checked = true;
         registerAtAnyTime.disabled = true;
-      }
-      else {
+      } else {
         chapterSelect.style.display = "none";
         clubSelect.style.display = "none";
         registerAtAnyTime.checked = false;
         registerAtAnyTime.disabled = false;
       }
     });
+  }
+
+  const chapterableTypeSelect = document.getElementById(
+    "chapterable_account_assignment_chapterable_type"
+  );
+
+  if (chapterableTypeSelect) {
+    const chapterContainer = document.getElementById("chapter-container");
+    const chapterSelect = document.getElementById(
+      "chapterable_account_assignment_chapter_id"
+    );
+    const clubContainer = document.getElementById("club-container");
+    const clubSelect = document.getElementById(
+      "chapterable_account_assignment_club_id"
+    );
+
+    const updateDropdownVisibility = () => {
+      const selectedChapterableType = chapterableTypeSelect.value;
+
+      if (selectedChapterableType === "chapter") {
+        chapterContainer.classList.remove("hidden");
+        clubContainer.classList.add("hidden");
+        clubSelect.value = "";
+      } else if (selectedChapterableType === "club") {
+        clubContainer.classList.remove("hidden");
+        chapterContainer.classList.add("hidden");
+        chapterSelect.value = "";
+      } else {
+        chapterContainer.classList.add("hidden");
+        clubContainer.classList.add("hidden");
+      }
+    };
+
+    chapterableTypeSelect.addEventListener("change", updateDropdownVisibility);
+    updateDropdownVisibility();
   }
 });
 

--- a/app/controllers/admin/chapterable_account_assignments_controller.rb
+++ b/app/controllers/admin/chapterable_account_assignments_controller.rb
@@ -2,27 +2,30 @@ module Admin
   class ChapterableAccountAssignmentsController < AdminController
     def new
       @account = Account.find(params.fetch(:account_id))
-      @chapterables = Club.all.order(:country, :name)
       @chapterable_account_assignment = ChapterableAccountAssignment.new
+      @chapters = Chapter.all.order(:country, :organization_name)
+      @clubs = Club.all.order(:country, :name)
     end
 
     def create
       account = Account.find(params.fetch(:account_id))
       chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
+      chapterable_id = chapterable_account_assignment_params.fetch(:chapter_id).presence ||
+        chapterable_account_assignment_params.fetch(:club_id).presence
 
       account
         .current_chapterable_assignments
         .where(primary: true)
         .delete_all
 
-      if chapterable_account_assignment_params.fetch(:chapterable_id).present?
+      if chapterable_id.present?
         account.chapterable_assignments.create(
           profile: account.chapter_ambassador_profile.presence ||
             account.club_ambassador_profile.presence ||
             account.mentor_profile.presence ||
             account.student_profile,
-          chapterable_id: chapterable_account_assignment_params.fetch(:chapterable_id),
-          chapterable_type: chapterable_type,
+          chapterable_id: chapterable_id,
+          chapterable_type: chapterable_type.capitalize,
           season: Season.current.year,
           primary: true
         )
@@ -37,20 +40,23 @@ module Admin
 
     def edit
       @account = Account.find(params.fetch(:account_id))
-      @chapterables = Club.all.order(:country, :name)
       @chapterable_account_assignment = @account.current_chapterable_assignment
+      @chapters = Chapter.all.order(:country, :organization_name)
+      @clubs = Club.all.order(:country, :name)
     end
 
     def update
       account = Account.find(params.fetch(:account_id))
       chapterable_account_assignment = ChapterableAccountAssignment.find(params.fetch(:id))
       chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
+      chapterable_id = chapterable_account_assignment_params.fetch(:chapter_id).presence ||
+        chapterable_account_assignment_params.fetch(:club_id).presence
 
 
-      if chapterable_account_assignment_params.fetch(:chapterable_id).present?
+      if chapterable_id.present?
         chapterable_account_assignment.update(
-          chapterable_id: chapterable_account_assignment_params.fetch(:chapterable_id),
-          chapterable_type: chapterable_type
+          chapterable_id: chapterable_id,
+          chapterable_type: chapterable_type.capitalize
         )
 
         account.update(no_chapterable_selected: nil)
@@ -63,13 +69,13 @@ module Admin
       end
 
       redirect_to admin_participant_path(account),
-        success: "Successfully updated #{account.full_name}'s #{chapterable_type} assignment"
+        success: "Successfully updated #{account.full_name}'s #{chapterable_type.downcase} assignment"
     end
 
     private
 
     def chapterable_account_assignment_params
-      params.require(:chapterable_account_assignment).permit(:chapterable_id, :chapterable_type)
+      params.require(:chapterable_account_assignment).permit(:chapter_id, :club_id, :chapterable_type)
     end
   end
 end

--- a/app/views/admin/chapterable_account_assignments/_form.en.html.erb
+++ b/app/views/admin/chapterable_account_assignments/_form.en.html.erb
@@ -1,20 +1,52 @@
+<%
+  pre_selected_chapterable_type = if @account.is_a_club_ambassador?
+    "club"
+  elsif @account.is_an_ambassador?
+    "chapter"
+  end
+%>
+
+<p>
+  You are updating the primary assignment for <%= @account.full_name %>.
+</p>
+
 <%= form_with model: @chapterable_account_assignment,
   url: (
     @chapterable_account_assignment.new_record? ?
-    admin_account_chapterable_account_assignments_path(@account) :
-    admin_account_chapterable_account_assignment_path(@account, @chapterable_account_assignment)
+      admin_account_chapterable_account_assignments_path(@account) :
+      admin_account_chapterable_account_assignment_path(@account, @chapterable_account_assignment)
   ),
   local: true do |form| %>
 
   <div>
-    <%= form.label :chapterable_id, "Select Club" %>
-    <%= form.collection_select :chapterable_id,
-      @chapterables,
+    <%= form.label :chapterable_type, "Select Chapter or Club" %>
+    <%= form.select :chapterable_type,
+      [
+        ["Chapter", "chapter"],
+        ["Club", "club"]
+      ],
+      prompt: "Select Chapter or Club",
+      selected: @chapterable_account_assignment.chapterable_type&.downcase.presence || pre_selected_chapterable_type %>
+  </div>
+
+  <div id="chapter-container" class="hidden">
+    <%= form.label :chapter_id, "Select Chapter" %>
+    <%= form.collection_select :chapter_id,
+      @chapters,
       :id,
-      ->(club) { "#{club.name} - #{club.country.presence || 'No Country'}" },
+      ->(chapter) { "#{chapter.name.presence || chapter.organization_name.presence} - #{chapter.country.presence || "No Country"}" },
       include_blank: "None",
-      selected: @account.current_club&.id %>
-    <%= form.hidden_field :chapterable_type, value: "Club" %>
+      selected: @account.current_chapter&.id  %>
+  </div>
+
+  <div id="club-container" class="hidden">
+    <%= form.label :club_id, "Select Club" %>
+    <%= form.collection_select :club_id,
+    @clubs,
+    :id,
+    ->(club) { "#{club.name.presence} - #{club.country.presence || "No Country"}" },
+    include_blank: "None",
+    selected: @account.current_club&.id %>
   </div>
 
   <div style="margin-top: 16px;">

--- a/app/views/admin/chapterable_account_assignments/_form.en.html.erb
+++ b/app/views/admin/chapterable_account_assignments/_form.en.html.erb
@@ -34,7 +34,7 @@
     <%= form.collection_select :chapter_id,
       @chapters,
       :id,
-      ->(chapter) { "#{chapter.name.presence || chapter.organization_name.presence} - #{chapter.country.presence || "No Country"}" },
+      ->(chapter) { "#{chapter.organization_name.presence} - #{chapter.country.presence || "No Country"}" },
       include_blank: "None",
       selected: @account.current_chapter&.id  %>
   </div>

--- a/app/views/admin/participants/_assigned_to_chapterable.en.html.erb
+++ b/app/views/admin/participants/_assigned_to_chapterable.en.html.erb
@@ -1,43 +1,33 @@
-<% if @account.assigned_to_chapter? %>
-  <dt>Chapter (Program name)</dt>
-  <dd>
-    <%= link_to(@account.friendly_chapter_program_name,
-      admin_chapter_path(@account.current_chapter)) %>
-  </dd>
+<% chapterable_type = chapterable_assignment.chapterable_type %>
 
+<dt><%= chapterable_type %> (Name)</dt>
+<dd>
+  <%= link_to(chapterable_assignment.chapterable.name.presence || "Name not set",
+    send("admin_#{chapterable_type.downcase}_path",
+      chapterable_assignment.chapterable)) %>
+</dd>
+
+<% if account.assigned_to_chapter? %>
   <dt>Chapter Organization</dt>
   <dd>
-    <%= @account.friendly_chapter_organization_name %>
+    <%= account.friendly_chapter_organization_name %>
   </dd>
-
-  <p>
-    <% case @account.current_primary_chapterable_assignment.profile_type %>
-    <% when "StudentProfile" %>
-      <% link_text = "Edit chapter" %>
-    <% when "MentorProfile" %>
-      <% link_text = "Edit chapter for mentor" %>
-    <% else %>
-      <% link_text = "Edit chapter for ChA" %>
-    <% end %>
-
-    <%= link_to link_text,
-      edit_admin_account_chapter_account_assignment_path(
-        @account,
-        @account.current_primary_chapterable_assignment
-      ),
-      class: "button secondary small" %>
-  </p>
-<% elsif @account.assigned_to_club? %>
-  <dt>Club</dt>
-  <dd>
-    <%= link_to(@account.current_club.name.presence,
-      admin_club_path(@account.current_club)) %>
-  </dd>
-
-  <%= link_to "Edit club",
-    edit_admin_account_chapterable_account_assignment_path(
-      @account,
-      @account.current_primary_chapterable_assignment
-    ),
-    class: "button secondary small" %>
 <% end %>
+
+<% case chapterable_assignment.profile_type %>
+<% when "StudentProfile" %>
+  <% link_text = "Edit #{chapterable_type.downcase} for student" %>
+<% when "MentorProfile" %>
+  <% link_text = "Edit #{chapterable_type.downcase} for mentor" %>
+<% when "ClubAmbassadorProfile" %>
+  <% link_text = "Edit club for ClA" %>
+<% else %>
+  <% link_text = "Edit chapter for ChA" %>
+<% end %>
+
+<%= link_to link_text,
+  edit_admin_account_chapterable_account_assignment_path(
+    account,
+    chapterable_assignment
+  ),
+  class: "button secondary small" %>

--- a/app/views/admin/participants/_not_assigned_to_chapterable.en.html.erb
+++ b/app/views/admin/participants/_not_assigned_to_chapterable.en.html.erb
@@ -1,21 +1,19 @@
-<% if @account.is_a_club_ambassador? %>
-  <dt>Club</dt>
-  <dd>Not assigned to a club</dd>
-  <p>
-    <%= link_to "Assign to club",
-      new_admin_account_chapterable_account_assignment_path(
-        @account
-      ),
-      class: "button secondary small" %>
-  </p>
-<% else %>
-  <dt>Chapter</dt>
-  <dd>Not assigned to a chapter</dd>
-  <p>
-    <%= link_to "Assign #{(@account.is_an_ambassador? && @account.is_a_mentor?) ? 'ChA' : ''} to a chapter",
-      new_admin_account_chapter_account_assignment_path(
-        @account
-      ),
-      class: "button secondary small" %>
-  </p>
-<% end %>
+<%
+  chapterable_options_text = if account.is_chapter_ambassador?
+    "chapter"
+  elsif account.is_club_ambassador?
+    "club"
+  else
+    "chapter or club"
+  end
+%>
+
+<dt><%= chapterable_options_text.capitalize %></dt>
+<dd><%= "Not assigned to #{chapterable_options_text}" %></dd>
+<p>
+  <%= link_to "Assign to #{chapterable_options_text}",
+    new_admin_account_chapterable_account_assignment_path(
+      account
+    ),
+    class: "button secondary small" %>
+</p>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -90,7 +90,7 @@
             <dl class="chapterable-info">
               <% if @account.assigned_to_chapterable? %>
                 <%= render partial: "admin/participants/assigned_to_chapterable",
-                  locals: { account: @account, chapterable_assignment: @account.current_chapterable_assignment} %>
+                  locals: { account: @account, chapterable_assignment: @account.current_chapterable_assignment } %>
               <% else %>
                 <%= render "admin/participants/not_assigned_to_chapterable",
                   account: @account %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -89,8 +89,8 @@
 
             <dl class="chapterable-info">
               <% if @account.assigned_to_chapterable? %>
-                <%= render "admin/participants/assigned_to_chapterable",
-                  account: @account %>
+                <%= render partial: "admin/participants/assigned_to_chapterable",
+                  locals: { account: @account, chapterable_assignment: @account.current_chapterable_assignment} %>
               <% else %>
                 <%= render "admin/participants/not_assigned_to_chapterable",
                   account: @account %>

--- a/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
+++ b/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
-            chapterable_id: club.id,
+            club_id: club.id,
+            chapter_id: nil,
             chapterable_type: "Club"
           }
         }
@@ -26,7 +27,8 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
-            chapterable_id: club.id,
+            club_id: club.id,
+            chapter_id: nil,
             chapterable_type: "Club"
           }
         }
@@ -40,7 +42,8 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
-            chapterable_id: nil,
+            club_id: nil,
+            chapter_id: nil,
             chapterable_type: "Club"
           }
         }

--- a/spec/features/admin/view_chapter_ambassadors_spec.rb
+++ b/spec/features/admin/view_chapter_ambassadors_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Admins view Chapter Ambassador participant details" do
 
     expect(current_path).to eq(admin_participant_path(chapter_ambassador.account))
 
-    expect(page).to have_content "Chapter (Program name)"
+    expect(page).to have_content "Chapter (Name)"
     expect(page).to have_link chapter.name, href: admin_chapter_path(chapter)
     expect(page).to have_content "Chapter Organization"
     expect(page).to have_content "#{chapter.organization_name}"
@@ -29,7 +29,7 @@ RSpec.feature "Admins view Chapter Ambassador participant details" do
     expect(current_path).to eq(admin_participant_path(chapter_ambassador.account))
 
     expect(page).to have_content "Chapter"
-    expect(page).to have_content "Not assigned to a chapter"
+    expect(page).to have_content "Not assigned to chapter"
   end
 end
 

--- a/spec/system/admin/chapter_assignment_spec.rb
+++ b/spec/system/admin/chapter_assignment_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe "Admins assigning participants to chapters" do
       it "assigns the selected chapter to the student" do
         visit admin_participant_path(student.account)
 
-        click_link "Assign to a chapter"
+        click_link "Assign to chapter or club"
 
-        select chapter.organization_name
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
+        select "#{chapter.organization_name} - No Country", from: "chapterable_account_assignment_chapter_id"
         click_button "Save"
 
         expect(student.account.current_chapter).to eq(chapter)
@@ -45,7 +46,8 @@ RSpec.describe "Admins assigning participants to chapters" do
 
         click_link "Edit chapter"
 
-        select new_chapter.organization_name
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
+        select "#{new_chapter.organization_name} - No Country", from: "chapterable_account_assignment_chapter_id"
         click_button "Save"
 
         expect(student.account.current_chapter).to eq(new_chapter)
@@ -69,9 +71,10 @@ RSpec.describe "Admins assigning participants to chapters" do
       it "assigns the selected chapter to the mentor" do
         visit admin_participant_path(mentor.account)
 
-        click_link "Assign to a chapter"
+        click_link "Assign to chapter or club"
 
-        select chapter.organization_name
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
+        select "#{chapter.organization_name} - No Country", from: "chapterable_account_assignment_chapter_id"
         click_button "Save"
 
         expect(mentor.account.current_chapter).to eq(chapter)
@@ -97,7 +100,8 @@ RSpec.describe "Admins assigning participants to chapters" do
 
         click_link "Edit chapter"
 
-        select new_chapter.organization_name
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
+        select "#{new_chapter.organization_name} - No Country", from: "chapterable_account_assignment_chapter_id"
         click_button "Save"
 
         expect(mentor.account.current_chapter).to eq(new_chapter)
@@ -121,7 +125,9 @@ RSpec.describe "Admins assigning participants to chapters" do
       it "assigns the selected chapter to the chapter ambassador" do
         visit admin_participant_path(chapter_ambassador.account)
 
-        click_link "Assign to a chapter"
+        click_link "Assign to chapter"
+
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
 
         select chapter.organization_name
         click_button "Save"
@@ -149,6 +155,7 @@ RSpec.describe "Admins assigning participants to chapters" do
 
         click_link "Edit chapter"
 
+        select "Chapter", from: "chapterable_account_assignment_chapterable_type"
         select new_chapter.organization_name
         click_button "Save"
 


### PR DESCRIPTION
Refs #5324 

This PR refactors the admin chapterable assignment flow to allow for chapter and club assignments.
My initial attempt was to dynamically load "chapterables" (clubs or chapters) depending on what the admin selected as chapterable type. After working through that approach I decided to shift to a more straightforward approach by preloading the chapters/clubs into their own dropdowns and using JS to display/hide the dropdowns. 

This refactor will admin to assign students and mentors to either a club or a chapter and to switch between the two. Admin can also assign ChAs to chapter and ClAs to clubs. 

![CleanShot 2025-01-29 at 17 06 23@2x](https://github.com/user-attachments/assets/bb9f8a73-06a4-4655-9b1c-9dc808842bcb)
