### PR TITLE
Allow club ambassassdor in judge mode to return to mentor mode

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -816,7 +816,7 @@ class Account < ActiveRecord::Base
   end
 
   def can_switch_to_mentor?
-    if is_an_ambassador?
+    if chapter_ambassador? || club_ambassador?
       true
     elsif is_a_judge?
       !!ENV.fetch("ENABLE_MENTOR_MODE_FOR_ALL_JUDGES", false) ||


### PR DESCRIPTION
For club ambassadors who are mentors and judges, if they are in judge mode, this will allow them to return to mentor mode.


