### PR TITLE
Fix Firefox CircleCI issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -124,6 +124,7 @@ jobs:
       - checkout
       - browser-tools/install-browser-tools:
           chrome-version: 128.0.6613.84 # TODO: remove when chromedriver downloads are fixed
+          firefox-version: 134.0.2
 
       - run:
           name: Install libc6


### PR DESCRIPTION
Similar to the solution we did recently (pinning a previous version of Chrome), this temporary fix will pin a previous version of Firefox.


