### PR TITLE
Handle blank parent/guardian names

### DIFF
--- a/app/models/student_profile.rb
+++ b/app/models/student_profile.rb
@@ -399,7 +399,7 @@ class StudentProfile < ActiveRecord::Base
   end
 
   def parent_guardian_name_parts
-    @parent_guardian_name_parts ||= parent_guardian_name.split(/\s+/, 2)
+    @parent_guardian_name_parts ||= parent_guardian_name.present? ? parent_guardian_name.split(/\s+/, 2) : []
   end
 
   def reset_parent

--- a/spec/models/student_profile_spec.rb
+++ b/spec/models/student_profile_spec.rb
@@ -185,6 +185,18 @@ RSpec.describe StudentProfile do
         expect(student_profile.parent_guardian_last_name).to eq(nil)
       end
     end
+
+    context "when the parent/guardian name is blank" do
+      let(:parent_guardian_name) { nil }
+
+      it "doesn't return anything for the first name" do
+        expect(student_profile.parent_guardian_first_name).to eq(nil)
+      end
+
+      it "doesn't return anything for the last name" do
+        expect(student_profile.parent_guardian_last_name).to eq(nil)
+      end
+    end
   end
 
   it "allows ON FILE as the email ONLY by admin action" do


### PR DESCRIPTION
When trying to split the parent/guardian name into first/last name, there is an error being caused if the parent/guardian name doesn't exist, this will address that by checking if a parent/guardian name is present before trying to split it up.


