### PR TITLE
Add team matching for club ambassadors

### DIFF
--- a/app/controllers/ambassador/team_memberships_controller.rb
+++ b/app/controllers/ambassador/team_memberships_controller.rb
@@ -1,5 +1,5 @@
-module ChapterAmbassador
-  class TeamMembershipsController < ChapterAmbassadorController
+module Ambassador
+  class TeamMembershipsController < AmbassadorController
     def create
       team = Team.find(params.fetch(:team_id))
       account = Account.find(params.fetch(:account_id))
@@ -10,8 +10,7 @@ module ChapterAmbassador
 
       msg = if team.members.include?(profile)
         {
-          success: "You have added #{account.full_name} " +
-            "to #{team.name}"
+          success: "You have added #{account.full_name} to #{team.name}"
         }
       elsif account.student_profile
         {alert: team.errors[:add_student][0]}
@@ -19,7 +18,7 @@ module ChapterAmbassador
         {alert: "An error occurred."}
       end
 
-      redirect_to chapter_ambassador_participant_path(account), msg
+      redirect_to send(:"#{current_scope}_participant_path", account), msg
     end
 
     def destroy

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -209,26 +209,24 @@
   </dl>
 </div>
 
-<% if current_scope == "chapter_ambassador" %>
-  <h4 class="reset">Help them with their team matching</h4>
+<h4 class="reset">Help them with their team matching</h4>
 
-  <div class="panel">
-    <%= form_tag(send("#{current_scope}_team_memberships_path")) do %>
-      <%= hidden_field_tag :account_id, profile.account_id %>
+<div class="panel">
+  <%= form_tag(send("#{current_scope}_team_memberships_path")) do %>
+    <%= hidden_field_tag :account_id, profile.account_id %>
 
-      <h6>Add <%= profile.full_name %> to a team</h6>
+    <h6>Add <%= profile.full_name %> to a team</h6>
 
-      <p>
-        <%= select_tag "team_id",
-          options_from_collection_for_select(@teams, "id", "name"),
-          prompt: "Select a team",
-          required: true,
-          class: "chosen" %>
-      </p>
+    <p>
+      <%= select_tag "team_id",
+        options_from_collection_for_select(@teams, "id", "name"),
+        prompt: "Select a team",
+        required: true,
+        class: "chosen" %>
+    </p>
 
-      <p>
-        <%= submit_tag 'Add', class: "button" %>
-      </p>
-    <% end %>
-  </div>
-<% end %>
+    <p>
+      <%= submit_tag 'Add', class: "button" %>
+    </p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,7 +182,7 @@ Rails.application.routes.draw do
     resources :teams, only: :index, controller: "/data_grids/ambassador/teams"
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"
     resources :team_submissions, only: :index, controller: "/data_grids/ambassador/team_submissions"
-    resources :team_memberships, only: [:create, :destroy]
+    resources :team_memberships, only: [:create, :destroy], controller: "/ambassador/team_memberships"
     resources :team_member_invites, only: [:destroy]
 
     resources :activities, only: :index
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
 
     resources :teams, only: :show, controller: "/ambassador/teams"
     resources :teams, only: :index, controller: "/data_grids/ambassador/teams"
-
+    resources :team_memberships, only: [:create, :destroy], controller: "/ambassador/team_memberships"
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"
     resources :team_submissions, only: :index, controller: "/data_grids/ambassador/team_submissions"
 

--- a/spec/controllers/team_memberships_controller_spec.rb
+++ b/spec/controllers/team_memberships_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Team Memberships Controllers" do
     end
   end
 
-  %w[chapter_ambassador admin].each do |scope|
+  %w[ambassador admin].each do |scope|
     describe "#{scope.camelize}::TeamMembershipsController".constantize do
       describe "DELETE #destroy" do
         it "reconsiders divisions" do


### PR DESCRIPTION
This will let club ambassadors assign a student or a mentor to a team.

Chapter ambassadors already have this functionality, to make it work for club ambassadors I extracted the existing functionality and made it so that both chapter ambassadors and club ambassadors can share the same functionality.



