### PR TITLE
Add validation for admin chapterable assignment flow

### DIFF
--- a/app/controllers/admin/chapterable_account_assignments_controller.rb
+++ b/app/controllers/admin/chapterable_account_assignments_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class ChapterableAccountAssignmentsController < AdminController
-    before_action :chapterables
+    before_action :get_chapterables
 
     def new
       @account = Account.find(params.fetch(:account_id))
@@ -85,7 +85,7 @@ module Admin
       params.require(:chapterable_account_assignment).permit(:chapter_id, :club_id, :chapterable_type)
     end
 
-    def chapterables
+    def get_chapterables
       @chapters = Chapter.all.order(:country, :organization_name)
       @clubs = Club.all.order(:country, :name)
     end

--- a/app/controllers/admin/chapterable_account_assignments_controller.rb
+++ b/app/controllers/admin/chapterable_account_assignments_controller.rb
@@ -1,81 +1,93 @@
 module Admin
   class ChapterableAccountAssignmentsController < AdminController
+    before_action :chapterables
+
     def new
       @account = Account.find(params.fetch(:account_id))
       @chapterable_account_assignment = ChapterableAccountAssignment.new
-      @chapters = Chapter.all.order(:country, :organization_name)
-      @clubs = Club.all.order(:country, :name)
     end
 
     def create
-      account = Account.find(params.fetch(:account_id))
+      @account = Account.find(params.fetch(:account_id))
       chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
       chapterable_id = chapterable_account_assignment_params.fetch(:chapter_id).presence ||
         chapterable_account_assignment_params.fetch(:club_id).presence
 
-      account
+      @account
         .current_chapterable_assignments
         .where(primary: true)
         .delete_all
 
       if chapterable_id.present?
-        account.chapterable_assignments.create(
-          profile: account.chapter_ambassador_profile.presence ||
-            account.club_ambassador_profile.presence ||
-            account.mentor_profile.presence ||
-            account.student_profile,
+        assignment = @account.chapterable_assignments.create(
+          profile: @account.chapter_ambassador_profile.presence ||
+            @account.club_ambassador_profile.presence ||
+            @account.mentor_profile.presence ||
+            @account.student_profile,
           chapterable_id: chapterable_id,
           chapterable_type: chapterable_type.capitalize,
           season: Season.current.year,
           primary: true
         )
 
-        account.update(no_chapterable_selected: nil)
-        account.update(no_chapterables_available: nil)
+        if assignment.save
+          @account.update(no_chapterable_selected: nil)
+          @account.update(no_chapterables_available: nil)
+          redirect_to admin_participant_path(@account),
+            success: "Successfully assigned #{@account.full_name} to a new #{chapterable_type}"
+        else
+          @chapterable_account_assignment = ChapterableAccountAssignment.new
+          flash.now[:alert] = assignment.errors.full_messages.to_sentence
+          render :new
+        end
       end
-
-      redirect_to admin_participant_path(account),
-        success: "Successfully assigned #{account.full_name} to a new #{chapterable_type}"
     end
 
     def edit
       @account = Account.find(params.fetch(:account_id))
       @chapterable_account_assignment = @account.current_chapterable_assignment
-      @chapters = Chapter.all.order(:country, :organization_name)
-      @clubs = Club.all.order(:country, :name)
     end
 
     def update
-      account = Account.find(params.fetch(:account_id))
-      chapterable_account_assignment = ChapterableAccountAssignment.find(params.fetch(:id))
+      @account = Account.find(params.fetch(:account_id))
+      @chapterable_account_assignment = ChapterableAccountAssignment.find(params.fetch(:id))
       chapterable_type = chapterable_account_assignment_params.fetch(:chapterable_type)
       chapterable_id = chapterable_account_assignment_params.fetch(:chapter_id).presence ||
         chapterable_account_assignment_params.fetch(:club_id).presence
 
-
       if chapterable_id.present?
-        chapterable_account_assignment.update(
+        if @chapterable_account_assignment.update(
           chapterable_id: chapterable_id,
           chapterable_type: chapterable_type.capitalize
         )
+          @account.update(no_chapterable_selected: nil)
 
-        account.update(no_chapterable_selected: nil)
-      else
-        chapterable_account_assignment.delete
-
-        if account.is_a_mentor? || account.is_a_student?
-          account.update(no_chapterable_selected: true)
+          redirect_to admin_participant_path(@account),
+            success: "Successfully updated #{@account.full_name}'s #{chapterable_type.downcase} assignment"
+        else
+          flash.now[:alert] = @chapterable_account_assignment.errors.full_messages.to_sentence
+          render :edit
         end
-      end
+      else
+        @chapterable_account_assignment.delete
 
-      redirect_to admin_participant_path(account),
-        success: "Successfully updated #{account.full_name}'s #{chapterable_type.downcase} assignment"
+        if @account.is_a_mentor? || @account.is_a_student?
+          @account.update(no_chapterable_selected: true)
+        end
+        redirect_to admin_participant_path(@account),
+          success: "Successfully removed #{@account.full_name}'s #{chapterable_type.downcase} assignment"
+      end
     end
 
     private
 
     def chapterable_account_assignment_params
       params.require(:chapterable_account_assignment).permit(:chapter_id, :club_id, :chapterable_type)
+    end
+
+    def chapterables
+      @chapters = Chapter.all.order(:country, :organization_name)
+      @clubs = Club.all.order(:country, :name)
     end
   end
 end

--- a/app/models/chapterable_account_assignment.rb
+++ b/app/models/chapterable_account_assignment.rb
@@ -22,9 +22,9 @@ class ChapterableAccountAssignment < ApplicationRecord
   def ambassador_chapterable_assignment_type
     type = chapterable_type.capitalize
 
-    if account.is_a_club_ambassador? && type == "Chapter"
+    if account.club_ambassador? && type == "Chapter"
       errors.add(:base, "Club ambassadors cannot be assigned to a chapter.")
-    elsif account.is_an_ambassador? && type == "Club"
+    elsif account.chapter_ambassador? && type == "Club"
       errors.add(:base, "Chapter ambassadors cannot be assigned to a club.")
     end
   end

--- a/app/models/chapterable_account_assignment.rb
+++ b/app/models/chapterable_account_assignment.rb
@@ -14,4 +14,18 @@ class ChapterableAccountAssignment < ApplicationRecord
   scope :clubs, -> {
     where(chapterable_type: "Club")
   }
+
+  validate :ambassador_chapterable_assignment_type
+
+  private
+
+  def ambassador_chapterable_assignment_type
+    type = chapterable_type.capitalize
+
+    if account.is_a_club_ambassador? && type == "Chapter"
+      errors.add(:base, "Club ambassadors cannot be assigned to a chapter.")
+    elsif account.is_an_ambassador? && type == "Club"
+      errors.add(:base, "Chapter ambassadors cannot be assigned to a club.")
+    end
+  end
 end

--- a/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
+++ b/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
         expect(club_ambassador.account.reload.no_chapterable_selected).to be_nil
       end
 
-      it "creates a chapterable assignment for this account" do
+      it "creates the assignment for this account" do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
@@ -40,7 +40,7 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
     end
 
     context "when no chapterable is selected" do
-      it "does not create a chapterable assignment" do
+      it "does not create the assignment" do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
@@ -49,13 +49,12 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
             chapterable_type: "Club"
           }
         }
-
-        expect(club_ambassador.account.reload.current_club).to be_empty
+        expect(club_ambassador.account.reload.current_club).to be_blank
       end
     end
 
-    context "when a Club Ambassador is assigned to a chapter" do
-      it "does not create a chapterable assignment" do
+    context "assigning a club ambassador to a chapter" do
+      it "does not create the assignment" do
         post :create, params: {
           account_id: club_ambassador.account.id,
           chapterable_account_assignment: {
@@ -64,13 +63,12 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
             chapterable_type: "Chapter"
           }
         }
-
-        expect(club_ambassador.account.reload.current_chapterable_assignment).to be_empty
+        expect(club_ambassador.account.reload.current_chapterable_assignment).to be_blank
       end
     end
 
-    context "when a Chapter Ambassador is assigned to a club" do
-      it "does not create a chapterable assignment" do
+    context "assigning a chapter ambassador to a club" do
+      it "does not create the assignment" do
         post :create, params: {
           account_id: chapter_ambassador.account.id,
           chapterable_account_assignment: {
@@ -79,8 +77,7 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
             chapterable_type: "Club"
           }
         }
-
-        expect(club_ambassador.account.reload.current_chapterable_assignment).to be_empty
+        expect(chapter_ambassador.account.reload.current_chapterable_assignment).to be_blank
       end
     end
   end

--- a/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
+++ b/spec/controllers/admin/chapterable_account_assignments_controller_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe Admin::ChapterableAccountAssignmentsController do
   let(:club_ambassador) { FactoryBot.create(:club_ambassador) }
+  let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
   let(:club) { FactoryBot.create(:club) }
+  let(:chapter) { FactoryBot.create(:chapter) }
 
   before do
     sign_in(:admin)
@@ -49,6 +51,36 @@ RSpec.describe Admin::ChapterableAccountAssignmentsController do
         }
 
         expect(club_ambassador.account.reload.current_club).to be_empty
+      end
+    end
+
+    context "when a Club Ambassador is assigned to a chapter" do
+      it "does not create a chapterable assignment" do
+        post :create, params: {
+          account_id: club_ambassador.account.id,
+          chapterable_account_assignment: {
+            club_id: nil,
+            chapter_id: chapter.id,
+            chapterable_type: "Chapter"
+          }
+        }
+
+        expect(club_ambassador.account.reload.current_chapterable_assignment).to be_empty
+      end
+    end
+
+    context "when a Chapter Ambassador is assigned to a club" do
+      it "does not create a chapterable assignment" do
+        post :create, params: {
+          account_id: chapter_ambassador.account.id,
+          chapterable_account_assignment: {
+            club_id: club.id,
+            chapter_id: nil,
+            chapterable_type: "Club"
+          }
+        }
+
+        expect(club_ambassador.account.reload.current_chapterable_assignment).to be_empty
       end
     end
   end


### PR DESCRIPTION
Refs #5324 

This PR adds validation for admin chapterable assignment flow so that ChAs can only be assigned to chapters and CAs can only be assigned to clubs. 