### PR TITLE
Fix unaffilated list for club ambassadors not assigned to a club

### DIFF
--- a/app/null_objects/null_chapterable.rb
+++ b/app/null_objects/null_chapterable.rb
@@ -18,4 +18,12 @@ class NullChapterable < NullObject
   def build_chapter_program_information
     ChapterProgramInformation.none
   end
+
+  def country
+    nil
+  end
+
+  def country_code
+    nil
+  end
 end


### PR DESCRIPTION
Simple fix for club ambassadors who aren't assigned to a club accessing the unaffiliated list.

Seems like an edge case since all club ambassadors should be assigned to a club; and if they're not maybe they shouldn't have access to certain things. Anywho, since it's possible now, this a simple fix for the time being.