### PR TITLE
Fix profile_type enum order and add rake task to update affected club ambassador invitations

### DIFF
--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -1,11 +1,11 @@
 class UserInvitation < ApplicationRecord
   enum profile_type: %i[
     chapter_ambassador
-    club_ambassador
     judge
     mentor
     student
     parent_student
+    club_ambassador
   ]
 
   enum status: %i[

--- a/lib/tasks/update_club_ambassador_invitation.rake
+++ b/lib/tasks/update_club_ambassador_invitation.rake
@@ -1,0 +1,18 @@
+desc "Update club ambassador invitation"
+task :update_club_ambassador_invitation, [:dry_run] => :environment do |t, args|
+  dry_run = args[:dry_run] != "run"
+
+  club_ambassador_invites = UserInvitation.where(profile_type: 1).where.not(club_id: nil)
+
+  puts "DRY RUN: #{dry_run ? "on" : "off"}"
+  puts("Updating profile type for #{club_ambassador_invites.count} club ambassador invites")
+
+  if !dry_run
+    puts("Starting update")
+    club_ambassador_invites.find_each do |invite|
+      puts("Updating invitation: ID: #{invite.id} | Email: #{invite.email}")
+      invite.update_column(:profile_type, 5)
+    end
+    puts("Update complete")
+  end
+end


### PR DESCRIPTION
Refs #5343 

This PR reorders the `profile_type` enum, moving `club_ambassador` from index 1 to the end.

In a previous PR, I incorrectly inserted `club_ambassador` at index 1, which caused two issues:
- Club ambassador invitations were incorrectly assigned `profile_type`: 1
- The user invitations grid displayed the wrong profile type for existing invitations

To fix this I added the following:
- Moved `club_ambassador` to the end of the profile_type enum
- Added a rake take to update previous club ambassador user invitations (`profile_type` from 1 to 5)

I checked the prod db and found 12 affected records (which I am verifying with VET). I also checked other invitations from the timeframe and did not see any others with the incorrect `profile_type`.

Next Steps
- Run rake task this on QA to update the 5 affected club ambassador invites
<img width="936" alt="Screenshot 2025-02-11 at 3 44 19 PM" src="https://github.com/user-attachments/assets/0d6d7128-8fcb-4649-859c-fcdf7e96c332" />

- After it is on Prod - run rake task to update the 12 records