### PR TITLE
Update "Find A missing participant" page for ChAs

### DIFF
--- a/app/views/chapter_ambassador/missing_participant_locations/edit.en.html.erb
+++ b/app/views/chapter_ambassador/missing_participant_locations/edit.en.html.erb
@@ -1,7 +1,5 @@
 <% provide :title, "Fix location data" %>
 
-<% provide :subnav, render('chapter_ambassador/participants/sub_menu') %>
-
 <div class="grid grid--justify-space-around">
   <div class="grid__col-8">
     <div class="panel">

--- a/app/views/chapter_ambassador/missing_participant_searches/new.en.html.erb
+++ b/app/views/chapter_ambassador/missing_participant_searches/new.en.html.erb
@@ -1,7 +1,5 @@
 <% provide :title, "Find Missing Participants" %>
 
-<% provide :subnav, render('chapter_ambassador/participants/sub_menu') %>
-
 <div class="grid grid--bleed grid--justify-space-around">
   <div class="grid__col-8">
     <div class="panel">

--- a/app/views/chapter_ambassador/missing_participant_searches/show.en.html.erb
+++ b/app/views/chapter_ambassador/missing_participant_searches/show.en.html.erb
@@ -1,7 +1,5 @@
 <% provide :title, "Find Missing Participants" %>
 
-<% provide :subnav, render('chapter_ambassador/participants/sub_menu') %>
-
 <div class="grid grid--justify-space-around">
   <div class="grid__col-8">
     <div class="panel">


### PR DESCRIPTION
Refs #5362 

When reviewing airbrake logs for a separate issue, I discovered the "find a missing participant" page was erroring out due to a missing partial (this error is on PROD). I found the original sub_menu partial and tested it locally. It actually didn't render anything at all (maybe due to layout). All the appropriate links are in the the side menu anyway, so I removed all references to this submenu. 

```ActionView::Template::Error:  Missing partial chapter_ambassador/participants/_sub_menu ```