### PR TITLE
Add rake task to remove students from the unaffiliated list

### DIFF
--- a/lib/tasks/remove_students_from_unaffilated_list.rake
+++ b/lib/tasks/remove_students_from_unaffilated_list.rake
@@ -1,0 +1,20 @@
+desc "Remove students from unaffiliated list"
+task remove_students_from_unaffiliated_list: :environment do |task, args|
+  puts "Removing students from unaffiliated list"
+  args.extras.each do |email_address|
+    account = Account.find_by(email: email_address)
+
+    if account.blank?
+      puts "#{email_address} could not be found"
+    elsif account.student_profile.blank?
+      puts "#{email_address} is not a student"
+    else
+      account.update_columns(
+        no_chapterable_selected: nil,
+        no_chapterables_available: nil
+      )
+
+      puts "Removed #{email_address} from the unaffiliated list"
+    end
+  end
+end


### PR DESCRIPTION
We ran the rake task to assign students to a chapter, but they weren't removed from the unaffiliated list; that's because the original chapter assignment rake task was meant for "limbo" students who aren't on the unaffiliated list.

This rake task will take list of email addresses (like the original chapter assignment rake task) and if they're a student it will remove them from the unaffiliated list.


