### PR TITLE
Ensure one primary chapter assignment per profile type per season

### DIFF
--- a/app/models/chapterable_account_assignment.rb
+++ b/app/models/chapterable_account_assignment.rb
@@ -3,6 +3,8 @@ class ChapterableAccountAssignment < ApplicationRecord
   belongs_to :chapterable, polymorphic: true
   belongs_to :profile, polymorphic: true
 
+  validate :ensure_one_primary_assignment_per_profile_type_per_season, if: :new_record?
+
   scope :current, -> {
     where(season: Season.current.year)
   }
@@ -14,4 +16,21 @@ class ChapterableAccountAssignment < ApplicationRecord
   scope :clubs, -> {
     where(chapterable_type: "Club")
   }
+
+  private
+
+  def ensure_one_primary_assignment_per_profile_type_per_season
+    if primary && ChapterableAccountAssignment
+        .where(
+          account_id: account_id,
+          profile_type: profile_type,
+          profile_id: profile_id,
+          season: season,
+          primary: true
+        )
+        .exists?
+
+      errors.add(:base, "This participant is already assigned to a chapter or club")
+    end
+  end
 end

--- a/spec/factories/ambassadors.rb
+++ b/spec/factories/ambassadors.rb
@@ -49,6 +49,8 @@ FactoryBot.define do
 
     trait :assigned_to_chapter do
       after(:create) do |chapter_ambassador|
+        chapter_ambassador.account.chapters.destroy_all
+
         chapter_ambassador.chapterable_assignments.create(
           account: chapter_ambassador.account,
           chapterable: FactoryBot.create(:chapter),
@@ -93,6 +95,8 @@ FactoryBot.define do
 
     after(:create) do |r, e|
       chapter = FactoryBot.create(:chapter, primary_contact: r.account)
+
+      r.chapters.destroy_all
 
       r.chapterable_assignments.create(
         chapterable: chapter,

--- a/spec/factories/mentors.rb
+++ b/spec/factories/mentors.rb
@@ -30,6 +30,8 @@ FactoryBot.define do
       end
 
       after(:create) do |mentor, _eval|
+        mentor.chapterable_assignments.destroy_all
+
         mentor.chapterable_assignments.create(
           account: mentor.account,
           chapterable: FactoryBot.create(:chapter),
@@ -131,6 +133,8 @@ FactoryBot.define do
     end
 
     after(:create) do |m, e|
+      m.chapterable_assignments.destroy_all
+
       m.chapterable_assignments.create(
         account: m.account,
         chapterable: FactoryBot.create(:chapter),

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -179,6 +179,8 @@ FactoryBot.define do
     end
 
     after(:create) do |s, e|
+      s.chapterable_assignments.destroy_all
+
       s.chapterable_assignments.create(
         account: s.account,
         chapterable: FactoryBot.create(:chapter),

--- a/spec/features/chapter_ambassador/delete_team_invite_spec.rb
+++ b/spec/features/chapter_ambassador/delete_team_invite_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Chapter Ambassadors deleting a team invite", :js do
       primary: true
     )
 
-    affiliated_student = FactoryBot.create(:student, :chicago)
+    affiliated_student = FactoryBot.create(:student, :chicago, :not_assigned_to_chapter)
     affiliated_student.chapterable_assignments.create(
       account: affiliated_student.account,
       chapterable: chapter,

--- a/spec/features/chapter_ambassador/view_scores_spec.rb
+++ b/spec/features/chapter_ambassador/view_scores_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature "Chapter Ambassador views scores" do
       )
 
       submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
         student.chapterable_assignments.create(
           chapterable: chapter_ambassador.chapterable,
           account: student.account,
@@ -53,6 +55,8 @@ RSpec.feature "Chapter Ambassador views scores" do
       )
 
       submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
         student.chapterable_assignments.create(
           chapterable: chapter_ambassador.chapterable,
           account: student.account,
@@ -84,6 +88,8 @@ RSpec.feature "Chapter Ambassador views scores" do
       )
 
       submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
         student.chapterable_assignments.create(
           chapterable: chapter_ambassador.chapterable,
           account: student.account,
@@ -153,6 +159,8 @@ RSpec.feature "Chapter Ambassador views scores" do
       )
 
       submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
         student.chapterable_assignments.create(
           chapterable: chapter_ambassador.chapterable,
           account: student.account,
@@ -176,6 +184,8 @@ RSpec.feature "Chapter Ambassador views scores" do
       )
 
       submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
         student.chapterable_assignments.create(
           chapterable: chapter_ambassador.chapterable,
           account: student.account,
@@ -216,6 +226,8 @@ RSpec.feature "Chapter Ambassador views scores" do
     )
 
     submission.team.students.each do |student|
+      student.chapterable_assignments.destroy_all
+
       student.chapterable_assignments.create(
         chapterable: chapter_ambassador.chapterable,
         account: student.account,

--- a/spec/features/chapter_ambassador/view_students_spec.rb
+++ b/spec/features/chapter_ambassador/view_students_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.feature "chapter ambassadors view student profile pages" do
   scenario "viewing a new student that belongs to the chapter ambassador's chapter" do
     chapter_ambassador = FactoryBot.create(:chapter_ambassador)
-    student = FactoryBot.create(:student)
+    student = FactoryBot.create(:student, :not_assigned_to_chapter)
+
     student.chapterable_assignments.create(
       chapterable: chapter_ambassador.current_chapter,
       account: student.account,
@@ -26,7 +27,8 @@ RSpec.feature "chapter ambassadors view student profile pages" do
 
   scenario "viewing a past student that belongs to the chapter ambassador's chapter" do
     chapter_ambassador = FactoryBot.create(:chapter_ambassador)
-    student = FactoryBot.create(:student, :past)
+    student = FactoryBot.create(:student, :past, :not_assigned_to_chapter)
+
     student.chapterable_assignments.create(
       chapterable: chapter_ambassador.current_chapter,
       account: student.account,
@@ -48,7 +50,8 @@ RSpec.feature "chapter ambassadors view student profile pages" do
 
   scenario "viewing a returning student that belongs to the chapter ambassador's chapter" do
     chapter_ambassador = FactoryBot.create(:chapter_ambassador)
-    student = FactoryBot.create(:student, :returning)
+    student = FactoryBot.create(:student, :returning, :not_assigned_to_chapter)
+
     student.chapterable_assignments.create(
       chapterable: chapter_ambassador.current_chapter,
       account: student.account,

--- a/spec/features/chapter_ambassador/view_team_submissions_spec.rb
+++ b/spec/features/chapter_ambassador/view_team_submissions_spec.rb
@@ -14,7 +14,8 @@ RSpec.feature "Chapter Ambassador viewing their team submissions" do
   end
 
   scenario "displays team submissions of students assigned to their chapter" do
-    affiliated_student = FactoryBot.create(:student, :chicago)
+    affiliated_student = FactoryBot.create(:student, :chicago, :not_assigned_to_chapter)
+
     affiliated_student.chapterable_assignments.create(
       account: affiliated_student.account,
       chapterable: chapter,
@@ -29,7 +30,8 @@ RSpec.feature "Chapter Ambassador viewing their team submissions" do
       app_name: "hello",
       team: team)
 
-    affiliated_student_2 = FactoryBot.create(:student, :chicago)
+    affiliated_student_2 = FactoryBot.create(:student, :chicago, :not_assigned_to_chapter)
+
     affiliated_student_2.chapterable_assignments.create(
       account: affiliated_student_2.account,
       chapterable: chapter,

--- a/spec/features/chapter_ambassador/view_teams_spec.rb
+++ b/spec/features/chapter_ambassador/view_teams_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Chapter Ambassador viewing their teams" do
   end
 
   scenario "displays teams of students assigned to their chapter" do
-    affiliated_student = FactoryBot.create(:student, :chicago)
+    affiliated_student = FactoryBot.create(:student, :chicago, :not_assigned_to_chapter)
     affiliated_student.chapterable_assignments.create(
       account: affiliated_student.account,
       chapterable: chapter,
@@ -25,7 +25,7 @@ RSpec.feature "Chapter Ambassador viewing their teams" do
     team = FactoryBot.create(:team)
     TeamRosterManaging.add(team, affiliated_student)
 
-    affiliated_student_2 = FactoryBot.create(:student, :chicago)
+    affiliated_student_2 = FactoryBot.create(:student, :chicago, :not_assigned_to_chapter)
     affiliated_student_2.chapterable_assignments.create(
       account: affiliated_student_2.account,
       chapterable: chapter,

--- a/spec/models/chapterable_account_assignments_spec.rb
+++ b/spec/models/chapterable_account_assignments_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe ChapterableAccountAssignment do
+  describe "validations" do
+    let(:abc_chapter) { FactoryBot.create(:chapter, name: "ABC Chapter") }
+
+    describe "ensuring only one primary chapterable assignment exists per profile type per season" do
+      context "as a student" do
+        let(:student) { FactoryBot.create(:student) }
+
+        context "when trying to create another primary assignment for the student for the same season" do
+          let(:chapter_assignment_result) do
+            student.chapterable_assignments.create(
+              account: student.account,
+              chapterable: abc_chapter,
+              season: Season.current.year,
+              primary: true
+            )
+          end
+
+          it "does not create the assignment and includes an error message" do
+            expect(student.chapterable_assignments.length).to eq(1)
+
+            expect(chapter_assignment_result.errors[:base]).to include("This participant is already assigned to a chapter or club")
+          end
+        end
+
+        context "when trying to create a primary assignment for the student for another season" do
+          before do
+            student.chapterable_assignments.create(
+              account: student.account,
+              chapterable: abc_chapter,
+              season: Season.current.year + 1,
+              primary: true
+            )
+          end
+
+          it "successfully creates the assignment" do
+            expect(student.chapterable_assignments.length).to eq(2)
+          end
+        end
+      end
+
+      context "as a mentor" do
+        let(:mentor) { FactoryBot.create(:mentor) }
+
+        context "when trying to create another primary assignment for the mentor for the same season" do
+          let(:chapter_assignment_result) do
+            mentor.chapterable_assignments.create(
+              account: mentor.account,
+              chapterable: abc_chapter,
+              season: Season.current.year,
+              primary: true
+            )
+          end
+
+          it "does not create the assignment and includes an error message" do
+            expect(mentor.chapterable_assignments.length).to eq(1)
+
+            expect(chapter_assignment_result.errors[:base]).to include("This participant is already assigned to a chapter or club")
+          end
+        end
+
+        context "when trying to create a non-primary assignment for the mentor for the same season" do
+          before do
+            mentor.chapterable_assignments.create(
+              account: mentor.account,
+              chapterable: abc_chapter,
+              season: Season.current.year,
+              primary: false
+            )
+          end
+
+          it "successfully creates the assignment" do
+            expect(mentor.chapterable_assignments.length).to eq(2)
+          end
+        end
+
+        context "when a non-primary assignment already exists for the mentor" do
+          before do
+            mentor.chapterable_assignments.first.update_column(:primary, false)
+          end
+
+          context "when trying to create a primary assignment for the mentor (and a non-primary assignment already exits)" do
+            before do
+              mentor.chapterable_assignments.create!(
+                account: mentor.account,
+                chapterable: abc_chapter,
+                season: Season.current.year,
+                primary: true
+              )
+            end
+
+            it "successfully creates the assignment" do
+              expect(mentor.chapterable_assignments.length).to eq(2)
+            end
+          end
+        end
+
+        context "when trying to create a primary assignment for the mentor for another season" do
+          before do
+            mentor.chapterable_assignments.create(
+              account: mentor.account,
+              chapterable: abc_chapter,
+              season: Season.current.year + 1,
+              primary: true
+            )
+          end
+
+          it "successfully creates the assignment" do
+            expect(mentor.chapterable_assignments.length).to eq(2)
+          end
+        end
+      end
+
+      context "as a chapter ambassador" do
+        let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador) }
+
+        context "when trying to create another primary assignment for the chapter ambassador for the same season" do
+          let(:chapter_assignment_result) do
+            chapter_ambassador.chapterable_assignments.create(
+              account: chapter_ambassador.account,
+              chapterable: abc_chapter,
+              season: Season.current.year,
+              primary: true
+            )
+          end
+
+          it "does not create the assignment and includes an error message" do
+            expect(chapter_ambassador.chapterable_assignments.length).to eq(1)
+
+            expect(chapter_assignment_result.errors[:base]).to include("This participant is already assigned to a chapter or club")
+          end
+        end
+
+        context "when trying to create a primary assignment for the chapter ambassador for another season" do
+          before do
+            chapter_ambassador.chapterable_assignments.create(
+              account: chapter_ambassador.account,
+              chapterable: abc_chapter,
+              season: Season.current.year + 1,
+              primary: true
+            )
+          end
+
+          it "successfully creates the assignment" do
+            expect(chapter_ambassador.chapterable_assignments.length).to eq(2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin/add_chapter_ambassador_profile_to_account_spec.rb
+++ b/spec/system/admin/add_chapter_ambassador_profile_to_account_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe "Admin add chapter ambassador profile to an account" do
   context "when a chapter ambassador views the mentor debugging section of a mentor profile" do
     it "does not show an add chapter ambassador profile button" do
       chapter_ambassador = FactoryBot.create(:chapter_ambassador, intro_summary: "Here is my intro summary!")
-      mentor = FactoryBot.create(:mentor)
+      mentor = FactoryBot.create(:mentor, :not_assigned_to_chapter)
+
       mentor.chapterable_assignments.create(
         chapterable: chapter_ambassador.current_chapter,
         account: mentor.account,

--- a/spec/system/chapter_ambassador/convert_students_to_mentors_spec.rb
+++ b/spec/system/chapter_ambassador/convert_students_to_mentors_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "chapter ambassador convert students to mentors" do
   context "when the student is under 18" do
     it "does not show the convert button" do
       chapter_ambassador = FactoryBot.create(:chapter_ambassador)
-      student = FactoryBot.create(:student, date_of_birth: 17.years.ago)
+      student = FactoryBot.create(:student, :not_assigned_to_chapter, date_of_birth: 17.years.ago)
+
       student.chapterable_assignments.create(
         chapterable: chapter_ambassador.current_chapter,
         account: student.account,
@@ -27,7 +28,8 @@ RSpec.describe "chapter ambassador convert students to mentors" do
   context "when the student is 18 and older" do
     it "shows the convert button" do
       chapter_ambassador = FactoryBot.create(:chapter_ambassador)
-      student = FactoryBot.create(:student, date_of_birth: 18.years.ago)
+      student = FactoryBot.create(:student, :not_assigned_to_chapter, date_of_birth: 18.years.ago)
+
       student.chapterable_assignments.create(
         chapterable: chapter_ambassador.current_chapter,
         account: student.account,

--- a/spec/system/chapter_ambassador/review_mentors_spec.rb
+++ b/spec/system/chapter_ambassador/review_mentors_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "chapter ambassadors reviewing mentors" do
 
   describe "training completion status" do
     it "displays on their debugging page" do
-      untrained_mentor = FactoryBot.create(:mentor, :onboarding)
-      trained_mentor = FactoryBot.create(:mentor, :onboarded)
+      untrained_mentor = FactoryBot.create(:mentor, :onboarding, :not_assigned_to_chapter)
+      trained_mentor = FactoryBot.create(:mentor, :onboarded, :not_assigned_to_chapter)
 
       untrained_mentor.chapterable_assignments.create(
         chapterable: chapter_ambassador.current_chapter,
@@ -42,7 +42,7 @@ RSpec.describe "chapter ambassadors reviewing mentors" do
     end
 
     it "displays not required for mentors who signed up before the training date" do
-      mentor = FactoryBot.create(:mentor, :onboarding)
+      mentor = FactoryBot.create(:mentor, :onboarding, :not_assigned_to_chapter)
       mentor.account.update(
         season_registered_at: ImportantDates.mentor_training_required_since - 1.day
       )

--- a/spec/system/chapter_ambassador/view_score_details_spec.rb
+++ b/spec/system/chapter_ambassador/view_score_details_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "viewing score details page" do
 
   before do
     team_submission.team.students.each do |student|
+      student.chapterable_assignments.destroy_all
+
       student.chapterable_assignments.create(
         chapterable: chapter_ambassador.chapterable,
         account: student.account,


### PR DESCRIPTION
This will add a validation to ensure that only primary chapterable assignment per profile type per season is created.

Also, a lot of the specs had to be updated because the specs were creating more than one assignment and only one primary assignment is valid now.


