### PR TITLE
Add rake task to remove duplicate chapterable assignments

### DIFF
--- a/lib/tasks/remove_duplicate_chapterable_assignments.rake
+++ b/lib/tasks/remove_duplicate_chapterable_assignments.rake
@@ -1,0 +1,6 @@
+desc "Remove duplicate chapterable assignments"
+task remove_duplicate_chapterable_assignments: :environment do |task, args|
+  count_of_removed_assignments = ChapterableAccountAssignment.where(id: [args.extras]).delete_all
+
+  puts "Removed #{count_of_removed_assignments} chapterable assignments"
+end


### PR DESCRIPTION
A pretty simple rake task will take a list of chapterable assignment ids and remove them.

We can use the CSV that you posted in Slack, or we can pull another dataclip to get the ids we want to remove. 👍 

To run it:

```
bundle exec rails remove_duplicate_chapterable_assignments[idx,idy,idz]
```