### PR TITLE
Remove submissions with more than 4 recusals

### DIFF
--- a/app/controllers/admin/scores_controller.rb
+++ b/app/controllers/admin/scores_controller.rb
@@ -10,7 +10,7 @@ module Admin
       unless request.xhr?
         @round = grid_params[:round]
       end
-      @removed_submissions = TeamSubmission.current.complete.removed_from_judging_pool
+      @submissions_removed_from_judging_pool = TeamSubmission.current.complete.removed_from_judging_pool
     }, only: :index
 
     def show

--- a/app/controllers/admin/scores_controller.rb
+++ b/app/controllers/admin/scores_controller.rb
@@ -10,6 +10,7 @@ module Admin
       unless request.xhr?
         @round = grid_params[:round]
       end
+      @removed_submissions = TeamSubmission.current.complete.removed_from_judging_pool
     }, only: :index
 
     def show

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -84,7 +84,7 @@ class ScoredSubmissionsGrid
 
   column :judge_recusal_count, header: "Recusals", mandatory: true, order: true
 
-  column :recused, header: "Removed from judging pool", mandatory: true do |submission|
+  column :removed_from_judging_pool, header: "Removed from judging pool", mandatory: true do |submission|
     ApplicationController.helpers.humanize_boolean(submission.removed_from_judging_pool)
   end
 

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -7,7 +7,7 @@ class ScoredSubmissionsGrid
 
   scope do
     TeamSubmission.complete.current
-      .includes(:team, {submission_scores: :judge_profile})
+      .includes(team: :division, submission_scores: :judge_profile)
       .references(:teams, :submission_scores, :judge_profiles)
   end
 

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -84,9 +84,7 @@ class ScoredSubmissionsGrid
 
   column :judge_recusal_count, header: "Recusals", mandatory: true, order: true
 
-  column :removed_from_judging_pool, header: "Removed from judging pool", mandatory: true do |submission|
-    ApplicationController.helpers.humanize_boolean(submission.removed_from_judging_pool)
-  end
+  column :removed_from_judging_pool?, header: "Removed from judging pool", mandatory: true
 
   column :quarterfinals_average, order: :quarterfinals_average_score, mandatory: true do |submission|
     str = submission.quarterfinals_average_score.to_s

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -84,6 +84,10 @@ class ScoredSubmissionsGrid
 
   column :judge_recusal_count, header: "Recusals", mandatory: true, order: true
 
+  column :recused, header: "Removed from judging pool", mandatory: true do |submission|
+    ApplicationController.helpers.humanize_boolean(submission.removed_from_judging_pool)
+  end
+
   column :quarterfinals_average, order: :quarterfinals_average_score, mandatory: true do |submission|
     str = submission.quarterfinals_average_score.to_s
     str += "/#{submission.total_possible_score}"
@@ -364,6 +368,8 @@ class ScoredSubmissionsGrid
     ] do |value, scope, grid|
     scope.joins(:"#{grid.round}_#{value}_submission_scores")
   end
+
+  filter(:removed_from_judging_pool, :xboolean, header: "Removed from judging pool")
 
   filter :country,
     :enum,

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -33,6 +33,8 @@ class SubmissionScore < ActiveRecord::Base
     )
   }, on: [:create, :update], if: :complete?
 
+  after_commit :update_removed_from_judging_pool, if: :saved_change_to_judge_recusal?
+
   after_commit -> {
     update_column(:official, official?)
   }, on: [:create, :update]
@@ -564,5 +566,9 @@ class SubmissionScore < ActiveRecord::Base
 
   def update_team_score_summaries
     team_submission.update_score_summaries
+  end
+
+  def update_removed_from_judging_pool
+    team_submission.reload.update(removed_from_judging_pool: team_submission.judge_recusal_count > 4)
   end
 end

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -569,6 +569,10 @@ class SubmissionScore < ActiveRecord::Base
   end
 
   def update_removed_from_judging_pool
-    team_submission.reload.update(removed_from_judging_pool: team_submission.judge_recusal_count > 4)
+    team_submission.reload
+
+    if team_submission.judge_recusal_count >= 5
+      team_submission.update(removed_from_judging_pool: true)
+    end
   end
 end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -128,6 +128,9 @@ class TeamSubmission < ActiveRecord::Base
   scope :complete, -> { where("published_at IS NOT NULL") }
   scope :incomplete, -> { where("published_at IS NULL") }
 
+  scope :removed_from_judging_pool, -> { where(removed_from_judging_pool: true) }
+  scope :not_removed_from_judging_pool, -> { where(removed_from_judging_pool: false) }
+
   scope :live, -> { complete.joins(team: :current_official_events) }
 
   scope :virtual, -> {

--- a/app/technovation/find_eligible_submission_id.rb
+++ b/app/technovation/find_eligible_submission_id.rb
@@ -69,7 +69,7 @@ module FindEligibleSubmissionId
         []
       end
 
-      candidates = TeamSubmission.current.complete.public_send(
+      candidates = TeamSubmission.current.complete.not_removed_from_judging_pool.public_send(
         rank_for_current_round
       )
         .where.not(

--- a/app/views/admin/scores/_removed_submissions.html.erb
+++ b/app/views/admin/scores/_removed_submissions.html.erb
@@ -1,0 +1,29 @@
+<div class="panel">
+  <h4>Removed Submissions</h4>
+  <p>These submissions are automatically removed from the judging pool due to the number of recusals.</p>
+
+  <% if removed_submissions.any? %>
+    <table class="datagrid">
+      <thead>
+        <tr>
+          <th>Team Name</th>
+          <th>Submission</th>
+          <th>Division</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+      <% removed_submissions.each do |submission| %>
+        <tr>
+          <td><%= link_to(submission.team_name, admin_team_path(submission.team)) %></td>
+          <td><%= link_to(submission.app_name, admin_team_submission_path(submission)) %></td>
+          <td><%= submission.team.division_name %></td>
+          <td><%= link_to("View Recusals", admin_score_detail_path(submission.id)) %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>There are no submissions removed for recusal count at this time.</p>
+  <% end %>
+</div>

--- a/app/views/admin/scores/_submissions_removed_from_judging_pool.html.erb
+++ b/app/views/admin/scores/_submissions_removed_from_judging_pool.html.erb
@@ -1,8 +1,8 @@
 <div class="panel">
-  <h4>Removed Submissions</h4>
+  <h4>Submissions Removed from Judging Pool</h4>
   <p>These submissions are automatically removed from the judging pool due to the number of recusals.</p>
 
-  <% if removed_submissions.any? %>
+  <% if submissions_removed_from_judging_pool.any? %>
     <table class="datagrid">
       <thead>
         <tr>
@@ -13,7 +13,7 @@
         </tr>
       </thead>
       <tbody>
-      <% removed_submissions.each do |submission| %>
+      <% submissions_removed_from_judging_pool.each do |submission| %>
         <tr>
           <td><%= link_to(submission.team_name, admin_team_path(submission.team)) %></td>
           <td><%= link_to(submission.app_name, admin_team_submission_path(submission)) %></td>

--- a/app/views/data_grids/scores/index.html.erb
+++ b/app/views/data_grids/scores/index.html.erb
@@ -14,6 +14,8 @@
     <router-view v-else></router-view>
   </div>
 
+  <%= render partial: "admin/scores/removed_submissions", locals: { removed_submissions: @removed_submissions } %>
+
   <h1>Season <%= Season.current.year %> Scores</h1>
 <% end %>
 

--- a/app/views/data_grids/scores/index.html.erb
+++ b/app/views/data_grids/scores/index.html.erb
@@ -14,7 +14,7 @@
     <router-view v-else></router-view>
   </div>
 
-  <%= render partial: "admin/scores/removed_submissions", locals: { removed_submissions: @removed_submissions } %>
+  <%= render partial: "admin/scores/submissions_removed_from_judging_pool", locals: { submissions_removed_from_judging_pool: @submissions_removed_from_judging_pool } %>
 
   <h1>Season <%= Season.current.year %> Scores</h1>
 <% end %>

--- a/db/migrate/20250224213654_add_removed_from_judging_pool_to_team_submissions.rb
+++ b/db/migrate/20250224213654_add_removed_from_judging_pool_to_team_submissions.rb
@@ -1,0 +1,5 @@
+class AddRemovedFromJudgingPoolToTeamSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :team_submissions, :removed_from_judging_pool, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2365,7 +2365,8 @@ CREATE TABLE public.team_submissions (
     solves_education_description character varying,
     scratch_project_url character varying,
     uses_gadgets boolean,
-    uses_gadgets_description character varying
+    uses_gadgets_description character varying,
+    removed_from_judging_pool boolean DEFAULT false
 );
 
 
@@ -4967,6 +4968,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250103180055'),
 ('20250103182555'),
 ('20250211205130'),
-('20250219221626');
+('20250219221626'),
+('20250224213654');
 
 

--- a/spec/models/submission_score_spec.rb
+++ b/spec/models/submission_score_spec.rb
@@ -484,6 +484,48 @@ RSpec.describe SubmissionScore do
     ).to eq(1)
   end
 
+  describe "updating removed_from_judging_pool based on judge recusal count" do
+    context "when the judge recusal count is less than or equal to 4" do
+      it "leaves the submission from the judging pool" do
+        team = FactoryBot.create(:team)
+        team_submission = FactoryBot.create(
+          :submission,
+          :complete,
+          team: team,
+          judge_recusal_count: 3,
+          removed_from_judging_pool: false
+        )
+
+        team_submission.reload
+        expect(team_submission.removed_from_judging_pool).to eq(false)
+      end
+    end
+
+    context "when the judge recusal count is greater than 4" do
+      it "removes the submission from the judging pool" do
+        judge = FactoryBot.create(:judge)
+        team = FactoryBot.create(:team)
+        team_submission = FactoryBot.create(
+          :submission,
+          :complete,
+          team: team,
+          judge_recusal_count: 4,
+          removed_from_judging_pool: false
+        )
+
+        SubmissionScore.create!(
+          judge_profile: judge,
+          team_submission: team_submission,
+          judge_recusal: true,
+          judge_recusal_reason: "submission_not_in_english"
+        )
+
+        team_submission.reload
+        expect(team_submission.removed_from_judging_pool).to eq(true)
+      end
+    end
+  end
+
   describe "scopes" do
     let(:not_started_score) { FactoryBot.create(:score, :not_started) }
     let(:in_progress_score) { FactoryBot.create(:score, :in_progress) }

--- a/spec/technovation/find_eligible_submission_id_spec.rb
+++ b/spec/technovation/find_eligible_submission_id_spec.rb
@@ -138,6 +138,29 @@ RSpec.describe FindEligibleSubmissionId do
       expect(FindEligibleSubmissionId.call(judge)).to be_nil
     end
 
+    it "does not pick submissions that have been removed from the judging pool based on recusal count" do
+      judge = FactoryBot.create(:judge)
+      team = FactoryBot.create(:team)
+      submission = FactoryBot.create(
+        :submission,
+        :complete,
+        team: team,
+        removed_from_judging_pool: false,
+        judge_recusal_count: 4
+      )
+
+      SubmissionScore.create!(
+        judge_profile: judge,
+        team_submission: submission,
+        judge_recusal: true,
+        judge_recusal_reason: "submission_not_in_english"
+      )
+
+      submission.reload
+      expect(submission.removed_from_judging_pool).to eq(true)
+      expect(FindEligibleSubmissionId.call(judge)).to be_nil
+    end
+
     it "picks submission for an unofficial regional pitch event" do
       judge = FactoryBot.create(:judge)
       team = FactoryBot.create(:team)


### PR DESCRIPTION
Refs #5335 and #5336 

This PR adds functionality to automatically remove a submission from the judging pool on the 5th recusal.

Key Changes:
- Added a new `remove_from_judging_pool` boolean field to team_submissions
- Updated the logic to set `remove_from_judging_pool` to true when `judge_recusal_count exceeds` 4 recusals
- Added scopes
- Updated eligible submissions so that only submissions that are not removed from the judging pool are eligible for judging
- Added a "removed submissions" partial on the scores page (similar to suspicious scores)
- Added removed from judging filter & column to scored submissions datagrid  
- Added tests

