### PR TITLE
Updated search logic for team name and app name on teams and submissions datagrids

### DIFF
--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -310,12 +310,16 @@ class SubmissionsGrid
     team.mentors.collect(&:email).join(",")
   end
 
-  filter :team_name do |value, scope, grid|
-    scope.where("teams.name ilike ?", "#{value}%")
+  filter :team_name do |value, scope|
+    processed_value = I18n.transliterate(value.strip.downcase).gsub(/['\s]+/, "%")
+    scope
+      .where("lower(unaccent(teams.name)) ILIKE ?", "%#{processed_value}%")
   end
 
   filter :app_name do |value, scope, grid|
-    scope.where("team_submissions.app_name ilike ?", "#{value}%")
+    processed_value = I18n.transliterate(value.strip.downcase).gsub(/['\s]+/, "%")
+    scope
+      .where("lower(unaccent(team_submissions.app_name)) ILIKE ?", "%#{processed_value}%")
   end
 
   filter :division,

--- a/app/data_grids/teams_grid.rb
+++ b/app/data_grids/teams_grid.rb
@@ -221,8 +221,10 @@ class TeamsGrid
     send(value)
   end
 
-  filter :name, filter_group: "more-specific" do |value|
-    fuzzy_search(name: value)
+  filter :name, filter_group: "more-specific" do |value, scope|
+    processed_value = I18n.transliterate(value.strip.downcase).gsub(/['\s]+/, "%")
+    scope
+      .where("lower(unaccent(teams.name)) ILIKE ?", "%#{processed_value}%")
   end
 
   filter :season,


### PR DESCRIPTION
Refs #5225 

Updated search logic for team name and app name on teams and submissions datagrids. Used same approach from other updated datagrid name search functionality. This handles accents, apostrophes, spaces, etc. 