### PR TITLE
Add rake task to assign mentors who are on a team to students primary chapterable

### DIFF
--- a/app/null_objects/null_chapterable_account_asignment.rb
+++ b/app/null_objects/null_chapterable_account_asignment.rb
@@ -1,5 +1,0 @@
-class NullChapterableAccountAssignment < NullObject
-  def chapterable
-    NullChapterable.new
-  end
-end

--- a/app/null_objects/null_chapterable_account_assignment.rb
+++ b/app/null_objects/null_chapterable_account_assignment.rb
@@ -1,0 +1,17 @@
+class NullChapterableAccountAssignment < NullObject
+  def chapterable
+    NullChapterable.new
+  end
+
+  def primary
+    false
+  end
+
+  def chapterable_id
+    nil
+  end
+
+  def chapterable_type
+    nil
+  end
+end

--- a/lib/tasks/assign_mentors_to_students_primary_chapterable.rake
+++ b/lib/tasks/assign_mentors_to_students_primary_chapterable.rake
@@ -1,0 +1,42 @@
+desc "Assign mentors to students primary chapterable"
+task assign_mentors_to_students_primary_chapterable: :environment do
+  Team.current.where(has_mentor: true, has_students: true)
+    .includes(memberships: {member: {account: :chapterable_assignments}})
+    .find_each do |team|
+
+    puts "Team: #{team.id} - #{team.name}"
+
+    students = team.students.select { |s| s.account.assigned_to_chapterable? }
+    student_primary_assignments = students.map { |s| s.account.current_chapterable_assignment }.uniq { |assignment| assignment.chapterable_id }
+    mentors = team.mentors
+
+    if student_primary_assignments.empty?
+      puts "Skipping team: #{team.id} - #{team.name} - no student primary assignments"
+      next
+    end
+
+    mentors.each do |mentor|
+      mentor_chapterable_ids = mentor.account.chapterable_assignments.where(profile_type: "MentorProfile").pluck(:chapterable_id)
+
+      assignments_to_add = student_primary_assignments.reject do |assignment|
+        mentor_chapterable_ids.include?(assignment.chapterable_id)
+      end
+
+      if assignments_to_add.empty?
+        puts "Skipping - no assignments to add for #{mentor.account.email}"
+        next
+      end
+
+      assignments_to_add.each do |assignment|
+        puts "Assigning account #{mentor.account.id} - #{mentor.account.email} to #{assignment.chapterable_type} #{assignment.chapterable_id}"
+        mentor.account.chapterable_assignments.create(
+          profile: mentor.account.mentor_profile,
+          chapterable_id: assignment.chapterable_id,
+          chapterable_type: assignment.chapterable_type.capitalize,
+          season: Season.current.year,
+          primary: false
+        )
+      end
+    end
+  end
+end

--- a/spec/tasks/assign_mentors_to_students_primary_chapterable_spec.rb
+++ b/spec/tasks/assign_mentors_to_students_primary_chapterable_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "assign_mentors_to_students_primary_chapterable" do
+  let(:task) { Rake::Task["assign_mentors_to_students_primary_chapterable"] }
+  let(:team) { FactoryBot.create(:team, :with_mentor) }
+
+  after(:each) do
+    task.reenable
+  end
+
+  context "when a team has a student without a primary chapterable assignment" do
+    it "does not assign the mentor to a chapterable" do
+      student = team.students.first
+      student.account.current_chapterable_assignment.destroy
+      mentor = team.mentors.first
+
+      expect {
+        task.invoke
+      }.not_to change { mentor.account.chapterable_assignments.count }
+    end
+  end
+
+  context "when a team has a student with a primary chapterable assignment" do
+    it "assigns the mentor to the student's primary chapterable" do
+      student = team.students.first
+      mentor = team.mentors.first
+
+      task.invoke
+      expect(mentor.account.chapterable_assignments.map(&:chapterable)).to include(student.account.current_chapterable_assignment.chapterable)
+    end
+  end
+
+  context "when a team has two students with different primary chapterable assignments" do
+    it "assigns the mentor to all unique student primary chapterables" do
+      student1 = team.students.first
+      student2 = FactoryBot.create(:student)
+      TeamRosterManaging.add(team, student2)
+
+      mentor = team.mentors.first
+      mentor.account.current_chapterable_assignment.destroy
+
+      task.invoke
+
+      expect(mentor.account.chapterable_assignments.map(&:chapterable)).to include(
+        student1.account.current_chapterable_assignment.chapterable,
+        student2.account.current_chapterable_assignment.chapterable
+      )
+
+      expect(mentor.account.chapterable_assignments.count).to eq(2)
+    end
+  end
+
+  context "when a team has a student with a primary chapterable assignment and the mentor is already assigned to that chapterable" do
+    it "does not create a duplicate assignment" do
+      student = team.students.first
+      mentor = team.mentors.first
+
+      mentor.account.current_chapterable_assignment.destroy
+      mentor.chapterable_assignments.create(
+        chapterable: student.account.current_chapterable_assignment.chapterable,
+        account: mentor.account,
+        season: Season.current.year,
+        primary: false
+      )
+
+      expect {
+        task.invoke
+      }.not_to change { mentor.account.chapterable_assignments.count }
+    end
+  end
+end


### PR DESCRIPTION
Refs #5194 

This PR adds the rake task to assign mentors who are on a team to all the unique student primary chapterables. This was needed because some mentors were already on teams before the logic was added to add them to the student's primary chapterable. 
