### PR TITLE
Updated removed club ambassador profile type migration - Changed destroy_all to delete_all

### DIFF
--- a/db/migrate/20250211205130_remove_club_ambassador_from_mentor_profile_types.rb
+++ b/db/migrate/20250211205130_remove_club_ambassador_from_mentor_profile_types.rb
@@ -2,7 +2,7 @@ class RemoveClubAmbassadorFromMentorProfileTypes < ActiveRecord::Migration[6.1]
   def up
     club_ambassador_mentor_type = MentorType.find_by(name: "Club Ambassador", order: 6)
 
-    club_ambassador_mentor_type.mentor_profile_mentor_types.destroy_all
+    club_ambassador_mentor_type.mentor_profile_mentor_types.delete_all
     club_ambassador_mentor_type.delete
   end
 


### PR DESCRIPTION
There was an issue with this migration failing during deployment. Shaun confirmed locally with production data and this change should allow the deployment to work as expected. 