### PR TITLE
Add ability for admin to return submission to judging pool

### DIFF
--- a/app/controllers/admin/score_details_controller.rb
+++ b/app/controllers/admin/score_details_controller.rb
@@ -1,9 +1,9 @@
 module Admin
   class ScoreDetailsController < AdminController
     def show
-      @submission = TeamSubmission.includes(:team, :scores_including_deleted)
+      @submission = TeamSubmission.includes(:team)
         .find(params.fetch(:id))
-      @recused_scores = @submission.submission_scores.recused
+      @recused_scores = @submission.submission_scores.recused.includes(judge_profile: :account)
 
       render "ambassador/score_details/show"
     end

--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -65,6 +65,14 @@ module Admin
       end
     end
 
+    def return_to_judging_pool
+      team_submission = TeamSubmission.friendly.find(params[:team_submission_id])
+      team_submission.update(removed_from_judging_pool: false, returned_by_id: current_account.id)
+
+      redirect_back fallback_location: admin_score_detail_path(team_submission.id),
+        success: "You have returned the submission back to the judging pool."
+    end
+
     private
 
     def grid_params

--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -67,9 +67,9 @@ module Admin
 
     def return_to_judging_pool
       team_submission = TeamSubmission.friendly.find(params[:team_submission_id])
-      team_submission.update(removed_from_judging_pool: false, returned_by_id: current_account.id)
+      team_submission.update(removed_from_judging_pool: false, returned_to_judging_pool_by_account_id: current_account.id)
 
-      redirect_back fallback_location: admin_score_detail_path(team_submission.id),
+      redirect_back fallback_location: admin_score_detail_path(team_submission),
         success: "You have returned the submission back to the judging pool."
     end
 

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -86,8 +86,8 @@ class ScoredSubmissionsGrid
 
   column :removed_from_judging_pool?, header: "Removed from judging pool", mandatory: true
 
-  column :returned_by_id, header: "Returned to judging pool by", order: true do |submission|
-    submission.returned_by.name
+  column :returned_to_judging_pool_by_account_id, header: "Last returned to judging pool by", order: true do |submission|
+    submission.returned_to_judging_pool_by&.name.presence || "-"
   end
 
   column :quarterfinals_average, order: :quarterfinals_average_score, mandatory: true do |submission|

--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -86,6 +86,10 @@ class ScoredSubmissionsGrid
 
   column :removed_from_judging_pool?, header: "Removed from judging pool", mandatory: true
 
+  column :returned_by_id, header: "Returned to judging pool by", order: true do |submission|
+    submission.returned_by.name
+  end
+
   column :quarterfinals_average, order: :quarterfinals_average_score, mandatory: true do |submission|
     str = submission.quarterfinals_average_score.to_s
     str += "/#{submission.total_possible_score}"

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -145,6 +145,7 @@ class Account < ActiveRecord::Base
     dependent: :destroy
 
   has_many :registration_invites, class_name: "UserInvitation", foreign_key: :invited_by_id
+  has_many :returned_team_submissions, class_name: "TeamSubmission", foreign_key: :returned_by_id
 
   has_one :background_check, dependent: :destroy
   accepts_nested_attributes_for :background_check

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -145,7 +145,7 @@ class Account < ActiveRecord::Base
     dependent: :destroy
 
   has_many :registration_invites, class_name: "UserInvitation", foreign_key: :invited_by_id
-  has_many :returned_team_submissions, class_name: "TeamSubmission", foreign_key: :returned_by_id
+  has_many :returned_to_judging_pool_team_submissions, class_name: "TeamSubmission", foreign_key: :returned_to_judging_pool_by_account_id
 
   has_one :background_check, dependent: :destroy
   accepts_nested_attributes_for :background_check

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -148,7 +148,7 @@ class TeamSubmission < ActiveRecord::Base
     )
   end
 
-  belongs_to :returned_by, class_name: "Account", required: false
+  belongs_to :returned_to_judging_pool_by, class_name: "Account", foreign_key: "returned_to_judging_pool_by_account_id", required: false
   belongs_to :team, touch: true
   has_many :screenshots, -> { order(:sort_position) },
     dependent: :destroy,

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -148,6 +148,7 @@ class TeamSubmission < ActiveRecord::Base
     )
   end
 
+  belongs_to :returned_by, class_name: "Account", required: false
   belongs_to :team, touch: true
   has_many :screenshots, -> { order(:sort_position) },
     dependent: :destroy,

--- a/app/views/ambassador/score_details/show.en.html.erb
+++ b/app/views/ambassador/score_details/show.en.html.erb
@@ -73,5 +73,20 @@
     ) %>
   </p>
 
+  <% if current_profile.admin? && SeasonToggles.judging_enabled? && @submission.removed_from_judging_pool? %>
+    <div class="panel">
+      <h5 class="margin--t-none margin--b-medium">Return Submission to Judging Pool</h5>
+      <p>This submission has been automatically removed from the judging pool due to recusal count.</p>
+      <%= link_to("Return to judging pool",
+        admin_team_submission_return_to_judging_pool_path(@submission),
+        class: "button button--small",
+        data: {
+          method: :patch,
+          confirm: "This will return the submission to the judging pool"
+        }
+      ) %>
+    </div>
+  <% end %>
+
   <%= render "admin/team_submissions/judge_assignment", current_account: @current_account, submission: @submission %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -360,6 +360,7 @@ Rails.application.routes.draw do
       resources :screenshots, only: [:new, :create]
       patch :publish
       patch :unpublish
+      patch :return_to_judging_pool
 
       collection do
         get :bulk_publish

--- a/db/migrate/20250226214919_add_returned_by_to_team_submissions.rb
+++ b/db/migrate/20250226214919_add_returned_by_to_team_submissions.rb
@@ -1,5 +1,0 @@
-class AddReturnedByToTeamSubmissions < ActiveRecord::Migration[6.1]
-  def change
-    add_column :team_submissions, :returned_by_id, :integer
-  end
-end

--- a/db/migrate/20250226214919_add_returned_by_to_team_submissions.rb
+++ b/db/migrate/20250226214919_add_returned_by_to_team_submissions.rb
@@ -1,0 +1,5 @@
+class AddReturnedByToTeamSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :team_submissions, :returned_by_id, :integer
+  end
+end

--- a/db/migrate/20250226214919_add_returned_to_judging_pool_by_to_team_submissions.rb
+++ b/db/migrate/20250226214919_add_returned_to_judging_pool_by_to_team_submissions.rb
@@ -1,0 +1,5 @@
+class AddReturnedToJudgingPoolByToTeamSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :team_submissions, :returned_to_judging_pool_by_account_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2366,7 +2366,8 @@ CREATE TABLE public.team_submissions (
     scratch_project_url character varying,
     uses_gadgets boolean,
     uses_gadgets_description character varying,
-    removed_from_judging_pool boolean DEFAULT false
+    removed_from_judging_pool boolean DEFAULT false,
+    returned_by_id integer
 );
 
 
@@ -4969,6 +4970,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250103182555'),
 ('20250211205130'),
 ('20250219221626'),
-('20250224213654');
+('20250224213654'),
+('20250226214919');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2367,7 +2367,7 @@ CREATE TABLE public.team_submissions (
     uses_gadgets boolean,
     uses_gadgets_description character varying,
     removed_from_judging_pool boolean DEFAULT false,
-    returned_by_id integer
+    returned_to_judging_pool_by_account_id integer
 );
 
 

--- a/spec/controllers/admin/team_submissions_controller_spec.rb
+++ b/spec/controllers/admin/team_submissions_controller_spec.rb
@@ -10,4 +10,19 @@ RSpec.describe Admin::TeamSubmissionsController do
       }.to change { Export.count }.by(1)
     end
   end
+
+  describe "PATCH #return_to_judging_pool" do
+    let(:team_submission) { FactoryBot.create(:submission, removed_from_judging_pool: true) }
+    let(:admin) { FactoryBot.create(:admin) }
+
+    it "sets removed from judging pool to false" do
+      sign_in(admin)
+
+      patch :return_to_judging_pool, params: {team_submission_id: team_submission.id}
+
+      team_submission.reload
+      expect(team_submission.removed_from_judging_pool).to be false
+      expect(team_submission.returned_by_id).to eq(admin.account.id)
+    end
+  end
 end

--- a/spec/controllers/admin/team_submissions_controller_spec.rb
+++ b/spec/controllers/admin/team_submissions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Admin::TeamSubmissionsController do
 
       team_submission.reload
       expect(team_submission.removed_from_judging_pool).to be false
-      expect(team_submission.returned_by_id).to eq(admin.account.id)
+      expect(team_submission.returned_to_judging_pool_by_account_id).to eq(admin.account.id)
     end
   end
 end


### PR DESCRIPTION
Refs #5337 

This PR adds the ability for an admin to return a removed submission back to the judging pool. When a submission is automatically removed, an admin can now review it and return it to the judging pool. This change also captures which admin last performed the return action (which is expected behavior from VET).

Main changes
- Migration to add `returned_by_id` to `team_submissions_table`
- Added `return_to_judging_pool` action
- Added test
- Addressed bullet warning 

