### PR TITLE
Added rake task to bulk delete accounts

### DIFF
--- a/lib/tasks/bulk_delete_accounts.rake
+++ b/lib/tasks/bulk_delete_accounts.rake
@@ -1,0 +1,10 @@
+desc "Bulk delete accounts by id"
+task bulk_delete_accounts_by_id: :environment do |task, args|
+  accounts = Account.where(id: [args.extras])
+
+  accounts.each do |account|
+    account.really_destroy!
+  end
+
+  puts "Deleted #{accounts.size} accounts"
+end


### PR DESCRIPTION
Refs #5414 

Added rake task to bulk delete accounts

to run: `bundle exec rails bulk_delete_accounts_by_id[idx,idy,idz]`