### PR TITLE
Fix error when trying to export events as a chapter ambassador

### DIFF
--- a/app/controllers/data_grids/ambassador/events_controller.rb
+++ b/app/controllers/data_grids/ambassador/events_controller.rb
@@ -13,11 +13,9 @@ module DataGrids::Ambassador
       },
 
       csv_scope: "->(scope, user, params) {
-        scope.by_chapterable(
-            user.chapterable_type,
-            user.current_chapterable.id
-          )
-          .distinct
+        scope
+          .current
+          .in_region(user.chapterable)
       }"
 
     private


### PR DESCRIPTION
This should address an error when trying to export the events datagrid as a chapter ambassador.

