### PR TITLE
Added skip callback to bulk delete account

### DIFF
--- a/lib/tasks/bulk_delete_accounts.rake
+++ b/lib/tasks/bulk_delete_accounts.rake
@@ -2,9 +2,10 @@ desc "Bulk delete accounts by id"
 task bulk_delete_accounts_by_id: :environment do |task, args|
   accounts = Account.where(id: [args.extras])
 
+  MentorProfileMentorType.skip_callback(:commit, :after, :update_mentor_info_in_crm)
   accounts.each do |account|
     account.really_destroy!
   end
-
+  MentorProfileMentorType.set_callback(:commit, :after, :update_mentor_info_in_crm)
   puts "Deleted #{accounts.size} accounts"
 end


### PR DESCRIPTION
The rake task errored out locally when running against prod data due to crm integration. This update will disable the CRM callback and then enable it after the deletion is complete. 