### PR TITLE
Added generic ambassador team member invite route and controller 

### DIFF
--- a/app/controllers/ambassador/team_member_invites_controller.rb
+++ b/app/controllers/ambassador/team_member_invites_controller.rb
@@ -1,0 +1,5 @@
+module Ambassador
+  class TeamMemberInvitesController < AmbassadorController
+    include Admin::DeleteTeamMemberInviteConcern
+  end
+end

--- a/app/controllers/chapter_ambassador/team_member_invites_controller.rb
+++ b/app/controllers/chapter_ambassador/team_member_invites_controller.rb
@@ -1,5 +1,0 @@
-module ChapterAmbassador
-  class TeamMemberInvitesController < ChapterAmbassadorController
-    include Admin::DeleteTeamMemberInviteConcern
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,7 +186,7 @@ Rails.application.routes.draw do
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"
     resources :team_submissions, only: :index, controller: "/data_grids/ambassador/team_submissions"
     resources :team_memberships, only: [:create, :destroy], controller: "/ambassador/team_memberships"
-    resources :team_member_invites, only: [:destroy]
+    resources :team_member_invites, only: [:destroy], controller: "/ambassador/team_member_invites"
 
     resources :activities, only: :index
 
@@ -254,6 +254,7 @@ Rails.application.routes.draw do
     resources :team_memberships, only: [:create, :destroy], controller: "/ambassador/team_memberships"
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"
     resources :team_submissions, only: :index, controller: "/data_grids/ambassador/team_submissions"
+    resources :team_member_invites, only: [:destroy], controller: "/ambassador/team_member_invites"
 
     resources :saved_searches, only: [:show, :create, :update, :destroy]
     resources :export_downloads, only: :update


### PR DESCRIPTION
Refs #5427 

When reviewing airbrake I discovered this error`undefined method 'club_ambassador_team_member_invite_path' for #<ActionView::Base:0x00000000081ad8>`

After further investigation I found that if a team had a pending invite, the view would error out due to a missing path. This PR removes the ChA specific team member invite controller and a generic ambassassador team member invite route and controller 