### PR TITLE
Ensure mentors are assigned to unique chapterable assignments when joining a team

### DIFF
--- a/app/controllers/mentor/mentor_invites_controller.rb
+++ b/app/controllers/mentor/mentor_invites_controller.rb
@@ -32,7 +32,7 @@ module Mentor
 
         student_chapterables.each do |chapterable|
           if chapterable.present?
-            chapterable.chapterable_account_assignments.create(
+            chapterable.chapterable_account_assignments.find_or_create_by(
               profile: current_mentor,
               account: current_mentor.account,
               season: Season.current.year,

--- a/app/controllers/mentor/team_member_invites_controller.rb
+++ b/app/controllers/mentor/team_member_invites_controller.rb
@@ -15,7 +15,7 @@ module Mentor
 
         student_chapterables.each do |chapterable|
           if chapterable.present?
-            chapterable.chapterable_account_assignments.create(
+            chapterable.chapterable_account_assignments.find_or_create_by(
               profile: current_mentor,
               account: current_mentor.account,
               season: Season.current.year,

--- a/app/technovation/join_request_approved.rb
+++ b/app/technovation/join_request_approved.rb
@@ -14,7 +14,7 @@ module JoinRequestApproved
 
       student_chapterables.each do |chapterable|
         if chapterable.present?
-          chapterable.chapterable_account_assignments.create(
+          chapterable.chapterable_account_assignments.find_or_create_by(
             profile: join_request.requestor,
             account: join_request.requestor.account,
             season: Season.current.year,


### PR DESCRIPTION
This should ensure that when a mentor joins a team (either through an invite or a join request) that they don't get reassigned to the same chapter or club that they already belong to, creating duplicate chapter assignment records.