### PR TITLE
Install Brakeman security scanner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ group :development do
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
   gem "bullet"
+  gem "brakeman", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    brakeman (7.0.0)
+      racc
     browser (2.7.1)
     builder (3.3.0)
     bullet (7.1.6)
@@ -568,6 +570,7 @@ DEPENDENCIES
   barnes (~> 0.0.7)
   bcrypt (~> 3.1)
   bootsnap
+  brakeman
   browser (~> 2.5)
   bullet
   capybara (~> 3.0)


### PR DESCRIPTION
This will install the Brakeman security scanner into the development group in our Gemfile.

This can be run locally with the `brakeman` command:
https://github.com/presidentbeef/brakeman?tab=readme-ov-file#basic-options

I ran it locally and put the report of all the "High" security items in a Zenhub issue, it's pinned in the Icebox column.


