### PR TITLE
Update teams datagrid scope and teams lookup to account for national view permission

### DIFF
--- a/app/controllers/ambassador/teams_controller.rb
+++ b/app/controllers/ambassador/teams_controller.rb
@@ -3,10 +3,15 @@ module Ambassador
     layout "ambassador"
 
     def show
-      @team = Team.by_chapterable(
-        current_ambassador.chapterable_type,
-        current_ambassador.current_chapterable.id
-      ).find(params[:id])
+      @team = if current_ambassador.national_view?
+        Team.in_region(current_ambassador.chapter)
+          .find(params.fetch(:id))
+      else
+        Team.by_chapterable(
+          current_ambassador.chapterable_type,
+          current_ambassador.current_chapterable.id
+        ).find(params[:id])
+      end
     end
   end
 end

--- a/app/controllers/data_grids/ambassador/teams_controller.rb
+++ b/app/controllers/data_grids/ambassador/teams_controller.rb
@@ -6,20 +6,31 @@ module DataGrids::Ambassador
 
     use_datagrid with: TeamsGrid,
       html_scope: ->(scope, user, params) {
-        scope
-          .by_chapterable(
-            user.chapterable_type,
-            user.current_chapterable.id
-          )
-          .distinct
-          .page(params[:page])
+        if user.chapter_ambassador_profile&.national_view?
+          scope
+            .in_region(user.chapterable)
+            .page(params[:page])
+        else
+          scope
+            .by_chapterable(
+              user.chapterable_type,
+              user.current_chapterable.id
+            )
+            .distinct
+            .page(params[:page])
+        end
       },
       csv_scope: "->(scope, user, params) {
-        scope
-          .by_chapterable(
-      user.chapterable_type,
-      user.current_chapterable.id)
-          .distinct
+        if user.chapter_ambassador_profile&.national_view?
+          scope
+            .in_region(user.chapterable)
+        else
+          scope
+            .by_chapterable(
+              user.chapterable_type,
+              user.current_chapterable.id)
+            .distinct
+        end
       }"
 
     private

--- a/spec/controllers/ambassador/teams_controller_spec.rb
+++ b/spec/controllers/ambassador/teams_controller_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe Ambassador::TeamsController do
+  describe "GET #show" do
+    context "as a chapter ambassador" do
+      let(:chapter_ambassador) do
+        FactoryBot.create(
+          :chapter_ambassador,
+          :not_assigned_to_chapter,
+          national_view: national_view
+        )
+      end
+      let(:brazil_chapter) do
+        FactoryBot.create(
+          :chapter,
+          :brazil,
+          primary_contact: chapter_ambassador.account
+        )
+      end
+      let(:national_view) { false }
+
+      before do
+        chapter_ambassador.chapterable_assignments.create(
+          chapterable: brazil_chapter,
+          account: chapter_ambassador.account,
+          season: Season.current.year,
+          primary: true
+        )
+
+        sign_in(chapter_ambassador)
+      end
+
+      context "when a chapter ambassador has the 'national view' ability" do
+        let(:national_view) { true }
+
+        context "when viewing a team in the chapter ambassador's region" do
+          let(:brazil_team) { FactoryBot.create(:team, :brazil) }
+
+          before do
+            get :show, params: {
+              id: brazil_team.id
+            }
+          end
+
+          it "returns an OK 200 success status code" do
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "when viewing a team that is not in the chapter ambassador's region" do
+          let(:chicago_team) { FactoryBot.create(:team, :chicago) }
+
+          it "raises an 'ActiveRecord::RecordNotFound' error" do
+            expect {
+              get :show, params: {
+                id: chicago_team.id
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context "when a chapter ambassador does not have the 'national view' ability" do
+        let(:national_view) { false }
+
+        context "when viewing a team for a student who is assigned to the chapter ambassador's chapter" do
+          let(:brazil_student) { FactoryBot.create(:student, :brazil, :not_assigned_to_chapter) }
+          let(:brazil_team) { FactoryBot.create(:team, :brazil) }
+
+          before do
+            brazil_student.chapterable_assignments.create(
+              account: brazil_student.account,
+              chapterable: brazil_chapter
+            )
+
+            brazil_team.students << brazil_student
+            brazil_team.save
+
+            get :show, params: {
+              id: brazil_team.id
+            }
+          end
+
+          it "returns an OK 200 success status code" do
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "when viewing a team for a student in the chapter ambassador's region, but not assigned to their chapter" do
+          let(:brazil_team) { FactoryBot.create(:team, :brazil) }
+
+          it "raises an 'ActiveRecord::RecordNotFound' error" do
+            expect {
+              get :show, params: {
+                id: brazil_team.id
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
+        context "when viewing a team that is not in the chapter ambassador's region" do
+          let(:chicago_team) { FactoryBot.create(:team, :chicago) }
+
+          it "raises an 'ActiveRecord::RecordNotFound' error" do
+            expect {
+              get :show, params: {
+                id: chicago_team.id
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refs #5410 

This PR updates the following:
- Updates the `show` action in the ambassador teams controller to conditionally fetch a team based on the national view permission 
- Updates the teams datagrid to fetch teams either in region (for national view) or in current chapter
- Added test