### PR TITLE
Create initial dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
If I'm understanding the documentation correctly, this will allow Dependabot to automatically check for and open PRs for NPM security vulnerabilities:

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

Maybe we could look at setting this to only look at production dependencies too:

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

Also, it doesn't seem like there's a way to set this up for Ruby on Rails vulnerabilities.