### PR TITLE
Added mentor rebrand layout + basic rebranded mentor my profile tab

### DIFF
--- a/app/controllers/mentor/profiles_controller.rb
+++ b/app/controllers/mentor/profiles_controller.rb
@@ -2,6 +2,8 @@ module Mentor
   class ProfilesController < MentorController
     include ProfileController
 
+    layout "mentor_rebrand"
+
     before_action :expertises, :mentor_types
 
     def profile_params

--- a/app/views/layouts/mentor_rebrand.html.erb
+++ b/app/views/layouts/mentor_rebrand.html.erb
@@ -1,0 +1,4 @@
+<% provide :root_path, mentor_dashboard_path %>
+<% provide :main_header, render('application/templates/tg_green_header', heading: "Technovation Girls") %>
+
+<%= render template: "layouts/application_rebrand" %>

--- a/app/views/layouts/mentor_rebrand.html.erb
+++ b/app/views/layouts/mentor_rebrand.html.erb
@@ -1,4 +1,4 @@
 <% provide :root_path, mentor_dashboard_path %>
-<% provide :main_header, render('application/templates/tg_green_header', heading: "Technovation Girls") %>
+<% provide :main_header, render("application/templates/tg_green_header", heading: "Technovation Girls") %>
 
 <%= render template: "layouts/application_rebrand" %>

--- a/app/views/mentor/profiles/_basic.en.html.erb
+++ b/app/views/mentor/profiles/_basic.en.html.erb
@@ -21,7 +21,7 @@
         <dt>Job Title</dt>
         <dd><%= current_mentor.job_title %></dd>
 
-        <dt><%= t('views.mentor.form.mentor_types') %></dt>
+        <dt><%= t("views.mentor.form.mentor_types") %></dt>
         <dd>
           <ul>
             <% current_mentor.mentor_types.each do |mentor_type| %>
@@ -63,10 +63,10 @@
 
     <div id="profile-picture" class="flex flex-col items-center self-start mb-4">
       <div>
-        <%= render 'profiles/filestack_profile_image_tag' %>
+        <%= render "profiles/filestack_profile_image_tag" %>
       </div>
       <div>
-        <%= render 'profiles/filestack_profile_image_upload' %>
+        <%= render "profiles/filestack_profile_image_upload" %>
       </div>
     </div>
   </div>

--- a/app/views/mentor/profiles/_basic.en.html.erb
+++ b/app/views/mentor/profiles/_basic.en.html.erb
@@ -1,67 +1,73 @@
-<dl>
-  <dt>Name</dt>
-  <dd><%= current_mentor.full_name %></dd>
+<div id="basic-info" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper ">
+    <p class="font-bold">Basic Information</p>
+  </div>
 
-  <dt>Phone Number</dt>
-  <dd><%= current_mentor.phone_number.presence || "-" %></dd>
+  <div id="information-wrapper" class="p-6 flex flex-col-reverse lg:flex-row lg:justify-between">
+    <div id="information-details">
+      <dl>
+        <dt>Name</dt>
+        <dd><%= current_mentor.full_name %></dd>
 
-  <dt>Gender identity</dt>
-  <dd><%= current_mentor.gender || "Not specified" %></dd>
+        <dt>Phone Number</dt>
+        <dd><%= current_mentor.phone_number.presence || "-" %></dd>
 
-  <dt>School / Company name</dt>
-  <dd><%= current_mentor.school_company_name %></dd>
+        <dt>Gender Identity</dt>
+        <dd><%= current_mentor.gender || "Not specified" %></dd>
 
-  <dt>Job title</dt>
-  <dd><%= current_mentor.job_title %></dd>
+        <dt>School/Company Name</dt>
+        <dd><%= current_mentor.school_company_name %></dd>
 
-  <dt><%= t('views.mentor.form.mentor_types') %></dt>
-  <dd>
-    <ul>
-      <% current_mentor.mentor_types.each do |mentor_type| %>
-        <li><%= mentor_type.name %></li>
-      <% end %>
-    </ul>
-  </dd>
+        <dt>Job Title</dt>
+        <dd><%= current_mentor.job_title %></dd>
 
-  <dt>Skills &amp; Interests</dt>
-  <dd><%= current_mentor.expertises.map(&:name).to_sentence %></dd>
+        <dt><%= t('views.mentor.form.mentor_types') %></dt>
+        <dd>
+          <ul>
+            <% current_mentor.mentor_types.each do |mentor_type| %>
+              <li class="list-disc ml-8"><%= mentor_type.name %></li>
+            <% end %>
+          </ul>
+        </dd>
 
-  <dt>Personal summary</dt>
-  <dd><%= simple_format h(current_mentor.bio) %></dd>
-</dl>
+        <dt>Skills &amp; Interests</dt>
+        <dd><%= current_mentor.expertises.map(&:name).to_sentence %></dd>
 
-<% if current_mentor.onboarded? %>
-  <%= form_with(model: current_mentor,
-    data: { submit_on_change: true },
-    url: mentor_profile_path(format: :json),
-    method: :patch) do |f| %>
-    <p>
-      <%= f.check_box :accepting_team_invites,
-        id: :mentor_profile_accepting_team_invites %>
+        <dt>Personal summary</dt>
+        <dd><%= simple_format h(current_mentor.bio) %></dd>
 
-      <%= f.label :accepting_team_invites,
-        "Allow teams to find you in search results and invite you to join" %>
-    </p>
+        <dt>Connection Preferences</dt>
+        <dd>
+          <ul class="list-disc">
+            <li class="ml-8">
+              Allow teams to find you in search results and invite you to join:
+              <span class="font-medium"><%= humanize_boolean(current_mentor.accepting_team_invites) %></span>
+            </li>
+            <li class="ml-8">
+              Indicate to teams that you can be an online, remote mentor:
+              <span class="font-medium"><%= humanize_boolean(current_mentor.virtual) %></span>
+            </li>
+            <li class="ml-8">
+              Allow other mentors to find you in search results and connect:
+              <span class="font-medium"><%= humanize_boolean(current_mentor.connect_with_mentors) %></span>
+            </li>
+          </ul>
+        </dd>
+      </dl>
+      <p class="mt-8">
+        <%= link_to "Change your basic profile details",
+          edit_profile_path,
+          class: "tw-green-btn" %>
+      </p>
+    </div>
 
-    <p>
-      <%= f.check_box :virtual, id: :mentor_profile_virtual %>
-
-      <%= f.label :virtual,
-        "Indicate to teams that you can be an online, remote mentor" %>
-    </p>
-
-    <p>
-      <%= f.check_box :connect_with_mentors,
-        id: :mentor_profile_connect_with_mentors %>
-
-      <%= f.label :connect_with_mentors,
-        "Allow other mentors to find you in search results and connect via email" %>
-    </p>
-  <% end %>
-<% end %>
-
-<p>
-  <%= link_to "Change your basic profile details",
-    edit_profile_path,
-    class: "button" %>
-</p>
+    <div id="profile-picture" class="flex flex-col items-center self-start mb-4">
+      <div>
+        <%= render 'profiles/filestack_profile_image_tag' %>
+      </div>
+      <div>
+        <%= render 'profiles/filestack_profile_image_upload' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/mentor/profiles/_menu.en.html.erb
+++ b/app/views/mentor/profiles/_menu.en.html.erb
@@ -1,51 +1,29 @@
-<ul class="tabs__menu" data-closed="true">
-  <li class="hidden-sm hidden-md hidden-lg tabs__menu-link">
-    <button
-      role="button"
-      class="tabs__menu-button"
-      data-tab-id="avatar"
-    >
-      Profile image
-    </button>
-  </li>
+<div id="profile-settings" class="h-auto mb-10 lg:mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper bg-energetic-blue text-white p-2">
+    <p class="font-bold">Profile Settings</p>
+  </div>
 
-  <li class="tabs__menu-link">
-    <button
-      role="button"
-      class="tabs__menu-button"
-      data-tab-id="basic"
-    >
-      Basic
-    </button>
-  </li>
+  <div id="tab-wrapper" class="p-6">
+    <div class="tw-tab-content">
+      <a class="tw-active active-tab" id="basic-info-tab" href="#basic-tab-content">Basic Information</a>
+    </div>
 
-  <li class="tabs__menu-link">
-    <button
-      role="button"
-      class="tabs__menu-button"
-      data-tab-id="location"
-    >
-      Location
-    </button>
-  </li>
+    <div class="tw-thick-rule"></div>
 
-  <li class="tabs__menu-link">
-    <button
-      role="button"
-      class="tabs__menu-button"
-      data-tab-id="change-email"
-    >
-      Change email
-    </button>
-  </li>
+    <div class="tw-tab-content">
+      <a id="location-tab" href="#location-tab-content">Location</a>
+    </div>
 
-  <li class="tabs__menu-link">
-    <button
-      role="button"
-      class="tabs__menu-button"
-      data-tab-id="change-password"
-    >
-      Change password
-    </button>
-  </li>
-</ul>
+    <div class="tw-thick-rule"></div>
+
+    <div class="tw-tab-content">
+      <a id="email-tab" href="#email-tab-content">Change Email</a>
+    </div>
+
+    <div class="tw-thick-rule"></div>
+
+    <div class="tw-tab-content">
+      <a id="pw-tab" href="#pw-tab-content" >Change Password</a>
+    </div>
+  </div>
+</div>

--- a/app/views/mentor/profiles/show.html.erb
+++ b/app/views/mentor/profiles/show.html.erb
@@ -1,48 +1,23 @@
 <% provide :title, "My profile" %>
 
-<div class="grid tabs tabs--vertical">
-  <div class="grid__col-sm-3 col--sticky-parent">
-    <div class="col--sticky-spacer">
-      <div class="col--sticky">
-        <div class="hidden-xs hidden-xxs">
-          <h3><%= current_mentor.full_name %></h3>
-          <%= image_tag current_mentor.profile_image_url,
-                        id: "main-profile-image",
-                        class: "grid__cell-img og-style-filestack-img" %>
-          <div>
-            <%= render 'profiles/filestack_profile_image_upload' %>
-          </div>
-        </div>
-        <%= render 'mentor/profiles/menu' %>
-      </div>
+<div class="container mx-auto flex flex-col lg:flex-row justify-center gap-6 profile-tab-container">
+  <%= render 'mentor/profiles/menu' %>
+
+  <div class="tab">
+    <div id="basic-tab-content" class="tab-content tw-active">
+      <%= render 'mentor/profiles/basic' %>
     </div>
-  </div>
 
-  <div class="tabs__content grid__col-sm-9 col--sticky-parent">
-    <div class="col--sticky-spacer">
-      <div class="col--sticky">
-        <div class="tabs__tab-content" id="basic">
-          <%= render 'mentor/profiles/basic' %>
-        </div>
+    <div id="location-tab-content" class="tab-content">
+      <%#= render 'profiles/rebrand/location' %>
+    </div>
 
-        <div class="hidden-sm hidden-md hidden-lg tabs__tab-content" id="avatar">
-          <%= image_tag current_mentor.profile_image_url, class: "grid__cell-img" %>
+    <div id="email-tab-content" class="tab-content">
+      <%= render 'profiles/rebrand/email' %>
+    </div>
 
-
-        </div>
-
-        <div class="tabs__tab-content" id="location">
-          <%= render 'mentor/profiles/location' %>
-        </div>
-
-        <div class="tabs__tab-content" id="change-email">
-          <%= render 'profiles/email' %>
-        </div>
-
-        <div class="tabs__tab-content" id="change-password">
-          <%= render 'profiles/password' %>
-        </div>
-      </div>
+    <div id="pw-tab-content" class="tab-content">
+      <%= render 'profiles/rebrand/password' %>
     </div>
   </div>
 </div>

--- a/app/views/mentor/profiles/show.html.erb
+++ b/app/views/mentor/profiles/show.html.erb
@@ -1,23 +1,23 @@
 <% provide :title, "My profile" %>
 
 <div class="container mx-auto flex flex-col lg:flex-row justify-center gap-6 profile-tab-container">
-  <%= render 'mentor/profiles/menu' %>
+  <%= render "mentor/profiles/menu" %>
 
   <div class="tab">
     <div id="basic-tab-content" class="tab-content tw-active">
-      <%= render 'mentor/profiles/basic' %>
+      <%= render "mentor/profiles/basic" %>
     </div>
 
     <div id="location-tab-content" class="tab-content">
-      <%#= render 'profiles/rebrand/location' %>
+      <%#= render "profiles/rebrand/location" %>
     </div>
 
     <div id="email-tab-content" class="tab-content">
-      <%= render 'profiles/rebrand/email' %>
+      <%= render "profiles/rebrand/email" %>
     </div>
 
     <div id="pw-tab-content" class="tab-content">
-      <%= render 'profiles/rebrand/password' %>
+      <%= render "profiles/rebrand/password" %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,7 +1,7 @@
 <%
   url ||= send("#{current_scope}_profile_path")
   admin ||= false
-  form = current_profile.rebranded? ? 
+  form = (current_profile.rebranded? || current_profile.is_a?(MentorProfile)) ?
     'signups/rebranded/form' :
     'signups/form'
 %>

--- a/app/views/profiles/rebrand/_email.en.html.erb
+++ b/app/views/profiles/rebrand/_email.en.html.erb
@@ -1,30 +1,35 @@
-<div class="container mx-auto flex flex-col w-full lg:w-1/2">
-  <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Change your email'} do %>
-    <%= render 'errors', record: current_profile %>
+<div id="change-email" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+  <div class="sm-header-wrapper">
+    <p class="font-bold">Change Your Email</p>
+  </div>
+  <div id="change-email-wrapper" class="p-6">
+    <div id="change-email">
+      <%= render 'errors', record: current_profile %>
 
-    <p class="text-sm italic mb-4">
-      If you change your email address, we will send a message
-      to your inbox to confirm that you own the address.
-    </p>
-
-    <p class="text-sm italic mb-4">
-      You <span class="font-semibold">must</span> use the link in that message
-      to confirm your new email address and restore full access to this site.
-    </p>
-
-    <%= simple_form_for current_profile, url: send("#{current_scope}_profile_path", local: true) do |f| %>
-      <%= f.simple_fields_for :account, include_id: false do |a| %>
-        <%= a.input :existing_password,
-                    label: "Current password",
-                    id: "existing_password_field_email",
-                    placeholder: "Enter your password first" %>
-
-        <%= a.input :email %>
-      <% end %>
-
-      <p>
-        <%= f.submit "Change email", class: "tw-green-btn mx-auto" %>
+      <p class="text-sm italic mb-4">
+        If you change your email address, we will send a message
+        to your inbox to confirm that you own the address.
       </p>
-    <% end %>
-  <% end %>
+
+      <p class="text-sm italic mb-4">
+        You <span class="font-semibold">must</span> use the link in that message
+        to confirm your new email address and restore full access to this site.
+      </p>
+
+      <%= simple_form_for current_profile, url: send("#{current_scope}_profile_path", local: true) do |f| %>
+        <%= f.simple_fields_for :account, include_id: false do |a| %>
+          <%= a.input :existing_password,
+            label: "Current password",
+            id: "existing_password_field_email",
+            placeholder: "Enter your password first" %>
+
+          <%= a.input :email %>
+        <% end %>
+
+        <p>
+          <%= f.submit "Change email", class: "tw-green-btn" %>
+        </p>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/profiles/rebrand/_email.en.html.erb
+++ b/app/views/profiles/rebrand/_email.en.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div id="change-email-wrapper" class="p-6">
     <div id="change-email">
-      <%= render 'errors', record: current_profile %>
+      <%= render "errors", record: current_profile %>
 
       <p class="text-sm italic mb-4">
         If you change your email address, we will send a message

--- a/app/views/profiles/rebrand/_password.en.html.erb
+++ b/app/views/profiles/rebrand/_password.en.html.erb
@@ -1,4 +1,4 @@
-<div id="change-email" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
+<div id="change-pw" class="h-auto mb-auto rounded-md border-solid border-4 border-energetic-blue">
   <div class="sm-header-wrapper">
     <p class="font-bold">Change Your Password</p>
   </div>

--- a/app/views/signups/_mentor_profile_fields.html.erb
+++ b/app/views/signups/_mentor_profile_fields.html.erb
@@ -13,12 +13,10 @@
   <%= f.input :bio, label: "#{t('models.chapter_ambassador_profile.bio.signup_label')}" %>
 <% end %>
 
-<h4><%= t('views.mentor.form.mentor_types') %></h4>
+<%= f.label :mentor_types, t('views.mentor.form.mentor_types'), class: "mt-6" %>
 <%= f.association :mentor_types, as: :check_boxes, label: false %>
 
-<br>
-<h4><%= t('views.signups.form.skills_and_interests_html') %></h4>
-
+<%= f.label :expertise_ids, t('views.signups.form.skills_and_interests_html'), class: "mt-6" %>
 <%= f.collection_check_boxes :expertise_ids, @expertises, :id, :name do |b| %>
   <span class="inline-checkbox">
     <%= b.check_box %><%= b.label { b.text } %>

--- a/spec/features/mentor/connect_with_mentors_spec.rb
+++ b/spec/features/mentor/connect_with_mentors_spec.rb
@@ -7,6 +7,6 @@ RSpec.feature "Mentors connect with other mentors" do
     sign_in(mentor)
     visit mentor_profile_path
 
-    expect(page).to have_unchecked_field("mentor_profile_connect_with_mentors")
+    expect(page).to have_content("Allow other mentors to find you in search results and connect: No")
   end
 end


### PR DESCRIPTION
Refs #5443, #5446, #5477

This PR adds the following
- Mentor rebrand layout
- Basic rebranded mentor my profile tab with side nav and main energetic container section
- Rebranded mentor profile partials (basic information, generic rebranded change my email partial)

The basic profile tab, update email, and update password are all updated and working. Location tab will be updated in another ticket. 

![CleanShot 2025-03-25 at 13 45 57@2x](https://github.com/user-attachments/assets/65d7b0e2-84b2-45d3-ac87-e43a8e794583)

 