### PR TITLE
Added mentor scores and certificates tab

### DIFF
--- a/app/controllers/mentor/scores_controller.rb
+++ b/app/controllers/mentor/scores_controller.rb
@@ -1,5 +1,12 @@
 module Mentor
   class ScoresController < MentorController
+
+    layout "mentor_rebrand"
+
+    def index
+      @current_teams = current_mentor.teams.current.order("teams.name")
+    end
+
     def show
       submission_ids = TeamSubmission.where(team_id: current_mentor.teams.pluck(:id))
       @score = SubmissionScore.where(team_submission_id: submission_ids).find(params[:id])

--- a/app/null_objects/null_team_submission.rb
+++ b/app/null_objects/null_team_submission.rb
@@ -35,6 +35,10 @@ class NullTeamSubmission < NullObject
   end
   alias_method :is_complete, :complete?
 
+  def incomplete?
+    true
+  end
+
   def published_at
     nil
   end

--- a/app/views/application/templates/_side_nav_item.html.erb
+++ b/app/views/application/templates/_side_nav_item.html.erb
@@ -1,0 +1,5 @@
+<li>
+  <a href="<%= url %>" class="group flex items-center hover:text-gray-900">
+    <span class="ml-4 text-sm <%= is_active_item ? 'font-bold' : 'font-medium' %>"><%= name %></span>
+  </a>
+</li>

--- a/app/views/mentor/navigation/_tg_sub_nav.html.erb
+++ b/app/views/mentor/navigation/_tg_sub_nav.html.erb
@@ -6,6 +6,10 @@
 
     <%= link_to t("views.mentor.navigation.my_profile"),
       mentor_profile_path,
-      class: al(club_ambassador_profile_path) + " sub-nav-item"%>
+      class: al(mentor_profile_path) + " sub-nav-item"%>
+
+    <%= link_to t("views.mentor.navigation.scores_and_certificates"),
+      mentor_scores_path,
+      class: al(mentor_scores_path) + " sub-nav-item"%>
   </nav>
 </div>

--- a/app/views/mentor/scores/_no_scores.html.erb
+++ b/app/views/mentor/scores/_no_scores.html.erb
@@ -1,0 +1,24 @@
+<% if team.submission.blank? || team.submission.incomplete? %>
+  <p>
+    Unfortunately, no scores are available for <%= team.name %>
+    because the submission was incomplete. Give your team some
+    feedback on how to improve for next year!
+  </p>
+<% else %>
+  <p>
+    Congratulations on completing the <%= Season.current.year %>
+    season of Technovation! Your team can use the feedback they
+    received at their pitch event to help learn more and to
+    participate in Technovation next year. Your team should be proud
+    of their work and share it with friends and mentors!
+  </p>
+<% end %>
+
+<% if team.submission.present? %>
+  <p class="mt-8">
+    <%= link_to "Open your submission page",
+      project_path(team.submission),
+      class: "tw-green-btn mt-8",
+      target: "_blank" %>
+  </p>
+<% end %>

--- a/app/views/mentor/scores/_no_teams.erb
+++ b/app/views/mentor/scores/_no_teams.erb
@@ -1,0 +1,35 @@
+<div class="relative">
+  <div class="absolute -top-2 -right-6">
+    <span class="block mb-2 px-2 py-1 text-right text-sm font-bold tw-flag-magenta">Season close</span>
+  </div>
+
+  <h2 class="text-2xl text-energetic-blue font-semibold tracking-wide mb-2">
+    Thank you!
+  </h2>
+
+  <p class="mb-3">
+    Thank you for participating in this season of Technovation Girls.
+    We appreciate your feedback and the time you spent supporting teams from around the world!
+  </p>
+
+  <p>We’d love to stay connected with you! We have a couple of ways for you to remain involved:</p>
+
+  <ul class="list-disc ml-8 mb-3">
+    <li>
+      <%= link_to "Sign up for our newsletter", ENV.fetch("NEWSLETTER_URL"),
+        target: "_blank",
+        class: "tw-link" %>
+      to learn more about the girls you helped this season
+    </li>
+    <li>
+      <%= link_to "Consider mentoring", "https://technovationchallenge.org/get-started/",
+        target: "_blank",
+        class: "tw-link" %>
+      a team in the <%=Season.current.year %>-<%= Season.next.year %> season
+    </li>
+  </ul>
+
+  <p>
+    We hope to see you soon!
+  </p>
+</div>

--- a/app/views/mentor/scores/_side_nav.html.erb
+++ b/app/views/mentor/scores/_side_nav.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: "Scores & Certificates" } do %>
+  <div class="p-4" id="tab-wrapper">
+    <%= render "mentor/scores/side_nav_content" %>
+  </div>
+<% end %>

--- a/app/views/mentor/scores/_side_nav_content.html.erb
+++ b/app/views/mentor/scores/_side_nav_content.html.erb
@@ -1,0 +1,9 @@
+  <nav class="p-4">
+    <ol role="list" class="space-y-6 mb-6 overflow-hidden">
+      <%= render "application/templates/side_nav_item",
+         name: "Scores",
+         url: mentor_scores_path,
+         is_active_item: al(mentor_scores_path).present?
+      %>
+    </ol>
+  </nav>

--- a/app/views/mentor/scores/_team_scores_and_certificates.html.erb
+++ b/app/views/mentor/scores/_team_scores_and_certificates.html.erb
@@ -1,0 +1,26 @@
+<% current_teams.each do |team| %>
+  <div class="rounded-lg shadow-lg border mb-8">
+    <div class="px-4 py-5 sm:p-6">
+      <div class="mb-8">
+        <p class="text-xl font-semibold">
+          Team:
+          <span class="tw-link"><%= link_to team.name, mentor_team_path(team) %></span>
+        </p>
+        <p class="text-xl font-semibold">
+          Submission:
+          <span class="tw-link"><%= link_to team.submission.app_name, mentor_published_team_submission_path(team.submission) %></span>
+        </p>
+      </div>
+
+      <div class="mt-8">
+        <% scores = team.submission.submission_scores.complete %>
+
+        <% if scores.any?  %>
+          <%= render "scores/finished_scores", team: team, scores: scores %>
+        <% else %>
+          <%= render "mentor/scores/no_scores", team: team %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/mentor/scores/index.html.erb
+++ b/app/views/mentor/scores/index.html.erb
@@ -1,0 +1,17 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/scores/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Scores & Certificates" } do %>
+
+    <% if current_mentor.onboarded? && SeasonToggles.display_scores? %>
+      <% if @current_teams.any? %>
+        <%= render "mentor/scores/team_scores_and_certificates", current_teams: @current_teams %>
+      <% else %>
+        <%= render "mentor/scores/no_teams" %>
+      <% end %>
+    <% else %>
+      <%= render "explanations/feature_not_available", feature: :scores %>
+    <% end %>
+
+  <% end %>
+</div>

--- a/app/views/scores/_finished_scores.html.erb
+++ b/app/views/scores/_finished_scores.html.erb
@@ -1,0 +1,51 @@
+<div>
+  <h2 class="text-xl text-energetic-blue font-semibold">
+    Finished Scores
+  </h2>
+
+  <div class="mt-2 mb-8 flex flex-col">
+    <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+          <table class="min-w-full divide-y divide-gray-300" id="student-finished-scores-table">
+            <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="py-3 pl-4 pr-3 text-left text-base font-medium uppercase tracking-wide text-gray-500 sm:pl-6">
+                Judging Session
+              </th>
+              <th scope="col" class="px-3 py-3 text-left text-base font-medium uppercase tracking-wide text-gray-500">
+                Judging Location
+              </th>
+              <th scope="col" colspan="2" class="px-3 py-3 text-left text-base font-medium uppercase tracking-wide text-gray-500">
+                Score
+              </th>
+            </tr>
+            </thead>
+
+            <tbody class="divide-y divide-gray-200 bg-white">
+
+            <% scores.sort_by(&:round).reverse.each do |score| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-base font-medium text-gray-900 sm:pl-6">
+                  <%= score.round.titlecase%>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
+                  <%= score.judge_profile.address_details %>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
+                  <%= score.total %>/<%= score.total_possible %>
+                </td>
+                <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-base font-medium sm:pr-6">
+                  <%= link_to 'View details',
+                    send("#{current_scope}_score_path", score),
+                    class: "tw-green-btn cursor-pointer" %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -147,6 +147,7 @@ en:
           already_requested: "You have asked to join this team"
       navigation:
         my_profile: "My Profile"
+        scores_and_certificates: "Scores & Certificates"
 
       mentors:
         show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ Rails.application.routes.draw do
     resource :regional_pitch_events_team_list, only: :show
     resource :regional_pitch_event_selection, only: :create
     resources :regional_pitch_events, only: [:index, :show]
-    resources :scores, only: :show
+    resources :scores, only: [:index, :show]
   end
 
   namespace :ambassador do


### PR DESCRIPTION
Refs #5487 

This PR adds the following:
- A new template partial `app/views/application/templates/_side_nav_item.html.erb` that follows the same format as `_completion_step.` This will allow us to remove the old "tabs" JS approach mostly used on the "my profile" sections of the different profiles. 
- Side nav and main energetic container for mentor `Scores & Certificates` tab
- Mentor score partials(no_scores, team_scores_and_certificates, no_teams)
- Mentor scores index
- A general partial `views/scores/_finished_scores.html.erb` which is the finished scores table currently used for students. This will be used for students and mentors
- Updated mentor scores route 

Also just noting that I did encounter some issues with tailwind styles not rendering appropriately. It was difficult to recreate so I'm not sure if some wires are crossed or something is caching or maybe it is just on my end. Regardless, the rebrand styles seem to be working as expected, but just something to be aware of!

![CleanShot 2025-04-07 at 16 15 27@2x](https://github.com/user-attachments/assets/f58678dc-4fc4-4bd9-acfc-f487d4a02c9e)

