### PR TITLE
Add "judging location" to judge's "program participant" record in Salesforce

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -184,6 +184,13 @@ module Salesforce
             Mentor_Team_Status__c: account.mentor_profile.current_teams.present? ? "On Team" : "Not On Team"
           }
         )
+      when "judge"
+        initial_program_participant_info.merge(
+          {
+            Judging_Location__c: account.judge_profile.events.present? ? "RPE (In-person)" : "Platform (Virtual)"
+          }
+        )
+
       else
         {}
       end

--- a/spec/models/judge_profile_spec.rb
+++ b/spec/models/judge_profile_spec.rb
@@ -36,4 +36,28 @@ RSpec.describe JudgeProfile do
       }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
+
+  context "callbacks" do
+    let(:judge) { FactoryBot.create(:judge) }
+
+    describe "#after_add event" do
+      it "makes a call to upsert the judge info in the CRM after an event is added to the judge " do
+        expect(CRM::UpsertProgramInfoJob).to receive(:perform_later).with(account_id: judge.account_id, profile_type: "judge")
+
+        judge.events << FactoryBot.create(:event)
+      end
+    end
+
+    describe "#after_remove event" do
+      before do
+        judge.events << FactoryBot.create(:event)
+      end
+
+      it "makes a call to upsert the judge info in the CRM after an event is removed from the judge " do
+        expect(CRM::UpsertProgramInfoJob).to receive(:perform_later).with(account_id: judge.account_id, profile_type: "judge")
+
+        judge.events.destroy_all
+      end
+    end
+  end
 end

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -270,6 +270,24 @@ RSpec.describe Salesforce::ApiClient do
           end
         end
 
+        context "when updating a judge's program info" do
+          let(:judge_profile) { FactoryBot.build(:judge_profile) }
+          let(:account) { judge_profile.account }
+          let(:profile_type) { "judge" }
+
+          it "calls update! to update the 'program participant' info for the judge" do
+            expect(salesforce_client).to receive(:update!).with(
+              "Program_Participant__c",
+              {
+                Id: program_participant_id,
+                Judging_Location__c: "Platform (Virtual)"
+              }
+            )
+
+            salesforce_api_client.upsert_program_info
+          end
+        end
+
         context "when updating a student's program info" do
           let(:student_profile) { FactoryBot.create(:student_profile, :on_team, :submitted) }
           let(:account) { student_profile.account }


### PR DESCRIPTION
This will add "judging location" when updating a judge's "program participant" record in Salesforce.

If a judge is attending an RPE, the value will be "RPE (In-person)" and if not (if they are removed from an event) it will be "Platform (Virtual)".

From our dev team conversations, we just want to be able to identify RPE judges and this should let us do that; by default everyone is a virtual judge.


