### PR TITLE
Updated grid params for ChA judges datagrid to allow for state/province filtering in non-US countries

### DIFF
--- a/app/controllers/chapter_ambassador/judges_controller.rb
+++ b/app/controllers/chapter_ambassador/judges_controller.rb
@@ -21,9 +21,23 @@ module ChapterAmbassador
     private
 
     def grid_params
-      params[:judges_grid] ||= {}
-      grid = GridParams.for(params[:judges_grid], current_ambassador, admin: false)
-      grid.merge(column_names: detect_extra_columns(grid))
+      grid = (params[:judges_grid] ||= {}).merge(
+        current_account: current_ambassador.account,
+        admin: false,
+        allow_state_search: current_ambassador.country_code != "US",
+        country: [current_ambassador.country_code],
+        state_province: (
+          if current_ambassador.country_code == "US"
+            [current_ambassador.state_province]
+          else
+            Array(params[:judges_grid][:state_province])
+          end
+        )
+      )
+
+      grid.merge(
+        column_names: detect_extra_columns(grid)
+      )
     end
   end
 end


### PR DESCRIPTION
Refs #5524 

This PR updates the grid params for the ChA judges datagrid to allow for state/province filtering in non-US countries.

To achieve this, I removed the use of the `GridParams` module in this controller and updated the `grid_params` method with the necessary parameters to allow for the state/province filter. Just calling out that this seems to be the only datagrid that uses the `GridParams`module. This controller/grid now mirrors the same approach for other datagrids. 