### PR TITLE
Add rake task to bulk assign judges to an RPE

### DIFF
--- a/lib/tasks/assign_judges_to_rpe.rake
+++ b/lib/tasks/assign_judges_to_rpe.rake
@@ -1,0 +1,24 @@
+desc "Assign judges to RPE"
+task assign_judges_to_rpe: :environment do |task, args|
+  rpe = RegionalPitchEvent.find(args.extras.last)
+
+  puts "Assigning judges to RPE #{rpe.name} (ID #{rpe.id})"
+  args.extras[0..-2].each do |email_address|
+    account = Account.find_by(email: email_address)
+    judge_profile = account.judge_profile
+
+    if account.blank?
+      puts "#{email_address} could not be found"
+    elsif judge_profile.blank?
+      puts "#{email_address} is not a judge"
+    elsif !account.current_season?
+      puts "#{email_address} is not registered to the current season"
+    elsif judge_profile.events.include?(rpe)
+      puts "#{email_address} is already assigned to this event"
+    else
+      judge_profile.events << rpe
+
+      puts "Assigned #{email_address} to #{rpe.name}"
+    end
+  end
+end


### PR DESCRIPTION
This rake task will use a list of judges email addresses and assign them to an RPE.

Here's how it can be used:

```
bundle exec rails assign_judges_to_rpe[judge1@example.com,judge2@example.com,RPE_ID]
```


