### PR TITLE
Add rake task to bulk assign teams to an RPE

### DIFF
--- a/lib/tasks/assign_teams_to_rpe.rake
+++ b/lib/tasks/assign_teams_to_rpe.rake
@@ -1,0 +1,23 @@
+desc "Assign teams to RPE"
+task assign_teams_to_rpe: :environment do |task, args|
+  rpe = RegionalPitchEvent.find(args.extras.last)
+
+  puts "Assigning teams to RPE #{rpe.name} (ID #{rpe.id})"
+  args.extras[0..-2].each do |team_id|
+    team = Team.find(team_id)
+
+    if team.blank?
+      puts "#{team_id} could not be found"
+    elsif !team.current_season?
+      puts "#{team.name} is not a part of the current season"
+    elsif team.submission.blank?
+      puts "#{team.name} does not have a submission"
+    elsif team.events.include?(rpe)
+      puts "#{team.name} is already assigned to this event"
+    else
+      team.events << rpe
+
+      puts "Assigned #{team.name} to #{rpe.name}"
+    end
+  end
+end


### PR DESCRIPTION
This rake task will take a list of team IDs and assign the teams to an RPE.

A team must meet this criteria to be assigned to an RPE:

- the team must exist in our system
- the team must be a part of the current season
- the team must have a submission
- the team must not be assigned to the event already

Here's how it can be used:

```
bundle exec rails assign_teams_to_rpe[team_id_1,team_id_2,rpe_id]
```

