### PR TITLE
Rebranded mentor dashboard tab and mentor training tab

### DIFF
--- a/app/controllers/mentor/new_dashboards_controller.rb
+++ b/app/controllers/mentor/new_dashboards_controller.rb
@@ -1,0 +1,20 @@
+module Mentor
+  class NewDashboardsController < MentorController
+    include LocationStorageController
+
+    layout "mentor_rebrand"
+
+    private
+
+    def create_judge_mentor_on_dashboard
+      return if current_session.authenticated?
+      # Chapter ambassador/Admin Logged in as someone else
+
+      if CreateMentorProfile.call(current_account)
+        flash.now[:success] = t(
+          "controllers.mentor.dashboards.show.mentor_profile_created"
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/mentor/trainings_controller.rb
+++ b/app/controllers/mentor/trainings_controller.rb
@@ -1,0 +1,6 @@
+module Mentor
+  class TrainingsController < MentorController
+
+    layout "mentor_rebrand"
+  end
+end

--- a/app/views/mentor/navigation/_tg_sub_nav.html.erb
+++ b/app/views/mentor/navigation/_tg_sub_nav.html.erb
@@ -1,8 +1,12 @@
 <div class="sub-nav-wrapper w-full lg:w-3/4 mx-auto">
   <nav class="list-reset flex">
-    <%= link_to t("views.application.dashboards.menu.dashboard"),
+    <%= link_to "Old Dashboard",
       mentor_dashboard_path,
       class: al(mentor_dashboard_path) + " sub-nav-item"%>
+
+    <%= link_to t("views.application.dashboards.menu.dashboard"),
+      mentor_new_dashboard_path,
+      class: al(mentor_new_dashboard_path) + " sub-nav-item"%>
 
     <%= link_to t("views.mentor.navigation.my_profile"),
       mentor_profile_path,

--- a/app/views/mentor/new_dashboards/_side_nav.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: "Dashboard" } do %>
+  <div class="p-4" id="tab-wrapper">
+    <%= render "mentor/new_dashboards/side_nav_content" %>
+  </div>
+<% end %>

--- a/app/views/mentor/new_dashboards/_side_nav_content.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav_content.html.erb
@@ -1,0 +1,31 @@
+  <nav class="p-4">
+    <ol role="list" class="space-y-6 mb-6 overflow-hidden">
+      <%= render "application/templates/completion_step",
+         name: "Background Check",
+         url: "#",
+         is_complete: false,
+         is_active_item: false
+      %>
+
+      <%= render "application/templates/completion_step",
+         name: "Mentor Training",
+         url: mentor_training_path,
+         is_complete: current_mentor.training_complete?,
+         is_active_item:  al(mentor_training_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
+         name: "Consent Waiver",
+         url: "#",
+         is_complete: false,
+         is_active_item: false
+      %>
+
+      <%= render "application/templates/completion_step",
+         name: "Personal Summary",
+         url: "#",
+         is_complete: false,
+         is_active_item: false
+      %>
+    </ol>
+  </nav>

--- a/app/views/mentor/new_dashboards/show.html.erb
+++ b/app/views/mentor/new_dashboards/show.html.erb
@@ -1,0 +1,11 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Dashboard" } do %>
+    <p>
+      Welcome! Please review and complete the onboarding checklist items to officially become a Mentor
+      for the upcoming season. Completing these onboarding items will allow you to connect with teams and begin the
+      mentoring process.
+    </p>
+  <% end %>
+</div>

--- a/app/views/mentor/trainings/show.html.erb
+++ b/app/views/mentor/trainings/show.html.erb
@@ -1,0 +1,24 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Training" } do %>
+    <% if !current_mentor.training_required? %>
+      <p>
+        Training is not required because it was not available when you signed up.
+        However, we encourage you to complete the training to help you do your best!
+      </p>
+    <% elsif current_mentor.training_complete? %>
+      <p>Thank you for completing the training!</p>
+      <p>You are welcome to re-visit the training at any time.</p>
+    <% elsif !current_mentor.training_complete? %>
+      <p>To be able to mentor this season, please complete the mentor training.</p>
+    <% end %>
+
+    <p class="mt-8">
+      <%= link_to "Mentor Training",
+        "https://technovationchallenge.org/courses/mentor-training/",
+        class: "tw-green-btn",
+        target: "_blank" %>
+    </p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     resources :consent_waivers, only: [:new, :create, :show]
 
     resource :dashboard, only: :show
+    resource :new_dashboard, only: :show
     resource :profile, only: [:show, :edit, :update]
     resource :basic_profile, only: :update
     resource :bio, only: [:edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
     resource :location_details, only: :show
     resource :current_location, only: :show
     resource :location, only: [:update, :create]
+    resource :training, only: :show
     resource :training_completion, only: :show
     resources :consent_waivers, only: [:new, :create, :show]
 


### PR DESCRIPTION
Refs #5509 and #5510


This PR adds the basic skeleton for the new mentor dashboard tab. It includes the energetic container and the dashboard side nav. I also included the mentor training tab.

Just calling out that I used the name `new_dashboard` but this is just temporary until we remove all of the old dashboard functionality. I am using it for reference as I work through these tasks. 

<img width="1376" alt="Screenshot 2025-04-29 at 11 46 26 AM" src="https://github.com/user-attachments/assets/18341b2d-63b6-4704-bb33-082b18810727" />
