### PR TITLE
Update rake task to bulk assign teams to an RPE

### DIFF
--- a/lib/tasks/assign_teams_to_rpe.rake
+++ b/lib/tasks/assign_teams_to_rpe.rake
@@ -1,13 +1,17 @@
 desc "Assign teams to RPE"
 task assign_teams_to_rpe: :environment do |task, args|
-  rpe = RegionalPitchEvent.find(args.extras.last)
+  rpe = RegionalPitchEvent.find_by(id: args.extras.last)
+
+  if rpe.blank?
+    raise "Could not find RPE with ID: #{args.extras.last}"
+  end
 
   puts "Assigning teams to RPE #{rpe.name} (ID #{rpe.id})"
   args.extras[0..-2].each do |team_id|
-    team = Team.find(team_id)
+    team = Team.find_by(id: team_id)
 
     if team.blank?
-      puts "#{team_id} could not be found"
+      puts "Could not find team with ID: #{team_id}"
     elsif !team.current_season?
       puts "#{team.name} is not a part of the current season"
     elsif team.submission.blank?


### PR DESCRIPTION
This will use `find_by` instead of `find` so it won't raise an error if a team or RPE can't be found; raising an error causes the rake task to fail/halt.