### PR TITLE
Update rake task that bulk assigns judges to an RPE to handle nonexistent accounts

### DIFF
--- a/lib/tasks/assign_judges_to_rpe.rake
+++ b/lib/tasks/assign_judges_to_rpe.rake
@@ -9,7 +9,7 @@ task assign_judges_to_rpe: :environment do |task, args|
   puts "Assigning judges to RPE #{rpe.name} (ID #{rpe.id})"
   args.extras[0..-2].each do |email_address|
     account = Account.find_by(email: email_address)
-    judge_profile = account.judge_profile
+    judge_profile = account&.judge_profile
 
     if account.blank?
       puts "Could not find account with email address: #{email_address}"


### PR DESCRIPTION
This will handle the case where we're trying to access a judge profile for an account that doesn't exist, which causes this error:

```
NoMethodError: undefined method `judge_profile' for nil:NilClass
```


