### PR TITLE
Added mentor rebranded personal summary

### DIFF
--- a/app/controllers/mentor/bios_controller.rb
+++ b/app/controllers/mentor/bios_controller.rb
@@ -1,5 +1,7 @@
 module Mentor
   class BiosController < MentorController
+    layout "mentor_rebrand"
+
     def update
       if bio_params[:bio].blank?
         current_mentor.errors.add(:bio, :blank)

--- a/app/views/mentor/bios/_form.en.html.erb
+++ b/app/views/mentor/bios/_form.en.html.erb
@@ -13,11 +13,11 @@
     <span><%= "character".pluralize((f.object.bio || "").length) %></span>
   <% end %>
 
-  <p class="hint">
+  <p class="tw-hint">
     Please provide at least 100 characters, or about 15 words
   </p>
 
-  <p>
-    <%= f.submit "Save", class: "button" %>
+  <p class="text-center">
+    <%= f.submit "Save", class: "tw-green-btn inline-block" %>
   </p>
 <% end %>

--- a/app/views/mentor/bios/edit.en.html.erb
+++ b/app/views/mentor/bios/edit.en.html.erb
@@ -1,11 +1,8 @@
 <% provide :title, "Update your personal summary" %>
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-1/2">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Personal Summary" } do %>
+    <%= render "errors", record: current_mentor %>
 
-<div class="grid grid--justify-space-around">
-  <div class="panel grid__col-sm-8">
-    <h3>Add your personal summary</h3>
-
-    <%= render 'errors', record: current_mentor %>
-
-    <%= render 'form' %>
-  </div>
+    <%= render "form" %>
+  <% end %>
 </div>

--- a/app/views/mentor/bios/show.en.html.erb
+++ b/app/views/mentor/bios/show.en.html.erb
@@ -1,0 +1,19 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Personal Summary" } do %>
+    <% if current_mentor.bio.present? %>
+      <%= simple_format h(current_mentor.bio) %>
+    <% else %>
+      <p>
+        <%= t("views.profile_requirements.build_profile.label") %>
+      </p>
+    <% end %>
+
+    <p class="text-center mt-8">
+      <%= link_to current_mentor.bio.present? ? "Change your summary": "Add your summary",
+        edit_mentor_bio_path,
+        class: "tw-green-btn" %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/mentor/new_dashboards/_side_nav_content.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav_content.html.erb
@@ -23,9 +23,9 @@
 
       <%= render "application/templates/completion_step",
          name: "Personal Summary",
-         url: "#",
-         is_complete: false,
-         is_active_item: false
+         url: mentor_bio_path,
+         is_complete: current_mentor.bio.present?,
+         is_active_item: al(mentor_bio_path).present?
       %>
 
       <%= render "application/templates/side_nav_item",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
     resource :new_dashboard, only: :show
     resource :profile, only: [:show, :edit, :update]
     resource :basic_profile, only: :update
-    resource :bio, only: [:edit, :update]
+    resource :bio, only: [:show, :edit, :update]
 
     resources :cookies, only: :create
     resource :survey_reminder, only: :create

--- a/spec/features/mentor/personal_summary_spec.rb
+++ b/spec/features/mentor/personal_summary_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature "Mentor personal summary" do
+  let(:mentor) { FactoryBot.create(:mentor, :onboarded) }
+
+  before do
+    sign_in(mentor)
+  end
+
+  scenario "displays 'Add your summary' button when personal summary is missing" do
+    mentor.bio = nil
+    mentor.save
+
+    visit mentor_new_dashboard_path
+    click_link "Personal Summary"
+
+    expect(page).to have_link("Add your summary", href: edit_mentor_bio_path)
+  end
+
+  scenario "displays existing summary and 'Change your summary' button when personal summary is present" do
+    visit mentor_new_dashboard_path
+    click_link "Personal Summary"
+
+    expect(page).to have_link("Change your summary", href: edit_mentor_bio_path)
+    expect(page).to have_content(mentor.bio)
+  end
+
+  scenario "allows mentor to update their personal summary" do
+    visit mentor_new_dashboard_path
+    click_link "Personal Summary"
+    click_link "Change your summary"
+
+    fill_in "Tell the students about yourself", with: "Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore."
+
+    click_button "Save"
+    expect(current_path).to eq(mentor_dashboard_path)
+  end
+end


### PR DESCRIPTION
Refs #5512 

This PR adds the mentor "personal summary" section to the new dashboard

<img width="1478" alt="Screenshot 2025-05-02 at 10 43 50 AM" src="https://github.com/user-attachments/assets/0bbf682f-648c-41d5-8b78-26c3a2253125" />
