### PR TITLE
Added mentor rebrand curriculum tab

### DIFF
--- a/app/controllers/mentor/curriculum_controller.rb
+++ b/app/controllers/mentor/curriculum_controller.rb
@@ -1,0 +1,5 @@
+module Mentor
+  class CurriculumController < MentorController
+    layout "mentor_rebrand"
+  end
+end

--- a/app/views/mentor/curriculum/show.html.erb
+++ b/app/views/mentor/curriculum/show.html.erb
@@ -1,0 +1,68 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Curriculum" } do %>
+    <div>
+      <p class="mb-10">
+        Learn how to make your project as strong as possible by following these lessons.
+        Most participants spend around 40+ hours working on their ideas.
+      </p>
+
+      <div class="mb-8">
+        <h4 class="text-xl font-medium mb-4">Students</h4>
+        <p>
+          <a href="https://technovationchallenge.org/technovation-curriculum/" class="tw-green-btn" target="_blank">
+            Go to Student Curriculum
+          </a>
+        </p>
+      </div>
+
+      <div class="mb-8">
+        <h4 class="text-xl font-medium mb-4">Mentors</h4>
+        <p>
+          <a href="https://technovationchallenge.org/mentor-curriculum/" class="tw-green-btn" target="_blank">
+            Go to Mentor Curriculum
+          </a>
+        </p>
+      </div>
+
+      <div>
+        <h4 class="text-xl font-medium">Judging</h4>
+        <p class="mb-2">
+          Visit these helpful links to prepare your project for judging:
+        </p>
+        <ul class="list-disc ml-8">
+          <li>
+            <a href="https://technovationchallenge.org/submission-guidelines/" target="_blank">
+              Submission Guidelines (updated each season)
+            </a>
+          </li>
+
+          <li>
+            <a href="https://technovationchallenge.org/curriculum/judging-rubric/" target="_blank">
+              Judging Rubrics
+            </a>
+          </li>
+
+          <li>
+            <a href="https://technovationchallenge.org/program-timeline" target="_blank">
+              Suggested Milestones
+            </a>
+          </li>
+
+          <li>
+            <a href="https://technovationchallenge.org/award-structure/" target="_blank">
+              Awards Page
+            </a>
+          </li>
+
+          <li>
+            <a href="https://www.technovation.org/app-gallery/" target="_blank">
+              Apps and AI Inventions from Past Teams
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/mentor/new_dashboards/_side_nav_content.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav_content.html.erb
@@ -27,5 +27,11 @@
          is_complete: false,
          is_active_item: false
       %>
+
+      <%= render "application/templates/side_nav_item",
+        name: "Learn from the Curriculum",
+        url: mentor_curriculum_path,
+        is_active_item: al(mentor_curriculum_path).present?
+      %>
     </ol>
   </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     resource :training, only: :show
     resource :training_completion, only: :show
     resources :consent_waivers, only: [:new, :create, :show]
+    resource :curriculum, only: :show, controller: "curriculum"
 
     resource :dashboard, only: :show
     resource :new_dashboard, only: :show


### PR DESCRIPTION
Refs #5550 

This PR adds the rebranded mentor `Learn from the curriculum` tab

<img width="1462" alt="Screenshot 2025-05-02 at 2 50 42 PM" src="https://github.com/user-attachments/assets/37d3c285-2848-49c3-b627-3d911ec4756a" />

