### PR TITLE
Updated mentor sidenav and onboarding checkmark bubble size

### DIFF
--- a/app/views/application/templates/_completion_step.html.erb
+++ b/app/views/application/templates/_completion_step.html.erb
@@ -2,18 +2,18 @@
   <a href="<%= url %>" class="group flex items-center hover:text-gray-900">
     <span class="flex h-9 items-center" aria-hidden="true">
       <% if is_complete %>
-        <span class="flex h-6 w-6 items-center justify-center rounded-full bg-tg-green">
-          <svg class="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <span class="flex h-4 w-4 items-center justify-center rounded-full bg-tg-green">
+          <svg class="h-3 w-3 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd">
           </svg>
         </span>
       <% elsif is_active_item %>
-        <span class=" flex h-6 w-6 items-center justify-center rounded-full border-2 border-tg-green bg-white">
-          <span class="h-2.5 w-2.5 rounded-full bg-tg-green"></span>
+        <span class=" flex h-4 w-4 items-center justify-center rounded-full border-2 border-tg-green bg-white">
+          <span class="h-2 w-2 rounded-full bg-tg-green"></span>
         </span>
       <% else %>
-        <span class=" flex h-6 w-6 items-center justify-center rounded-full border-2 border-gray-300 bg-white group-hover:border-gray-300">
-          <span class="h-2.5 w-2.5 rounded-full bg-transparent group-hover:bg-gray-300"></span>
+        <span class=" flex h-4 w-4 items-center justify-center rounded-full border-2 border-gray-300 bg-white group-hover:border-gray-300">
+          <span class="h-2 w-2 rounded-full bg-transparent group-hover:bg-gray-300"></span>
         </span>
       <% end %>
     </span>

--- a/app/views/mentor/new_dashboards/_side_nav_content.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav_content.html.erb
@@ -1,32 +1,40 @@
   <nav class="p-4">
-    <ol role="list" class="space-y-6 mb-6 overflow-hidden">
-      <%= render "application/templates/completion_step",
-         name: "Background Check",
-         url: "#",
-         is_complete: false,
-         is_active_item: false
+    <ol role="list" class="space-y-4 mb-6 overflow-hidden">
+      <%= render "application/templates/side_nav_item",
+         name: "Onboarding",
+         url: mentor_new_dashboard_path,
+         is_active_item: al(mentor_new_dashboard_path).present?
       %>
 
-      <%= render "application/templates/completion_step",
-         name: "Mentor Training",
-         url: mentor_training_path,
-         is_complete: current_mentor.training_complete?,
-         is_active_item:  al(mentor_training_path).present?
-      %>
+      <ol class="ml-6">
+        <%= render "application/templates/completion_step",
+           name: "Background Check",
+           url: "#",
+           is_complete: false,
+           is_active_item: false
+        %>
 
-      <%= render "application/templates/completion_step",
-         name: "Consent Waiver",
-         url: "#",
-         is_complete: false,
-         is_active_item: false
-      %>
+        <%= render "application/templates/completion_step",
+           name: "Mentor Training",
+           url: mentor_training_path,
+           is_complete: current_mentor.training_complete?,
+           is_active_item:  al(mentor_training_path).present?
+        %>
 
-      <%= render "application/templates/completion_step",
-         name: "Personal Summary",
-         url: mentor_bio_path,
-         is_complete: current_mentor.bio.present?,
-         is_active_item: al(mentor_bio_path).present?
-      %>
+        <%= render "application/templates/completion_step",
+           name: "Consent Waiver",
+           url: "#",
+           is_complete: false,
+           is_active_item: false
+        %>
+
+        <%= render "application/templates/completion_step",
+           name: "Personal Summary",
+           url: mentor_bio_path,
+           is_complete: current_mentor.bio.present?,
+           is_active_item: al(mentor_bio_path).present?
+        %>
+      </ol>
 
       <%= render "application/templates/side_nav_item",
         name: "Learn from the Curriculum",


### PR DESCRIPTION
Refs #5569 

This PR does the following:
- Updates mentor dashboard sidenav (Nested the onboarding steps underneath an onboarding list item)
- Update the checkmark bubble size to be a bit smaller 

<img width="1535" alt="Screenshot 2025-05-07 at 8 48 00 PM" src="https://github.com/user-attachments/assets/c669823e-160d-4337-8898-ae3cf61742ef" />
