### PR TITLE
Fix issue with ChAs trying to export judge list from an RPE

### DIFF
--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -177,6 +177,10 @@ class UserInvitation < ApplicationRecord
     "UserInvitation"
   end
 
+  def assigned_teams_for_event(event)
+    assigned_teams.where(id: event.teams.pluck(:id))
+  end
+
   def locale
     :en
   end
@@ -195,6 +199,10 @@ class UserInvitation < ApplicationRecord
 
   def mailer_token
     admin_permission_token
+  end
+
+  def company_name
+    nil
   end
 
   private


### PR DESCRIPTION
If a chapter ambassador tries to export judges from an RPE and there are judges who were invited but not registered to the platform yet, it will cause an error. This is because invited judges are a `UserInvitation` record, not a `JudgeProfile` record. The error is being caused because there are two methods that are being called that only existed on the `JudgeProfile` model and not on `UserInvitation`:

- `#assigned_teams_for_event`
- `#company_name`

I added these^ methods to `UserInvitation` and it seems to work now (I can't export the CSV locally, but I was getting an error and then made the fix and it seems to work now).

