### PR TITLE
Fix judge names on events datagrid

### DIFF
--- a/app/data_grids/events_grid.rb
+++ b/app/data_grids/events_grid.rb
@@ -46,7 +46,7 @@ class EventsGrid
 
   column :judges, preload: [:judges, :user_invitations] do
     judge_list
-      .map { |j| j.account.full_name }
+      .map { |j| j.account.present? ? j.account&.full_name : "Invited Judge" }
       .join(",")
   end
 


### PR DESCRIPTION
Adding the "judge names" column to the events datagrid can cause an error when there are judges who are assigned to an event via an invite but they aren't registered to the platform yet.

This will make it so that if a judge is registered we'll display their name and if they're not registered yet we'll display "Invited Judge" (which is how we refer to them on the events show page).

