### PR TITLE
Club ambassador background check and onboarding groundwork

### DIFF
--- a/app/models/chapter_ambassador_profile.rb
+++ b/app/models/chapter_ambassador_profile.rb
@@ -1,4 +1,5 @@
 class ChapterAmbassadorProfile < ActiveRecord::Base
+  include BackgroundCheckHelpers
   include OnboardingTasksConcern
 
   scope :onboarded, -> {
@@ -81,30 +82,6 @@ class ChapterAmbassadorProfile < ActiveRecord::Base
 
   def provided_intro?
     !intro_summary.blank?
-  end
-
-  def background_check_exempt_or_complete?
-    background_check_exempt? || background_check_complete?
-  end
-
-  def background_check_complete?
-    background_check.present? && background_check.clear?
-  end
-
-  def background_check_exempt?
-    account.background_check_exemption?
-  end
-
-  def requires_background_check?
-    !background_check_exempt? && !background_check_complete?
-  end
-
-  def in_background_check_country?
-    country_code == "US"
-  end
-
-  def in_background_check_invitation_country?
-    false
   end
 
   def profile_complete?

--- a/app/models/club_ambassador_profile.rb
+++ b/app/models/club_ambassador_profile.rb
@@ -1,4 +1,6 @@
 class ClubAmbassadorProfile < ActiveRecord::Base
+  include BackgroundCheckHelpers
+
   belongs_to :account
   accepts_nested_attributes_for :account
   validates_associated :account
@@ -47,7 +49,20 @@ class ClubAmbassadorProfile < ActiveRecord::Base
   end
 
   def can_be_marked_onboarded?
-    !!account.email_confirmed?
+    !!(account.email_confirmed? &&
+      background_check_exempt_or_complete? &&
+      training_completed? &&
+      viewed_community_connections?)
+  end
+
+  def in_background_check_country?
+    ENV.fetch("BACKGROUND_CHECK_COUNTRY_CODES", "")
+      .split(",")
+      .include?(account.country_code)
+  end
+
+  def chapter_volunteer_agreement_complete?
+    false
   end
 
   def training_completed?

--- a/app/models/concerns/background_check_helpers.rb
+++ b/app/models/concerns/background_check_helpers.rb
@@ -1,0 +1,25 @@
+module BackgroundCheckHelpers
+  extend ActiveSupport::Concern
+
+  def requires_background_check?
+    in_background_check_country? && !background_check_exempt?
+  end
+
+  def background_check_exempt?
+    !in_background_check_country? || account.background_check_exemption?
+  end
+
+  def background_check_exempt_or_complete?
+    background_check_exempt? || background_check_complete?
+  end
+
+  def background_check_complete?
+    return true if !requires_background_check?
+
+    background_check.present? && background_check.clear?
+  end
+
+  def in_background_check_country?
+    true
+  end
+end

--- a/app/views/admin/participants/_background_check_exemption.html.erb
+++ b/app/views/admin/participants/_background_check_exemption.html.erb
@@ -1,32 +1,38 @@
 <% if profile.requires_background_check? %>
   <p>
-    <%= profile.name %> is in a country that requires a background check. By clicking the button below, <%= profile.name %> will be exempt from the background check requirement.
+    <%= profile.name %> is in a country that requires a background check.
+    By clicking the button below, <%= profile.name %> will be exempt from
+    the background check requirement.
   </p>
 
   <p>
     <%= link_to "Exempt from background check requirement",
-                grant_admin_participant_background_check_exemption_path(profile.account),
-                class: 'button',
-                data: {
-                  method: :patch,
-                  confirm: "Exempt #{profile.name} from the background check requirement?" +
-                    "<p>Please document reason in your records.</p>"
-                } %>
+      grant_admin_participant_background_check_exemption_path(profile.account),
+      class: "button",
+      data: {
+        method: :patch,
+        confirm: "Exempt #{profile.name} from the background check requirement?" +
+        "<p>Please document reason in your records.</p>"
+      }
+    %>
   </p>
 <% elsif profile.background_check_exemption? %>
-    <p>
-      <%= profile.name %> is in a country that requires a background check. They currently have a background check exemption. <br>
-      By clicking the button below, you will revoke the background check exemption and they will be required to complete a background check.
-    </p>
+  <p>
+    <%= profile.name %> is in a country that requires a background check.
+    They currently have a background check exemption. <br> By clicking the
+    button below, you will revoke the background check exemption and they
+    will be required to complete a background check.
+  </p>
 
-    <p>
-      <%= link_to "Revoke background check exemption",
-                  revoke_admin_participant_background_check_exemption_path(profile.account),
-                  class: 'button',
-                  data: {
-                    method: :patch,
-                    confirm: "Revoke background check exemption for #{profile.name}?" +
-                      "<p>Please document reason in your records.</p>"
-                  } %>
-    </p>
-  <% end %>
+  <p>
+    <%= link_to "Revoke background check exemption",
+      revoke_admin_participant_background_check_exemption_path(profile.account),
+      class: "button",
+      data: {
+        method: :patch,
+        confirm: "Revoke background check exemption for #{profile.name}?" +
+        "<p>Please document reason in your records.</p>"
+      }
+    %>
+  </p>
+<% end %>

--- a/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_chapter_ambassador_onboarding.html.erb
@@ -1,94 +1,16 @@
-  <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
-    <h4 class="reset">Required onboarding steps:</h4>
-    <p class="hint">
-      Chapter Ambassadors must complete these items to be considered onboarded:
-    </p>
+<div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+  <h4 class="reset">Required onboarding steps:</h4>
+  <p class="hint">
+    Chapter Ambassadors must complete these items to be considered onboarded:
+  </p>
 
-    <dl>
-      <%= render "admin/participants/email_confirmed_status", account: chapter_ambassador.account %>
+  <dl>
+    <%= render "admin/participants/email_confirmed_status", account: chapter_ambassador.account %>
+    <%= render "admin/participants/onboarding/background_check", profile: chapter_ambassador %>
+    <%= render "admin/participants/onboarding/training", profile: chapter_ambassador %>
+    <%= render "admin/participants/onboarding/sign_volunteer_agreemnt", profile: chapter_ambassador %>
+    <%= render "admin/participants/onboarding/view_community_connections", profile: chapter_ambassador %>
+  </dl>
 
-      <dt>Complete Background Check</dt>
-      <dd>
-        <div style="display: flex;">
-          <% if chapter_ambassador.background_check_exempt_or_complete? %>
-            <%= web_icon("check-circle icon-green") %>
-            <div><%= chapter_ambassador.background_check_complete? ? "Complete" : "Background check exempt" %></div>
-          <% else %>
-            <%= web_icon("exclamation-circle icon-red") %>
-            <div>
-              Incomplete
-              <%= render 'admin/participants/background_check_invitation_status',
-                profile: chapter_ambassador %>
-            </div>
-          <% end %>
-        </div>
-      </dd>
-
-      <dt>Complete Training & Checkpoint</dt>
-      <dd>
-        <% if chapter_ambassador.training_completed? %>
-          <div>
-            <%= web_icon("check-circle icon-green") %>
-            Complete
-          </div>
-        <% else %>
-          <div>
-            <%= web_icon("exclamation-circle icon-red") %>
-            Incomplete
-          </div>
-        <% end %>
-      </dd>
-
-      <dt>Sign Chapter Volunteer Agreement</dt>
-      <dd>
-        <div style="display: flex;">
-          <% if chapter_ambassador.chapter_volunteer_agreement_complete? %>
-            <%= web_icon("check-circle icon-green") %>
-            <div>
-              Complete
-
-              <p class="hint margin--b-none">
-                <% if chapter_ambassador.chapter_volunteer_agreement.signed? %>
-                  Signed <%= chapter_ambassador.chapter_volunteer_agreement.signed_at.strftime("%b %d, %Y") %>
-                <% elsif chapter_ambassador.chapter_volunteer_agreement.off_platform? %>
-                  Completed Off-platform
-                <% end %>
-              </p>
-            </div>
-          <% else %>
-            <%= web_icon("exclamation-circle icon-red") %>
-            <div>
-              Incomplete
-
-              <% if chapter_ambassador.chapter_volunteer_agreement.blank? %>
-                <p class="hint margin--b-none">
-                  Not sent
-                </p>
-              <% else %>
-                <p class="hint margin--b-none">
-                  Not signed
-                </p>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      </dd>
-
-      <dt>View Community Connections Page</dt>
-      <dd>
-        <% if chapter_ambassador.viewed_community_connections? %>
-          <div>
-            <%= web_icon("check-circle icon-green") %>
-            Viewed community connections
-          </div>
-        <% else %>
-          <div>
-            <%= web_icon("exclamation-circle icon-red") %>
-            Not viewed
-          </div>
-        <% end %>
-      </dd>
-    </dl>
-
-    <hr style="height: 1px; width: 100%;">
-  </div>
+  <hr style="height: 1px; width: 100%;">
+</div>

--- a/app/views/admin/participants/_club_ambassador_debugging.html.erb
+++ b/app/views/admin/participants/_club_ambassador_debugging.html.erb
@@ -3,6 +3,11 @@
     <%= render "admin/participants/club_ambassador_onboarding", club_ambassador: profile %>
 
     <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
+      <% if current_account.is_admin? && (profile.requires_background_check? || profile.background_check_exemption?) %>
+        <%= render "admin/participants/background_check_exemption", profile: profile %>
+        <hr style="height: 1px; width: 100%;">
+      <% end %>
+
       <dl>
         <dt>Club Onboarding Status</dt>
         <dd>

--- a/app/views/admin/participants/_club_ambassador_onboarding.html.erb
+++ b/app/views/admin/participants/_club_ambassador_onboarding.html.erb
@@ -6,6 +6,10 @@
 
   <dl>
     <%= render "admin/participants/email_confirmed_status", account: club_ambassador.account %>
+    <%= render "admin/participants/onboarding/background_check", profile: club_ambassador %>
+    <%= render "admin/participants/onboarding/training", profile: club_ambassador %>
+    <%= render "admin/participants/onboarding/sign_volunteer_agreemnt", profile: club_ambassador %>
+    <%= render "admin/participants/onboarding/view_community_connections", profile: club_ambassador %>
   </dl>
 
   <hr style="height: 1px; width: 100%;">

--- a/app/views/admin/participants/onboarding/_background_check.en.html.erb
+++ b/app/views/admin/participants/onboarding/_background_check.en.html.erb
@@ -1,0 +1,16 @@
+<dt>Complete Background Check</dt>
+<dd>
+  <div style="display: flex;">
+    <% if profile.background_check_exempt_or_complete? %>
+      <%= web_icon("check-circle icon-green") %>
+      <div><%= profile.background_check_complete? ? "Complete" : "Background check exempt" %></div>
+    <% else %>
+      <%= web_icon("exclamation-circle icon-red") %>
+      <div>
+        Incomplete
+        <%= render "admin/participants/background_check_invitation_status",
+          profile: profile %>
+      </div>
+    <% end %>
+  </div>
+</dd>

--- a/app/views/admin/participants/onboarding/_sign_volunteer_agreemnt.en.html.erb
+++ b/app/views/admin/participants/onboarding/_sign_volunteer_agreemnt.en.html.erb
@@ -1,0 +1,34 @@
+<dt>Sign Volunteer Agreement</dt>
+<dd>
+  <div style="display: flex;">
+    <% if profile.chapter_volunteer_agreement_complete? %>
+      <%= web_icon("check-circle icon-green") %>
+      <div>
+        Complete
+
+        <p class="hint margin--b-none">
+        <% if profile.chapter_volunteer_agreement.signed? %>
+          Signed <%= profile.chapter_volunteer_agreement.signed_at.strftime("%b %d, %Y") %>
+      <% elsif profile.chapter_volunteer_agreement.off_platform? %>
+        Completed Off-platform
+      <% end %>
+        </p>
+      </div>
+    <% else %>
+      <%= web_icon("exclamation-circle icon-red") %>
+      <div>
+        Incomplete
+
+        <% if profile.is_a?(ClubAmbassadorProfile) || profile.chapter_volunteer_agreement.blank? %>
+          <p class="hint margin--b-none">
+          Not sent
+          </p>
+        <% else %>
+          <p class="hint margin--b-none">
+          Not signed
+          </p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</dd>

--- a/app/views/admin/participants/onboarding/_training.en.html.erb
+++ b/app/views/admin/participants/onboarding/_training.en.html.erb
@@ -1,0 +1,14 @@
+<dt>Complete Training & Checkpoint</dt>
+<dd>
+  <% if profile.training_completed? %>
+    <div>
+      <%= web_icon("check-circle icon-green") %>
+      Complete
+    </div>
+  <% else %>
+    <div>
+      <%= web_icon("exclamation-circle icon-red") %>
+      Incomplete
+    </div>
+  <% end %>
+</dd>

--- a/app/views/admin/participants/onboarding/_view_community_connections.en.html.erb
+++ b/app/views/admin/participants/onboarding/_view_community_connections.en.html.erb
@@ -1,0 +1,14 @@
+<dt>View Community Connections Page</dt>
+<dd>
+  <% if profile.viewed_community_connections? %>
+    <div>
+      <%= web_icon("check-circle icon-green") %>
+      Viewed community connections
+    </div>
+  <% else %>
+    <div>
+      <%= web_icon("exclamation-circle icon-red") %>
+      Not viewed
+    </div>
+  <% end %>
+</dd>

--- a/app/views/club_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/club_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -1,10 +1,31 @@
   <nav class="p-4" aria-label="Progress">
     <ol role="list" class="space-y-6 mb-6 overflow-hidden">
       <%= render "application/templates/completion_step",
-        name: "Welcome",
-        url: club_ambassador_dashboard_path,
-        is_complete: false,
-        is_active_item: al(club_ambassador_dashboard_path).present?
+        name: "Background Check",
+        url: club_ambassador_background_check_path,
+        is_complete: current_ambassador.background_check_exempt_or_complete?,
+        is_active_item: al(club_ambassador_background_check_path).present?
+      %>
+
+      <%= render "application/templates/completion_step",
+        name: "Chapter Ambassador Training",
+        url: "#",
+        is_complete: current_ambassador.training_completed?,
+        is_active_item: false
+      %>
+
+      <%= render "application/templates/completion_step",
+        name: "Chapter Volunteer Agreement",
+        url: "#",
+        is_complete: current_ambassador.chapter_volunteer_agreement_complete?,
+        is_active_item: false
+      %>
+
+      <%= render "application/templates/completion_step",
+        name: "Community Connections",
+        url: "#",
+        is_complete: current_ambassador.viewed_community_connections?,
+        is_active_item: false
       %>
     </ol>
   </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,10 @@ Rails.application.routes.draw do
     resource :club_location, only: [:show, :edit, :update, :create], controller: "club_locations"
     resource :club_current_location, only: :show
 
+    resource :background_check, only: :show
+    resources :background_checks, only: [:new, :create]
+
+    post "/background_check_invitation", to: "background_checks#create_invitation"
     resource :public_information, only: [:show, :edit, :update], controller: "club_public_information"
 
     resource :club_admin, only: :show, controller: "club_admin"

--- a/db/migrate/20250509211826_add_viewed_community_connections_to_club_ambassadors.rb
+++ b/db/migrate/20250509211826_add_viewed_community_connections_to_club_ambassadors.rb
@@ -1,0 +1,5 @@
+class AddViewedCommunityConnectionsToClubAmbassadors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :club_ambassador_profiles, :viewed_community_connections, :boolean, null: false, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -700,7 +700,8 @@ CREATE TABLE public.club_ambassador_profiles (
     training_completed_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    onboarded boolean DEFAULT false
+    onboarded boolean DEFAULT false,
+    viewed_community_connections boolean DEFAULT false NOT NULL
 );
 
 
@@ -4926,6 +4927,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250226214919'),
 ('20250319195255'),
 ('20250319200014'),
-('20250319200353');
+('20250319200353'),
+('20250509211826');
 
 

--- a/spec/models/club_ambassador_profile_spec.rb
+++ b/spec/models/club_ambassador_profile_spec.rb
@@ -3,10 +3,12 @@ require "rails_helper"
 RSpec.describe ClubAmbassadorProfile do
   let(:club_ambassador_profile) do
     FactoryBot.create(:club_ambassador_profile,
-      training_completed_at: training_completed_at)
+      training_completed_at: training_completed_at,
+      viewed_community_connections: viewed_community_connections)
   end
 
   let(:training_completed_at) { Time.now }
+  let(:viewed_community_connections) { true }
 
   context "callbacks" do
     context "#after_update" do
@@ -14,22 +16,48 @@ RSpec.describe ClubAmbassadorProfile do
         before do
           allow(club_ambassador_profile).to receive(:account)
             .and_return(account)
+
+          allow(account).to receive(:background_check)
+            .and_return(background_check)
         end
 
         let(:account) do
           instance_double(Account,
+            country_code: "US",
             email_confirmed?: email_address_confirmed,
+            background_check_exemption?: false,
             marked_for_destruction?: false,
             valid?: true)
         end
 
         let(:email_address_confirmed) { true }
+        let(:background_check) { instance_double(BackgroundCheck, clear?: background_check_cleared) }
+        let(:background_check_cleared) { true }
 
         context "when all onboarding steps have been completed" do
           let(:email_address_confirmed) { true }
+          let(:background_check_cleared) { true }
+          let(:training_completed_at) { Time.now }
+          let(:viewed_community_connections) { true }
+
+          before do
+            club_ambassador_profile.save
+          end
 
           it "returns true" do
             expect(club_ambassador_profile.onboarded?).to eq(true)
+          end
+        end
+
+        context "when the background check has not been cleared" do
+          let(:background_check_cleared) { false }
+
+          before do
+            club_ambassador_profile.save
+          end
+
+          it "returns false" do
+            expect(club_ambassador_profile.onboarded?).to eq(false)
           end
         end
 
@@ -38,7 +66,17 @@ RSpec.describe ClubAmbassadorProfile do
             club_ambassador_profile.update(training_completed_at: false)
           end
 
-          xit "returns false" do
+          it "returns false" do
+            expect(club_ambassador_profile.onboarded?).to eq(false)
+          end
+        end
+
+        context "when the community connections page has not been viewed" do
+          before do
+            club_ambassador_profile.update(viewed_community_connections: false)
+          end
+
+          it "returns false" do
             expect(club_ambassador_profile.onboarded?).to eq(false)
           end
         end


### PR DESCRIPTION
Basic overview of the changes here:

- all onboarding steps will be added to the club ambassador dashboard and to the admin area
- groundwork is setup all club ambassador onboarding steps
- viewed_community_connections database migration for club ambassadors
- background checks for club ambassadors
  - extracting common background check functionality so it can be reused


