### PR TITLE
Fix club ambassadors not being able to edit their profile

### DIFF
--- a/app/controllers/club_ambassador/profiles_controller.rb
+++ b/app/controllers/club_ambassador/profiles_controller.rb
@@ -13,7 +13,7 @@ module ClubAmbassador
     private
 
     def profile
-      current_club_ambassador
+      current_ambassador
     end
 
     def edit_profile_path


### PR DESCRIPTION
If a club ambassador tries to edit their profile it will cause an error, here's a simple update that will address/fix the issue.