### PR TITLE
Background check exemptions and mentor searchability

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -288,6 +288,7 @@ class Account < ActiveRecord::Base
   before_update :update_division, if: -> { !is_a_judge? && !is_chapter_ambassador? }
   after_commit :update_crm_contact_info, on: :update
   after_update :update_chapter_ambassador_onboarding_status
+  after_update :update_mentor_searchability_status
   after_update :send_assigned_to_chapterable_email
 
   after_commit -> {
@@ -1127,14 +1128,10 @@ class Account < ActiveRecord::Base
 
   def grant_background_check_exemption
     update(background_check_exemption: true)
-
-    mentor_profile&.enable_searchability_with_save
   end
 
   def revoke_background_check_exemption
     update(background_check_exemption: false)
-
-    mentor_profile&.enable_searchability_with_save
   end
 
   def update_chapter_ambassador_onboarding_status
@@ -1252,6 +1249,12 @@ class Account < ActiveRecord::Base
       find_chapter_ambassador_by({
         "accounts.country" => country_code
       })
+    end
+  end
+
+  def update_mentor_searchability_status
+    if saved_change_to_background_check_exemption? && mentor_profile.present?
+      mentor_profile.enable_searchability_with_save
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -324,6 +324,28 @@ RSpec.describe Account do
           end
         end
       end
+
+      describe "updating a mentor's searchability status" do
+        context "for a mentor account" do
+          let(:mentor) { FactoryBot.create(:mentor) }
+
+          it "makes a call to update the mentor searchability status when they're granted a background check exemption" do
+            expect(mentor.mentor_profile).to receive(:enable_searchability_with_save)
+
+            mentor.account.update(background_check_exemption: true)
+          end
+        end
+
+        context "for a chapter ambassador account with a mentor profile" do
+          let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :has_mentor_profile) }
+
+          it "makes a call to update the mentor searchability status when they're granted a background check exemption" do
+            expect(chapter_ambassador.mentor_profile).to receive(:enable_searchability_with_save)
+
+            chapter_ambassador.account.update(background_check_exemption: true)
+          end
+        end
+      end
     end
   end
 
@@ -1407,6 +1429,10 @@ RSpec.describe Account do
     describe "#revoke_background_check_exemption" do
       context "when the background check exemption is for a mentor" do
         let!(:mentor_account) { FactoryBot.create(:account, :mentor) }
+
+        before do
+          mentor_account.grant_background_check_exemption
+        end
 
         it "makes a call to enable searchability for the mentor" do
           expect(mentor_account.mentor_profile).to receive(:enable_searchability_with_save).at_least(:once)


### PR DESCRIPTION
If an admin grants or revokes a background check exemption for an ambassador that doesn't have a mentor profile an error will be displayed.

The change here will address that by moving the `mentor_profile.enable_searchability_with_save` call to an `after_update` hook.


