### PR TITLE
Rebrand mentor 'find a pitch event' tab

### DIFF
--- a/app/controllers/mentor/regional_pitch_events_controller.rb
+++ b/app/controllers/mentor/regional_pitch_events_controller.rb
@@ -1,5 +1,8 @@
 module Mentor
   class RegionalPitchEventsController < MentorController
+
+    layout "mentor_rebrand"
+
     def index
       @regional_events = RegionalPitchEvent.available_to(
         current_team.submission

--- a/app/controllers/mentor/regional_pitch_events_finder_controller.rb
+++ b/app/controllers/mentor/regional_pitch_events_finder_controller.rb
@@ -1,0 +1,5 @@
+module Mentor
+  class RegionalPitchEventsFinderController < MentorController
+    layout "mentor_rebrand"
+  end
+end

--- a/app/controllers/mentor/regional_pitch_events_team_lists_controller.rb
+++ b/app/controllers/mentor/regional_pitch_events_team_lists_controller.rb
@@ -1,5 +1,8 @@
 module Mentor
   class RegionalPitchEventsTeamListsController < MentorController
+
+    layout "mentor_rebrand"
+
     helper_method :events_available_to,
       :can_select_live_event?
 

--- a/app/views/mentor/dashboards/onboarded/_regional_pitch_events.html.erb
+++ b/app/views/mentor/dashboards/onboarded/_regional_pitch_events.html.erb
@@ -1,14 +1,12 @@
-<h1 class="content-heading">Select Pitch Events</h1>
-
 <p>
   Select pitch events in your area for your teams to
   pitch to a live panel of judges!
 </p>
 
-<%= render 'regional_pitch_events/dashboard_disclaimer' %>
+<%= render "regional_pitch_events/dashboard_disclaimer" %>
 
-<div class="step-actions margin--t-large">
-  <%= link_to 'Select Events',
+<div class="mt-8 text-center">
+  <%= link_to "Select Events",
     mentor_regional_pitch_events_team_list_path,
-    class: "button" %>
+    class: "tw-green-btn" %>
 </div>

--- a/app/views/mentor/new_dashboards/_side_nav_content.html.erb
+++ b/app/views/mentor/new_dashboards/_side_nav_content.html.erb
@@ -49,6 +49,12 @@
       %>
 
       <%= render "application/templates/side_nav_item",
+         name: "Find a Pitch Event",
+         url: mentor_regional_pitch_events_finder_path,
+         is_active_item: al(mentor_regional_pitch_events_finder_path).present?
+      %>
+
+      <%= render "application/templates/side_nav_item",
         name: "View Scores & Certificates",
         url: mentor_scores_path,
         is_active_item: al(mentor_scores_path).present?

--- a/app/views/mentor/regional_pitch_events_finder/show.html.erb
+++ b/app/views/mentor/regional_pitch_events_finder/show.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Live Pitch Events in your Region" } do %>
+    <% if current_mentor.onboarding? %>
+      <p>Please complete mentor onboarding to view live pitch events in your region.</p>
+    <% elsif SeasonToggles.select_regional_pitch_event? %>
+      <%= render "mentor/dashboards/onboarded/regional_pitch_events", current_teams: @current_teams %>
+    <% else %>
+      <%= render "explanations/feature_not_available", feature: :events %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
+++ b/app/views/mentor/regional_pitch_events_team_lists/show.html.erb
@@ -1,104 +1,89 @@
-<div class="grid grid--justify-space-around">
-  <div class= "grid__col-8">
-    <h3>Select Regional Pitch Events</h3>
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/new_dashboards/side_nav" %>
 
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: {heading: "Select Regional Pitch Events"} do %>
     <% @current_teams.each do |team| %>
-      <div class="panel">
-        <h3 class="mentor-teams__heading">
-          <%= link_to team.name, mentor_team_path(team) %>
-        </h3>
-
-        <div class="grid">
-          <div class="grid__col-4">
-            <%= link_to image_tag(
-              team.team_photo_url,
-              class: "thumbnail--mdlg grid__cell-img"
-            ), mentor_team_path(team) %>
+      <div class="mb-8 rounded-lg shadow-md border border-gray-300">
+        <div class="p-6">
+          <div class="flex lg:flex-row gap-6">
+            <%= link_to image_tag(team.team_photo_url, class: "w-14"), mentor_team_path(team) %>
+            <div class="flex flex-col">
+              <p class="text-xl">
+                <%= link_to team.name, mentor_team_path(team) %>
+              </p>
+              <p class="text-sm">
+                <%= web_icon(
+                  "flag-o",
+                  text: "#{team.division_name.humanize} Division"
+                ) %>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="p-6">
+          <% if not SeasonToggles.select_regional_pitch_event? %>
+            <p>
+              Regional Pitch Events cannot be selected at this time.
+            </p>
+          <% elsif not team.submission.present? %>
+            <p>
+              This team needs to start a submission in
+              order to select an event.
+            </p>
 
             <p>
-              <%= web_icon(
-                "flag-o",
-                text: "#{team.division_name.humanize} Division"
-              ) %>
+              <%= link_to "Start a submission now",
+                new_mentor_team_submission_path(team_id: team.id),
+                class: "tw-green-btn small" %>
             </p>
-          </div>
+          <% elsif team.division.none_assigned_yet? %>
+            <p>
+              This team needs students registered and listed in
+              order to be eligible to attend an event.
+            </p>
 
-          <div class="grid__col-8 ">
-            <% if not SeasonToggles.select_regional_pitch_event? %>
-              <p>
-                Regional Pitch Events cannot be selected at this time.
-              </p>
-            <% elsif not team.submission.present? %>
-              <p>
-                This team needs to start a submission in
-                order to select an event.
-              </p>
+            <p>
+              <%= link_to "Manage this team",
+                mentor_team_path(team),
+                class: "tw-green-btn" %>
+            </p>
+          <% elsif can_select_live_event?(team) %>
+            <p>
+              There
+              <%= "is".pluralize(events_available_to(team.submission).count) %>
+              <%= pluralize(events_available_to(team.submission).count, "regional pitch event") %>
+              that <%= team.name %> can attend.
+            </p>
 
-              <p>
-                <%= link_to "Start a submission now",
-                  new_mentor_team_submission_path(team_id: team.id),
-                  class: "button small" %>
-              </p>
-            <% elsif team.division.none_assigned_yet? %>
-              <p>
-                This team needs students registered and listed in
-                order to be eligible to attend an event.
-              </p>
+            <p class="text-center mt-4">
+              <%= link_to "Select an Event",
+                mentor_regional_pitch_events_path(team_id: team.id),
+                class: "tw-green-btn"
+              %>
+            </p>
+          <% elsif team.live_event? %>
+            <dl>
+              <dt>Selected Event:</dt>
+              <dd><%= team.event_name %></dd>
+            </dl>
 
-              <p>
-                <%= link_to "Manage this team",
-                  mentor_team_path(team),
-                  class: "button" %>
-              </p>
-            <% elsif can_select_live_event?(team) %>
-              <p>
-                There
-                <%= 'is'.pluralize(
-                  events_available_to(team.submission).count
-                ) %>
-                <%= pluralize(
-                  events_available_to(team.submission).count,
-                  'regional pitch event'
-                ) %>
-                that <%= team.name %> can attend.
-              </p>
+            <p>
+              If this is a mistake or you want to change the event
+              please contact your ambassador.
+            </p>
 
-              <p>
-                <%= link_to 'Select an Event',
-                  mentor_regional_pitch_events_path(team_id: team.id),
-                  class: "button"
-                %>
-              </p>
-            <% elsif team.live_event? %>
-              <dl>
-                <dt>Selected Event:</dt>
-                <dd><%= team.event_name %></dd>
-              </dl>
-
-              <p>
-                If this is a mistake or you want to change the event
-                please contact your chapter ambassador.
-              </p>
-
-              <p>
-                <%= link_to 'View event details',
-                  mentor_regional_pitch_event_path(team.event, team_id: team.id) %>
-              </p>
-            <% else %>
-              <p>
-                There are no nearby events <%= team.name %> can attend.
-                <%= team.name %> will be judged online.
-              </p>
-            <% end %>
-          </div>
+            <div class="mt-8 text-center">
+              <%= link_to "View event details",
+                mentor_regional_pitch_event_path(team.event, team_id: team.id), class: "tw-green-btn" %>
+            </div>
+          <% else %>
+            <p>
+              There are no nearby events <%= team.name %> can attend.
+              <%= team.name %> will be judged online.
+            </p>
+          <% end %>
         </div>
       </div>
     <% end %>
-
-    <p>
-      <%= link_to 'Back',
-          public_send("#{current_account.scope_name}_dashboard_path"),
-          class: "button small" %>
-    <p>
-  </div>
+  <% end %>
 </div>

--- a/app/views/regional_pitch_events/index.en.html.erb
+++ b/app/views/regional_pitch_events/index.en.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto flex w-full lg:w-3/4">
-  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Available Events"} do %>
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Available Events" } do %>
     <section class="mb-8">
       <p class="mb-4">
         <%= link_to "Go back!",
@@ -11,7 +11,7 @@
         Events will be confirmed as either Regional Pitch Events or
         Celebration Events after <%= ImportantDates.rpe_officiality_finalized.strftime("%B %-d") %>.
         For more information, please check out the
-        <%= link_to "Technovation FAQ", "https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events" %>
+        <%= link_to "Technovation FAQ", ENV.fetch("REGIONAL_PITCH_EVENTS_FAQ_URL") %>
         or contact your ambassador.
       </p>
     </section>

--- a/app/views/regional_pitch_events/index.en.html.erb
+++ b/app/views/regional_pitch_events/index.en.html.erb
@@ -1,43 +1,22 @@
-<% if current_scope == "mentor" %>
-  <div class="grid grid--justify-space-around">
-    <div class="grid__col-8">
-      <h4 class="content-heading">Select a Regional Pitch Event</h4>
-
-        <div class="panel">
-          <%= render "mentor/teams/team_list_item_content",
-                     team: current_team %>
-        </div>
-
-        <%= render partial: 'regional_pitch_events/event',
-                   collection: @regional_events %>
-        <p>
-          <%= link_to 'Go back',
-                      back_from_event_path,
-                      class: "button small" %>
-        </p>
-    </div>
-  </div>
-<% else %>
-  <div class="container mx-auto flex w-full lg:w-3/4">
-    <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Available Events'} do %>
-      <section class="mb-8">
-        <p class="mb-4">
-          <%= link_to 'Go back!',
-                      back_from_event_path,
-                      class: "tw-gray-btn text-sm" %>
-        </p>
-        <p>These are the available events in your area. </p>
-        <p>
-          Events will be confirmed as either Regional Pitch Events or
-          Celebration Events after <%= ImportantDates.rpe_officiality_finalized.strftime("%B %-d") %>.
-          For more information, please check out the
-          <%= link_to 'Technovation FAQ', 'https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events' %>
-          or contact your chapter ambassador.
-        </p>
-      </section>
-      <%= render partial: 'regional_pitch_events/rebrand/event',
-                 locals: { multiple_events: true },
-                 collection: @regional_events %>
-    <% end %>
-  </div>
-<% end %>
+<div class="container mx-auto flex w-full lg:w-3/4">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Available Events"} do %>
+    <section class="mb-8">
+      <p class="mb-4">
+        <%= link_to "Go back!",
+          back_from_event_path,
+          class: "tw-gray-btn text-sm" %>
+      </p>
+      <p>These are the available events in your area. </p>
+      <p>
+        Events will be confirmed as either Regional Pitch Events or
+        Celebration Events after <%= ImportantDates.rpe_officiality_finalized.strftime("%B %-d") %>.
+        For more information, please check out the
+        <%= link_to "Technovation FAQ", "https://iridescentsupport.zendesk.com/hc/en-us/sections/360007469154-Regional-Pitch-Events" %>
+        or contact your ambassador.
+      </p>
+    </section>
+    <%= render partial: "regional_pitch_events/rebrand/event",
+      locals: { multiple_events: true },
+      collection: @regional_events %>
+  <% end %>
+</div>

--- a/app/views/regional_pitch_events/show.en.html.erb
+++ b/app/views/regional_pitch_events/show.en.html.erb
@@ -1,33 +1,23 @@
-<% if current_scope == "mentor" %>
-  <div class="grid grid--justify-center">
-    <div class="grid__col-8">
-        <div class="panel">
-          <%= render "mentor/teams/team_list_item_content",
-                     team: current_team %>
-        </div>
+ <div class="container mx-auto flex w-full lg:w-3/4">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Event Details"} do %>
+    <div class="mb-12">
+      <p class="mb-4">
+        <%= link_to "Go back!",
+          back_from_event_path,
+          class: "tw-gray-btn text-sm" %>
+      </p>
 
-        <%= render 'regional_pitch_events/event',
-                   event: @regional_pitch_event %>
-        <p>
-          <%= link_to 'Go back',
-                      back_from_event_path,
-                      class: "button small" %>
-        </p>
-    </div>
-  </div>
-<% else %>
+      <%= render "regional_pitch_events/rebrand/event", event: @regional_pitch_event %>
 
-  <div class="container mx-auto flex w-full lg:w-3/4">
-    <%= render layout: 'application/templates/dashboards/energetic_container', locals: { heading: 'Event Details'} do %>
-      <section class="mb-8">
-        <p class="mb-4">
-          <%= link_to 'Go back!',
-                      back_from_event_path,
-                      class: "tw-gray-btn text-sm" %>
-        </p>
-        <%= render 'regional_pitch_events/rebrand/event',
-                   event: @regional_pitch_event %>
-      </section>
+      <% if SeasonToggles.pitch_presentation_needed?(current_team) %>
+        <%= render "team_submissions/pieces/pitch_presentation",
+          team: current_team,
+          submission: current_team.submission %>
       <% end %>
     </div>
-<% end %>
+
+    <div class="tw-hint">
+      <%= render "regional_pitch_events/dashboard_disclaimer" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
+++ b/app/views/team_submissions/pieces/_pitch_presentation.en.html.erb
@@ -1,9 +1,10 @@
 <% provide :title, "Pitch Presentation Slides" %>
 
-<div>
+<div class="my-12">
+  <p class="font-medium">Pitch Presentation Slides</p>
   <% if team.selected_regional_pitch_event.live? %>
     <% if submission.pitch_presentation_url_complete? %>
-      <div class="field__existing-value">
+      <div class="bg-gray-200 p-4 rounded">
         Your team has uploaded:
         <%= link_to submission.pitch_presentation_filename,
           submission.pitch_presentation_url %>
@@ -26,7 +27,7 @@
 
         <%= f.hidden_field :pitch_presentation_cache %>
 
-        <%= f.submit "Upload", class: "button" %>
+        <%= f.submit "Upload", class: "tw-green-btn" %>
       </div>
     <% end %>
 
@@ -59,7 +60,7 @@
   <% else %>
     <p>
       If you are attending a local celebration or unofficial pitch event, your
-      Chapter Ambassador may ask you to share your pitch presentation slides with
+      Ambassador may ask you to share your pitch presentation slides with
       them before the event. Coordinate with them directly and good luck!
     </p>
   <% end %>

--- a/circle.yml
+++ b/circle.yml
@@ -114,6 +114,7 @@ jobs:
           PGUSER: root
           RAILS_ENV: test
           REDIS_URL: redis://127.0.0.1:6379/0
+          REGIONAL_PITCH_EVENTS_FAQ_URL: 'https://some-url'
           THUNKABLE_PROMO_IMAGE: n-a
           WKHTMLTOPDF_PATH: /usr/bin/wkhtmltopdf
       - image: cimg/postgres:13.7

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,7 @@ Rails.application.routes.draw do
     resource :regional_pitch_events_team_list, only: :show
     resource :regional_pitch_event_selection, only: :create
     resources :regional_pitch_events, only: [:index, :show]
+    resource :regional_pitch_events_finder, only: :show, controller: "regional_pitch_events_finder"
     resources :scores, only: [:index, :show]
     resources :certificates, only: :index
   end

--- a/spec/features/admin/select_regional_pitch_event_toggle_spec.rb
+++ b/spec/features/admin/select_regional_pitch_event_toggle_spec.rb
@@ -41,22 +41,22 @@ RSpec.feature "Select regional pitch event toggles user controls" do
     scenario "Toggled on" do
       SeasonToggles.select_regional_pitch_event = "on"
       visit path
-      expect(page).to have_css(".button", text: "Select an Event")
+      expect(page).to have_link("Select an Event")
     end
 
     scenario "Toggled off" do
       SeasonToggles.select_regional_pitch_event = "off"
       visit path
-      expect(page).not_to have_css(".button", text: "Select an Event")
+      expect(page).not_to have_link("Select an Event")
     end
   end
 
-  context "Mentor dashboard" do
+  context "Mentor dashboard 'Find a Pitch Event' tab" do
     let(:user) { FactoryBot.create(:mentor, :onboarded) }
     let(:team) { FactoryBot.create(:team) }
     let(:sub) { FactoryBot.create(:submission, :junior) }
     let!(:rpe) { FactoryBot.create(:rpe) }
-    let(:path) { mentor_dashboard_path }
+    let(:path) { mentor_regional_pitch_events_finder_path }
 
     before do
       team.team_submissions << sub
@@ -68,13 +68,13 @@ RSpec.feature "Select regional pitch event toggles user controls" do
     scenario "Toggled on" do
       SeasonToggles.select_regional_pitch_event = "on"
       visit path
-      expect(page).to have_css(".button", text: "Select Events")
+      expect(page).to have_link("Select Events")
     end
 
     scenario "Toggled off" do
       SeasonToggles.select_regional_pitch_event = "off"
       visit path
-      expect(page).not_to have_css(".button", text: "Select Events")
+      expect(page).not_to have_link("Select Events")
     end
   end
 end

--- a/spec/features/mentor/find_a_pitch_event_spec.rb
+++ b/spec/features/mentor/find_a_pitch_event_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.feature "Mentor finds a pitch event" do
+  context "Mentor is not onboarded" do
+    let(:mentor) { FactoryBot.create(:mentor, :onboarding) }
+
+    before do
+      sign_in(mentor)
+    end
+
+    scenario "Select pitch events toggle is ON" do
+      SeasonToggles.select_regional_pitch_event = "on"
+      visit mentor_regional_pitch_events_finder_path
+
+      expect(page).to have_content("Please complete mentor onboarding to view live pitch events in your region.")
+      expect(page).not_to have_link("Select Events")
+    end
+
+    scenario "Select pitch events toggle is OFF" do
+      SeasonToggles.select_regional_pitch_event = "off"
+      visit mentor_regional_pitch_events_finder_path
+
+      expect(page).to have_content("Please complete mentor onboarding to view live pitch events in your region.")
+      expect(page).not_to have_link("Select Events")
+    end
+  end
+
+  context "Mentor is onboarded" do
+    let!(:rpe) { FactoryBot.create(:rpe, :junior, :chicago) }
+    let(:mentor) { FactoryBot.create(:mentor, :onboarded) }
+    let(:team) { FactoryBot.create(:team) }
+    let(:submission) { FactoryBot.create(:submission, :junior, :chicago) }
+
+    before do
+      team.team_submissions << submission
+      TeamRosterManaging.add(team, mentor)
+
+      sign_in(mentor)
+    end
+
+    scenario "Select pitch events toggle is ON" do
+      SeasonToggles.select_regional_pitch_event = "on"
+      visit mentor_regional_pitch_events_finder_path
+
+      expect(page).to have_link("Select Events")
+      click_link "Select Events"
+
+      expect(page).to have_content("There is 1 regional pitch event that #{team.name} can attend.")
+      click_link "Select an Event"
+      expect(page).to have_content(rpe.name)
+    end
+
+    scenario "Select pitch events toggle is OFF" do
+      SeasonToggles.select_regional_pitch_event = "off"
+      visit mentor_regional_pitch_events_finder_path
+
+      expect(page).to have_content("Selecting an event is not available right now.")
+      expect(page).not_to have_link("Select Events")
+    end
+  end
+end


### PR DESCRIPTION
Refs #5552 

This PR adds the following:
- `RegionalPitchEventsFinder` controller/route/view. I struggled with a name for this. This essentially is the "placeholder" tab view. I am open to other naming suggestions. I did not want to change existing routes since it seemed out of scope to refactor other routes/controllers/views.
- Rebranded pitch event views
- Updated the side nav
- Added tests
