### PR TITLE
Updated mentor edit presentation slides path

### DIFF
--- a/app/views/mentor/dashboards/_app.en.html.erb
+++ b/app/views/mentor/dashboards/_app.en.html.erb
@@ -63,7 +63,7 @@
                     "Edit presentation slides"
                   ),
                   send(
-                    "#{current_scope}_team_submission_path",
+                    "#{current_scope}_team_submission_section_path",
                     team.submission,
                     section: :pitch_presentation
                   ) %>


### PR DESCRIPTION
Refs #5594 (more info on the ticket or directly at [this thread](https://iridescentlearning.slack.com/archives/C06CHBQ4E/p1747771432483579))

This PR updates the mentor “Edit Presentation Slides” path so it uses the same section-specific path (using the TeamSubmissionSections controller) as students.

Sometimes, mentors were landing on the wrong submission view because of the following code in the TeamSubmissionController:
```
  section = get_cookie(CookieNames::LAST_VISITED_SUBMISSION_SECTION) ||
        SubmissionSection::SECTION_NAMES[1]
```
The platform tries to read the `last_visited_submission_section` cookie and, if it’s missing, falls back to the section name at index 1 which is `Ideation`. This also explains why I was directed to the presentation section on QA while others were on the ideation section.