### PR TITLE
Removed "complete" scope from scores grid

### DIFF
--- a/app/data_grids/scores_grid.rb
+++ b/app/data_grids/scores_grid.rb
@@ -6,7 +6,7 @@ class ScoresGrid
   self.batch_size = 10
 
   scope do
-    SubmissionScore.complete.judge_not_deleted
+    SubmissionScore.judge_not_deleted
       .includes({judge_profile: [:account, :events]})
       .includes({team_submission: {team: :division}})
       .references(:teams, :team_submissions)

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
-            RUN sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g'
+            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g'
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.leaseweb.net|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.leaseweb.net|g' /etc/apt/sources.list
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            sudeo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
-            sudeo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g'
+            sudeo sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            sudeo sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.leaseweb.net/ubuntu/|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.leaseweb.net/ubuntu/|g' /etc/apt/sources.list
+            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.rit.edu/ubuntu/|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.rit.edu/ubuntu/|g' /etc/apt/sources.list
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,8 +157,8 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
-            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.leaseweb.net|g' /etc/apt/sources.list
-            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.leaseweb.net|g' /etc/apt/sources.list
+            sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.leaseweb.net/ubuntu/|g' /etc/apt/sources.list
+            sudo sed -i 's|http://security.ubuntu.com|http://mirrors.leaseweb.net/ubuntu/|g' /etc/apt/sources.list
             
             sudo apt update
             sudo apt install wkhtmltopdf

--- a/circle.yml
+++ b/circle.yml
@@ -157,6 +157,9 @@ jobs:
       - run:
           name: Install wkhtmltopdf
           command: |
+            RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g' /etc/apt/sources.list
+            RUN sed -i 's|http://security.ubuntu.com|http://mirrors.ubuntu.com/mirrors.txt|g'
+            
             sudo apt update
             sudo apt install wkhtmltopdf
 


### PR DESCRIPTION
Refs #5613


This PR addresses the support request where the "incomplete" scores filter was not returning incomplete scores. I removed the "complete" scope from the grid scope which was added back in January. 