### PR TITLE
Remove onboarding requirement for club ambassador profile section

### DIFF
--- a/app/controllers/club_ambassador/profiles_controller.rb
+++ b/app/controllers/club_ambassador/profiles_controller.rb
@@ -2,6 +2,8 @@ module ClubAmbassador
   class ProfilesController < AmbassadorController
     include ProfileController
 
+    skip_before_action :require_chapterable_and_ambassador_onboarded
+
     layout "club_ambassador_rebrand"
 
     def profile_params


### PR DESCRIPTION
By default all club ambassador sections are locked down by default (requiring the club ambassador to be fully onboarded before they can be accessed) and need to be explicitly opted out of the onboarding requirement, the change here will make the club ambassador profile section available w/o requiring onboarding.


