### PR TITLE
Fix bug viewing chapter onboarding steps on ChA datagrid

### DIFF
--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -99,7 +99,11 @@ class ChapterAmbassadorsGrid
   end
 
   column :remaining_chapter_onboarding_tasks do
-    current_chapter&.incomplete_onboarding_tasks&.to_sentence
+    if current_chapter.present?
+      current_chapter.incomplete_onboarding_tasks.to_sentence
+    else
+      "(Not assigned to a chapter)"
+    end
   end
 
   column :completed_chapter_ambassador_onboarding_tasks,
@@ -113,7 +117,11 @@ class ChapterAmbassadorsGrid
   end
 
   column :completed_chapter_onboarding_tasks do
-    current_chapter&.complete_onboarding_tasks&.to_sentence
+    if current_chapter.present?
+      current_chapter.complete_onboarding_tasks.to_sentence
+    else
+      "(Not assigned to a chapter)"
+    end
   end
 
   column :actions, mandatory: true, html: true do |account|


### PR DESCRIPTION
On the chapter ambassadors datagrid, this will fix an error with viewing the remaining and completed onboarding chapter steps for chapter ambassadors who don't belong a chapter yet.


