### PR TITLE
Added condition to only include rpe assigned submissions in the "submissions to score" table if the round is QF

### DIFF
--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -11,6 +11,9 @@ module Judge
         .references(:team_submissions)
         .order("team_submissions.app_name")
 
+      not_started = not_started_scores
+      not_started += not_started_rpe_assigned_submissions if SeasonToggles.quarterfinals?
+
       render json: {
         current_round: SeasonToggles.judging_round,
 
@@ -24,7 +27,7 @@ module Judge
           }
         },
 
-        not_started: not_started_rpe_assigned_submissions + not_started_scores
+        not_started: not_started
       }
     end
 


### PR DESCRIPTION
Refs #5639 

We received a support request where RPE submission scores that were completed during QF were showing up in the "submissions to score" section for SF judging.

This PR adds a condition to only include rpe assigned submissions in the "submissions to score" table if the round is QF

