### PR TITLE
Only show submissions removed from judging pool due to recusals from the current judging round

### DIFF
--- a/app/controllers/admin/scores_controller.rb
+++ b/app/controllers/admin/scores_controller.rb
@@ -10,7 +10,7 @@ module Admin
       unless request.xhr?
         @round = grid_params[:round]
       end
-      @submissions_removed_from_judging_pool = TeamSubmission.current.complete.removed_from_judging_pool
+      @submissions_removed_from_judging_pool = TeamSubmission.current.complete.current_round.removed_from_judging_pool
     }, only: :index
 
     def show

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -130,7 +130,7 @@ class TeamSubmission < ActiveRecord::Base
   scope :complete, -> { where("published_at IS NOT NULL") }
   scope :incomplete, -> { where("published_at IS NULL") }
 
-  scope :removed_from_judging_pool, -> { where(removed_from_judging_pool: true) }
+  scope :removed_from_judging_pool, -> { where(removed_from_judging_pool: true, returned_to_judging_pool_by_account_id: nil) }
   scope :not_removed_from_judging_pool, -> { where(removed_from_judging_pool: false) }
 
   scope :live, -> { complete.joins(team: :current_official_events) }

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -133,6 +133,19 @@ class TeamSubmission < ActiveRecord::Base
   scope :removed_from_judging_pool, -> { where(removed_from_judging_pool: true, returned_to_judging_pool_by_account_id: nil) }
   scope :not_removed_from_judging_pool, -> { where(removed_from_judging_pool: false) }
 
+  scope :current_round, -> {
+    contest_rank = case SeasonToggles.judging_round
+    when "qf"
+      "quarterfinalist"
+    when "sf"
+      "semifinalist"
+    else
+      none
+    end
+
+    where(contest_rank: contest_rank)
+  }
+
   scope :live, -> { complete.joins(team: :current_official_events) }
 
   scope :virtual, -> {

--- a/app/views/admin/scores/_submissions_removed_from_judging_pool.html.erb
+++ b/app/views/admin/scores/_submissions_removed_from_judging_pool.html.erb
@@ -1,5 +1,5 @@
 <div class="panel">
-  <h4>Submissions Removed from Judging Pool</h4>
+  <h4>Submissions Removed from Judging Pool during <%= SeasonToggles.judging_round(full_name: true) %></h4>
   <p>These submissions are automatically removed from the judging pool due to the number of recusals.</p>
 
   <% if submissions_removed_from_judging_pool.any? %>

--- a/app/views/data_grids/scores/index.html.erb
+++ b/app/views/data_grids/scores/index.html.erb
@@ -1,10 +1,10 @@
 <% provide :title, "Scores" %>
 
-<% if current_account.admin? %>
+<% if current_account.admin? && SeasonToggles.judging_enabled? %>
   <%= render partial: "admin/scores/submissions_removed_from_judging_pool", locals: { submissions_removed_from_judging_pool: @submissions_removed_from_judging_pool } %>
-
-  <h1>Season <%= Season.current.year %> Scores</h1>
 <% end %>
+
+<h1>Season <%= Season.current.year %> Scores</h1>
 
 <%= render "datagrid/datagrid",
   grid: @scored_submissions_grid,


### PR DESCRIPTION
Refs #5639 

We received a support request to only show submissions removed from judging pool due to recusal count for the current round. Team submissions do not have a "round" the way scores do, but there is a contest rank. This solution utilizes the contest rank. For example, a submission with a contest rank of "semifinalist" is in the semifinals round. I'm not sure if there is another approach or something I didn't consider, so please lmk. 

This PR also does the following
- Updated conditional to only show submissions removed during judging (QF & SF)
- Updated `removed_from_judging_pool` scope to include submissions that have been removed and not returned to the pool 