### PR TITLE
Hide contest ranking for ambassadors

### DIFF
--- a/app/data_grids/scored_submissions_grid.rb
+++ b/app/data_grids/scored_submissions_grid.rb
@@ -11,7 +11,9 @@ class ScoredSubmissionsGrid
       .references(:teams, :submission_scores, :judge_profiles)
   end
 
-  column :contest_rank
+  column :contest_rank, if: ->(g) { g.admin } do |submission|
+    submission.contest_rank.humanize.titleize
+  end
 
   column :division do
     team_division_name
@@ -368,6 +370,7 @@ class ScoredSubmissionsGrid
 
   filter :submission_contest_rank,
     :enum,
+    if: ->(g) { g.admin },
     select: TeamSubmission.contest_ranks.keys,
     filter_group: "common" do |value, scope, grid|
     scope.public_send(value)

--- a/app/data_grids/submissions_grid.rb
+++ b/app/data_grids/submissions_grid.rb
@@ -17,7 +17,7 @@ class SubmissionsGrid
     team.division_name.humanize
   end
 
-  column :contest_rank, mandatory: true, order: false do |submission|
+  column :contest_rank, if: ->(g) { g.admin } do |submission|
     submission.contest_rank.humanize.titleize
   end
 
@@ -335,6 +335,7 @@ class SubmissionsGrid
 
   filter :contest_rank,
     :enum,
+    if: ->(g) { g.admin },
     select: TeamSubmission.contest_ranks.map { |key, _value| [key.humanize.titleize, key] } do |value|
       public_send(value)
     end

--- a/app/views/ambassador/score_details/show.en.html.erb
+++ b/app/views/ambassador/score_details/show.en.html.erb
@@ -2,8 +2,10 @@
   <h1><%= @submission.team_name %></h1>
 
   <dl>
-    <dt>Rank:</dt>
-    <dd><%= @submission.contest_rank %></dd>
+    <% if SeasonToggles.display_scores_and_certs? || current_account.is_admin? %>
+      <dt>Rank:</dt>
+      <dd><%= @submission.contest_rank.humanize.titleize %></dd>
+    <% end %>
 
     <dt>Event:</dt>
     <dd><%= @submission.team.event.name %></dd>

--- a/app/views/ambassador/team_submissions/show.html.erb
+++ b/app/views/ambassador/team_submissions/show.html.erb
@@ -23,11 +23,13 @@
                 class: "grid__cell--padding-sm-y"
               ) %>
 
-          <%= web_icon(
-                "flag-o",
-                text: "Rank: #{@team_submission.contest_rank.capitalize}",
-                class: "grid__cell--padding-sm-y"
-              ) %>
+          <% if SeasonToggles.display_scores_and_certs? || current_account.is_admin? %>
+            <%= web_icon(
+                  "flag-o",
+                  text: "Rank: #{@team_submission.contest_rank.humanize.titleize}",
+                  class: "grid__cell--padding-sm-y"
+                ) %>
+          <% end %>
 
           <div class="grid__cell--padding-sm-y">
             <%= submission_progress_bar(@team_submission) %>

--- a/spec/system/chapter_ambassador/view_score_details_spec.rb
+++ b/spec/system/chapter_ambassador/view_score_details_spec.rb
@@ -103,10 +103,6 @@ RSpec.describe "viewing score details page" do
           end
         end
 
-        it "displays the team's rank" do
-          expect(page).to have_content("semifinalist")
-        end
-
         it "displays the name of the RPE" do
           expect(page).to have_content("Windy City Event")
         end
@@ -213,10 +209,6 @@ RSpec.describe "viewing score details page" do
         within "h1" do
           expect(page).to have_content("Ravenclaw")
         end
-      end
-
-      it "displays the team's rank" do
-        expect(page).to have_content("semifinalist")
       end
 
       it "displays the name of the RPE" do


### PR DESCRIPTION
This will hide the contest ranking for ambassadors for the following areas:

- Submissions datagrid (both the filter and column)
- Scores datagrid (both the filter and column)
- Viewing an individual submission
  - The rank will be viewable by ambassadors when certs become available
- Viewing an individual score
  - The rank will be viewable by ambassadors when certs become available


