### PR TITLE
Rebrand mentor team details view (includes team overview, students, mentors, and division tabs)

### DIFF
--- a/app/controllers/concerns/team_controller.rb
+++ b/app/controllers/concerns/team_controller.rb
@@ -9,7 +9,8 @@ module TeamController
   end
 
   def show
-    @team = current_profile.teams.find(params.fetch(:id))
+    team_id = params[:id].presence || params[:team_id].presence
+    @team = current_profile.teams.find(team_id)
 
     if @team.current?
       @team_member_invite = TeamMemberInvite.new(team_id: @team.id)

--- a/app/controllers/mentor/students_controller.rb
+++ b/app/controllers/mentor/students_controller.rb
@@ -1,5 +1,6 @@
 module Mentor
   class StudentsController < MentorController
+    layout "mentor_rebrand"
     def show
       @student = StudentProfile.find(params.fetch(:id))
     end

--- a/app/controllers/mentor/teams/division_controller.rb
+++ b/app/controllers/mentor/teams/division_controller.rb
@@ -1,0 +1,6 @@
+module Mentor::Teams
+  class DivisionController < MentorController
+    include MentorTeamDetailsConcern
+    layout "mentor_rebrand"
+  end
+end

--- a/app/controllers/mentor/teams/division_controller.rb
+++ b/app/controllers/mentor/teams/division_controller.rb
@@ -1,6 +1,6 @@
 module Mentor::Teams
   class DivisionController < MentorController
-    include MentorTeamDetailsConcern
+    include TeamController
     layout "mentor_rebrand"
   end
 end

--- a/app/controllers/mentor/teams/mentors_controller.rb
+++ b/app/controllers/mentor/teams/mentors_controller.rb
@@ -1,6 +1,6 @@
 module Mentor::Teams
   class MentorsController < MentorController
-    include MentorTeamDetailsConcern
+    include TeamController
     layout "mentor_rebrand"
   end
 end

--- a/app/controllers/mentor/teams/mentors_controller.rb
+++ b/app/controllers/mentor/teams/mentors_controller.rb
@@ -1,0 +1,6 @@
+module Mentor::Teams
+  class MentorsController < MentorController
+    include MentorTeamDetailsConcern
+    layout "mentor_rebrand"
+  end
+end

--- a/app/controllers/mentor/teams/students_controller.rb
+++ b/app/controllers/mentor/teams/students_controller.rb
@@ -1,0 +1,6 @@
+module Mentor::Teams
+  class StudentsController < MentorController
+    include MentorTeamDetailsConcern
+    layout "mentor_rebrand"
+  end
+end

--- a/app/controllers/mentor/teams/students_controller.rb
+++ b/app/controllers/mentor/teams/students_controller.rb
@@ -1,6 +1,6 @@
 module Mentor::Teams
   class StudentsController < MentorController
-    include MentorTeamDetailsConcern
+    include TeamController
     layout "mentor_rebrand"
   end
 end

--- a/app/views/mentor/students/show.html.erb
+++ b/app/views/mentor/students/show.html.erb
@@ -1,3 +1,7 @@
-<%= render "profiles/public_show",
-  title: @student.first_name,
-  account: @student %>
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Viewing Student Profile" } do %>
+    <%= render "profiles/rebrand/public_show",
+      title: @student.first_name,
+      account: @student %>
+  <% end %>
+</div>

--- a/app/views/mentor/teams/_side_nav.html.erb
+++ b/app/views/mentor/teams/_side_nav.html.erb
@@ -1,5 +1,5 @@
-<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: @team.name } do %>
+<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: team.name } do %>
   <div class="p-4" id="tab-wrapper">
-    <%= render "mentor/teams/side_nav_content", team: @team %>
+    <%= render "mentor/teams/side_nav_content", team: team %>
   </div>
 <% end %>

--- a/app/views/mentor/teams/_side_nav.html.erb
+++ b/app/views/mentor/teams/_side_nav.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "application/templates/dashboards/side_nav", locals: { heading: @team.name } do %>
+  <div class="p-4" id="tab-wrapper">
+    <%= render "mentor/teams/side_nav_content", team: @team %>
+  </div>
+<% end %>

--- a/app/views/mentor/teams/_side_nav_content.html.erb
+++ b/app/views/mentor/teams/_side_nav_content.html.erb
@@ -1,0 +1,27 @@
+  <nav class="p-4">
+    <ol role="list" class="space-y-6 mb-6 overflow-hidden">
+      <%= render "application/templates/side_nav_item",
+        name: "Team Overview",
+        url: mentor_team_path(@team),
+        is_active_item: request.path == mentor_team_path(@team)
+      %>
+
+      <%= render "application/templates/side_nav_item",
+         name: "Students",
+         url: mentor_team_students_path(@team),
+         is_active_item: al(mentor_team_students_path(@team)).present?
+      %>
+
+      <%= render "application/templates/side_nav_item",
+         name: "Mentors",
+         url: mentor_team_mentors_path(@team),
+         is_active_item: al(mentor_team_mentors_path(@team)).present?
+      %>
+
+      <%= render "application/templates/side_nav_item",
+         name: "Division Details",
+         url: mentor_team_division_path(@team),
+         is_active_item: al(mentor_team_division_path(@team)).present?
+      %>
+    </ol>
+  </nav>

--- a/app/views/mentor/teams/_side_nav_content.html.erb
+++ b/app/views/mentor/teams/_side_nav_content.html.erb
@@ -2,26 +2,26 @@
     <ol role="list" class="space-y-6 mb-6 overflow-hidden">
       <%= render "application/templates/side_nav_item",
         name: "Team Overview",
-        url: mentor_team_path(@team),
-        is_active_item: request.path == mentor_team_path(@team)
+        url: mentor_team_path(team),
+        is_active_item: request.path == mentor_team_path(team)
       %>
 
       <%= render "application/templates/side_nav_item",
          name: "Students",
-         url: mentor_team_students_path(@team),
-         is_active_item: al(mentor_team_students_path(@team)).present?
+         url: mentor_team_students_path(team),
+         is_active_item: al(mentor_team_students_path(team)).present?
       %>
 
       <%= render "application/templates/side_nav_item",
          name: "Mentors",
-         url: mentor_team_mentors_path(@team),
-         is_active_item: al(mentor_team_mentors_path(@team)).present?
+         url: mentor_team_mentors_path(team),
+         is_active_item: al(mentor_team_mentors_path(team)).present?
       %>
 
       <%= render "application/templates/side_nav_item",
          name: "Division Details",
-         url: mentor_team_division_path(@team),
-         is_active_item: al(mentor_team_division_path(@team)).present?
+         url: mentor_team_division_path(team),
+         is_active_item: al(mentor_team_division_path(team)).present?
       %>
     </ol>
   </nav>

--- a/app/views/mentor/teams/division/show.html.erb
+++ b/app/views/mentor/teams/division/show.html.erb
@@ -1,0 +1,7 @@
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/teams/side_nav", team: @team %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Division Details" } do %>
+    <%= render "teams/division", team: @team %>
+  <% end %>
+</div>

--- a/app/views/mentor/teams/mentors/_mentors_list.html.erb
+++ b/app/views/mentor/teams/mentors/_mentors_list.html.erb
@@ -1,3 +1,5 @@
 <ul>
-  <%= render partial: "teams/rebrand/member", collection: mentors %>
+  <%= render partial: "teams/rebrand/member",
+    collection: mentors,
+    locals: { team: team } %>
 </ul>

--- a/app/views/mentor/teams/mentors/_mentors_list.html.erb
+++ b/app/views/mentor/teams/mentors/_mentors_list.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <%= render partial: "teams/rebrand/member", collection: mentors %>
+</ul>

--- a/app/views/mentor/teams/mentors/show.html.erb
+++ b/app/views/mentor/teams/mentors/show.html.erb
@@ -1,5 +1,3 @@
-<% admin_chapter_ambassador ||= false %>
-
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "mentor/teams/side_nav", team: @team %>
 
@@ -8,7 +6,8 @@
 
     <% if @team.mentors.any? %>
       <%= render "mentor/teams/mentors/mentors_list",
-        mentors: @team.mentors.where.not(account_id: nil) %>
+        mentors: @team.mentors.where.not(account_id: nil),
+        team: @team %>
     <% else %>
       <p>Your team does not have any mentors</p>
     <% end %>
@@ -31,7 +30,7 @@
     <h5 class="font-medium mt-16">Do you want more mentors?</h5>
     <p class="tw-hint">
       If you're looking to add a student to your team,
-      <%= link_to "go here", public_send("#{current_scope}_team_students_path", @team), class: "text-energetic-blue" %>.
+      <%= link_to "go here", public_send("#{current_scope}_team_students_path", @team), class: "tw-link" %>.
     </p>
 
     <% if SeasonToggles.team_building_enabled? %>

--- a/app/views/mentor/teams/mentors/show.html.erb
+++ b/app/views/mentor/teams/mentors/show.html.erb
@@ -4,8 +4,54 @@
   <%= render "mentor/teams/side_nav", team: @team %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Mentors" } do %>
-    <%= render "teams/mentor_list",
-      admin_chapter_ambassador: admin_chapter_ambassador,
-      team: @team %>
+    <p class="mb-8">You can add as many mentors as your team needs.</p>
+
+    <% if @team.mentors.any? %>
+      <%= render "mentor/teams/mentors/mentors_list",
+        mentors: @team.mentors.where.not(account_id: nil) %>
+    <% else %>
+      <p>Your team does not have any mentors</p>
+    <% end %>
+
+    <h5 class="font-medium mt-16">Invitations and Requests</h5>
+    <p class="tw-hint">
+      Only students can invite mentors to a team.
+      You can connect with other mentors
+      <%= link_to "here", new_mentor_mentor_search_path, class: "tw-link" %>.
+    </p>
+
+    <% if @team.pending_mentor_join_requests.present? %>
+      <%= render "teams/rebrand/pending_requests",
+        team: @team,
+        requests: @team.pending_mentor_join_requests %>
+    <% else %>
+      <p>There are no pending join requests</p>
+    <% end %>
+
+    <h5 class="font-medium mt-16">Do you want more mentors?</h5>
+    <p class="tw-hint">
+      If you're looking to add a student to your team,
+      <%= link_to "go here", public_send("#{current_scope}_team_students_path", @team), class: "text-energetic-blue" %>.
+    </p>
+
+    <% if SeasonToggles.team_building_enabled? %>
+      <%= form_with model: @team,
+        data: { submit_on_change: true },
+        url: send("#{current_scope}_team_path", @team, { format: :json }),
+        method: :patch do |f| %>
+        <p>
+          <%= f.check_box :accepting_mentor_requests,
+            id: :team_accepting_mentor_requests %>
+
+          <%= f.label :accepting_mentor_requests,
+            "Allow mentors to find our team and request to join us",
+            for: :team_accepting_mentor_requests %>
+        </p>
+      <% end %>
+    <% else %>
+      <%= render "application/templates/alerts/info" do %>
+        Team building is not enabled at this time, so your team cannot add mentors.
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/mentor/teams/mentors/show.html.erb
+++ b/app/views/mentor/teams/mentors/show.html.erb
@@ -1,0 +1,11 @@
+<% admin_chapter_ambassador ||= false %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/teams/side_nav", team: @team %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Mentors" } do %>
+    <%= render "teams/mentor_list",
+      admin_chapter_ambassador: admin_chapter_ambassador,
+      team: @team %>
+  <% end %>
+</div>

--- a/app/views/mentor/teams/show.html.erb
+++ b/app/views/mentor/teams/show.html.erb
@@ -1,5 +1,3 @@
-<% admin_chapter_ambassador ||= false %>
-
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "mentor/teams/side_nav", team: @team %>
 

--- a/app/views/mentor/teams/show.html.erb
+++ b/app/views/mentor/teams/show.html.erb
@@ -1,7 +1,7 @@
 <% admin_chapter_ambassador ||= false %>
 
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
-  <%= render "mentor/teams/side_nav" %>
+  <%= render "mentor/teams/side_nav", team: @team %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Team Overview" } do %>
     <div class="flex flex-col lg:flex-row lg:space-x-12 mb-4">

--- a/app/views/mentor/teams/show.html.erb
+++ b/app/views/mentor/teams/show.html.erb
@@ -1,1 +1,36 @@
-<%= render "teams/show", team: @team, account: current_mentor %>
+<% admin_chapter_ambassador ||= false %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/teams/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Team Overview" } do %>
+    <div class="flex flex-col lg:flex-row lg:space-x-12 mb-4">
+      <%= image_tag @team.team_photo_url, class: "rounded-tr-3xl rounded-bl-3xl w-1/4" %>
+      <div class="mb-auto">
+        <h3 class="font-medium text-2xl mb-2"><%= @team.name %></h3>
+
+        <div class="mb-4">
+          <p class="font-medium">Location</p>
+          <p><%= @team.primary_location %></p>
+        </div>
+
+        <div class="mb-4">
+          <p class="font-medium">Division</p>
+          <p>
+            <%= @team.division_name.humanize %>
+            <%= @team.division.none_assigned_yet? ? "" : "Division"  %>
+          </p>
+        </div>
+
+        <div class="mb-4">
+          <p class="font-medium">Summary</p>
+          <% if @team.description.blank? %>
+            <p>Your team has not written a summary.</p>
+          <% else %>
+            <%= simple_format @team.description %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/mentor/teams/students/_students_list.html.erb
+++ b/app/views/mentor/teams/students/_students_list.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <%= render partial: "teams/rebrand/member", collection: students %>
+</ul>

--- a/app/views/mentor/teams/students/_students_list.html.erb
+++ b/app/views/mentor/teams/students/_students_list.html.erb
@@ -1,3 +1,5 @@
 <ul>
-  <%= render partial: "teams/rebrand/member", collection: students %>
+  <%= render partial: "teams/rebrand/member",
+    collection: students,
+    locals: { team: team } %>
 </ul>

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -1,5 +1,3 @@
-<% admin_chapter_ambassador ||= false %>
-
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "mentor/teams/side_nav", team: @team %>
 

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -38,13 +38,17 @@
 
     <h5 class="font-medium mt-16">Do you want more teammates?</h5>
 
-    <%= render "application/templates/alerts/info" do %>
-      <% if !SeasonToggles.team_building_enabled? || SeasonToggles.judging_enabled_or_between? %>
+    <% if !SeasonToggles.team_building_enabled? || SeasonToggles.judging_enabled_or_between? %>
+      <%= render "application/templates/alerts/info" do %>
         Team building is not enabled at this time, so your team cannot add students.
-      <% elsif !@team.spot_available? %>
+      <% end %>
+    <% elsif !@team.spot_available? %>
+      <%= render "application/templates/alerts/info" do %>
         You cannot invite more students while you have a combined total
         of five members, invitations, and/or join requests.
-      <% elsif !@team.current? %>
+      <% end %>
+    <% elsif !@team.current? %>
+      <%= render "application/templates/alerts/info" do %>
         <%= t("views.teams.show.past_team") %>
       <% end %>
     <% end %>

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -38,19 +38,15 @@
 
     <h5 class="font-medium mt-16">Do you want more teammates?</h5>
 
-    <% if !SeasonToggles.team_building_enabled? || SeasonToggles.judging_enabled_or_between? %>
-      <p class="notice">
+    <%= render "application/templates/alerts/info" do %>
+      <% if !SeasonToggles.team_building_enabled? || SeasonToggles.judging_enabled_or_between? %>
         Team building is not enabled at this time, so your team cannot add students.
-      </p>
-    <% elsif !@team.spot_available? %>
-      <p class="notice">
+      <% elsif !@team.spot_available? %>
         You cannot invite more students while you have a combined total
         of five members, invitations, and/or join requests.
-      </p>
-    <% elsif !@team.current? %>
-      <p class="notice">
+      <% elsif !@team.current? %>
         <%= t("views.teams.show.past_team") %>
-      </p>
+      <% end %>
     <% end %>
 
     <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -1,0 +1,11 @@
+<% admin_chapter_ambassador ||= false %>
+
+<div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
+  <%= render "mentor/teams/side_nav" %>
+
+  <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Students" } do %>
+    <%= render "teams/edit_students",
+        admin_chapter_ambassador: admin_chapter_ambassador,
+        team: @team %>
+  <% end %>
+</div>

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -1,14 +1,15 @@
 <% admin_chapter_ambassador ||= false %>
 
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
-  <%= render "mentor/teams/side_nav" %>
+  <%= render "mentor/teams/side_nav", team: @team %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Students" } do %>
     <h5 class="font-medium mb-4">Current Students</h5>
 
     <% if @team.students.onboarded.any? %>
       <%= render "mentor/teams/students/students_list",
-        students: @team.students.onboarded %>
+        students: @team.students.onboarded,
+        team: @team %>
     <% else %>
       <p>Your team does not have any students</p>
     <% end %>
@@ -21,12 +22,13 @@
 
     <% if @team.students.onboarding.any? %>
       <%= render "mentor/teams/students/students_list",
-        students: @team.students.onboarding %>
+        students: @team.students.onboarding,
+        team: @team %>
     <% else %>
       <p>Your team does not have any pending students</p>
     <% end %>
 
-    <h5 class="font-medium mt-16">Requests to join your team</h5>
+    <h5 class="font-medium mt-16 mb-4">Requests to join your team</h5>
 
     <% if @team.pending_student_join_requests.present? %>
       <%= render "teams/rebrand/pending_requests",

--- a/app/views/mentor/teams/students/show.html.erb
+++ b/app/views/mentor/teams/students/show.html.erb
@@ -4,8 +4,70 @@
   <%= render "mentor/teams/side_nav" %>
 
   <%= render layout: "application/templates/dashboards/energetic_container", locals: { heading: "Students" } do %>
-    <%= render "teams/edit_students",
-        admin_chapter_ambassador: admin_chapter_ambassador,
-        team: @team %>
+    <h5 class="font-medium mb-4">Current Students</h5>
+
+    <% if @team.students.onboarded.any? %>
+      <%= render "mentor/teams/students/students_list",
+        students: @team.students.onboarded %>
+    <% else %>
+      <p>Your team does not have any students</p>
+    <% end %>
+
+    <h5 class="font-medium mt-16">Pending Students</h5>
+    <p class="tw-hint">
+      These students are listed on your team,
+      but are not yet eligible to compete.
+    </p>
+
+    <% if @team.students.onboarding.any? %>
+      <%= render "mentor/teams/students/students_list",
+        students: @team.students.onboarding %>
+    <% else %>
+      <p>Your team does not have any pending students</p>
+    <% end %>
+
+    <h5 class="font-medium mt-16">Requests to join your team</h5>
+
+    <% if @team.pending_student_join_requests.present? %>
+      <%= render "teams/rebrand/pending_requests",
+        team: @team,
+        requests: @team.pending_student_join_requests %>
+    <% else %>
+      <p>There are no pending join requests</p>
+    <% end %>
+
+    <h5 class="font-medium mt-16">Do you want more teammates?</h5>
+
+    <% if !SeasonToggles.team_building_enabled? || SeasonToggles.judging_enabled_or_between? %>
+      <p class="notice">
+        Team building is not enabled at this time, so your team cannot add students.
+      </p>
+    <% elsif !@team.spot_available? %>
+      <p class="notice">
+        You cannot invite more students while you have a combined total
+        of five members, invitations, and/or join requests.
+      </p>
+    <% elsif !@team.current? %>
+      <p class="notice">
+        <%= t("views.teams.show.past_team") %>
+      </p>
+    <% end %>
+
+    <% if SeasonToggles.team_building_enabled? && !SeasonToggles.judging_enabled_or_between? %>
+      <%= form_with model: @team,
+        data: { submit_on_change: true },
+        url: send("#{current_scope}_team_path", @team, { format: :json }),
+        method: :patch do |f| %>
+
+        <p>
+          <%= f.check_box :accepting_student_requests,
+            id: :team_accepting_student_requests %>
+
+          <%= f.label :accepting_student_requests,
+            "Allow other students to find our team and request to join us",
+            for: :team_accepting_student_requests %>
+        </p>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/teams/rebrand/_member.html.erb
+++ b/app/views/teams/rebrand/_member.html.erb
@@ -6,7 +6,7 @@
       <p><%= member.full_name %></p>
       <p><%= mail_to member.email %></p>
 
-      <% if member.actions_needed.present? %>
+      <% if member.student_profile.present? && member.actions_needed.present? %>
         <div class="text-sm text-gray-900 truncate">
           <p class="font-medium">Onboarding steps required:</p>
           <ul class="list-disc list-inside ml-4">

--- a/app/views/teams/rebrand/_member.html.erb
+++ b/app/views/teams/rebrand/_member.html.erb
@@ -20,9 +20,9 @@
       <% if CanRemoveTeamMember.(current_account, member) %>
         <%= link_to "remove this member",
           send("#{current_scope}_team_membership_path",
-               @team,
-               member_id: member.id,
-               member_type: member.class.name
+            team,
+            member_id: member.id,
+            member_type: member.class.name
           ),
           data: {
             method: :delete,

--- a/app/views/teams/rebrand/_member.html.erb
+++ b/app/views/teams/rebrand/_member.html.erb
@@ -1,4 +1,4 @@
-<li id="<%= dom_id(member) %>">
+<li id="<%= dom_id(member) %>" class="mb-8">
   <div class="flex flex-row space-x-4">
     <%= image_tag member.profile_image_url,
       class: "rounded-tl-sm rounded-tr-xl rounded-bl-xl rounded-br-sm w-12 h-12" %>

--- a/app/views/teams/rebrand/_member.html.erb
+++ b/app/views/teams/rebrand/_member.html.erb
@@ -1,0 +1,36 @@
+<li id="<%= dom_id(member) %>">
+  <div class="flex flex-row space-x-4">
+    <%= image_tag member.profile_image_url,
+      class: "rounded-tl-sm rounded-tr-xl rounded-bl-xl rounded-br-sm w-12 h-12" %>
+    <div>
+      <p><%= member.full_name %></p>
+      <p><%= mail_to member.email %></p>
+
+      <% if member.actions_needed.present? %>
+        <div class="text-sm text-gray-900 truncate">
+          <p class="font-medium">Onboarding steps required:</p>
+          <ul class="list-disc list-inside ml-4">
+            <% member.actions_needed.each do |action| %>
+              <li class="text-sm text-gray-800"><%= action %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if CanRemoveTeamMember.(current_account, member) %>
+        <%= link_to "remove this member",
+          send("#{current_scope}_team_membership_path",
+               @team,
+               member_id: member.id,
+               member_type: member.class.name
+          ),
+          data: {
+            method: :delete,
+            confirm: t("views.teams.show.confirm_leave", name: member.name),
+          },
+          class: "text-red-700 text-base"
+        %>
+      <% end %>
+    </div>
+  </div>
+</li>

--- a/app/views/teams/rebrand/_pending_requests.html.erb
+++ b/app/views/teams/rebrand/_pending_requests.html.erb
@@ -1,0 +1,39 @@
+<% if requests.any? %>
+  <% if SeasonToggles.judging_enabled_or_between? %>
+    <p class="tw-hint">
+      You cannot approve or decline invitations after the submission deadline.
+    </p>
+  <% else %>
+    <p class="tw-hint">
+      These people are waiting for your team's response
+    </p>
+  <% end %>
+
+  <ul>
+    <% requests.each do |join_request| %>
+      <%= content_tag :li, id: dom_id(join_request) do %>
+        <div class="flex flex-row space-x-4">
+          <%= image_tag join_request.requestor.profile_image_url,
+            class: "rounded-tl-sm rounded-tr-xl rounded-bl-xl rounded-br-sm w-12 h-12" %>
+            <div>
+              <p><%= join_request.requestor_full_name %></p>
+              <p><%= join_request.requestor_scope_name %></p>
+
+              <%= link_to "View Profile",
+                send(
+                  "#{current_scope}_#{join_request.requestor_scope_name}_path",
+                  join_request.requestor,
+                  back_title: "Back to your team",
+                  back: send(
+                    "#{current_scope}_team_path",
+                    team
+                  )
+                ), class: "text-energetic-blue" %>
+
+              <%= render "teams/rebrand/request_controls", join_request: join_request %>
+            </div>
+        </div>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/teams/rebrand/_request_controls.html.erb
+++ b/app/views/teams/rebrand/_request_controls.html.erb
@@ -1,0 +1,22 @@
+<% if !SeasonToggles.judging_enabled_or_between? %>
+  <p>
+    <%= link_to t("views.application.approved"),
+      send("#{current_scope}_join_request_path", join_request, join_request: {status: :approved}),
+      class: "tw-green-btn text-xs",
+      data: {
+        method: :put,
+        confirm: t("views.application.confirm_approved",
+          name: join_request.requestor_first_name),
+        positive: true,
+      } %>
+      
+    <%= link_to t("views.application.declined"),
+      send("#{current_scope}_join_request_path", join_request, join_request: {status: :declined}),
+      class: "tw-red-btn text-xs",
+      data: {
+        method: :put,
+        confirm: t("views.application.confirm_declined",
+          name: join_request.requestor_first_name),
+      } %>
+  </p>
+<% end %>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -189,7 +189,7 @@ en:
     team_memberships:
       destroy:
         link: "Remove your membership from %{name}"
-        success: "You have left the team `%{name}`"
+        success: "You have removed the member from %{name}"
 
     team_member_invites:
       create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,11 @@ Rails.application.routes.draw do
     resources :team_searches, except: [:index, :destroy]
     resources :mentor_searches, except: [:index, :destroy]
 
-    resources :teams, except: [:destroy]
+    resources :teams, except: [:destroy] do
+      resource :students, only: :show, controller: "teams/students"
+      resource :mentors, only: :show, controller: "teams/mentors"
+      resource :division, only: :show, controller: "teams/division"
+    end
     resources :team_memberships, only: :destroy
 
     resources :team_submissions

--- a/spec/features/admin/team_building_toggle_spec.rb
+++ b/spec/features/admin/team_building_toggle_spec.rb
@@ -205,15 +205,15 @@ RSpec.feature "Team submissions editable toggles team roster controls" do
 
     scenario "Team building enabled" do
       enable_team_building
-      visit mentor_team_path(team)
-
+      visit mentor_team_students_path(team)
       expect(page).to have_text("Do you want more teammates?")
+      visit mentor_team_mentors_path(team)
       expect(page).to have_text("Do you want more mentors?")
     end
 
     scenario "Team building disabled" do
       disable_team_building
-      visit mentor_team_path(team)
+      visit mentor_team_students_path(team)
 
       expect(page).to have_text("Team building is not enabled at this time")
     end

--- a/spec/features/mentor/leave_team_spec.rb
+++ b/spec/features/mentor/leave_team_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Mentors leave their own team" do
     TeamRosterManaging.add(team, mentor)
 
     sign_in(mentor)
-    click_link "My Teams"
-    click_link mentor.team_names.last
+    visit mentor_team_mentors_path(team)
     click_link "remove this member"
 
     expect(current_path).to eq(mentor_dashboard_path)

--- a/spec/features/mentor/remove_onboarding_student_spec.rb
+++ b/spec/features/mentor/remove_onboarding_student_spec.rb
@@ -9,12 +9,9 @@ RSpec.feature "Mentors removing students from a team" do
     TeamRosterManaging.add(team, [onboarding_student, mentor])
 
     sign_in(mentor)
-    click_link "My Teams"
-    click_link team.name
+    visit mentor_team_students_path(team)
 
-    within(".onboarding_students") do
-      click_link "remove this member"
-    end
+    click_link "remove this member"
 
     expect(team.reload.mentors).to include(mentor)
     expect(team.students).not_to include(onboarding_student)

--- a/spec/system/student/request_to_join_a_team_spec.rb
+++ b/spec/system/student/request_to_join_a_team_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "Students request to join a team",
       sign_out
       sign_in(team.mentors.sample)
 
-      visit mentor_team_path(team)
+      visit mentor_team_students_path(team)
 
       expect {
         click_link "Approve"
@@ -204,7 +204,7 @@ RSpec.describe "Students request to join a team",
       sign_out
       sign_in(team.mentors.sample)
 
-      visit mentor_team_path(team)
+      visit mentor_team_students_path(team)
 
       expect {
         click_link "Decline"


### PR DESCRIPTION
Refs #5648 

This is the last big piece for the mentor rebrand. This PR updates the mentor team details view/flow. 

Changes include
- Mentor teams sidenav
- Added mentor team routes/controllers/views (students, mentors, division)
- Rebranded the mentor team mentors and students tabs 
- Added rebranded member partial
- Updated pending member 
- Updated specs

<img width="1476" alt="Screenshot 2025-07-01 at 2 45 19 PM" src="https://github.com/user-attachments/assets/5977705e-9cf4-4379-8744-d18de5eed6e4" />
