### PR TITLE
Reassign mentors and students to previous season's chapterable

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,6 +63,9 @@ class Account < ActiveRecord::Base
   has_many :current_chapterable_assignments, -> { current },
     class_name: "ChapterableAccountAssignment"
 
+  has_many :last_seasons_chapterable_assignments, -> { last_season },
+    class_name: "ChapterableAccountAssignment"
+
   has_many :current_chapter_assignments, -> { current.chapters },
     class_name: "ChapterableAccountAssignment"
 
@@ -1132,6 +1135,10 @@ class Account < ActiveRecord::Base
 
   def current_primary_chapterable_assignment
     current_chapterable_assignments.find_by(primary: true) || ::NullChapterableAccountAssignment.new
+  end
+
+  def last_seasons_primary_chapterable_assignment
+    last_seasons_chapterable_assignments.find_by(primary: true) || ::NullChapterableAccountAssignment.new
   end
 
   def chapter_program_name

--- a/app/models/chapterable_account_assignment.rb
+++ b/app/models/chapterable_account_assignment.rb
@@ -7,6 +7,10 @@ class ChapterableAccountAssignment < ApplicationRecord
     where(season: Season.current.year)
   }
 
+  scope :last_season, -> {
+    where(season: Season.current.year - 1)
+  }
+
   scope :chapters, -> {
     where(chapterable_type: "Chapter")
   }

--- a/app/models/concerns/status_helpers.rb
+++ b/app/models/concerns/status_helpers.rb
@@ -5,6 +5,10 @@ module StatusHelpers
     seasons.include?(Season.current.year)
   end
 
+  def inactive?
+    !active?
+  end
+
   def activate
     update(seasons: seasons << Season.current.year)
   end

--- a/app/services/chapterable_reassigner.rb
+++ b/app/services/chapterable_reassigner.rb
@@ -1,0 +1,31 @@
+class ChapterableReassigner
+  def initialize(account:)
+    @account = account
+  end
+
+  def call
+    return if !account.is_a_mentor? && !account.is_a_student?
+    return if account.assigned_to_chapterable?
+    return if account.last_seasons_primary_chapterable_assignment.blank?
+    return if account.last_seasons_primary_chapterable_assignment.chapterable.inactive?
+
+    assign_account_to_last_seasons_chapterable
+  end
+
+  private
+
+  attr_accessor :account
+
+  def assign_account_to_last_seasons_chapterable
+    account.chapterable_assignments.create!(
+      profile: profile,
+      chapterable: account.last_seasons_primary_chapterable_assignment.chapterable,
+      season: Season.current.year,
+      primary: true
+    )
+  end
+
+  def profile
+    account.mentor_profile || account.student_profile
+  end
+end

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -14,6 +14,7 @@ module SignIn
     )
 
     unless signin.student? && signin.age_by_cutoff > 18
+      ChapterableReassigner.new(account: signin).call
       RegisterToCurrentSeasonJob.perform_later(signin)
     end
 
@@ -43,7 +44,7 @@ module SignIn
     last_profile_used = context.remove_cookie(CookieNames::LAST_PROFILE_USED)
 
     if last_profile_used and
-        !signin.public_send("#{last_profile_used}_profile").present?
+        !signin.public_send(:"#{last_profile_used}_profile").present?
       last_profile_used = nil
     end
 

--- a/spec/factories/club_ambassadors.rb
+++ b/spec/factories/club_ambassadors.rb
@@ -43,6 +43,12 @@ FactoryBot.define do
       end
     end
 
+    trait :not_assigned_to_club do
+      after(:create) do |club_ambassador|
+        club_ambassador.account.chapterable_assignments.destroy_all
+      end
+    end
+
     trait :training_not_completed do
       training_completed_at { nil }
     end

--- a/spec/services/chapterable_reassigner_spec.rb
+++ b/spec/services/chapterable_reassigner_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+describe ChapterableReassigner do
+  let(:chapterable_reassigner) { ChapterableReassigner.new(account: account) }
+
+  describe "#call" do
+    context "when it's a mentor" do
+      let(:mentor_profile) { FactoryBot.create(:mentor) }
+      let(:account) { mentor_profile.account }
+
+      before do
+        account.chapterable_assignments.delete_all
+      end
+
+      context "when the mentor is assigned to a primary chapterable for the previous season" do
+        let(:last_season) { Season.current.year - 1 }
+        let(:chapter) { FactoryBot.create(:chapter) }
+
+        before do
+          account.chapterable_assignments.create!(
+            profile: mentor_profile,
+            chapterable: chapter,
+            season: last_season,
+            primary: true
+          )
+        end
+
+        it "makes a new chapterable assignment for the current season" do
+          chapterable_reassigner.call
+
+          expect(account.chapterable_assignments.length).to eq(2)
+          expect(
+            account.chapterable_assignments.last.season
+          ).to eq(Season.current.year)
+        end
+
+        context "when the chapter is not active for the current season" do
+          before do
+            chapter.update(seasons: [last_season])
+          end
+
+          it "does not make a new chapterable assignment" do
+            chapterable_reassigner.call
+
+            expect(account.chapterable_assignments.length).to eq(1)
+          end
+        end
+      end
+
+      context "when the mentor is already assigned to a chapterable for the current season" do
+        let(:current_season) { Season.current.year }
+
+        before do
+          account.chapterable_assignments.create(
+            profile: mentor_profile,
+            chapterable: FactoryBot.create(:chapter),
+            season: current_season
+          )
+        end
+
+        it "does not make a new chapterable assignment" do
+          chapterable_reassigner.call
+
+          expect(account.chapterable_assignments.length).to eq(1)
+        end
+      end
+    end
+
+    context "when it's a student" do
+      let(:student_profile) { FactoryBot.create(:student) }
+      let(:account) { student_profile.account }
+
+      before do
+        account.chapterable_assignments.delete_all
+      end
+
+      context "when the student is assigned to a primary chapterable for the previous season" do
+        let(:last_season) { Season.current.year - 1 }
+        let(:chapter) { FactoryBot.create(:chapter) }
+
+        before do
+          account.chapterable_assignments.create!(
+            profile: student_profile,
+            chapterable: chapter,
+            season: last_season,
+            primary: true
+          )
+        end
+
+        it "makes a new chapterable assignment for the current season" do
+          chapterable_reassigner.call
+
+          expect(account.chapterable_assignments.length).to eq(2)
+          expect(
+            account.chapterable_assignments.last.season
+          ).to eq(Season.current.year)
+        end
+
+        context "when the chapter is not active for the current season" do
+          before do
+            chapter.update(seasons: [last_season])
+          end
+
+          it "does not make a new chapterable assignment" do
+            chapterable_reassigner.call
+
+            expect(account.chapterable_assignments.length).to eq(1)
+          end
+        end
+      end
+
+      context "when the student is already assigned to a chapterable for the current season" do
+        let(:current_season) { Season.current.year }
+
+        before do
+          account.chapterable_assignments.create(
+            profile: student_profile,
+            chapterable: FactoryBot.create(:chapter),
+            season: current_season
+          )
+        end
+
+        it "does not make a new chapterable assignment" do
+          chapterable_reassigner.call
+
+          expect(account.chapterable_assignments.length).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For students and mentors they will be assigned to last season's assignment, if:

- They have a primary assignment for last season
- They don't already have an assignment for the current season
- The chapterable is active for the current season


