### PR TITLE
Reassign ambassadors to chapterables

### DIFF
--- a/app/services/season_setup/chapter_ambassador_to_chapter_reassigner.rb
+++ b/app/services/season_setup/chapter_ambassador_to_chapter_reassigner.rb
@@ -1,0 +1,36 @@
+module SeasonSetup
+  class ChapterAmbassadorToChapterReassigner
+    def call
+      chapter_ambassadors.each do |chapter_ambassador|
+        next if chapter_ambassador.assigned_to_chapterable?
+        next if chapter_ambassador.last_seasons_primary_chapterable_assignment.chapterable.inactive?
+
+        assign_chapter_ambassador_to_last_seasons_chapter(account: chapter_ambassador)
+      end
+    end
+
+    private
+
+    def chapter_ambassadors
+      Account
+        .joins(:chapterable_assignments)
+        .where(chapterable_assignments: {
+          season: last_season,
+          profile_type: "ChapterAmbassadorProfile"
+        })
+    end
+
+    def last_season
+      Season.current.year - 1
+    end
+
+    def assign_chapter_ambassador_to_last_seasons_chapter(account:)
+      account.chapterable_assignments.create(
+        profile: account.chapter_ambassador_profile,
+        chapterable: account.last_seasons_primary_chapterable_assignment.chapterable,
+        season: Season.current.year,
+        primary: true
+      )
+    end
+  end
+end

--- a/app/services/season_setup/club_ambassador_to_club_reassigner.rb
+++ b/app/services/season_setup/club_ambassador_to_club_reassigner.rb
@@ -1,0 +1,36 @@
+module SeasonSetup
+  class ClubAmbassadorToClubReassigner
+    def call
+      club_ambassadors.each do |club_ambassador|
+        next if club_ambassador.assigned_to_chapterable?
+        next if club_ambassador.last_seasons_primary_chapterable_assignment.chapterable.inactive?
+
+        assign_club_ambassador_to_last_seasons_club(account: club_ambassador)
+      end
+    end
+
+    private
+
+    def club_ambassadors
+      Account
+        .joins(:chapterable_assignments)
+        .where(chapterable_assignments: {
+          season: last_season,
+          profile_type: "ClubAmbassadorProfile"
+        })
+    end
+
+    def last_season
+      Season.current.year - 1
+    end
+
+    def assign_club_ambassador_to_last_seasons_club(account:)
+      account.chapterable_assignments.create(
+        profile: account.club_ambassador_profile,
+        chapterable: account.last_seasons_primary_chapterable_assignment.chapterable,
+        season: Season.current.year,
+        primary: true
+      )
+    end
+  end
+end

--- a/lib/tasks/reset_for_season.rake
+++ b/lib/tasks/reset_for_season.rake
@@ -34,8 +34,14 @@ task :reset_for_season, [:force] => :environment do |t, args|
     puts "Activating chapters"
     SeasonSetup::ChapterActivator.new.call
 
+    puts "Reassigning chapter ambassadors to chapters"
+    SeasonSetup::ChapterAmbassadorToChapterReassigner.new.call
+
     puts "Activating clubs"
     SeasonSetup::ClubActivator.new.call
+
+    puts "Reassigning club ambassadors to clubs"
+    SeasonSetup::ClubAmbassadorToClubReassigner.new.call
 
     puts "Resetting unaffiliated list"
     SeasonSetup::UnaffiliatedListResetter.new.call

--- a/spec/services/season_setup/chapter_ambassador_to_chapter_reassigner_spec.rb
+++ b/spec/services/season_setup/chapter_ambassador_to_chapter_reassigner_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+describe SeasonSetup::ChapterAmbassadorToChapterReassigner do
+  let(:chapter_ambassador_to_chapter_reassigner) { SeasonSetup::ChapterAmbassadorToChapterReassigner.new }
+  let(:chapter_ambassador_profile) { FactoryBot.create(:chapter_ambassador) }
+  let(:account) { chapter_ambassador_profile.account }
+
+  before do
+    account.chapterable_assignments.delete_all
+  end
+
+  describe "#call" do
+    context "when the chapter ambassador is assigned to a primary chapter for the previous season" do
+      let(:last_season) { Season.current.year - 1 }
+      let(:chapter) { FactoryBot.create(:chapter) }
+
+      before do
+        account.chapterable_assignments.create(
+          profile: chapter_ambassador_profile,
+          chapterable: chapter,
+          season: last_season,
+          primary: true
+        )
+      end
+
+      context "when the chapter is active for the current season" do
+        let(:current_season) { Season.current.year }
+
+        before do
+          chapter.update(seasons: [current_season])
+        end
+
+        it "reassigns the chapter ambassador to the chapter" do
+          chapter_ambassador_to_chapter_reassigner.call
+
+          expect(account.reload.current_chapterable_assignment.chapterable).to eq(chapter)
+          expect(account.reload.current_chapterable_assignments.length).to eq(1)
+        end
+      end
+
+      context "when the chapter is not active for the current season" do
+        before do
+          chapter.update(seasons: [last_season])
+        end
+
+        it "does not make a new chapterable assignment" do
+          chapter_ambassador_to_chapter_reassigner.call
+
+          expect(account.current_chapterable_assignments.length).to eq(0)
+          expect(account.last_seasons_chapterable_assignments.length).to eq(1)
+        end
+      end
+    end
+
+    context "when the chapter ambassador is already assigned to a chapter for the current season" do
+      let(:current_season) { Season.current.year }
+
+      before do
+        account.chapterable_assignments.create(
+          profile: chapter_ambassador_profile,
+          chapterable: FactoryBot.create(:chapter),
+          season: current_season
+        )
+      end
+
+      it "does not make a new chapterable assignment" do
+        chapter_ambassador_to_chapter_reassigner.call
+
+        expect(account.current_chapterable_assignments.length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/season_setup/club_ambassador_to_club_reassigner_spec.rb
+++ b/spec/services/season_setup/club_ambassador_to_club_reassigner_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+describe SeasonSetup::ClubAmbassadorToClubReassigner do
+  let(:club_ambassador_to_club_reassigner) { SeasonSetup::ClubAmbassadorToClubReassigner.new }
+  let(:club_ambassador_profile) { FactoryBot.create(:club_ambassador) }
+  let(:account) { club_ambassador_profile.account }
+
+  before do
+    account.chapterable_assignments.delete_all
+  end
+
+  describe "#call" do
+    context "when the club ambassador is assigned to a primary club for the previous season" do
+      let(:last_season) { Season.current.year - 1 }
+      let(:club) { FactoryBot.create(:club) }
+
+      before do
+        account.chapterable_assignments.create(
+          profile: club_ambassador_profile,
+          chapterable: club,
+          season: last_season,
+          primary: true
+        )
+      end
+
+      context "when the club is active for the current season" do
+        let(:current_season) { Season.current.year }
+
+        before do
+          club.update(seasons: [current_season])
+        end
+
+        it "reassigns the club ambassador to the club" do
+          club_ambassador_to_club_reassigner.call
+
+          expect(account.reload.current_chapterable_assignment.chapterable).to eq(club)
+          expect(account.reload.current_chapterable_assignments.length).to eq(1)
+        end
+      end
+
+      context "when the club is not active for the current season" do
+        before do
+          club.update(seasons: [last_season])
+        end
+
+        it "does not make a new chapterable assignment" do
+          club_ambassador_to_club_reassigner.call
+
+          expect(account.current_chapterable_assignments.length).to eq(0)
+          expect(account.last_seasons_chapterable_assignments.length).to eq(1)
+        end
+      end
+    end
+
+    context "when the club ambassador is already assigned to a club for the current season" do
+      let(:current_season) { Season.current.year }
+
+      before do
+        account.chapterable_assignments.create(
+          profile: club_ambassador_profile,
+          chapterable: FactoryBot.create(:club),
+          season: current_season
+        )
+      end
+
+      it "does not make a new chapterable assignment" do
+        club_ambassador_to_club_reassigner.call
+
+        expect(account.current_chapterable_assignments.length).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will add two new services that will:

- Reassign chapter ambassadors to chapters
- Reassign club ambassadors to clubs

They will only get reassigned if:

- The chapterable is active for the current season
- They're not already assigned to a chapterable


