### PR TITLE
Update program name on chapter ambassador's datagrid

### DIFF
--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -12,7 +12,7 @@ class ChapterAmbassadorsGrid
 
   column :name, header: "Chapters (Program Name)", mandatory: true do |account|
     if account.current_chapter.present?
-      format(account.name) do
+      format(account.chapter_program_name) do
         link_to(
           account.chapter_program_name || "-",
           admin_chapter_path(account.current_chapter)


### PR DESCRIPTION
When exporting the chapter ambassadors datagrid, the program name column was displaying the chapter ambassador's name instead of the program name, this PR should fix that.


