### PR TITLE
Unset "force chapterable selection" flag

### DIFF
--- a/app/controllers/concerns/unset_force_chapterable_selection.rb
+++ b/app/controllers/concerns/unset_force_chapterable_selection.rb
@@ -1,0 +1,13 @@
+module UnsetForceChapterableSelection
+  extend ActiveSupport::Concern
+
+  included do
+    skip_before_action :require_chapterable_selection, only: :unset_force_chapterable_selection
+  end
+
+  def unset_force_chapterable_selection
+    current_account.update(force_chapterable_selection: false)
+
+    redirect_to send(:"#{current_account.scope_name}_dashboard_path")
+  end
+end

--- a/app/controllers/mentor/dashboards_controller.rb
+++ b/app/controllers/mentor/dashboards_controller.rb
@@ -1,6 +1,8 @@
 module Mentor
   class DashboardsController < MentorController
     include LocationStorageController
+    include UnsetForceChapterableSelection
+
     layout "mentor_rebrand"
 
     private

--- a/app/controllers/student/dashboards_controller.rb
+++ b/app/controllers/student/dashboards_controller.rb
@@ -3,6 +3,7 @@ module Student
     include RequireParentalConsentSigned
     include RequireLocationIsSet
     include LocationStorageController
+    include UnsetForceChapterableSelection
 
     def show
       @regional_events = available_regional_events

--- a/app/views/chapterable_account_assignments/new.en.html.erb
+++ b/app/views/chapterable_account_assignments/new.en.html.erb
@@ -34,7 +34,8 @@
 
             <div>
               <%= link_to "Confirm",
-                send("#{current_account.scope_name}_dashboard_path"),
+                send("unset_force_chapterable_selection_#{current_account.scope_name}_dashboard_path"),
+                method: :post,
                 class: "tw-green-btn"
               %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,10 @@ Rails.application.routes.draw do
     resources :cookies, only: :create
     resource :survey_reminder, only: :create
 
-    resource :dashboard, only: :show
+    resource :dashboard, only: :show do
+      post :unset_force_chapterable_selection
+    end
+
     resource :profile, only: [:show, :edit, :update]
     resource :basic_profile, only: :update
 
@@ -81,7 +84,10 @@ Rails.application.routes.draw do
     resource :team_building, only: :show, controller: "team_building"
     resource :pending_team_requests, only: :show, controller: "pending_team_requests"
 
-    resource :dashboard, only: :show
+    resource :dashboard, only: :show do
+      post :unset_force_chapterable_selection
+    end
+
     resource :profile, only: [:show, :edit, :update]
     resource :basic_profile, only: :update
     resource :bio, only: [:show, :edit, :update]

--- a/spec/controllers/mentor/dashboards_controller_spec.rb
+++ b/spec/controllers/mentor/dashboards_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Mentor::DashboardsController do
+  describe "POST #unset_force_chapterable_selection" do
+    let(:mentor_profile) { FactoryBot.create(:mentor) }
+
+    before do
+      mentor_profile.account.update(force_chapterable_selection: true)
+
+      sign_in(mentor_profile)
+    end
+
+    it "unsets the `force_chapterable_selection` flag" do
+      post :unset_force_chapterable_selection
+
+      expect(mentor_profile.account.reload.force_chapterable_selection).to eq(false)
+    end
+  end
+end

--- a/spec/controllers/student/dashboards_controller_spec.rb
+++ b/spec/controllers/student/dashboards_controller_spec.rb
@@ -53,4 +53,20 @@ RSpec.describe Student::DashboardsController do
       }
     end
   end
+
+  describe "POST #unset_force_chapterable_selection" do
+    let(:student_profile) { FactoryBot.create(:student) }
+
+    before do
+      student_profile.account.update(force_chapterable_selection: true)
+
+      sign_in(student_profile)
+    end
+
+    it "unsets the `force_chapterable_selection` flag" do
+      post :unset_force_chapterable_selection
+
+      expect(student_profile.account.reload.force_chapterable_selection).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
When a new season starts, students and mentors will get reassigned to their chapterable and be shown the chapterable selection screen (via the `force_chapterable_selection` boolean flag).

The functionality in this PR will make it so that when a student or mentor confirms their chapterable, we will unset the `force_chapterable_selection` flag in the database (preventing the chapterable selection screen from showing up again) and take them to their dashboard.



