### PR TITLE
Participants assigned to only chapterable in their region

### DIFF
--- a/app/views/chapterable_account_assignments/new.en.html.erb
+++ b/app/views/chapterable_account_assignments/new.en.html.erb
@@ -134,7 +134,7 @@
               and we'll connect your account with them.
             </p>
           </div>
-        <% else %>
+        <% elsif !current_account.assigned_to_chapterable? %>
           <%= render "chapterable_account_assignments/#{current_account.scope_name}/no_chapterables_found" %>
         <% end %>
       </div>


### PR DESCRIPTION
This will remove the "Unfortunately, there are no chapters or clubs currently active in your country.", when a participant is currently assigned to the only chapter or club in their country.


