### PR TITLE
Update dashboard sidenav to direct to chapterable profile tab

### DIFF
--- a/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/chapter_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -28,4 +28,10 @@
         is_active_item: al(chapter_ambassador_community_connections_path).present?
       %>
     </ol>
+
+    <% unless current_ambassador.chapterable&.onboarded %>
+      <%= link_to "Up Next: Chapter Profile",
+        chapter_ambassador_chapter_profile_path,
+        class: "text-sm tw-green-btn mx-auto" %>
+    <% end %>
   </nav>

--- a/app/views/club_ambassador/dashboards/onboarding/_side_nav_content.html.erb
+++ b/app/views/club_ambassador/dashboards/onboarding/_side_nav_content.html.erb
@@ -28,4 +28,10 @@
         is_active_item: false
       %>
     </ol>
+
+    <% unless current_ambassador.chapterable&.onboarded %>
+      <%= link_to "Up Next: Club Profile",
+        club_ambassador_club_profile_path,
+        class: "text-sm tw-green-btn mx-auto" %>
+    <% end %>
   </nav>


### PR DESCRIPTION
In dev priorities, chapter/club team asked about helper text to direct to the profile tab. This is an idea to achieve this request. When the chapter/club tasks are complete the checkmark is filled. 

<img width="2254" height="900" alt="CleanShot 2025-07-29 at 19 14 30@2x" src="https://github.com/user-attachments/assets/efcc71e5-bd8a-42e6-825d-8170ed8235f2" />
