### PR TITLE
Update PostgreSQL repository to use apt-archive

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -160,7 +160,7 @@ jobs:
           name: Install PostgreSQL
           command: |
             wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
+            echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
             sudo apt update
             sudo apt install postgresql-client-13
 


### PR DESCRIPTION
CircleCI builds were failing with a 404 error when trying to install PostgreSQL:

```
OK
deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main
Ign:1 http://apt.postgresql.org/pub/repos/apt focal-pgdg InRelease
Err:2 http://apt.postgresql.org/pub/repos/apt focal-pgdg Release               
  404  Not Found [IP: 146.75.39.52 80]
Hit:3 https://download.docker.com/linux/ubuntu focal InRelease                 
Hit:4 http://archive.ubuntu.com/ubuntu focal InRelease                         
Hit:5 http://security.ubuntu.com/ubuntu focal-security InRelease               
Hit:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease                 
Hit:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease               
Get:8 https://dl.google.com/linux/chrome/deb stable InRelease [1,825 B]    
Hit:9 http://ppa.launchpad.net/git-core/ppa/ubuntu focal InRelease
Get:10 https://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1,221 B]
Reading package lists... Done         
E: The repository 'http://apt.postgresql.org/pub/repos/apt focal-pgdg Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.

Exited with code exit status 100
```

I believe this is due to focal (20.04) being removed from the original download directory on July 31, 2025.[ Announcement is here](https://www.postgresql.org/message-id/aItWGvIAWFEsLqds%40msg.df7cb.de). 

```
Re: To PostgreSQL in Debian
> Ubuntu focal (20.04) is EOL on the Ubuntu side; we will stop building
> packages for that release on [apt.postgresql.org](http://apt.postgresql.org/) at the beginning of
> July 2025. The focal-pgdg suite will be copied to
> [apt-archive.postgresql.org](http://apt-archive.postgresql.org/) so people still relying on focal can use it
> from there. The suite will then be removed from [apt.postgresql.org](http://apt.postgresql.org/) at
> the end of July.
> 
> I plan to remove s390x from [apt.postgresql.org](http://apt.postgresql.org/) at the same time unless
> a miracle happens and we get a stable build daemon by then.

Ubuntu focal (20.04) and oracular (24.10) have just been removed from
[apt.postgresql.org](http://apt.postgresql.org/). If you still need the packages, go to
[apt-archive.postgresql.org](http://apt-archive.postgresql.org/).

The s390x architecture has been removed, it was a nice experiment but
the cost-to-numberofusers ratio was infinite.

Christoph

```

I updated the postgresql download url based on the announcement. This seems to fix the issue for now but we should look into the appropriate updates needed. 