### PR TITLE
Only display ambassadors from the current season

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -13,6 +13,17 @@ class Chapter < ActiveRecord::Base
 
   has_many :chapterable_account_assignments, as: :chapterable, class_name: "ChapterableAccountAssignment"
   has_many :accounts, through: :chapterable_account_assignments
+  has_many :current_ambassadors,
+    -> {
+      where(
+        chapterable_account_assignments: {
+          profile_type: "ChapterAmbassadorProfile",
+          season: Season.current.year
+        }
+      )
+    },
+    through: :chapterable_account_assignments,
+    source: :account
   has_many :chapter_ambassadors, -> { where "profile_type = 'ChapterAmbassadorProfile'" },
     through: :chapterable_account_assignments,
     source: :account

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -10,6 +10,17 @@ class Club < ActiveRecord::Base
 
   has_many :chapterable_account_assignments, as: :chapterable, class_name: "ChapterableAccountAssignment"
   has_many :accounts, through: :chapterable_account_assignments
+  has_many :current_ambassadors,
+    -> {
+      where(
+        chapterable_account_assignments: {
+          profile_type: "ClubAmbassadorProfile",
+          season: Season.current.year
+        }
+      )
+    },
+    through: :chapterable_account_assignments,
+    source: :account
   has_many :club_ambassadors, -> { where "profile_type = 'ClubAmbassadorProfile'" },
     through: :chapterable_account_assignments,
     source: :account

--- a/app/views/admin/chapters/_chapter_ambassadors.html.erb
+++ b/app/views/admin/chapters/_chapter_ambassadors.html.erb
@@ -6,9 +6,9 @@
 
     <div class="panel">
       <ul>
-        <% chapter.chapter_ambassadors.each do |chapter_ambassador| %>
+        <% chapter.current_ambassadors.each do |ambassador| %>
           <li>
-            <%= link_to chapter_ambassador.full_name, admin_participant_path(chapter_ambassador) %>
+            <%= link_to ambassador.full_name, admin_participant_path(ambassador) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/admin/clubs/_club_ambassadors.html.erb
+++ b/app/views/admin/clubs/_club_ambassadors.html.erb
@@ -6,9 +6,9 @@
 
     <div class="panel">
       <ul>
-        <% club.club_ambassadors.each do |club_ambassador| %>
+        <% club.current_ambassadors.each do |ambassador| %>
           <li>
-            <%= link_to club_ambassador.full_name, admin_participant_path(club_ambassador) %>
+            <%= link_to ambassador.full_name, admin_participant_path(ambassador) %>
           </li>
         <% end %>
       </ul>

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -38,7 +38,7 @@
 
   <div>
     <%= f.input :primary_account_id,
-                collection: current_chapter.chapter_ambassadors,
+                collection: current_chapter.current_ambassadors,
                 prompt: "Select a primary contact",
                 label: "Primary Contact",
                 value_method: :id,

--- a/app/views/club_ambassador/club_public_information/_form.en.html.erb
+++ b/app/views/club_ambassador/club_public_information/_form.en.html.erb
@@ -30,7 +30,7 @@
 
   <div>
     <%= f.input :primary_account_id,
-      collection: current_chapterable.club_ambassadors,
+      collection: current_chapterable.current_ambassadors,
       prompt: "Select a primary contact",
       label: "Primary Contact",
       value_method: :id,


### PR DESCRIPTION
This will display chapter ambassadors and club ambassadors for the current season:

- When viewing a chapter or club in the admin area
- When an ambassador is setting their primary contact


