### PR TITLE
Reverted bg check logic "requires bg check" method for mentors

### DIFF
--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -285,7 +285,8 @@ class MentorProfile < ActiveRecord::Base
 
   def requires_background_check?
     (account.valid? && (account.date_of_birth.present? && account.age >= 18 || account.meets_minimum_age_requirement?)) &&
-      in_background_check_country? && !account.background_check_exemption?
+      in_background_check_country? &&
+      !(background_check.present? && background_check.clear? || account.background_check_exemption?)
   end
 
   def requires_background_check_invitation?


### PR DESCRIPTION
Refs #5769 

The logic for mentors`requires_background_check?` was recently changed in [this commit](https://github.com/Iridescent-CM/technovation-app/commit/c32a7a6d9c3eaffd28d7ca3fa4634e859a0b5686), removing the check for whether a background check is present and clear.

This caused the following conditional in `app/views/completion_steps/rebrand/_background_check.html.erb`:
`<% if profile.requires_background_check? %>`
to incorrectly render the background check status partial, even when the user’s background check was already complete and clear.

This commit reverts the logic change to ensure the correct partial is shown. I am hesitant to change the logic in the main background check partial since it is a shared partial. this logic only affects/reverts the original mentor `requires_background_check?` method.  