### PR TITLE
Add Code.org App Lab as a development platform

### DIFF
--- a/app/controllers/admin/team_submissions_controller.rb
+++ b/app/controllers/admin/team_submissions_controller.rb
@@ -112,6 +112,7 @@ module Admin
         :source_code_cache,
         :thunkable_project_url,
         :scratch_project_url,
+        :code_org_app_lab_project_url,
         screenshots_attributes: [:id, :_destroy]
       )
     end

--- a/app/controllers/concerns/team_submission_controller.rb
+++ b/app/controllers/concerns/team_submission_controller.rb
@@ -249,6 +249,7 @@ module TeamSubmissionController
         :app_inventor_app_name,
         :thunkable_project_url,
         :scratch_project_url,
+        :code_org_app_lab_project_url,
         :ethics_description,
         screenshots: [],
         screenshots_attributes: [

--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -45,12 +45,14 @@ module StudentHelper
       if submission.app_inventor_fields_complete? ||
           submission.thunkable_fields_complete? ||
           submission.scratch_fields_complete? ||
+          submission.code_org_app_lab_fields_complete? ||
           submission.other_fields_complete?
         :complete
       end
     when :source_code, :source_code_url
       if submission.thunkable_source_code_fields_complete? ||
           submission.scratch_source_code_fields_complete? ||
+          submission.code_org_app_lab_source_code_fields_complete? ||
           submission.source_code_url_complete?
         :complete
       end
@@ -82,6 +84,8 @@ module StudentHelper
       submission.thunkable_project_url
     elsif submission.developed_on?("Scratch")
       submission.source_code.present? ? submission.source_code_url : submission.scratch_project_url
+    elsif submission.developed_on?("Code.org App Lab")
+      submission.code_org_app_lab_project_url
     elsif submission.developed_on?("Other") || submission.developed_on?("App Inventor")
       submission.source_code_url
     end

--- a/app/models/submissions/required_fields.rb
+++ b/app/models/submissions/required_fields.rb
@@ -102,7 +102,7 @@ class RequiredSourceCodeField < RequiredField
   end
 
   def blank?
-    if submission.developed_on?("Thunkable")
+    if submission.developed_on?("Thunkable") || submission.developed_on?("Code.org App Lab")
       submission.source_code_external_url.blank?
     elsif submission.developed_on?("Scratch")
       submission.source_code_external_url.blank? && submission.source_code.blank?

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -82,8 +82,8 @@ class TeamSubmission < ActiveRecord::Base
       Rails.logger.warn("Published submission id=#{id} is missing required fields.")
     end
 
-    if developed_on?("Thunkable") || developed_on?("Scratch")
-      columns[:source_code_external_url] = copy_possible_thunkable_or_scratch_url
+    if development_platform_requires_project_url?
+      columns[:source_code_external_url] = development_platform_project_url
     end
 
     columns[:percent_complete] = calculate_percent_complete
@@ -627,6 +627,22 @@ class TeamSubmission < ActiveRecord::Base
       "#{development_platform} - #{development_platform_other}"
     else
       development_platform
+    end
+  end
+
+  def development_platform_requires_project_url?
+    developed_on?("Thunkable") ||
+      developed_on?("Scratch") ||
+      developed_on?("Code.org App Lab")
+  end
+
+  def development_platform_project_url
+    if developed_on?("Thunkable")
+      thunkable_project_url
+    elsif developed_on?("Scratch")
+      scratch_project_url
+    elsif developed_on?("Code.org App Lab")
+      code_org_app_lab_project_url
     end
   end
 

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -19,7 +19,8 @@ class TeamSubmission < ActiveRecord::Base
     "App Inventor" => 0,
     "Thunkable" => 6,
     "Other" => 5,
-    "Scratch" => 8
+    "Scratch" => 8,
+    "Code.org App Lab" => 9
   }
 
   INACTIVE_DEVELOPMENT_PLATFORMS_ENUM = {
@@ -54,6 +55,7 @@ class TeamSubmission < ActiveRecord::Base
   before_validation :reset_development_platform_fields_for_thunkable
   before_validation :reset_development_platform_fields_for_other_platforms
   before_validation :reset_development_platform_fields_for_scratch
+  before_validation :reset_development_platform_fields_for_code_org_app_lab
 
   before_validation -> {
     return if thunkable_project_url.blank?
@@ -257,6 +259,10 @@ class TeamSubmission < ActiveRecord::Base
     presence: true,
     if: ->(s) { s.development_platform == "Thunkable" }
 
+  validates :code_org_app_lab_project_url,
+    presence: true,
+    if: ->(s) { s.development_platform == "Code.org App Lab" }
+
   validates :app_inventor_app_name,
     absence: {
       message: "Cannot add an App Inventor app name when Thunkable selected as the development platform."
@@ -273,6 +279,8 @@ class TeamSubmission < ActiveRecord::Base
   validates :thunkable_project_url, thunkable_share_url: true, allow_blank: true
 
   validates :scratch_project_url, scratch_share_url: true, allow_blank: true
+
+  validates :code_org_app_lab_project_url, code_org_app_lab_share_url: true, allow_blank: true
 
   validates :ai_description, presence: true, max_word_count: true,
     if: ->(team_submission) { team_submission.ai? }
@@ -640,6 +648,10 @@ class TeamSubmission < ActiveRecord::Base
     send(:Scratch?)
   end
 
+  def code_org_app_lab?
+    send("Code.org App Lab?")
+  end
+
   def app_inventor_fields_complete?
     developed_on?("App Inventor") &&
       app_inventor_app_name.present? &&
@@ -658,6 +670,12 @@ class TeamSubmission < ActiveRecord::Base
         scratch_project_url.present? && errors.attribute_names.exclude?(:scratch_project_url))
   end
 
+  def code_org_app_lab_fields_complete?
+    developed_on?("Code.org App Lab") &&
+      code_org_app_lab_project_url.present? &&
+      errors.attribute_names.exclude?(:code_org_app_lab_project_url)
+  end
+
   def other_fields_complete?
     developed_on?("Other")
   end
@@ -670,6 +688,11 @@ class TeamSubmission < ActiveRecord::Base
   def scratch_source_code_fields_complete?
     scratch_fields_complete? &&
       (source_code_external_url_fields_complete? || source_code.present?)
+  end
+
+  def code_org_app_lab_source_code_fields_complete?
+    code_org_app_lab_fields_complete? &&
+      source_code_external_url_fields_complete?
   end
 
   def source_code_external_url_fields_complete?
@@ -748,14 +771,6 @@ class TeamSubmission < ActiveRecord::Base
     app_name_changed? || team.name_changed? || super
   end
 
-  def copy_possible_thunkable_or_scratch_url
-    if developed_on?("Thunkable")
-      thunkable_project_url
-    elsif developed_on?("Scratch")
-      scratch_project_url
-    end
-  end
-
   def video_link_for(video_type)
     case video_type
     when "demo_video_link", "demo", :demo
@@ -779,6 +794,7 @@ class TeamSubmission < ActiveRecord::Base
       self.thunkable_account_email = nil
       self.thunkable_project_url = nil
       self.scratch_project_url = nil
+      self.code_org_app_lab_project_url = nil
     end
   end
 
@@ -788,6 +804,7 @@ class TeamSubmission < ActiveRecord::Base
       self.development_platform_other = nil
       self.scratch_project_url = nil
       self.app_inventor_app_name = nil
+      self.code_org_app_lab_project_url = nil
     end
   end
 
@@ -796,6 +813,7 @@ class TeamSubmission < ActiveRecord::Base
       self.thunkable_project_url = nil
       self.app_inventor_app_name = nil
       self.scratch_project_url = nil
+      self.code_org_app_lab_project_url = nil
     end
   end
 
@@ -804,6 +822,16 @@ class TeamSubmission < ActiveRecord::Base
       self.thunkable_project_url = nil
       self.app_inventor_app_name = nil
       self.development_platform_other = nil
+      self.code_org_app_lab_project_url = nil
+    end
+  end
+
+  def reset_development_platform_fields_for_code_org_app_lab
+    if development_platform == "Code.org App Lab"
+      self.thunkable_project_url = nil
+      self.app_inventor_app_name = nil
+      self.development_platform_other = nil
+      self.scratch_project_url = nil
     end
   end
 

--- a/app/validators/code_org_app_lab_share_url_validator.rb
+++ b/app/validators/code_org_app_lab_share_url_validator.rb
@@ -1,0 +1,7 @@
+class CodeOrgAppLabShareUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !value.match(/^https?:\/\/studio.code.org\/projects\/applab\/.+$/)
+      record.errors.add(attribute, :invalid)
+    end
+  end
+end

--- a/app/views/admin/team_submissions/edit.html.erb
+++ b/app/views/admin/team_submissions/edit.html.erb
@@ -53,6 +53,7 @@
           <%= f.input :app_inventor_app_name %>
           <%= f.input :thunkable_project_url %>
           <%= f.input :scratch_project_url %>
+          <%= f.input :code_org_app_lab_project_url %>
 
           <%= f.label :source_code %>
 

--- a/app/views/team_submissions/pieces/development_platform.en.html.erb
+++ b/app/views/team_submissions/pieces/development_platform.en.html.erb
@@ -34,7 +34,8 @@
             "App Inventor": "#app_inventor_fields",
             "Thunkable": "#thunkable_fields",
             "Other": "#other",
-            "Scratch": "#scratch_fields"
+            "Scratch": "#scratch_fields",
+            "Code.org App Lab": "#code_org_app_lab_fields",
           },
         },
         id: :team_submission_development_platform %>
@@ -111,6 +112,25 @@
         Enter the Scratch project page URL. To create a project page, click the orange
         "Share" button in your Scratch project. Then when the project page appears,
         click the Copy Link button. This is the URL you will enter here.
+      </p>
+    </div>
+
+    <div id="code_org_app_lab_fields" class="mt-8">
+      <p class="tw-hint">
+        We want to ask you one question about your use of Code.org App Lab.
+      </p>
+
+      <%= f.label :code_org_app_lab_project_url,
+        "What is the URL to your Code.org App Lab project?",
+        for: :team_submission_code_org_app_lab_project_url %>
+
+      <%= f.text_field :code_org_app_lab_project_url,
+        id: :team_submission_code_org_app_lab_project_url %>
+
+      <p class="tw-hint">
+        Enter the Code.org App Lab project page URL. To create a project page, click the
+        "Share" button in your Code.org App Lab project. Then click the "Copy Link to project" button.
+        This is the URL you will enter here.
       </p>
     </div>
 

--- a/app/views/team_submissions/pieces/source_code_pieces/_code_org_app_lab.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_pieces/_code_org_app_lab.en.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: submission,
+  url: send("#{current_scope}_team_submission_url", submission),
+  local: true do |f| %>
+  <p>
+    <%= f.label :code_org_app_lab_project_url %>
+    <%= f.text_field :code_org_app_lab_project_url %>
+  </p>
+
+  <div class="flex flex-row justify-end">
+    <%= f.submit "Save", class: "tw-green-btn cursor-pointer mt-4" %>
+  </div>
+<% end %>

--- a/app/views/team_submissions/pieces/source_code_url.en.html.erb
+++ b/app/views/team_submissions/pieces/source_code_url.en.html.erb
@@ -25,6 +25,9 @@
       <%= render "team_submissions/pieces/source_code_pieces/scratch",
         submission: @team_submission,
         source_code_uploader: @source_code_uploader %>
+    <% elsif @team_submission.developed_on?("Code.org App Lab") %>
+      <%= render "team_submissions/pieces/source_code_pieces/code_org_app_lab",
+        submission: @team_submission %>
     <% end %>
 
     <p class="py-2">

--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -30,17 +30,15 @@
     <% end %>
   </p>
 
-  <% if @team_submission.developed_on?("Thunkable") %>
+  <% if @team_submission.development_platform_requires_project_url? %>
     <p>
-      Project url:
-      <%= link_to @team_submission.thunkable_project_url,
-      @team_submission.thunkable_project_url %>
-    </p>
-  <% elsif @team_submission.developed_on?("Scratch") && @team_submission.scratch_project_url.present? %>
-    <p>
-      Project url:
-      <%= link_to @team_submission.scratch_project_url,
-      @team_submission.scratch_project_url %>
+      <% if @team_submission.development_platform_project_url.present? %>
+        Project url:
+        <%= link_to @team_submission.development_platform_project_url,
+                    @team_submission.development_platform_project_url %>
+      <% else %>
+        You have not added your project url
+      <% end %>
     </p>
   <% elsif @team_submission.developed_on?("App Inventor") %>
     <p class="mt-4">
@@ -71,18 +69,15 @@
   attribute: :source_code_url,
   cta_when_empty: "Upload your technical work",
   cta_when_filled: "Change your upload" do %>
-  <% if @team_submission.developed_on?("Thunkable") %>
+  <% if @team_submission.development_platform_requires_project_url? %>
     <p>
-      Project url:
-      <%= link_to @team_submission.thunkable_project_url,
-        @team_submission.thunkable_project_url %>
-    </p>
-  <% elsif @team_submission.developed_on?("Scratch") &&
-    @team_submission.scratch_project_url.present?%>
-    <p>
-      Project url:
-      <%= link_to @team_submission.scratch_project_url,
-                  @team_submission.scratch_project_url %>
+      <% if @team_submission.development_platform_project_url.present? %>
+        Project url:
+        <%= link_to @team_submission.development_platform_project_url,
+          @team_submission.development_platform_project_url %>
+      <% else %>
+        You have not added your project url
+      <% end %>
     </p>
   <% else %>
     <p>

--- a/db/migrate/20250812160844_add_code_org_app_lab_project_url_to_team_submissions.rb
+++ b/db/migrate/20250812160844_add_code_org_app_lab_project_url_to_team_submissions.rb
@@ -1,0 +1,5 @@
+class AddCodeOrgAppLabProjectUrlToTeamSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :team_submissions, :code_org_app_lab_project_url, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2440,7 +2440,8 @@ CREATE TABLE public.team_submissions (
     removed_from_judging_pool boolean DEFAULT false,
     returned_to_judging_pool_by_account_id integer,
     ai_usage boolean,
-    ethics_description character varying
+    ethics_description character varying,
+    code_org_app_lab_project_url character varying
 );
 
 
@@ -5148,6 +5149,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250730184414'),
 ('20250805025429'),
 ('20250806213828'),
-('20250807161706');
+('20250807161706'),
+('20250812160844');
 
 

--- a/spec/features/student/submission_dev_platform_spec.rb
+++ b/spec/features/student/submission_dev_platform_spec.rb
@@ -80,4 +80,25 @@ RSpec.feature "Students edit submission development platform" do
       expect(page).to have_link "https://scratch.mit.edu/projects/12345"
     end
   end
+
+  scenario "Choose Code.org App Lab" do
+    select "Code.org App Lab",
+      from: "Which coding language did your team use?"
+
+    click_button "Save"
+
+    expect(page).to have_css(
+      ".field_with_errors #team_submission_code_org_app_lab_project_url"
+    )
+
+    fill_in "What is the URL to your Code.org App Lab project?",
+      with: "https://studio.code.org/projects/applab/12345"
+
+    click_button "Save"
+
+    within(".development_platform.complete") do
+      expect(page).to have_content "Code.org App Lab"
+      expect(page).to have_link "https://studio.code.org/projects/applab/12345"
+    end
+  end
 end

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -70,6 +70,26 @@ RSpec.describe TeamSubmission do
     expect(submission.scratch_project_url).to eq("https://scratch.mit.edu/projects/12345")
   end
 
+  it "validates the code.org app lab URL" do
+    submission = FactoryBot.create(:submission, :complete)
+
+    submission.code_org_app_lab_project_url = "https://google.com"
+    expect(submission).not_to be_valid
+
+    submission.code_org_app_lab_project_url = "https://studio.code.org"
+    expect(submission).not_to be_valid
+
+    submission.code_org_app_lab_project_url = "https://studio.code.org/something"
+    expect(submission).not_to be_valid
+
+    submission.code_org_app_lab_project_url = "https://studio.code.org/not-projects/something"
+    expect(submission).not_to be_valid
+
+    submission.code_org_app_lab_project_url = "https://studio.code.org/projects/applab/12345"
+    expect(submission).to be_valid
+    expect(submission.code_org_app_lab_project_url).to eq("https://studio.code.org/projects/applab/12345")
+  end
+
   context "callbacks" do
     let(:submission) { FactoryBot.create(:submission) }
 
@@ -150,7 +170,8 @@ RSpec.describe TeamSubmission do
         "App Inventor" => 0,
         "Thunkable" => 6,
         "Other" => 5,
-        "Scratch" => 8
+        "Scratch" => 8,
+        "Code.org App Lab" => 9
       })
     end
   end
@@ -178,7 +199,8 @@ RSpec.describe TeamSubmission do
         "PhoneGap/Apache Cordova" => 4,
         "Other" => 5,
         "Thunkable Classic" => 7,
-        "Scratch" => 8
+        "Scratch" => 8,
+        "Code.org App Lab" => 9
       })
     end
   end
@@ -189,7 +211,8 @@ RSpec.describe TeamSubmission do
         "App Inventor",
         "Thunkable",
         "Other",
-        "Scratch"
+        "Scratch",
+        "Code.org App Lab"
       ])
     end
   end
@@ -209,6 +232,9 @@ RSpec.describe TeamSubmission do
 
       submission.development_platform = "Scratch"
       expect(submission.developed_on?("Scratch")).to be true
+
+      submission.development_platform = "Code.org App Lab"
+      expect(submission.developed_on?("Code.org App Lab")).to be true
     end
   end
 
@@ -400,6 +426,23 @@ RSpec.describe TeamSubmission do
     end
   end
 
+  describe "#code_org_app_lab_fields_complete?" do
+    it "returns true when all code.org app lab fields are complete" do
+      submission = FactoryBot.create(:submission)
+
+      submission.development_platform = "Code.org App Lab"
+      submission.code_org_app_lab_project_url = "https://studio.code.org/projects/applab/12345"
+      expect(submission.code_org_app_lab_fields_complete?).to be true
+    end
+
+    it "returns false when code.org app lab project url is missing" do
+      submission = FactoryBot.create(:submission)
+
+      submission.development_platform = "Code.org App Lab"
+      expect(submission.code_org_app_lab_fields_complete?).to be false
+    end
+  end
+
   describe "#other_fields_complete?" do
     it "returns true when all thunkable fields are complete" do
       submission = FactoryBot.create(:submission)
@@ -450,6 +493,28 @@ RSpec.describe TeamSubmission do
       submission.source_code_external_url = nil
 
       expect(submission.scratch_source_code_fields_complete?).to be false
+    end
+  end
+
+  describe "#code_org_app_lab_source_code_fields_complete?" do
+    it "returns true when code.org app lab project url is complete and all source code external fields are complete" do
+      submission = FactoryBot.create(:submission)
+
+      submission.development_platform = "Code.org App Lab"
+      submission.code_org_app_lab_project_url = "https://studio.code.org/projects/applab/12345"
+      submission.source_code_external_url = "https://studio.code.org/projects/applab/12345"
+
+      expect(submission.code_org_app_lab_source_code_fields_complete?).to be true
+    end
+
+    it "returns false when code.org app lab project url is complete and all source code external fields are incomplete " do
+      submission = FactoryBot.create(:submission)
+
+      submission.development_platform = "Code.org App Lab"
+      submission.code_org_app_lab_project_url = "https://studio.code.org/projects/applab/12345"
+      submission.source_code_external_url = nil
+
+      expect(submission.code_org_app_lab_source_code_fields_complete?).to be false
     end
   end
 


### PR DESCRIPTION
Refs #5763 

This PR adds the following:
- "Code.org App Lab" as a development platform option 
- `code_org_app_lab_project_url`, which is the link to their project page (Migration)
- URL Validation
- `development_platform_requires_project_url?` method that returns `true` for Thunkable, Scratch, and Code.org App Lab
- Updates tests 

