### PR TITLE
Basic URL validation for "other" development platform URL

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -278,10 +278,9 @@ class TeamSubmission < ActiveRecord::Base
     allow_blank: true
 
   validates :thunkable_project_url, thunkable_share_url: true, allow_blank: true
-
   validates :scratch_project_url, scratch_share_url: true, allow_blank: true
-
   validates :code_org_app_lab_project_url, code_org_app_lab_share_url: true, allow_blank: true
+  validates :development_platform_other_url, url: true, allow_blank: true
 
   validates :ai_description, presence: true, max_word_count: true,
     if: ->(team_submission) { team_submission.ai? }

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,7 @@
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !value.match(/^https?:\/\/.+$/)
+      record.errors.add(attribute, :invalid)
+    end
+  end
+end


### PR DESCRIPTION
This will add a generic URL validation (that's pretty rudimentary for now), that will be used to validate the "other" development platform URL.


