### PR TITLE
Fix AI usage display for unanswered questions

### DIFF
--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -59,7 +59,7 @@
         Did you use AI to help with your coding and/or to help you build your machine learning model?
       </dt>
       <dd>
-        <%= humanize_boolean(@team_submission.ai_usage?) %>
+        <%= humanize_boolean(@team_submission.ai_usage) %>
       </dd>
     </dl>
   <% end %>


### PR DESCRIPTION
Refs #5782 

Fixed issue where unanswered `AI usage` question displayed to "no" when left unanswered. I updated `@team_submission.ai_usage?` to `@team_submission.ai_usage` to work with the `humanize_boolean` method so that the correct Yes/No/- value would be displayed. 