### PR TITLE
Add various submission testing feedback

### DIFF
--- a/app/helpers/student_helper.rb
+++ b/app/helpers/student_helper.rb
@@ -42,13 +42,12 @@ module StudentHelper
     when :screenshots
       :complete if submission.screenshots.many?
     when :development_platform
-      if submission.app_inventor_fields_complete? ||
+      development_platform_complete = submission.app_inventor_fields_complete? ||
           submission.thunkable_fields_complete? ||
           submission.scratch_fields_complete? ||
           submission.code_org_app_lab_fields_complete? ||
           submission.other_fields_complete?
-        :complete
-      end
+      :complete if development_platform_complete && (submission.beginner_division? || !submission.ai_usage.nil?)
     when :source_code, :source_code_url
       if submission.thunkable_source_code_fields_complete? ||
           submission.scratch_source_code_fields_complete? ||

--- a/app/models/submissions/required_fields.rb
+++ b/app/models/submissions/required_fields.rb
@@ -23,6 +23,7 @@ class RequiredFields
     if submission.junior_division? || submission.senior_division?
       @fields << RequiredField.new(submission, :business_plan)
       @fields << RequiredField.new(submission, :bibliography)
+      @fields << RequiredField.for(submission, :ai_usage)
     end
 
     freeze
@@ -47,6 +48,8 @@ class RequiredField
       RequiredDevPlatformField.new(submission, method_name)
     elsif method_name.to_sym == :source_code_url
       RequiredSourceCodeField.new(submission, method_name)
+    elsif method_name.to_sym == :ai_usage
+      RequiredAiUsageField.new(submission, method_name)
     else
       RequiredField.new(submission, method_name)
     end
@@ -110,5 +113,15 @@ class RequiredSourceCodeField < RequiredField
     else
       value.blank?
     end
+  end
+end
+
+class RequiredAiUsageField < RequiredField
+  def invalidate!
+    submission.ai_usage = nil
+  end
+
+  def blank?
+    value.nil?
   end
 end

--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -305,13 +305,16 @@ class TeamSubmission < ActiveRecord::Base
     if: ->(team_submission) { team_submission.uses_gadgets? }
 
   validates :learning_journey, presence: true,
-    max_word_count: ->(team_submission) {team_submission.learning_journey_max_word_count},
-    if: ->(team_submission) {team_submission.learning_journey.present?}
+    max_word_count: { max_word_count: 200 },
+    if: ->(team_submission) {team_submission.learning_journey.present? && team_submission.beginner_division? }
+
+  validates :learning_journey, presence: true, max_word_count: true,
+    if: ->(team_submission) {team_submission.information_legitimacy_description.present? &&
+      (team_submission.junior_division? || team_submission.senior_division?)}
 
   validates :information_legitimacy_description, presence: true, max_word_count: true,
     if: ->(team_submission) {team_submission.information_legitimacy_description.present? &&
       (team_submission.junior_division? || team_submission.senior_division?)}
-
 
   validates :pitch_video_link,
     format: {
@@ -336,10 +339,6 @@ class TeamSubmission < ActiveRecord::Base
           and pitch videos are the same link. Please update one of the links."
       )
     end
-  end
-
-  def learning_journey_max_word_count
-    beginner_division? ? 200 : 100
   end
 
   delegate :name,

--- a/app/views/team_submissions/_learning_journey.en.html.erb
+++ b/app/views/team_submissions/_learning_journey.en.html.erb
@@ -5,7 +5,7 @@
   </dd>
 
   <% if !@team_submission.beginner_division? %>
-    <dt>Explain how your team decided what information you gathered for your project was legitimate</dt>
+    <dt>Explain how your team decided whether the information gathered for your project was legitimate</dt>
     <dd>
       <%= simple_format(@team_submission.information_legitimacy_description.presence || "-") %>
     </dd>

--- a/app/views/team_submissions/_menu.en.html.erb
+++ b/app/views/team_submissions/_menu.en.html.erb
@@ -244,7 +244,7 @@
           <%= link_to submission_progress_web_icon(
             submission,
             :business_plan,
-            "Your plan"
+            submission.junior_division? ? "Your plan" : "Your canvas"
           ),
           send(
             "#{current_scope}_team_submission_path",

--- a/app/views/team_submissions/pieces/business_plan.en.html.erb
+++ b/app/views/team_submissions/pieces/business_plan.en.html.erb
@@ -13,7 +13,7 @@
       <% if @team.junior? %>
         Submit your 1 to 2 page user adoption plan
       <% else %>
-        Submit your 5 to 10 page <%= t("submissions.business_plan").titleize %>
+        Submit your 1 page <%= t("submissions.business_plan").titleize %>
       <% end %>
 
       as a <span class="font-medium">PDF file</span>.
@@ -57,7 +57,7 @@
         Get some help writing your <%= t("submissions.business_plan") %> in the
         <%= link_to(
           "#{t("submissions.business_plan")} curriculum unit.",
-          "https://technovationchallenge.org/courses/senior-division-curriculum/lessons/business-plan//",
+          "https://technovationchallenge.org/courses/senior-division-curriculum/lessons/lean-canvas/",
           target: "_blank",
           class: "tw-link"
         ) %>

--- a/app/views/team_submissions/pieces/business_plan.en.html.erb
+++ b/app/views/team_submissions/pieces/business_plan.en.html.erb
@@ -61,16 +61,22 @@
           target: "_blank",
           class: "tw-link"
         ) %>
-
-    <% elsif @team.junior? %>
-      Check out what to include in your user adoption plan
-      <%= link_to(
-        "here",
-        "https://docs.google.com/document/d/1VWqsYbForZO5PERUUwCwkUUmlijl_pkAOvGg3WVkwSs/edit?usp=sharing",
-        target: "_blank",
-        class: "tw-link"
-      ) %>
-  <% end %>
+        You can access a template for the
+        <%= link_to(
+          "Business Canvas here.",
+          "https://docs.google.com/document/d/1Wh82j11aW0VkqzADimacpKXI6ffHPPcaWD_NgETQ3ZU/edit?tab=t.0",
+          target: "_blank",
+          class: "tw-link"
+        ) %>
+      <% elsif @team.junior? %>
+        Check out what to include in your user adoption plan
+        <%= link_to(
+          "here",
+          "https://docs.google.com/document/d/1VWqsYbForZO5PERUUwCwkUUmlijl_pkAOvGg3WVkwSs/edit?usp=sharing",
+          target: "_blank",
+          class: "tw-link"
+        ) %>
+      <% end %>
     </p>
   <% else %>
     <p class="tw-hint-strong">

--- a/app/views/team_submissions/pieces/development_platform.en.html.erb
+++ b/app/views/team_submissions/pieces/development_platform.en.html.erb
@@ -89,8 +89,14 @@
 
         <%= f.text_field :development_platform_other %>
 
-        <%= f.label :development_platform_other_url, "Coding language URL:" %>
+        <%= f.label :development_platform_other_url, "Optional: Project URL" %>
         <%= f.text_field :development_platform_other_url %>
+        <p class="tw-hint">
+          If your project is available at a URL, please add the link. This is an optional
+          field and having the project available at a URL is not required in order to submit
+          your project. On the Technical Additions page, you will be required to upload your
+          code, even if you add an optional project URL here.
+        </p>
       </div>
     </div>
 

--- a/app/views/team_submissions/pieces/learning_journey.en.html.erb
+++ b/app/views/team_submissions/pieces/learning_journey.en.html.erb
@@ -69,7 +69,7 @@
 
     <div class="field">
       <%= f.label :information_legitimacy_description,
-        "Explain how your team decided what information you gathered for your project was legitimate. (max 100 words)",
+        "Explain how your team decided whether the information gathered for your project was legitimate. (max 100 words)",
         for: :team_submission_information_legitimacy_description %>
 
       <%= f.text_area :information_legitimacy_description,

--- a/app/views/team_submissions/sections/code.en.html.erb
+++ b/app/views/team_submissions/sections/code.en.html.erb
@@ -27,11 +27,16 @@
       <span>
         - <%= @team_submission.development_platform_other %>
       </span>
-      <p>
-        URL:
-        <%= link_to @team_submission.development_platform_other_url,
-        @team_submission.development_platform_other_url %>
-      </p>
+      <br>
+      <span>
+        Optional - Project URL:
+        <% if  @team_submission.development_platform_other_url.present? %>
+          <%= link_to @team_submission.development_platform_other_url,
+          @team_submission.development_platform_other_url %>
+        <% else %>
+          blank
+        <% end %>
+      </span>
     <% end %>
   </p>
 

--- a/spec/factories/team_submissions.rb
+++ b/spec/factories/team_submissions.rb
@@ -51,7 +51,8 @@ FactoryBot.define do
           ethics_description: "Filled in by factory!",
           development_platform: "Swift or XCode",
           demo_video_link: "http://example.com/demo",
-          pitch_video_link: "http://example.com/pitch"
+          pitch_video_link: "http://example.com/pitch",
+          ai_usage: true
         )
       end
     end
@@ -101,6 +102,7 @@ FactoryBot.define do
       pitch_video_link { "http://example.com/pitch" }
       demo_video_link { "http://example.com/demo" }
       development_platform { "Swift or XCode" }
+      ai_usage { true }
 
       after(:create) do |team_submission|
         team_submission.update_column(:source_code, "source_code.zip")
@@ -120,6 +122,7 @@ FactoryBot.define do
       pitch_video_link { "http://example.com/pitch" }
       demo_video_link { "http://example.com/demo" }
       development_platform { "Swift or XCode" }
+      ai_usage { true }
 
       after(:create) do |team_submission|
         team_submission.update_column(:source_code, "source_code.zip")

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -646,6 +646,8 @@ RSpec.describe TeamSubmission do
         sub.update(development_platform: nil)
       elsif field.method_name == :source_code_url
         sub.remove_source_code!
+      elsif field.method_name == :ai_usage
+        sub.update(ai_usage: nil)
       else
         sub.update(field.method_name => nil)
       end


### PR DESCRIPTION
Refs #5794 

This PR addresses submission testing feedback 
- Business plan/canvas text and link updates
- Learning journey validation error
- Label updates (learning journey and optional url)
- Making `ai_usage` a required field (this is the one I am mostly concerned about!)