### PR TITLE
Update chapterable assignment panel for admin debugging section

### DIFF
--- a/app/models/chapterable_account_assignment.rb
+++ b/app/models/chapterable_account_assignment.rb
@@ -12,6 +12,10 @@ class ChapterableAccountAssignment < ApplicationRecord
     where(season: Season.current.year - 1)
   }
 
+  scope :past, -> {
+    where("season < ?", Season.current.year)
+  }
+
   scope :chapters, -> {
     where(chapterable_type: "Chapter")
   }

--- a/app/views/admin/participants/_chapterable_assignments.html.erb
+++ b/app/views/admin/participants/_chapterable_assignments.html.erb
@@ -1,26 +1,33 @@
-<div class="panel">
-  <ul>
-    <% chapterable_assignments.each do |chapterable_assignment| %>
-      <li>
-        <%= link_to chapterable_assignment.chapterable.name.presence || "Name not set",
-          send("admin_#{chapterable_assignment.chapterable_type.downcase}_path", chapterable_assignment.chapterable) %>
-        <% if chapterable_assignment.primary? %>
-          <span class="hint">*Primary</span>
-        <% end %>
-        <ul>
-          <li>
-            Type: <%= chapterable_assignment.chapterable_type %>
-          </li>
+<ul>
+  <% chapterable_assignments.each do |chapterable_assignment| %>
+    <li>
+      <%= link_to chapterable_assignment.chapterable.name.presence || "Name not set",
+        send("admin_#{chapterable_assignment.chapterable_type.downcase}_path", chapterable_assignment.chapterable) %>
+      <% if chapterable_assignment.primary? %>
+        <span class="hint">*Primary</span>
+      <% end %>
+      <ul>
+        <li>
+          Season: <%= chapterable_assignment.season %>
+        </li>
 
-          <li>
-            Id: <%= chapterable_assignment.chapterable.id %>
-          </li>
+        <li>
+          For: <%= chapterable_assignment.profile_type.titleize %>
+        </li>
 
-          <li>
-            Assignment By: <%= chapterable_assignment.assignment_by&.name&.presence || "<em>NA</em>".html_safe %>
-          </li>
-        </ul>
-      </li>
-    <% end %>
-  </ul>
-</div>
+        <li>
+          Type: <%= chapterable_assignment.chapterable_type %>
+        </li>
+
+        <li>
+          Id: <%= chapterable_assignment.chapterable.id %>
+        </li>
+
+        <li>
+          Assignment By: <%= chapterable_assignment.assignment_by&.name&.presence || "<em>NA</em>".html_safe %>
+        </li>
+      </ul>
+    </li>
+  <% end %>
+</ul>
+

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -156,12 +156,26 @@
 
 <div class="grid">
   <div class="grid__col-auto grid__col--bleed-x grid__col--bleed-y">
-    <% if @account.mentor_profile && @account.mentor_profile.chapterable_assignments.any? %>
-      <h3 class="reset">Chapter & club assignments</h3>
+    <h3 class="reset">Chapter & club assignments</h3>
 
-      <%= render 'admin/participants/chapterable_assignments',
-        chapterable_assignments: @account.mentor_profile.chapterable_assignments %>
-    <% end %>
+    <div class="panel" style="max-height: 400px; overflow-y: scroll;">
+      <% if @account.chapterable_assignments.any? %>
+        <% if @account.chapterable_assignments.current.any? %>
+          <h5>Current Assignments</h5>
+          <%= render 'admin/participants/chapterable_assignments',
+            chapterable_assignments: @account.chapterable_assignments.current %>
+        <% end %>
+
+        <% if @account.chapterable_assignments.past.any? %>
+          <h5>Previous Assignments</h5>
+
+          <%= render 'admin/participants/chapterable_assignments',
+            chapterable_assignments: @account.chapterable_assignments.past %>
+        <% end %>
+      <% else %>
+        <p>No current or previous assignments</p>
+      <% end %>
+    </div>
 
     <h3 class="reset">Profile debugging</h3>
 


### PR DESCRIPTION
Refs #5679 
This PR updates the chapterable assignment panel for the admin debugging section.

It includes the following:
- Displays the assignment section for all profile types not just mentors
- Adds a `past` scope for chapterable assignments
- Adds a max height and scroll feature to the panel 
- Adds a fallback message if there are no current or past assignments
- Adds season and profile type to the assignment information  


<img width="1479" height="467" alt="Screenshot 2025-08-21 at 12 16 32 PM" src="https://github.com/user-attachments/assets/6227cb10-5de0-4493-acb2-2e8504d81e2c" />
