### PR TITLE
Update checkr api error handling

### DIFF
--- a/app/services/checkr_api_client/api_client.rb
+++ b/app/services/checkr_api_client/api_client.rb
@@ -29,8 +29,9 @@ module CheckrApiClient
         if candidate_resp.success?
           @candidate_id = candidate_resp_body[:id]
         else
-          error = candidate_resp_body[:error].join(", ")
-          handle_error(error)
+          error = candidate_resp_body[:error]
+          error_msg = error.is_a?(Array) ? error.join(", ") : error
+          handle_error(error_msg)
         end
       end
 


### PR DESCRIPTION
Refs #5811

This PR updates the checkr api integration error logic to handle both arrays and strings. 

There was a recent [support request](https://iridescentlearning.slack.com/archives/C06CHBQ4E/p1755794542641539) where a participant began their background check process, but had a `( )` in their first name. Checkr rejected this as an invalid first name and returned the error as a string. Our implementation only expected errors as arrays, causing an issue when trying to handle the error response. This change will allow handling of both arrays and strings from the response before logging the error on our platform/DB. 