### PR TITLE
Add rake task to bulk update parental consents to "on file" signed status

### DIFF
--- a/lib/tasks/bulk_set_parental_consent_on_file.rake
+++ b/lib/tasks/bulk_set_parental_consent_on_file.rake
@@ -1,0 +1,29 @@
+desc "Bulk set parental consent on file"
+task bulk_set_parental_consent_on_file: :environment do |task, args|
+  puts "Starting bulk set parental consent on file"
+
+  args.extras.each do |email_address|
+    account = Account.find_by(email: email_address)
+
+    if account.blank?
+      puts "#{email_address} could not be found"
+    elsif account.student_profile.blank?
+      puts "#{email_address} is not a student"
+    elsif !account.current_season?
+      puts "#{email_address} is not registered to the current season"
+    elsif account.student_profile.parental_consent.nil?
+      puts "Parental consent for #{email_address} could not be found"
+    elsif account.student_profile.parental_consent.signed?
+      puts "Parental consent for #{email_address} already signed"
+    else
+      parental_consent = account.student_profile.parental_consent
+
+      parental_consent.update(
+        status: ParentalConsent.statuses[:signed],
+        electronic_signature: ConsentForms::PARENT_GUARDIAN_NAME_FOR_A_PAPER_CONSENT
+      )
+
+      puts "Set parental consent on file for #{email_address} - Account ID: #{account.id}"
+    end
+  end
+end


### PR DESCRIPTION
Refs #5809 

This rake task accepts a comma-separated list of email addresses and will update their parental consent record to a status of "on file" signed status.

I noticed that a parental consent record is automatically created once the student registers and selects their location and chapter. I am unsure if there are other "behind-the-scenes" actions that occur related to this process. For that reason, I added a check for a empty record. However, if this is not relevant, then the rake task could also create a parental consent record if it does not exist. This worked locally, but feel free to edit/update as needed if it needs to be run next week! 