### PR TITLE
Add background check text regarding "identifying documents"

### DIFF
--- a/app/views/background_checks/rebrand/_background_check_invitation.html.erb
+++ b/app/views/background_checks/rebrand/_background_check_invitation.html.erb
@@ -42,6 +42,26 @@
       </p>
     </div>
 
+    <div class="mb-4">
+      <p class="font-semibold">Identification Documents</p>
+
+      <p class="mb-4">
+        In order to apply for a background check, volunteers whose location on
+        the Technovation platform is listed as in the United States must have a
+        Social Security Number (SSN). If your location is listed as within the
+        United States and you have an ITIN or other legal identifier number,
+        please reach out to the Technovation Team at
+        <%= mail_to "volunteers@technovation.org" %>
+        before requesting a background check.
+      </p>
+
+      <p>
+        If your location on the Technovation platform is listed as outside of
+        the United States, you will have the option to select from a list of
+        identifying documents requested by your country.
+      </p>
+    </div>
+
     <div class="mb-8">
       <p class="font-semibold">Security Information</p>
 


### PR DESCRIPTION
This will add some text about required identifying documents, as per the support request in #5803.


