### PR TITLE
Remove phone number for students

### DIFF
--- a/app/views/signups/_basic_profile_fields.html.erb
+++ b/app/views/signups/_basic_profile_fields.html.erb
@@ -2,7 +2,10 @@
   <div class="signup-form-name-fields">
     <%= a.input :first_name %>
     <%= a.input :last_name %>
-    <%= a.input :phone_number %>
+
+    <% if !current_account.is_a_student? %>
+      <%= a.input :phone_number %>
+    <% end %>
   </div>
 
   <% if !a.object.chapter_ambassador? && !a.object.club_ambassador? %>


### PR DESCRIPTION
Looks like the student phone number snuck in when we made phone numbers editable for ambassadors, judges and mentors.


