### PR TITLE
Allow admins and ambassadors to create teams

### DIFF
--- a/app/controllers/admin/teams_controller.rb
+++ b/app/controllers/admin/teams_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class TeamsController < AdminController
     include DatagridController
+    include Admin::TeamCreationConcern
 
     use_datagrid with: TeamsGrid
 

--- a/app/controllers/ambassador/resources_controller.rb
+++ b/app/controllers/ambassador/resources_controller.rb
@@ -1,4 +1,4 @@
-module ClubAmbassador
+module Ambassador
   class ResourcesController < AmbassadorController
     skip_before_action :require_chapterable_and_ambassador_onboarded
 

--- a/app/controllers/ambassador/teams_controller.rb
+++ b/app/controllers/ambassador/teams_controller.rb
@@ -1,5 +1,7 @@
 module Ambassador
   class TeamsController < AmbassadorController
+    include Admin::TeamCreationConcern
+
     layout "ambassador"
 
     def show

--- a/app/controllers/chapter_ambassador/chapter_admin_controller.rb
+++ b/app/controllers/chapter_ambassador/chapter_admin_controller.rb
@@ -36,8 +36,6 @@ module ChapterAmbassador
         .not_staff
         .inactive
         .limit(3)
-
-      flash.now[:alert] = "Note: This page may not show accurate data. We're working on updating it, please refer to the participants page for accurate numbers."
     end
   end
 end

--- a/app/controllers/concerns/admin/team_creation_concern.rb
+++ b/app/controllers/concerns/admin/team_creation_concern.rb
@@ -1,0 +1,21 @@
+module Admin::TeamCreationConcern
+  extend ActiveSupport::Concern
+
+  def create
+    account = Account.find(params.fetch(:account_id))
+    @team = Team.new(
+      name: params.fetch(:team_name),
+      division: Division.for(account)
+    )
+
+    if @team.save
+      TeamCreating.execute(
+        @team,
+        account.student_profile || account.mentor_profile,
+        self
+      )
+    else
+      redirect_back fallback_location: send(:"#{current_scope}_participant_path", account)
+    end
+  end
+end

--- a/app/technovation/team_creating.rb
+++ b/app/technovation/team_creating.rb
@@ -16,11 +16,18 @@ class TeamCreating
       team.reverse_geocode
       team.save
 
-      context.redirect_to context.send("#{context.current_scope}_team_path", team),
-        success: I18n.t("controllers.teams.create.success")
+      sucess_message = if context.class.to_s.include?("Ambassador") ||
+          context.class.to_s.include?("Admin")
+        I18n.t("controllers.teams.create.admin.success", full_name: profile.full_name)
+      else
+        I18n.t("controllers.teams.create.success")
+      end
+
+      context.redirect_to context.send(:"#{context.current_scope}_team_path", team),
+        success: sucess_message
     else
       context.redirect_to(
-        context.send("edit_#{context.current_scope}_team_location_path", team),
+        context.send(:"edit_#{context.current_scope}_team_location_path", team),
         success: "Welcome to Technovation, #{team.name}! Please set the team's location"
       )
     end

--- a/app/views/admin/participants/_mentor_debugging.html.erb
+++ b/app/views/admin/participants/_mentor_debugging.html.erb
@@ -209,24 +209,4 @@
   </dl>
 </div>
 
-<h4 class="reset">Help them with their team matching</h4>
-
-<div class="panel">
-  <%= form_tag(send("#{current_scope}_team_memberships_path")) do %>
-    <%= hidden_field_tag :account_id, profile.account_id %>
-
-    <h6>Add <%= profile.full_name %> to a team</h6>
-
-    <p>
-      <%= select_tag "team_id",
-        options_from_collection_for_select(@teams, "id", "name"),
-        prompt: "Select a team",
-        required: true,
-        class: "chosen" %>
-    </p>
-
-    <p>
-      <%= submit_tag 'Add', class: "button" %>
-    </p>
-  <% end %>
-</div>
+<%= render "admin/participants/team_matching", profile: profile %>

--- a/app/views/admin/participants/_student_debugging.html.erb
+++ b/app/views/admin/participants/_student_debugging.html.erb
@@ -62,27 +62,7 @@
 </div>
 
 <% if !profile.team.present? %>
-  <h4 class="reset">Help them with their team matching</h4>
-
-  <div class="panel">
-    <%= form_tag(send("#{current_scope}_team_memberships_path")) do %>
-      <%= hidden_field_tag :account_id, profile.account_id %>
-
-      <h6>Add <%= profile.full_name %> to a team</h6>
-
-      <p>
-        <%= select_tag "team_id",
-          options_from_collection_for_select(@teams, "id", "name"),
-          prompt: "Select a team",
-          required: true,
-          class: "chosen" %>
-      </p>
-
-      <p>
-        <%= submit_tag 'Add', class: "button" %>
-      </p>
-    <% end %>
-  </div>
+  <%= render "admin/participants/team_matching", profile: profile %>
 <% end %>
 
 <% if (current_account.is_admin? && profile.age >= 14) ||

--- a/app/views/admin/participants/_team_matching.en.html.erb
+++ b/app/views/admin/participants/_team_matching.en.html.erb
@@ -1,0 +1,38 @@
+<h4 class="reset">Help them with their team matching</h4>
+
+<div class="panel">
+  <%= form_tag(send("#{current_scope}_team_memberships_path")) do %>
+    <%= hidden_field_tag :account_id, profile.account_id %>
+
+    <h6>Add <%= profile.full_name %> to a team</h6>
+
+    <p>
+      <%= select_tag "team_id",
+        options_from_collection_for_select(@teams, "id", "name"),
+        prompt: "Select a team",
+        required: true,
+        class: "chosen"
+      %>
+    </p>
+
+    <p>
+      <%= submit_tag 'Add', class: "button" %>
+    </p>
+  <% end %>
+
+  <hr><br>
+
+  <%= form_tag(send("#{current_scope}_teams_path")) do %>
+    <%= hidden_field_tag :account_id, profile.account_id %>
+
+    <h6>Create a team for <%= profile.full_name %></h6>
+
+    <p>
+      <%= text_field_tag :team_name %>
+    </p>
+
+    <p>
+      <%= submit_tag "Create", class: "button" %>
+    </p>
+  <% end %>
+</div>

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -171,6 +171,8 @@ en:
       create:
         already_on_team: "You cannot create a new team if you are already on a team"
         success: "Your team has been created! Lookin' good!"
+        admin:
+          success: "Your successfully created a team for %{full_name}"
       edit:
         link: "Change team name & summary"
       index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
     resource :missing_participant_search, only: [:new, :show, :create]
     resources :missing_participant_locations, only: [:edit, :update]
 
-    resources :teams, only: :show, controller: "/ambassador/teams"
+    resources :teams, only: [:show, :create], controller: "/ambassador/teams"
     resources :teams, only: :index, controller: "/data_grids/ambassador/teams"
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"
     resources :team_submissions, only: :index, controller: "/data_grids/ambassador/team_submissions"
@@ -276,7 +276,7 @@ Rails.application.routes.draw do
     resources :score_details, only: :show, controller: "/ambassador/score_details"
     resources :unaffiliated_participants, only: :index, controller: "/data_grids/ambassador/unaffiliated_participants"
 
-    resources :teams, only: :show, controller: "/ambassador/teams"
+    resources :teams, only: [:show, :create], controller: "/ambassador/teams"
     resources :teams, only: :index, controller: "/data_grids/ambassador/teams"
     resources :team_memberships, only: [:create, :destroy], controller: "/ambassador/team_memberships"
     resources :team_submissions, only: :show, controller: "/ambassador/team_submissions"


### PR DESCRIPTION
This will give admins and ambassadors the ability to create a team for a student or mentor.

This will add a new section under the "Help them with their team matching" section in the admin area that has a text field (for the team name) and a submit button. After providing a team name and submitting the form, it will create the team and assign the student or mentor to that team.

I extracted the "Help them with their team matching" content/functionality into a new partial.

I added a custom success message for admins or ambassadors creating a team, otherwise it would use the default, "Your team has been created! Lookin' good!" message.