### PR TITLE
Update Salesforce upsert program info functionality

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -57,26 +57,28 @@ module Salesforce
     def upsert_program_info(season: Season.current.year, contact_id: nil)
       return if season != Season.current.year
 
-      program_participant_record = client.query("select Id from Program_Participant__c where Platform_Participant_Id__c = #{account.id} and Type__c = '#{profile_type}' and Year__c = '#{season}'")
+      handle_request "Upserting program info for account #{account.id}" do
+        program_participant_record = client.query("select Id from Program_Participant__c where Platform_Participant_Id__c = #{account.id} and Type__c = '#{profile_type}' and Year__c = '#{season}'")
 
-      if program_participant_record.present?
-        update_program_participant_for(
-          program_participant_id: program_participant_record.first.Id
-        )
-      else
-        if contact_id.blank?
-          contact_record = client.query("select Id from Contact where Platform_Participant_Id__c = #{account.id}")
-
-          if contact_record.present?
-            contact_id = contact_record.first.Id
-          end
-        end
-
-        if contact_id.present?
-          create_program_participant_for(
-            contact_id: contact_id,
-            program_participant_info: program_participant_info
+        if program_participant_record.present?
+          update_program_participant_for(
+            program_participant_id: program_participant_record.first.Id
           )
+        else
+          if contact_id.blank?
+            contact_record = client.query("select Id from Contact where Platform_Participant_Id__c = #{account.id}")
+
+            if contact_record.present?
+              contact_id = contact_record.first.Id
+            end
+          end
+
+          if contact_id.present?
+            create_program_participant_for(
+              contact_id: contact_id,
+              program_participant_info: program_participant_info
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
A simple update here to wrap the upsert program info functionality with `handle_request` that way it will use the `ENABLE_SALESFORCE` setting, so that way if Salesforce is disabled it won't try to upsert program info.


