### PR TITLE
Display team creation validation errors

### DIFF
--- a/app/controllers/concerns/admin/team_creation_concern.rb
+++ b/app/controllers/concerns/admin/team_creation_concern.rb
@@ -15,6 +15,8 @@ module Admin::TeamCreationConcern
         self
       )
     else
+      flash[:error] = "There was an error creating this team: #{@team.errors.full_messages.join(", ")}"
+
       redirect_back fallback_location: send(:"#{current_scope}_participant_path", account)
     end
   end


### PR DESCRIPTION
A quick/easy way to display the validation errors when an admin or ambassador is creating a team (from a student or mentor profile page).


