### PR TITLE
Update parental consent check link to fix surveys and survey specs

### DIFF
--- a/app/assets/javascripts/rebrand-tabs.js
+++ b/app/assets/javascripts/rebrand-tabs.js
@@ -22,11 +22,15 @@ $(document).on("turbo:load", function () {
     $(`a[href*='#parent-tab-content']`).click();
   }
 
-  document
-    .getElementById("check-parental-consent-status")
-    .addEventListener("click", (e) => {
+  const checkParentalConsentStatusLink = document.getElementById(
+    "check-parental-consent-status"
+  );
+
+  if (checkParentalConsentStatusLink) {
+    checkParentalConsentStatusLink.addEventListener("click", (e) => {
       e.preventDefault();
 
       document.getElementById("parental-tab").click();
     });
+  }
 });

--- a/spec/features/admin/survey_link_toggles_spec.rb
+++ b/spec/features/admin/survey_link_toggles_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.xfeature "Set survey links and link text", :js do
+RSpec.feature "Set survey links and link text", :js do
   context "student survey link is configured" do
     let(:user) { FactoryBot.create(:student) }
 
@@ -15,7 +15,7 @@ RSpec.xfeature "Set survey links and link text", :js do
 
       sign_in(user)
 
-      expect(current_path).to eq(public_send(:student_dashboard_path))
+      expect(current_path).to eq(student_dashboard_path)
       expect(page).to have_link("link text", href: "google.com", count: 2)
 
       expect(page).to have_css(".swal2-modal")
@@ -30,7 +30,7 @@ RSpec.xfeature "Set survey links and link text", :js do
 
       sign_in(user)
 
-      expect(current_path).to eq(public_send(:student_dashboard_path))
+      expect(current_path).to eq(student_dashboard_path)
 
       find("#global-dropdown-wrapper").click
       expect(page).to have_link("link text", href: "google.com", count: 2)
@@ -53,7 +53,7 @@ RSpec.xfeature "Set survey links and link text", :js do
 
       sign_in(mentor)
 
-      expect(current_path).to eq(public_send(:mentor_dashboard_path))
+      expect(current_path).to eq(mentor_dashboard_path)
       expect(page).to have_link("link text", href: "google.com", count: 2)
 
       expect(page).to have_css(".swal2-modal")
@@ -68,7 +68,7 @@ RSpec.xfeature "Set survey links and link text", :js do
 
       sign_in(mentor)
 
-      expect(current_path).to eq(public_send(:mentor_dashboard_path))
+      expect(current_path).to eq(mentor_dashboard_path)
       expect(page).to have_link("link text", href: "google.com", count: 1)
 
       expect(page).not_to have_css(".swal2-modal")


### PR DESCRIPTION
During the Rails 7 update, the "check parental consent status" link broke, when I was fixing that, I broke the surveys. The "check parental consent status" link won't always be on the page, when it wasn't on the page it was causing a JS error, which was causing the surveys not to load.

The updates here will:

- Add a conditional for the "check parental consent status" link
- Update the survey specs


