### PR TITLE
Bifurcate AI-related judging question

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,5 @@
 class Question
-  attr_reader :section, :idx, :text, :worth, :score, :field, :submission_type
+  attr_reader :section, :idx, :text, :worth, :score, :field, :submission_type, :ai_usage
   attr_writer :score
 
   def initialize(attrs)
@@ -11,5 +11,6 @@ class Question
     @score = attrs[:score]
     @field = attrs[:field]
     @submission_type = attrs[:submission_type]
+    @ai_usage = attrs[:ai_usage]
   end
 end

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -264,7 +264,8 @@ class SubmissionScore < ActiveRecord::Base
   validates_uniqueness_of :judge_profile_id,
     scope: [:team_submission_id, :deleted_at]
 
-  delegate :app_name,
+  delegate :ai_usage,
+    :app_name,
     :team_photo,
     :team_name,
     :team_division_name,

--- a/app/services/judge_questions_for_submission_score.rb
+++ b/app/services/judge_questions_for_submission_score.rb
@@ -1,6 +1,7 @@
 class JudgeQuestionsForSubmissionScore
   def initialize(submission_score, judge_questions_constructor: JudgeQuestions)
     @submission_score = submission_score
+    @submission_ai_usage = submission_score.team_submission_ai_usage
     @submission_type = submission_score.team_submission_submission_type
     @questions = judge_questions_constructor
       .new(season: submission_score.seasons.last, division: submission_score.team_division_name)
@@ -13,7 +14,7 @@ class JudgeQuestionsForSubmissionScore
 
   private
 
-  attr_reader :submission_score, :submission_type, :questions
+  attr_reader :submission_score, :submission_type, :submission_ai_usage, :questions
 
   def questions_with_scores_populated
     filtered_questions.map do |question|
@@ -25,7 +26,9 @@ class JudgeQuestionsForSubmissionScore
 
   def filtered_questions
     questions.delete_if do |question|
-      question.section == "demo" && question.submission_type.to_s != submission_type.to_s
+      question.section == "demo" &&
+        (question.submission_type.to_s != submission_type.to_s) ||
+        (!question.ai_usage.nil? && question.ai_usage != submission_ai_usage)
     end
   end
 end

--- a/app/services/judging/twenty_twenty_six/beginner_questions.rb
+++ b/app/services/judging/twenty_twenty_six/beginner_questions.rb
@@ -80,10 +80,23 @@ module Judging
             idx: 3,
             section: "demo",
             submission_type: "",
+            ai_usage: true,
             field: :demo_3,
             worth: 5,
             text: %(
-              Do we explain the machine learning training and/or coding we did for 1 or 2 important parts of our project, other than the login screen?
+              Do we explain the generative AI process we used in either coding or building an AI model for the project, including tools and prompts?
+            )
+          ),
+
+          Question.new(
+            idx: 3,
+            section: "demo",
+            submission_type: "",
+            ai_usage: false,
+            field: :demo_3,
+            worth: 5,
+            text: %(
+              Do we explain what machine learning training and/or actual coding we did for 1-2 important parts of our app (not login screen)?
             )
           ),
 

--- a/app/services/judging/twenty_twenty_six/junior_questions.rb
+++ b/app/services/judging/twenty_twenty_six/junior_questions.rb
@@ -91,10 +91,23 @@ module Judging
             idx: 3,
             section: "demo",
             submission_type: "",
+            ai_usage: true,
             field: :demo_3,
             worth: 5,
             text: %(
-              Do we explain the machine learning training and/or actual coding we did for 1 or 2 important parts of our app, other than the login screen?
+              Do we explain the generative AI process we used in either coding or building an AI model for the project, including tools and prompts?
+            )
+          ),
+
+          Question.new(
+            idx: 3,
+            section: "demo",
+            submission_type: "",
+            ai_usage: false,
+            field: :demo_3,
+            worth: 5,
+            text: %(
+              Do we explain what machine learning training and/or actual coding we did for 1-2 important parts of our app (not login screen)?
             )
           ),
 

--- a/app/services/judging/twenty_twenty_six/senior_questions.rb
+++ b/app/services/judging/twenty_twenty_six/senior_questions.rb
@@ -92,10 +92,23 @@ module Judging
             idx: 3,
             section: "demo",
             submission_type: "",
+            ai_usage: true,
             field: :demo_3,
             worth: 5,
             text: %(
-              Do we explain the machine learning training and/or actual coding we did for 1 or 2 important parts of our app, other than the login screen?
+              Do we explain the generative AI process we used in either coding or building an AI model for the project, including tools and prompts?
+            )
+          ),
+
+          Question.new(
+            idx: 3,
+            section: "demo",
+            submission_type: "",
+            ai_usage: false,
+            field: :demo_3,
+            worth: 5,
+            text: %(
+              Do we explain what machine learning training and/or actual coding we did for 1-2 important parts of our app (not login screen)?
             )
           ),
 


### PR DESCRIPTION
This will update the "judge question" service to return a different question based on if the submission being judged used AI or not (based on the `ai_usage` question).