### PR TITLE
Disable turbo for mentor bio

### DIFF
--- a/app/views/mentor/bios/_form.en.html.erb
+++ b/app/views/mentor/bios/_form.en.html.erb
@@ -1,12 +1,6 @@
-<%= form_with model: current_mentor, url: mentor_bio_path, local: true do |f| %>
+<%= form_with model: current_mentor, url: mentor_bio_path, data: { turbo: false }, local: true  do |f| %>
   <%= f.label :bio, "Tell the students about yourself" %>
   <%= f.text_area :bio, id: "mentor_profile_bio" %>
-
-  <% if f.object.errors.any? %>
-    <div class="field_with_errors">
-      <span class="error"><%= f.object.errors[:bio][0] %></span>
-    </div>
-  <% end %>
 
   <%= content_tag :p, data: { keep_count_of: "#mentor_profile_bio" } do %>
     <span><%= (f.object.bio || "").length %></span>


### PR DESCRIPTION
Refs #2755 

This disables turbo for mentor bio form and removes an error message div (the page was overwhelming with error notices)