### PR TITLE
Disable turbo for admin user invite form

### DIFF
--- a/app/views/admin/user_invitations/_form.en.html.erb
+++ b/app/views/admin/user_invitations/_form.en.html.erb
@@ -1,5 +1,6 @@
 <%= form_with model: invitation,
   url: send("#{current_scope}_user_invitations_path"),
+  data: { turbo: false },
   local: true do |f| %>
   <% if invitation.errors.any? %>
     <div class="notice notice--error">


### PR DESCRIPTION
Refs #5929 

This PR disables turbo for the admin user invite form. This was preventing error messages from displaying