### PR TITLE
Update beginner division technical questions

### DIFF
--- a/app/services/judging/twenty_twenty_six/beginner_questions.rb
+++ b/app/services/judging/twenty_twenty_six/beginner_questions.rb
@@ -89,7 +89,6 @@ module Judging
             idx: 3,
             section: "demo",
             submission_type: "",
-            ai_usage: true,
             field: :demo_3,
             worth: 5,
             text: %(
@@ -98,14 +97,13 @@ module Judging
           ),
 
           Question.new(
-            idx: 3,
+            idx: 4,
             section: "demo",
             submission_type: "",
-            ai_usage: false,
-            field: :demo_3,
+            field: :demo_4,
             worth: 5,
             text: %(
-              Do we explain what machine learning training and/or actual coding we did for 1-2 important parts of our app (not login screen)?
+              Do we explain the machine learning training and/or coding we did for 1 or 2 important parts of our app, other than the login screen?
             )
           ),
 


### PR DESCRIPTION
A couple updates here the beginner division judging questions for the technical section:

- Remove the `ai_usage` field since this doesn't apply to the beginner division
- Update the "index" for the technical section questions so all the questions will be displayed; each index needs to be unique in order for the questions to be displayed
- Update the question text to match the Google Doc

