### PR TITLE
Display media consent status next to onboarding step

### DIFF
--- a/app/views/admin/participants/_student_debugging.html.erb
+++ b/app/views/admin/participants/_student_debugging.html.erb
@@ -29,7 +29,9 @@
     <dt>Media Consent</dt>
     <dd>
       <% if profile.media_consent_signed? %>
-        <%= web_icon("check-circle icon-green", text: "Signed! Yay!") %>
+        <%= web_icon("check-circle icon-green",
+                     text: profile.media_consent.consent_provided? ?
+                     "Signed, consent given" : "Signed, NO CONSENT") %>
       <% else %>
         <%= web_icon("exclamation-circle icon-red",
                      text: "Not signed... boo...") %>


### PR DESCRIPTION
If a media consent is signed, we don't display whether or not consent was given in the admin area under the onboarding steps; the change here will display the consented status there.

An issue from 2022, from Alex! *Lolsob!!!

Also, we do display consented or not a little further down on the student profile admin page, this change will show consented or not next to the green checkmark in the onboarding section.


