### PR TITLE
Add rake task to update all contacts in Salesforce

### DIFF
--- a/lib/tasks/update_all_salesforce_contacts.rake
+++ b/lib/tasks/update_all_salesforce_contacts.rake
@@ -1,0 +1,10 @@
+desc "Update ALL Salesforce contacts"
+task update_all_salesforce_contacts: :environment do
+  Account.not_admin.current.find_in_batches(batch_size: 500) do |accounts|
+    account_ids = accounts.pluck(:id).join(",")
+
+    system("bundle exec rake update_salesforce_contacts[#{account_ids}]")
+
+    sleep 15.minutes
+  end
+end


### PR DESCRIPTION
I ended up going with the simplest approach to update all accounts in Salesforce.

This will add a new rake task that will update 500 accounts (non-admin and in the current season) at a time in Salesforce every 15 minutes.

This rake task will leverage our existing rake task that takes a list of account ids and updates those accounts in Salesforce.
