### PR TITLE
Notify ambassadors of results from bulk-adding teams (via an CSV) to an RPE

### DIFF
--- a/app/controllers/concerns/bulk_add_teams_to_regional_pitch_event.rb
+++ b/app/controllers/concerns/bulk_add_teams_to_regional_pitch_event.rb
@@ -15,7 +15,11 @@ module BulkAddTeamsToRegionalPitchEvent
             row[:team_id] if row[:team_id].present?
           end.compact
 
-        AssignTeamsToRegionalPitchEventJob.perform_later(regional_pitch_event_id: @event.id, team_ids:)
+        AssignTeamsToRegionalPitchEventJob.perform_later(
+          regional_pitch_event_id: @event.id,
+          account_id: current_account.id,
+          team_ids:
+        )
       end
 
       redirect_to chapter_ambassador_event_path(@event), success: "Your CSV file was uploaded successfully! It will be processed soon!"

--- a/app/jobs/assign_teams_to_regional_pitch_event_job.rb
+++ b/app/jobs/assign_teams_to_regional_pitch_event_job.rb
@@ -1,9 +1,15 @@
 class AssignTeamsToRegionalPitchEventJob < ActiveJob::Base
   queue_as :default
 
-  def perform(regional_pitch_event_id:, team_ids:)
+  def perform(regional_pitch_event_id:, team_ids:, account_id:)
     regional_pitch_event = RegionalPitchEvent.find(regional_pitch_event_id)
+    account = Account.find(account_id)
+    assignment_result = DataProcessors::AssignTeamsToRegionalPitchEvent.new(regional_pitch_event:, team_ids:).call
 
-    DataProcessors::AssignTeamsToRegionalPitchEvent.new(regional_pitch_event:, team_ids:).call
+    AmbassadorMailer.assigned_teams_to_event(
+      event: regional_pitch_event,
+      account:,
+      assignment_result:
+    ).deliver_now
   end
 end

--- a/app/mailers/ambassador_mailer.rb
+++ b/app/mailers/ambassador_mailer.rb
@@ -102,6 +102,18 @@ class AmbassadorMailer < ApplicationMailer
     end
   end
 
+  def assigned_teams_to_event(account:, event:, assignment_result:)
+    @name = account.first_name
+    @event = event
+    @assignment_result = assignment_result
+    @event_url = chapter_ambassador_regional_pitch_events_url
+
+    I18n.with_locale(account.locale) do
+      mail to: account.email,
+        subject: "Your CSV has been processed for your event: #{@event.name}"
+    end
+  end
+
   def judge_joined_event(account, event, judge)
     @name = account.first_name
     @event = event

--- a/app/views/ambassador_mailer/assigned_teams_to_event.en.html.erb
+++ b/app/views/ambassador_mailer/assigned_teams_to_event.en.html.erb
@@ -1,0 +1,45 @@
+<tr>
+  <td class="content-wrap">
+    <meta itemprop="name" content="Download your file"/>
+    <table width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td class="content-block">
+          Hi <%= @name %>,
+        </td>
+      </tr>
+      <tr>
+        <td class="content-block">
+          Your CSV has been processed for the following event:
+          <strong><%= @event.name %></strong>
+        </td>
+      </tr>
+      <tr>
+        <td class="content-block">
+          <p><strong>Here are the results:</strong></p>
+          <ul>
+            <% @assignment_result.results.each do |result| %>
+              <li><%= result %></li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="content-block"
+            itemprop="handler"
+            itemscope
+            itemtype="http://schema.org/HttpActionHandler">
+          <%= link_to "Review Your Event",
+            @event_url,
+            class: "btn-primary",
+            role: "url" %>
+        </td>
+      </tr>
+      <tr>
+        <td class="content-block">
+          Regards,<br />
+          The Technovation Team
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/spec/jobs/assign_teams_to_regional_pitch_event_job_spec.rb
+++ b/spec/jobs/assign_teams_to_regional_pitch_event_job_spec.rb
@@ -1,17 +1,45 @@
 require "rails_helper"
 
 RSpec.describe AssignTeamsToRegionalPitchEventJob do
-  let(:regional_pitch_event) { instance_double(RegionalPitchEvent, id: 8192) }
+  let(:regional_pitch_event) {
+    instance_double(RegionalPitchEvent,
+      id: 8192,
+      name: "My Local Event")
+  }
+  let(:account) {
+    instance_double(Account,
+      id: 16384,
+      first_name: "Amy",
+      email: "amy@example.com",
+      locale: "en")
+  }
 
   before do
     allow(RegionalPitchEvent).to receive(:find).with(regional_pitch_event.id).and_return(regional_pitch_event)
+
+    allow(Account).to receive(:find).with(account.id).and_return(account)
+
+    allow(DataProcessors::AssignTeamsToRegionalPitchEvent).to receive_message_chain(:new, :call).and_return(assignment_result)
   end
 
-  it "calls the service that will assign the mentor to the appropriate chapterables" do
+  let(:assignment_result) { double("assignment_result", results: []) }
+
+  it "calls the service that will assign teams to the specified event" do
     expect(DataProcessors::AssignTeamsToRegionalPitchEvent).to receive_message_chain(:new, :call)
 
     AssignTeamsToRegionalPitchEventJob.perform_now(
       regional_pitch_event_id: regional_pitch_event.id,
+      account_id: account.id,
+      team_ids: [1, 2, 3]
+    )
+  end
+
+  it "calls the ambassador's 'assigned teams to event' mailer" do
+    expect(AmbassadorMailer).to receive_message_chain(:assigned_teams_to_event, :deliver_now)
+
+    AssignTeamsToRegionalPitchEventJob.perform_now(
+      regional_pitch_event_id: regional_pitch_event.id,
+      account_id: account.id,
       team_ids: [1, 2, 3]
     )
   end


### PR DESCRIPTION
This will add basic email functionality for when ambassadors upload a CSV to bulk-add teams to an RPE; after the CSV has been processed the ambassador will receive a basic email with the results.


