### PR TITLE
Update document#expired? check

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -20,7 +20,7 @@ class Document < ActiveRecord::Base
   end
 
   def expired?
-    !!sent_at&.before?(ENV.fetch("DOCUSIGN_NUM_DAYS_DOCUMENTS_EXPIRE_IN", 120).days.ago)
+    !!sent_at&.before?(ENV.fetch("DOCUSIGN_NUM_DAYS_DOCUMENTS_EXPIRE_IN", 120).to_i.days.ago)
   end
 
   def document_type


### PR DESCRIPTION
A simple change to add `to_i` because the ENV/Heroku config setting is a string and a string can't be converted to "days".

