### PR TITLE
Delete pending mentor join requests

### DIFF
--- a/app/jobs/register_to_current_season_job.rb
+++ b/app/jobs/register_to_current_season_job.rb
@@ -94,6 +94,7 @@ class RegisterToCurrentSeasonJob < ActiveJob::Base
     RegistrationMailer.welcome_mentor(record.id).deliver_later
 
     record.mentor_profile.update(training_completed_at: nil)
+    record.mentor_profile.pending_join_requests.delete_all
     record.mentor_profile.save # fire commit hooks, if needed
   end
 

--- a/spec/jobs/register_to_current_season_job_spec.rb
+++ b/spec/jobs/register_to_current_season_job_spec.rb
@@ -207,6 +207,25 @@ RSpec.describe RegisterToCurrentSeasonJob do
         profile.reload.training_complete?
       }.from(true).to(false)
     end
+
+    context "when a mentor has pending join requests" do
+      let(:mentor) { FactoryBot.create(:mentor) }
+      let!(:pending_mentor_join_request) { FactoryBot.create(:join_request, :pending, requestor: mentor) }
+
+      context "when the mentor is not registered to the current season (i.e. they're getting registered to the current season)" do
+        before do
+          mentor.account.update(seasons: [])
+        end
+
+        it "deletes pending join requests" do
+          expect(mentor.pending_join_requests.count).to eq(1)
+
+          RegisterToCurrentSeasonJob.perform_now(mentor.account)
+
+          expect(mentor.mentor_profile.pending_join_requests.count).to eq(0)
+        end
+      end
+    end
   end
 
   context "judges" do


### PR DESCRIPTION
This will add new functionality that will delete pending mentor join requests when a mentor gets registered to a new season.


