### PR TITLE
Email judges when being added to an RPE

### DIFF
--- a/app/controllers/chapter_ambassador/event_judges_controller.rb
+++ b/app/controllers/chapter_ambassador/event_judges_controller.rb
@@ -6,7 +6,18 @@ module ChapterAmbassador
       @event = RegionalPitchEvent.in_region(current_ambassador).find(params[:event_id])
       @judge = JudgeProfile.find(params[:judge_id])
 
-      @judge.events << @event
+      CreateEventAssignment.call(@event, {
+        invites: {
+          "0" => [
+            {
+              scope: "JudgeProfile",
+              id: @judge.id,
+              email: @judge.email,
+              name: @judge.full_name
+            }
+          ]
+        }
+      })
 
       @event = RegionalPitchEvent.find(params[:event_id])
       @available_judges = load_available_judges_for_event(@event)

--- a/app/technovation/create_event_assignment.rb
+++ b/app/technovation/create_event_assignment.rb
@@ -23,24 +23,20 @@ module CreateEventAssignment
         invite.events << event
       end
 
-      # FIXME "true" == ...
-      # make it a real boolean
-      if "true" == opts[:send_email]
-        if opts[:scope] == "Team"
-          invite.memberships.each do |membership|
-            EventMailer.invite(
-              membership.member_type,
-              membership.member_id,
-              event.id
-            ).deliver_later
-          end
-        else
+      if opts[:scope] == "Team"
+        invite.memberships.each do |membership|
           EventMailer.invite(
-            opts[:scope],
-            invite.id,
+            membership.member_type,
+            membership.member_id,
             event.id
           ).deliver_later
         end
+      else
+        EventMailer.invite(
+          opts[:scope],
+          invite.id,
+          event.id
+        ).deliver_later
       end
     end
   end


### PR DESCRIPTION
This will reuse the existing `CreateEventAssignment` functionality when adding judges to an RPE with our new Hotwire approach; which will send judges a notification email when they get added to an event.

I removed the `send_email` option b/c we want all judges to receive a notification email. A side effect of this is that if someone uses the old way of adding judges to an RPE (via Vue.js), all judges (currently assigned to the event (already received an email) or judges currently being added to an event) will receive an notification email. This shouldn't be an issue because we're planning to remove the Vue.js functionality.

