### PR TITLE
Assign judges to teams

### DIFF
--- a/app/assets/stylesheets/_application.scss
+++ b/app/assets/stylesheets/_application.scss
@@ -33,6 +33,7 @@ $chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 @import "img";
 @import "tabs";
 @import "screenshots";
+@import "modals";
 
 // font
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);

--- a/app/assets/stylesheets/_modals.scss
+++ b/app/assets/stylesheets/_modals.scss
@@ -1,0 +1,5 @@
+.swal2-container {
+  #swal2-html-container {
+    text-align: left;
+  }
+}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -40,6 +40,7 @@ $chosen-sprite-retina: image-url("chosen-sprite@2x.png");
 @import "season_schedule";
 @import "scores";
 @import "pills";
+@import "modals";
 
 // font
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);

--- a/app/controllers/chapter_ambassador/judge_assignments_controller.rb
+++ b/app/controllers/chapter_ambassador/judge_assignments_controller.rb
@@ -1,49 +1,36 @@
 module ChapterAmbassador
   class JudgeAssignmentsController < ChapterAmbassadorController
     def create
-      model = assignment_params.fetch(:model_scope).constantize
-      judge = model.find(assignment_params.fetch(:judge_id))
-      team = Team.find(assignment_params.fetch(:team_id))
+      @judge = JudgeProfile.find(params.fetch(:judge_id))
+      @team = Team.find(params.fetch(:team_id))
 
-      CreateJudgeAssignment.call(team: team, judge: judge)
+      CreateJudgeAssignment.call(team: @team, judge: @judge)
 
-      render json: {
-        flash: {
-          success: "You assigned #{judge.name} to #{team.name}"
-        }
-      }
+      flash.now[:success] = "Successfully assigned #{@judge.name} to #{@team.name}"
+
+      respond_to do |format|
+        format.turbo_stream
+      end
     end
 
     def destroy
-      model = assignment_params.fetch(:model_scope).constantize
-      judge = model.find(assignment_params.fetch(:judge_id))
+      @judge = JudgeProfile.find(params.fetch(:judge_id))
+      @team = Team.find(params.fetch(:team_id))
 
-      team = Team.find(assignment_params.fetch(:team_id))
+      @judge.assigned_teams.destroy(@team)
 
-      judge.assigned_teams.destroy(team)
-
-      unassigned_scores_in_event = judge.submission_scores
+      unassigned_scores_in_event = @judge.submission_scores
         .current_round
         .joins(team_submission: {team: :events})
-        .where("regional_pitch_events.id = ?", team.event.id)
-        .where.not(team_submission: judge.assigned_teams.map(&:submission))
+        .where("regional_pitch_events.id = ?", @team.event.id)
+        .where.not(team_submission: @judge.assigned_teams.map(&:submission))
       unassigned_scores_in_event.destroy_all
 
-      render json: {
-        flash: {
-          success: "You removed #{judge.name} from #{team.name}"
-        }
-      }
-    end
+      flash.now[:success] = "Successfully removed #{@judge.name} from #{@team.name}"
 
-    private
-
-    def assignment_params
-      params.require(:judge_assignment).permit(
-        :judge_id,
-        :team_id,
-        :model_scope
-      )
+      respond_to do |format|
+        format.turbo_stream
+      end
     end
   end
 end

--- a/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
+++ b/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
@@ -100,6 +100,46 @@ module ChapterAmbassador
       end
     end
 
+    def available_judges_for_team_assignment
+      event = RegionalPitchEvent.in_region(current_ambassador)
+        .find(params[:id])
+      team = Team.find(params[:team_id])
+
+      judges_assigned_to_event = JudgeProfile
+        .by_query(params[:query].presence)
+        .joins(:regional_pitch_events)
+        .left_joins(:judge_assignments)
+        .where(regional_pitch_events: {id: event.id})
+        .where.not(
+          id: JudgeProfile
+            .joins(:judge_assignments)
+            .where(judge_assignments: {team_id: team.id})
+            .select(:id)
+        )
+        .distinct
+        .paginate(page: params[:page], per_page: 10)
+      judges_assigned_to_team = team
+        .assigned_judges
+        .paginate(page: params[:page], per_page: 10)
+
+      if turbo_frame_request_id == "judges-available-for-team-assignment"
+        render partial: "admin/regional_pitch_events/judges/judges_available_for_team_assignment",
+          locals: {
+            event:,
+            team:,
+            judges_assigned_to_event:
+          }
+      else
+        render partial: "admin/regional_pitch_events/judges/available_judges_for_team_assignment",
+          locals: {
+            event:,
+            team:,
+            judges_assigned_to_event:,
+            judges_assigned_to_team:
+          }
+      end
+    end
+
     def available_judges
       @event = RegionalPitchEvent.in_region(current_ambassador)
         .find(params[:id])

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application";
 import DateFieldsController from "./date_fields_controller";
 application.register("date-fields", DateFieldsController);
 
+import ModalController from "./modal_controller";
+application.register("modal", ModalController);
+
 import SearchController from "./search_controller";
 application.register("search", SearchController);
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus";
+import Swal from "sweetalert2";
+
+export default class extends Controller {
+  static get targets() {
+    return ["flashMessages"];
+  }
+
+  connect() {
+    this.openModal();
+    this.clearFlashMessages();
+  }
+
+  openModal() {
+    Swal.fire({
+      template: "#modal-content",
+      width: "50%",
+      showCloseButton: true,
+      showConfirmButton: false,
+    });
+  }
+
+  clearFlashMessages() {
+    if (this.hasFlashMessagesTarget) {
+      flashMessages.innerHTML = "";
+    }
+  }
+}

--- a/app/models/judge_profile.rb
+++ b/app/models/judge_profile.rb
@@ -36,13 +36,15 @@ class JudgeProfile < ActiveRecord::Base
   }
 
   scope :by_query, ->(query) {
-    includes(:account)
-      .where(
-        "accounts.first_name ILIKE ? OR " +
-        "accounts.last_name ILIKE ?",
-        "%#{query}%",
-        "%#{query}%"
-      )
+    if query.present?
+      joins(:account)
+        .where(
+          "accounts.first_name ILIKE ? OR " \
+          "accounts.last_name ILIKE ?",
+          "%#{query}%",
+          "%#{query}%"
+        )
+    end
   }
 
   belongs_to :account, required: false

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -72,7 +72,7 @@ class RegionalPitchEvent < ActiveRecord::Base
     presence: true
 
   validates :capacity, presence: true,
-    numericality: { only_integer: true, greater_than: 0 },
+    numericality: {only_integer: true, greater_than: 0},
     if: :capacity_enabled?
 
   delegate :state_province,
@@ -213,6 +213,10 @@ class RegionalPitchEvent < ActiveRecord::Base
   def capacity_enabled?
     capacity_enabled == "1" ||
       (capacity.present? && capacity.to_i > 0)
+  end
+
+  def meets_requirement_to_assign_judges_to_teams?
+    teams.count >= ENV.fetch("MINIMUM_NUMBER_OF_TEAMS_ATTENDING_AN_RPE_TO_ENABLE_JUDGE_TO_TEAM_ASSIGNMENTS", 10).to_i
   end
 
   def clear_capacity

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -202,13 +202,13 @@ class Team < ActiveRecord::Base
   }
 
   scope :by_chapterable, ->(chapterable_type, chapterable_id, season = nil) do
-    scope = joins(students: { account: :chapterable_assignments})
-    .where(
-      chapterable_assignments: {
-        chapterable_type: chapterable_type.capitalize,
-        chapterable_id: chapterable_id
-      }
-    )
+    scope = joins(students: {account: :chapterable_assignments})
+      .where(
+        chapterable_assignments: {
+          chapterable_type: chapterable_type.capitalize,
+          chapterable_id: chapterable_id
+        }
+      )
 
     if season.present?
       scope.by_season(season).where(chapterable_assignments: {season: season})
@@ -282,11 +282,15 @@ class Team < ActiveRecord::Base
     after_remove: ->(team, event) { team.submission.touch }
 
   has_many :judge_assignments, -> { current }
+  has_many :assigned_judges,
+    through: :judge_assignments,
+    source: :assigned_judge,
+    source_type: "JudgeProfile"
 
   validates :name, presence: true, team_name_uniqueness: true
   validates :division, presence: true
 
-  validates :description, length: { maximum: 1500 }, if: :description_changed?
+  validates :description, length: {maximum: 1500}, if: :description_changed?
 
   delegate :name, to: :division, prefix: true
 

--- a/app/views/admin/regional_pitch_events/_registered_team.html.erb
+++ b/app/views/admin/regional_pitch_events/_registered_team.html.erb
@@ -28,12 +28,24 @@
       <%= team.human_status %>
     </span>
   </td>
+
   <% if current_account.chapter_ambassador? %>
     <td>
+      <div style="display: flex; justify-content: space-between;">
+        <% if event.meets_requirement_to_assign_judges_to_teams? %>
+          <%= link_to "Manage Judges",
+            available_judges_for_team_assignment_chapter_ambassador_event_path(@event, team_id: team.id),
+            class: "button",
+            data: {
+              turbo_frame: "modal"
+            } %>
+        <% end %>
+
         <%= button_to "Remove",
           chapter_ambassador_event_event_team_path(event, team),
           method: :delete,
           class: "button button--danger" %>
-      </td>
+      </div>
+    </td>
   <% end %>
 </tr>

--- a/app/views/admin/regional_pitch_events/judges/_available_judges_for_team_assignment.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_available_judges_for_team_assignment.html.erb
@@ -1,0 +1,44 @@
+<%= turbo_frame_tag :modal do %>
+  <template id="modal-content" data-controller="modal">
+    <swal-html>
+      <%= turbo_frame_tag "flash-messages", data: {
+        modal_target: "flashMessages"
+      } %>
+
+      <div class="grid grid--bleed">
+        <div class="grid__col-auto" style="overflow-x:auto;">
+          <h5 style="margin-top: 0px;">Available Judges</h5>
+
+          <%= form_with url: available_judges_for_team_assignment_chapter_ambassador_event_path(event),
+            method: :get,
+            data: {
+              controller: "search",
+              turbo_frame: "judges-available-for-team-assignment"
+            } do |f| %>
+
+            <%= f.text_field :query,
+              value: params[:query],
+              placeholder: "Search judges by name",
+              data: {
+                action: "input->search#search",
+                turbo_submits_with: "Searching..." } %>
+
+            <%= f.hidden_field :team_id, value: team.id %>
+          <% end %>
+
+          <%= render "admin/regional_pitch_events/judges/judges_available_for_team_assignment",
+            event:,
+            team:,
+            judges_assigned_to_event: %>
+
+          <hr style="height: 2px; width: 100%; color: #9ca3af;">
+          <h5 style="margin-bottom: 0px;">Judges Assigned to this Team</h5>
+          <%= render "admin/regional_pitch_events/judges/judges_assigned_to_team",
+            event:,
+            team:,
+            judges_assigned_to_team: %>
+        </div>
+      </div>
+    </swal-html>
+  </template>  
+<% end %>

--- a/app/views/admin/regional_pitch_events/judges/_judge.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_judge.html.erb
@@ -1,0 +1,24 @@
+<li id="<%= dom_id(judge) %>" class="py-2" style="padding: 0.5rem 0; border-bottom: 1px solid rgb(229,231,235);">
+  <div class="flex items-center space-x-4" style="display: flex; align-items: center;">
+    <div class="flex-shrink-0 self-start" style="flex-shrink: 0; align-self: flex-start; margin-right: 8px;">
+      <%= image_tag judge.profile_image_url, 
+        class: "rounded-tl-sm rounded-tr-xl rounded-bl-xl rounded-br-sm w-8 h-8",
+        style: "height: 2rem; width: 2rem; border-bottom-left-radius: 0.75rem; border-bottom-right-radius: 0.125rem; border-top-left-radius: 0.125rem; border-top-right-radius: 0.75rem;"
+      %>
+    </div>
+
+    <div class="flex-1 min-w-0" style="min-width: 0px; flex: 1 1 0%;">
+      <p class="flex text-sm font-medium text-gray-900 truncate" style="display: flex; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.875rem; line-height: 1.15rem; font-weight: 500; color: rgb(17,24,39); margin: 0;">
+        <%= judge.full_name %>
+      </p>
+
+      <p class="text-sm text-gray-500 truncate" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.875rem; line-height: 1.15rem; color: rgb(107,114,128); margin: 0;">
+        <%= judge.email %><br>
+      </p>
+    </div>
+
+    <div>
+      <%= yield %>
+    </div>
+  </div>
+</li>

--- a/app/views/admin/regional_pitch_events/judges/_judge_assigned_to_team.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_judge_assigned_to_team.html.erb
@@ -1,0 +1,6 @@
+<%= render "admin/regional_pitch_events/judges/judge", judge: do %>
+  <%= button_to "Remove",
+    chapter_ambassador_judge_assignments_path(team_id: team.id, judge_id: judge.id),
+    method: :delete,
+    class: "button gray" %>
+<% end %>

--- a/app/views/admin/regional_pitch_events/judges/_judge_available_for_team_assignment.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_judge_available_for_team_assignment.html.erb
@@ -1,0 +1,6 @@
+<%= render "admin/regional_pitch_events/judges/judge", judge: do %>
+  <%= button_to "Assign to Team",
+    chapter_ambassador_judge_assignments_path(team_id: team.id, judge_id: judge.id),
+    method: :post,
+    class: "button" %>
+<% end %>

--- a/app/views/admin/regional_pitch_events/judges/_judges_assigned_to_team.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_judges_assigned_to_team.html.erb
@@ -1,0 +1,9 @@
+<ul id="judges-assigned-to-team" class="divide-y divide-gray-200" style="list-style-type: none; padding: 0;" role="list">
+  <% if judges_assigned_to_team.any? %>
+    <% judges_assigned_to_team.each do |judge| %>
+      <%= render "admin/regional_pitch_events/judges/judge_assigned_to_team", judge:, team: %>
+    <% end %>
+  <% else %>
+    <p id="no-judges-found">Currently, there aren't any judges assigned to this team.</p>
+  <% end %>
+</ul>

--- a/app/views/admin/regional_pitch_events/judges/_judges_available_for_team_assignment.html.erb
+++ b/app/views/admin/regional_pitch_events/judges/_judges_available_for_team_assignment.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag "judges-available-for-team-assignment" do %>
+  <ul id="available-judges" class="divide-y divide-gray-200" style="list-style-type: none; padding: 0;" role="list">
+    <% if judges_assigned_to_event.any? %>
+      <% judges_assigned_to_event.each do |judge| %>
+        <%= render "admin/regional_pitch_events/judges/judge_available_for_team_assignment", judge:, team: %>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <div style="display: flex; justify-content: space-around; margin-top: 12px;">
+    <%= will_paginate judges_assigned_to_event,
+      params: {
+        controller: "chapter_ambassador/regional_pitch_events",
+        action: "available_judges_for_team_assignment", id: event.id } %>
+  </div>
+<% end %>

--- a/app/views/chapter_ambassador/judge_assignments/create.turbo_stream.erb
+++ b/app/views/chapter_ambassador/judge_assignments/create.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.remove(@judge) %>
+<%= turbo_stream.remove("no-judges-found") %>
+
+<%= turbo_stream.append "judges-assigned-to-team",
+  partial: "admin/regional_pitch_events/judges/judge_assigned_to_team",
+  locals: {judge: @judge, team: @team }
+%>
+
+<%= turbo_stream.append "flash-messages" do %>
+  <%= render "flash_messages" %>
+<% end %>

--- a/app/views/chapter_ambassador/judge_assignments/destroy.turbo_stream.erb
+++ b/app/views/chapter_ambassador/judge_assignments/destroy.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.remove(@judge) %>
+
+<%= turbo_stream.append "available-judges",
+  partial: "admin/regional_pitch_events/judges/judge_available_for_team_assignment", 
+  locals: {judge: @judge, team: @team}
+%>
+
+<%= turbo_stream.append "flash-messages" do %>
+  <%= render "flash_messages" %>
+<% end %>

--- a/app/views/layouts/chapter_ambassador.html.erb
+++ b/app/views/layouts/chapter_ambassador.html.erb
@@ -57,6 +57,8 @@
 
     <%= render 'application/queued_jobs' %>
 
+    <%= turbo_frame_tag :modal %>
+
     <% if ENV.fetch("GOOGLE_ANALYTICS_ID", nil).present? && cookies[CookieNames::CONSENTED_TO_ALL_COOKIES] == "true" %>
       <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Rails.application.routes.draw do
       resources :event_teams, only: [:create, :destroy]
 
       get :available_judges, on: :member
+      get :available_judges_for_team_assignment, on: :member
       get :available_teams, on: :member
       get :bulk_download_submission_pitch_presentations
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "luxon": "^2.5.0",
     "node-notifier": "8.0.1",
     "postcss": "^8.4.14",
-    "sweetalert2": "^10.0",
+    "sweetalert2": "^11.0",
     "tailwindcss": "^3.1.3",
     "url-search-params": "^0.10.0",
     "v-tooltip": "^2.0.2",

--- a/spec/controllers/chapter_ambassador/judge_assignments_controller_spec.rb
+++ b/spec/controllers/chapter_ambassador/judge_assignments_controller_spec.rb
@@ -28,12 +28,10 @@ RSpec.describe ChapterAmbassador::JudgeAssignmentsController do
       )
 
       post :create, params: {
-        judge_assignment: {
-          judge_id: judge.id,
-          team_id: team1.id,
-          model_scope: "JudgeProfile"
-        }
-      }
+        judge_id: judge.id,
+        team_id: team1.id,
+        model_scope: "JudgeProfile"
+      }, xhr: true
 
       teams = GatherAssignedTeams.call(judge)
       expect(teams).to contain_exactly(team1, team3)
@@ -69,12 +67,10 @@ RSpec.describe ChapterAmbassador::JudgeAssignmentsController do
       SeasonToggles.set_judging_round(:qf)
 
       post :create, params: {
-        judge_assignment: {
-          judge_id: judge.id,
-          team_id: team1.id,
-          model_scope: "JudgeProfile"
-        }
-      }
+        judge_id: judge.id,
+        team_id: team1.id,
+        model_scope: "JudgeProfile"
+      }, xhr: true
 
       teams = GatherAssignedTeams.call(judge)
       expect(teams).to contain_exactly(team1, team3)
@@ -85,12 +81,10 @@ RSpec.describe ChapterAmbassador::JudgeAssignmentsController do
       )
 
       delete :destroy, params: {
-        judge_assignment: {
-          judge_id: judge.id,
-          team_id: team1.id,
-          model_scope: "JudgeProfile"
-        }
-      }
+        judge_id: judge.id,
+        team_id: team1.id,
+        model_scope: "JudgeProfile"
+      }, xhr: true
 
       expect(score.reload).to be_deleted
       expect(judge.submission_scores).to be_empty

--- a/yarn.lock
+++ b/yarn.lock
@@ -8898,10 +8898,10 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-sweetalert2@^10.0:
-  version "10.15.7"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-10.15.7.tgz#ad4c8f08432952d3283adbaa9a309c534f5a863d"
-  integrity sha512-imY0MR03NGefPcGzSYjWYz1GMIlniusEBXilswvKrHD/GMiTxA5jnsdjtK2IoRyXfEaqV7GWt6DM4YVjAZU8gw==
+sweetalert2@^11.0:
+  version "11.26.18"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.26.18.tgz#86077ab19cd55f36d709e01a9b72ac4aef4c778e"
+  integrity sha512-3O5feBqV+hTIOwCRKGuZGHosjiuBAKP/vpBl6vKFZeVYfCUGdXqXuuidn6YXHan3f6e62UdmnjwJBt8UtDVBhg==
 
 tailwindcss@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
This will setup all the basic functionality to be able to assign judges to a team via a popup modal. This functionality will only be enabled if there are more ten teams attending the RPE.

A couple of other related changes:

- Adding flash messages for adding a removing judges
- Adding a new config variable for the minimum teams requirement
  - `MINIMUM_NUMBER_OF_TEAMS_ATTENDING_AN_RPE_TO_ENABLE_JUDGE_TO_TEAM_ASSIGNMENTS`
- Updating the sweet alerts library
- Adding new modal stimulus controller and functionality
- Some basic styling for the modal