### PR TITLE
RPE start/end date improvements

### DIFF
--- a/app/constants/important_dates.rb
+++ b/app/constants/important_dates.rb
@@ -41,6 +41,20 @@ module ImportantDates
     Time.zone.local(year, month, day)
   end
 
+  def self.rpe_start_date
+    year = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_YEAR"))
+    month = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_MONTH"))
+    day = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_DAY"))
+    Time.zone.local(year, month, day)
+  end
+
+  def self.rpe_end_date
+    year = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_YEAR"))
+    month = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_MONTH"))
+    day = Integer(ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_DAY"))
+    Time.zone.local(year, month, day)
+  end
+
   def self.rpe_officiality_finalized
     year = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_YEAR"))
     month = Integer(ENV.fetch("DATES_RPE_OFFICIALITY_FINALIZED_MONTH"))

--- a/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
+++ b/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
@@ -6,6 +6,8 @@ module ChapterAmbassador
     include RegionalPitchEvents::BulkAddJudgesToRegionalPitchEvent
     include RegionalPitchEvents::BulkAddTeamsToRegionalPitchEvent
 
+    before_action :set_rpe_date_ranges, only: [:new, :create, :edit, :update]
+
     def index
       respond_to do |f|
         f.html {}
@@ -46,8 +48,6 @@ module ChapterAmbassador
 
     def new
       @pitch_event = RegionalPitchEvent.new
-      @pitch_event_start_date_range = "#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_YEAR")}-#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_MONTH")}-#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_BEGINS_DAY")}"
-      @pitch_event_end_date_range = "#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_YEAR")}-#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_MONTH")}-#{ENV.fetch("DATES_REGIONAL_PITCH_EVENTS_ENDS_DAY")}"
     end
 
     def create
@@ -174,6 +174,11 @@ module ChapterAmbassador
         :division_id,
         division_ids: []
       )
+    end
+
+    def set_rpe_date_ranges
+      @pitch_event_start_date_range = ImportantDates.rpe_start_date.strftime("%Y-%-m-%-e")
+      @pitch_event_end_date_range = ImportantDates.rpe_end_date.strftime("%Y-%-m-%-e")
     end
 
     class NullInvitation < Struct.new(:token)

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -75,6 +75,10 @@ class RegionalPitchEvent < ActiveRecord::Base
     numericality: {only_integer: true, greater_than: 0},
     if: :capacity_enabled?
 
+  validate :starts_at_within_rpe_date_range
+  validate :ends_at_within_rpe_date_range
+  validate :ends_at_after_starts_at
+
   delegate :state_province,
     :country,
     :timezone,
@@ -229,6 +233,32 @@ class RegionalPitchEvent < ActiveRecord::Base
 
   def update_teams_count(team = nil)
     update(teams_count: teams.count)
+  end
+
+  private
+
+  def starts_at_within_rpe_date_range
+    rpe_start_date = ImportantDates.rpe_start_date.strftime("%B %e")
+    rpe_end_date = ImportantDates.rpe_end_date.strftime("%B %e, %Y")
+
+    if starts_at < ImportantDates.rpe_start_date || starts_at > ImportantDates.rpe_end_date
+      errors.add(:starts_at, "Please select a start date between #{rpe_start_date} and #{rpe_end_date}")
+    end
+  end
+
+  def ends_at_within_rpe_date_range
+    rpe_start_date = ImportantDates.rpe_start_date.strftime("%B %e")
+    rpe_end_date = ImportantDates.rpe_end_date.strftime("%B %e, %Y")
+
+    if ends_at < ImportantDates.rpe_start_date || ends_at > ImportantDates.rpe_end_date
+      errors.add(:ends_at, "Please select an end date between #{rpe_start_date} and #{rpe_end_date}")
+    end
+  end
+
+  def ends_at_after_starts_at
+    if ends_at < starts_at
+      errors.add(:ends_at, "The end date must come after the start date")
+    end
   end
 end
 

--- a/app/views/chapter_ambassador/regional_pitch_events/_form.html.erb
+++ b/app/views/chapter_ambassador/regional_pitch_events/_form.html.erb
@@ -24,7 +24,7 @@
       <div data-controller="date-fields" >
         <div class="field">
           <%= f.label :starts_at, "Event starts at" %>
-          <%= f.date_field :starts_at,
+          <%= f.datetime_local_field :starts_at,
             required: true,
             min: @pitch_event_start_date_range,
             max: @pitch_event_end_date_range,

--- a/spec/controllers/judge/score_completions_controller_spec.rb
+++ b/spec/controllers/judge/score_completions_controller_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Judge::ScoreCompletionsController do
 
         rpe = FactoryBot.create(:event,
           name: "RPE",
-          starts_at: Date.today,
-          ends_at: Date.today + 1.day,
+          starts_at: ImportantDates.rpe_start_date,
+          ends_at: ImportantDates.rpe_start_date + 1.day,
           division_id: Division.senior.id,
           city: "City",
           venue_address: "123 Street St.",
@@ -119,8 +119,8 @@ RSpec.describe Judge::ScoreCompletionsController do
 
           rpe = FactoryBot.create(:event,
             name: "RPE",
-            starts_at: Date.today,
-            ends_at: Date.today + 1.day,
+            starts_at: ImportantDates.rpe_start_date,
+            ends_at: ImportantDates.rpe_start_date + 1.day,
             division_id: Division.senior.id,
             city: "City",
             venue_address: "123 Street St.",

--- a/spec/controllers/judge/scores_controller_spec.rb
+++ b/spec/controllers/judge/scores_controller_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe Judge::ScoresController do
 
           rpe = FactoryBot.create(:event,
             name: "RPE",
-            starts_at: Date.today,
-            ends_at: Date.today + 1.day,
+            starts_at: ImportantDates.rpe_start_date,
+            ends_at: ImportantDates.rpe_start_date + 1.day,
             division_id: Division.senior.id,
             city: "City",
             venue_address: "123 Street St.",
@@ -239,8 +239,8 @@ RSpec.describe Judge::ScoresController do
 
           rpe = FactoryBot.create(:event,
             name: "RPE",
-            starts_at: Date.today,
-            ends_at: Date.today + 1.day,
+            starts_at: ImportantDates.rpe_start_date,
+            ends_at: ImportantDates.rpe_start_date + 1.day,
             division_id: Division.senior.id,
             city: "City",
             venue_address: "123 Street St.",

--- a/spec/factories/regional_pitch_events.rb
+++ b/spec/factories/regional_pitch_events.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     ambassador
 
     name { "RPE" }
-    starts_at { Date.current }
-    ends_at { Date.current + 1.day }
+    starts_at { ImportantDates.rpe_start_date }
+    ends_at { ImportantDates.rpe_start_date + 1.day }
     city { "City" }
     venue_address { "123 Street St." }
     unofficial { false }

--- a/spec/models/submission_score_spec.rb
+++ b/spec/models/submission_score_spec.rb
@@ -397,8 +397,8 @@ RSpec.describe SubmissionScore do
 
     rpe = FactoryBot.create(:event,
       name: "RPE",
-      starts_at: Date.today,
-      ends_at: Date.today + 1.day,
+      starts_at: ImportantDates.rpe_start_date,
+      ends_at: ImportantDates.rpe_start_date + 1.day,
       division_id: Division.senior.id)
 
     judge_profile.regional_pitch_events << rpe
@@ -427,8 +427,8 @@ RSpec.describe SubmissionScore do
 
     rpe = FactoryBot.create(:event,
       name: "RPE",
-      starts_at: Date.today,
-      ends_at: Date.today + 1.day,
+      starts_at: ImportantDates.rpe_start_date,
+      ends_at: ImportantDates.rpe_start_date + 1.day,
       division_id: Division.senior.id)
 
     judge_profile.regional_pitch_events << rpe
@@ -590,8 +590,8 @@ RSpec.describe SubmissionScore do
       judge_profile = FactoryBot.create(:judge_profile)
       rpe = FactoryBot.create(:event,
         name: "My RPE",
-        starts_at: Date.today,
-        ends_at: Date.today + 1.day,
+        starts_at: ImportantDates.rpe_start_date,
+        ends_at: ImportantDates.rpe_start_date + 1.day,
         division_id: Division.senior.id)
 
       judge_profile.regional_pitch_events << rpe

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -333,8 +333,8 @@ RSpec.describe TeamSubmission do
           solves_education: true,
           solves_education_description: "Some description",
           promotes_wellbeing: true,
-          promotes_wellbeing_description: "Some description",
-          )
+          promotes_wellbeing_description: "Some description"
+        )
       end
 
       it "returns true" do
@@ -683,8 +683,8 @@ RSpec.describe TeamSubmission do
       before(:each) do
         @rpe = FactoryBot.create(:event,
           name: "RPE",
-          starts_at: Date.today,
-          ends_at: Date.today + 1.day,
+          starts_at: ImportantDates.rpe_start_date,
+          ends_at: ImportantDates.rpe_start_date + 1.day,
           division_id: Division.senior.id,
           city: "City",
           venue_address: "123 Street St.",
@@ -774,8 +774,8 @@ RSpec.describe TeamSubmission do
       before(:each) do
         @rpe = FactoryBot.create(:event,
           name: "RPE",
-          starts_at: Date.today,
-          ends_at: Date.today + 1.day,
+          starts_at: ImportantDates.rpe_start_date,
+          ends_at: ImportantDates.rpe_start_date + 1.day,
           division_id: Division.senior.id,
           city: "City",
           venue_address: "123 Street St.",
@@ -1030,7 +1030,6 @@ RSpec.describe TeamSubmission do
         past_team = FactoryBot.create(:team, seasons: [Season.current.year - 1])
         student = past_team.students.first
         past_submission = FactoryBot.create(:submission, team: past_team)
-
 
         student.chapterable_assignments.destroy_all
         student.chapterable_assignments.create(

--- a/spec/technovation/find_eligible_submission_id_spec.rb
+++ b/spec/technovation/find_eligible_submission_id_spec.rb
@@ -166,8 +166,8 @@ RSpec.describe FindEligibleSubmissionId do
       team = FactoryBot.create(:team)
 
       team.regional_pitch_events << FactoryBot.create(:event,
-        starts_at: Date.today,
-        ends_at: Date.today + 1.day,
+        starts_at: ImportantDates.rpe_start_date,
+        ends_at: ImportantDates.rpe_start_date + 1.day,
         division_id: Division.senior.id,
         unofficial: true)
 
@@ -215,8 +215,8 @@ RSpec.describe FindEligibleSubmissionId do
       judge = FactoryBot.create(:judge)
       team = FactoryBot.create(:team)
       team.regional_pitch_events << FactoryBot.create(:event,
-        starts_at: Date.today,
-        ends_at: Date.today + 1.day,
+        starts_at: ImportantDates.rpe_start_date,
+        ends_at: ImportantDates.rpe_start_date + 1.day,
         division_id: Division.senior.id)
 
       TeamSubmission.create!({
@@ -443,8 +443,8 @@ RSpec.describe FindEligibleSubmissionId do
       judge = FactoryBot.create(:judge)
       team = FactoryBot.create(:team)
       team.regional_pitch_events << FactoryBot.create(:event,
-        starts_at: Date.today,
-        ends_at: Date.today + 1.day,
+        starts_at: ImportantDates.rpe_start_date,
+        ends_at: ImportantDates.rpe_start_date + 1.day,
         division_id: Division.senior.id)
 
       submission = FactoryBot.create(


### PR DESCRIPTION
Some general improvements for the RPE start/end date picker/functionality:

- Add back-end validations
- Add RPE start/end date to `ImportantDates`
- Add min/max date ranges for date picker when editing an RPE and when there are are validation errors
- Add time to start date picker
  - Make `date_field` `datetime_local_field`
- Update a bunch of the specs
  - The RPEs created in the specs became invalid w/ the new validations and needed to be updated

