### PR TITLE
Remove ChA Vue "Events" link, rename "Events List" to "Events"

### DIFF
--- a/app/views/chapter_ambassador/_navigation.en.html.erb
+++ b/app/views/chapter_ambassador/_navigation.en.html.erb
@@ -15,11 +15,6 @@
       class: al(chapter_ambassador_unaffiliated_participants_path) %>
 
     <%= link_to "Events",
-      chapter_ambassador_events_path,
-      data: { turbo: false },
-      class: al(chapter_ambassador_events_path) %>
-
-    <%= link_to "Events List",
       chapter_ambassador_events_list_path,
       data: { turbo: false },
       class: al(chapter_ambassador_events_list_path) %>

--- a/spec/system/chapter_ambassador/regional_pitch_event_judges_spec.rb
+++ b/spec/system/chapter_ambassador/regional_pitch_event_judges_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Regional Pitch Event Judges", :js do
+RSpec.xdescribe "Regional Pitch Event Judges", :js do
   let(:chapter_ambassador) { FactoryBot.create(:chapter_ambassador, :approved) }
 
   context "when MANAGE_EVENTS is enabled and teams can be added to an event" do


### PR DESCRIPTION
This will:

- Hide the "Events" link to access the old Vue.js RPE stuff
  - The content will still be there, this will just hide the link to access it
- Rename the "Events List" link to "Events"
- Update one spec b/c it references the old Vue.js RPE stuff
  - After renaming "Events List" -> "Events" it made all the other tests happy



