### PR TITLE
Add safe navigation to handle nil country in geocoding results

### DIFF
--- a/app/technovation/handle_geocoder_search.rb
+++ b/app/technovation/handle_geocoder_search.rb
@@ -35,7 +35,7 @@ module HandleGeocoderSearch
   def self.handle_possible_insert_of_palestine_multi_result(geocoded_results)
     return geocoded_results if geocoded_results.many? || geocoded_results.none?
 
-    if geocoded_results.first.country.downcase == "israel"
+    if geocoded_results.first.country&.downcase == "israel"
       palestine_copy = geocoded_results.first.dup
       palestine_copy.id = SecureRandom.hex(4)
       palestine_copy.state = palestine_copy.state_code = nil


### PR DESCRIPTION
This method errors out if the country is blank. This most recently occurred with the `Jammu & Kashmir` location. This change will allow an error to be returned to the user instead of just the form. 
<img width="300" height="479" alt="Screenshot 2026-03-03 at 11 54 08 AM" src="https://github.com/user-attachments/assets/4562264d-210c-4a14-88a6-07364955a2fe" />
