### PR TITLE
Add RPE Toolkit link to Chapter Resources list

### DIFF
--- a/app/views/ambassador/admin/_chapterable_resources.en.html.erb
+++ b/app/views/ambassador/admin/_chapterable_resources.en.html.erb
@@ -30,6 +30,13 @@
       target: "_blank"
     %>
   </li>
+
+  <li>
+    <%= link_to "RPE Toolkit",
+      ENV.fetch("RPE_TOOLKIT_URL"),
+      target: "_blank"
+    %>
+  </li>
 </ul>
 
 <h3 class="reset">Mentor Resources</h3>


### PR DESCRIPTION
This will add a link to the RPE Toolkit on the Chapter Resources page.


