### PR TITLE
Bug fix - Destroy judge team assignments when removing judge from event

### DIFF
--- a/app/technovation/invalidate_existing_judge_data.rb
+++ b/app/technovation/invalidate_existing_judge_data.rb
@@ -16,6 +16,7 @@ class InvalidateExistingJudgeData
         .where("regional_pitch_events.id = ?", event.id)
 
       event_scores_by_this_judge.destroy_all
+      participant.judge_assignments.where(team: event.teams).destroy_all
       participant.events.destroy(event)
     end
   end

--- a/spec/controllers/chapter_ambassador/event_assignments_controller_spec.rb
+++ b/spec/controllers/chapter_ambassador/event_assignments_controller_spec.rb
@@ -37,6 +37,30 @@ RSpec.describe ChapterAmbassador::EventAssignmentsController do
     end
   end
 
+  describe "DELETE #destroy" do
+    it "destroys the judge's team assignments in the event" do
+      judge = FactoryBot.create(:judge)
+      team = FactoryBot.create(:team, :submitted)
+      chapter_ambassador = FactoryBot.create(:chapter_ambassador)
+      event = FactoryBot.create(:event, ambassador: chapter_ambassador)
+
+      event.teams << team
+      event.judges << judge
+      judge.assigned_teams << team
+
+      sign_in(chapter_ambassador)
+      expect {
+        delete :destroy, params: {
+          event_assignment: {
+            event_id: event.id,
+            attendee_id: judge.id,
+            attendee_scope: "JudgeProfile"
+          }
+        }
+      }.to change { judge.assigned_teams.count }.by(-1)
+    end
+  end
+
   private
 
   def post_create(event:, invites: {})


### PR DESCRIPTION
Refs #6108 

When a judge was removed from an RPE, their team assignments in that event were not destroyed