### PR TITLE
Allow judges to flag specific content items when recusing

### DIFF
--- a/app/controllers/judge/scores_controller.rb
+++ b/app/controllers/judge/scores_controller.rb
@@ -214,7 +214,8 @@ module Judge
         :downloaded_source_code,
         :downloaded_business_plan,
         :judge_recusal_reason,
-        :judge_recusal_comment
+        :judge_recusal_comment,
+        judge_recusal_flagged_contents_attributes: [:name]
       )
     end
   end

--- a/app/javascript/judge/scores/JudgeRecusalPopup.vue
+++ b/app/javascript/judge/scores/JudgeRecusalPopup.vue
@@ -52,6 +52,33 @@ export default {
               <input type="radio" id="content-does-not-belong-to-team" name="judge-recusal-reason" value="content_does_not_belong_to_team">
               <label for="content-does-not-belong-to-team">Content doesn't belong to the team</label>
             </div>
+            <div id="recusal-flagged-contents" style="display: none; margin-left: 1.5rem;">
+              <p>Select all that apply:</p>
+              <div>
+                <input type="checkbox" id="problem-or-project-description" name="recusal-flagged-contents" value="problem_or_project_description">
+                <label for="problem-or-project-description">Problem or Project Description</label>
+              </div>
+              <div>
+                <input type="checkbox" id="pitch-video" name="recusal-flagged-contents" value="pitch_video">
+                <label for="pitch-video">Pitch Video</label>
+              </div>
+              <div>
+                <input type="checkbox" id="technical-video" name="recusal-flagged-contents" value="technical_video">
+                <label for="technical-video">Technical Video</label>
+              </div>
+              <div>
+                <input type="checkbox" id="learning-journey" name="recusal-flagged-contents" value="learning_journey">
+                <label for="learning-journey">Learning Journey</label>
+              </div>
+              <div>
+                <input type="checkbox" id="user-adoption-plan" name="recusal-flagged-contents" value="user_adoption_plan">
+                <label for="user-adoption-plan">User Adoption Plan</label>
+              </div>
+              <div>
+                <input type="checkbox" id="business-canvas" name="recusal-flagged-contents" value="business_canvas">
+                <label for="business-canvas">Business Canvas</label>
+              </div>
+            </div>
             <div>
               <input type="radio" id="other" name="judge-recusal-reason" value="other">
               <label for="other">Other</label>
@@ -85,6 +112,22 @@ export default {
             }
 
             characterCountEl.innerHTML = characterCount.toString();
+          });
+
+          const contentCheckboxEls = document.querySelector("#recusal-flagged-contents");
+          const radioEls = document.querySelectorAll('input[name="judge-recusal-reason"]');
+
+          radioEls.forEach((radio) => {
+            radio.addEventListener("change", () => {
+              if (radio.value === "content_does_not_belong_to_team") {
+                contentCheckboxEls.style.display = "block";
+              } else {
+                contentCheckboxEls.style.display = "none";
+                document.querySelectorAll('input[name="recusal-flagged-contents"]').forEach((checkbox) => {
+                  checkbox.checked = false;
+                });
+              }
+            });
           });
         },
         preConfirm: () => {
@@ -124,7 +167,21 @@ export default {
             );
           }
 
-          return { judgeRecusalReason, judgeRecusalComment };
+          const judgeRecusalFlaggedContents = [
+            ...document.querySelectorAll('input[name="recusal-flagged-contents"]:checked')
+          ].map((checkbox) => ({ name: checkbox.value }));
+
+          if (
+            judgeRecusalReason === "content_does_not_belong_to_team" &&
+            judgeRecusalFlaggedContents.length === 0
+          ) {
+            Swal.showValidationMessage(
+              "Please select at least one content item that does not belong to the team."
+            );
+            return false;
+          }
+
+          return { judgeRecusalReason, judgeRecusalComment, judgeRecusalFlaggedContents };
         },
         confirmButtonText: "Remove me from this submission",
         confirmButtonColor: "#3FA428",
@@ -142,6 +199,7 @@ export default {
             submission_score: {
               judge_recusal_reason: formValues.judgeRecusalReason,
               judge_recusal_comment: formValues.judgeRecusalComment,
+              judge_recusal_flagged_contents_attributes: formValues.judgeRecusalFlaggedContents,
             },
           }
         );
@@ -184,6 +242,12 @@ export default {
     display: flex;
     width: 50%;
     float: right;
+  }
+
+  #recusal-flagged-contents p {
+    font-size: 0.9rem;
+    font-weight: normal;
+    margin-bottom: 0.3rem;
   }
 }
 

--- a/app/models/judge_recusal_flagged_content.rb
+++ b/app/models/judge_recusal_flagged_content.rb
@@ -1,0 +1,12 @@
+class JudgeRecusalFlaggedContent < ActiveRecord::Base
+  belongs_to :submission_score
+
+  enum name: {
+    problem_or_project_description: 10,
+    pitch_video: 20,
+    technical_video: 30,
+    learning_journey: 40,
+    user_adoption_plan: 50,
+    business_canvas: 60
+  }
+end

--- a/app/models/submission_score.rb
+++ b/app/models/submission_score.rb
@@ -63,6 +63,9 @@ class SubmissionScore < ActiveRecord::Base
     other: "other"
   }
 
+  has_many :judge_recusal_flagged_contents, dependent: :destroy
+  accepts_nested_attributes_for :judge_recusal_flagged_contents
+
   belongs_to :team_submission, counter_cache: true
 
   counter_culture :team_submission,
@@ -562,6 +565,10 @@ class SubmissionScore < ActiveRecord::Base
 
   def pending_approval?
     complete? && !approved?
+  end
+
+  def recusal_flagged_content
+    judge_recusal_flagged_contents.map { |c| c.name.humanize }.join(", ")
   end
 
   private

--- a/app/views/admin/participants/_judge_recusal_reason.en.html.erb
+++ b/app/views/admin/participants/_judge_recusal_reason.en.html.erb
@@ -1,0 +1,6 @@
+<%= score.judge_recusal_reason.humanize %>
+<% if score.content_does_not_belong_to_team? %>
+  - <%= score.recusal_flagged_content %>
+<% elsif score.other? %>
+  - <%= score.judge_recusal_comment %>
+<% end %>

--- a/app/views/admin/participants/_judge_recused_scores.html.erb
+++ b/app/views/admin/participants/_judge_recused_scores.html.erb
@@ -15,11 +15,13 @@
           <td><%= score.team_name %></td>
           <td>
             <%= link_to score.team_submission_app_name,
-                        admin_team_submission_path(score.team_submission_id),
-                        class: "cta-link" %>
+              admin_team_submission_path(score.team_submission_id),
+              class: "cta-link" %>
           </td>
-          <td><%= content_tag :span, score.judge_recusal_reason.humanize, title: score.judge_recusal_comment %></td>
-          <td><%= score.round.humanize %></itd>
+          <td>
+            <%= render "admin/participants/judge_recusal_reason", score: score %>
+          </td>
+          <td><%= score.round.humanize %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/participants/_score_details_judge_recused_scores.erb
+++ b/app/views/admin/participants/_score_details_judge_recused_scores.erb
@@ -15,12 +15,10 @@
           <%= link_to score.judge_name,
             send("#{current_scope}_participant_path", id: score.judge_profile.account_id) %>
         </td>
-
-        <% if score.judge_recusal_reason.humanize === "Other" %>
-          <td><%= content_tag :span, score.judge_recusal_reason.humanize + ": " + score.judge_recusal_comment %></td>
-        <% else %>
-          <td><%= content_tag :span, score.judge_recusal_reason.humanize %></td>
-        <% end %>
+        
+        <td>
+          <%= render "admin/participants/judge_recusal_reason", score: score %>
+        </td>
 
         <td><%= score.round.humanize %></td>
       </tr>

--- a/db/migrate/20260331220350_create_judge_recusal_flagged_contents.rb
+++ b/db/migrate/20260331220350_create_judge_recusal_flagged_contents.rb
@@ -1,0 +1,10 @@
+class CreateJudgeRecusalFlaggedContents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :judge_recusal_flagged_contents do |t|
+      t.references :submission_score, null: false, foreign_key: true
+      t.integer :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1176,6 +1176,38 @@ CREATE TABLE public.judge_profiles_regional_pitch_events (
 
 
 --
+-- Name: judge_recusal_flagged_contents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.judge_recusal_flagged_contents (
+    id bigint NOT NULL,
+    submission_score_id bigint NOT NULL,
+    name integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: judge_recusal_flagged_contents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.judge_recusal_flagged_contents_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: judge_recusal_flagged_contents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.judge_recusal_flagged_contents_id_seq OWNED BY public.judge_recusal_flagged_contents.id;
+
+
+--
 -- Name: judge_types; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2947,6 +2979,13 @@ ALTER TABLE ONLY public.judge_profiles ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: judge_recusal_flagged_contents id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.judge_recusal_flagged_contents ALTER COLUMN id SET DEFAULT nextval('public.judge_recusal_flagged_contents_id_seq'::regclass);
+
+
+--
 -- Name: judge_types id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3463,6 +3502,14 @@ ALTER TABLE ONLY public.judge_profile_technical_skills
 
 ALTER TABLE ONLY public.judge_profiles
     ADD CONSTRAINT judge_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: judge_recusal_flagged_contents judge_recusal_flagged_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.judge_recusal_flagged_contents
+    ADD CONSTRAINT judge_recusal_flagged_contents_pkey PRIMARY KEY (id);
 
 
 --
@@ -4142,6 +4189,13 @@ CREATE INDEX index_judge_profiles_on_recusal_scores_count ON public.judge_profil
 --
 
 CREATE INDEX index_judge_profiles_on_user_invitation_id ON public.judge_profiles USING btree (user_invitation_id);
+
+
+--
+-- Name: index_judge_recusal_flagged_contents_on_submission_score_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_judge_recusal_flagged_contents_on_submission_score_id ON public.judge_recusal_flagged_contents USING btree (submission_score_id);
 
 
 --
@@ -4838,6 +4892,14 @@ ALTER TABLE ONLY public.screenshots
 
 
 --
+-- Name: judge_recusal_flagged_contents fk_rails_a1d30dd457; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.judge_recusal_flagged_contents
+    ADD CONSTRAINT fk_rails_a1d30dd457 FOREIGN KEY (submission_score_id) REFERENCES public.submission_scores(id);
+
+
+--
 -- Name: submission_scores fk_rails_afdf541e79; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5394,4 +5456,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260312213946'),
 ('20260312214123'),
 ('20260312214300'),
-('20260312214323');
+('20260312214323'),
+('20260331220350');
+
+

--- a/spec/controllers/judge/scores_controller_spec.rb
+++ b/spec/controllers/judge/scores_controller_spec.rb
@@ -292,28 +292,48 @@ RSpec.describe Judge::ScoresController do
       })
     end
 
-    before do
-      set_judging_round(:QF)
-      sign_in(judge)
-
-      patch :judge_recusal, params: {
-        score_id: score.id,
-        submission_score: {
-          judge_recusal_reason: "other",
-          judge_recusal_comment: "Wakarimasen"
-        }
-      }
-    end
-
+    before { set_judging_round(:QF) }
     after { reset_judging_round }
 
-    it "saves the recusal reason and comment" do
-      expect(score.reload.judge_recusal_reason).to eq("other")
-      expect(score.reload.judge_recusal_comment).to eq("Wakarimasen")
+    context "when the recusal reason is other" do
+      before do
+        sign_in(judge)
+        patch :judge_recusal, params: {
+          score_id: score.id,
+          submission_score: {
+            judge_recusal_reason: "other",
+            judge_recusal_comment: "Wakarimasen"
+          }
+        }
+      end
+
+      it "saves the recusal reason and comment" do
+        expect(score.reload.judge_recusal_reason).to eq("other")
+        expect(score.reload.judge_recusal_comment).to eq("Wakarimasen")
+      end
+
+      it "sets the judge recusal flag" do
+        expect(score.reload.judge_recusal).to eq(true)
+      end
     end
 
-    it "sets the judge recusal flag" do
-      expect(score.reload.judge_recusal).to eq(true)
+    context "when the recusal reason is content_does_not_belong_to_team" do
+      before do
+        sign_in(judge)
+        patch :judge_recusal, params: {
+          score_id: score.id,
+          submission_score: {
+            judge_recusal_reason: "content_does_not_belong_to_team",
+            judge_recusal_flagged_contents_attributes: [
+              { name: "pitch_video" },
+              { name: "technical_video" }
+            ]
+          }
+        }
+      end
+      it "saves the recusal flagged content" do
+        expect(score.reload.judge_recusal_flagged_contents.map(&:name)).to contain_exactly("pitch_video", "technical_video")
+      end
     end
   end
 end


### PR DESCRIPTION
Refs #6095 

This PR allows judges to flag specific content items when recusing

It includes the following:
- Adds `judge_recusal_flagged_contents` join table to track which specific content items a judge flags when recusing for "content doesn't belong to the team"
- Shows multi-select checkboxes in the recusal popup when that reason is selected. At least one content item must be checked to submit
- Flagged content are displayed in the admin portal