### PR TITLE
Allow RPEs to be set as "private" - they cannot be selected and do not appear on list of available events for students

### DIFF
--- a/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
+++ b/app/controllers/chapter_ambassador/regional_pitch_events_controller.rb
@@ -172,6 +172,7 @@ module ChapterAmbassador
         :event_link,
         :capacity_enabled,
         :capacity,
+        :selectable,
         :division_id,
         division_ids: []
       )

--- a/app/data_grids/events_grid.rb
+++ b/app/data_grids/events_grid.rb
@@ -30,6 +30,10 @@ class EventsGrid
     unofficial? ? "unofficial" : "official"
   end
 
+  column :selectable, header: "Event visibility" do
+    selectable? ? "public" : "private"
+  end
+
   column :date, order: "regional_pitch_events.starts_at"
 
   column :time
@@ -134,6 +138,17 @@ class EventsGrid
     :enum,
     select: ["official", "unofficial"] do |value|
     send(value)
+  end
+
+  filter :selectable,
+    :enum,
+    header: "Event visibility",
+    select: [
+     ["Public", true],
+     ["Private", false]
+    ],
+    filter_group: "common" do |value, scope|
+    scope.where(selectable: value)
   end
 
   filter :country,

--- a/app/models/regional_pitch_event.rb
+++ b/app/models/regional_pitch_event.rb
@@ -26,6 +26,8 @@ class RegionalPitchEvent < ActiveRecord::Base
   scope :unofficial, -> { where(unofficial: true) }
   scope :official, -> { where(unofficial: false) }
 
+  scope :selectable, -> { where(selectable: true) }
+
   scope :by_division, ->(division) {
     joins(:division)
       .where("divisions.name = ?", Division.names[division])
@@ -293,6 +295,7 @@ class TeamSubmissionEventScope < EventScope
   def execute
     if record.country === "US"
       scope.current
+        .selectable
         .joins(:division)
         .where("divisions.id = ?", record.division_id)
         .joins(ambassador: :account)
@@ -302,6 +305,7 @@ class TeamSubmissionEventScope < EventScope
         )
     else
       scope.current
+        .selectable
         .joins(:division)
         .where("divisions.id = ?", record.division_id)
         .joins(ambassador: :account)

--- a/app/views/admin/regional_pitch_events/show.en.html.erb
+++ b/app/views/admin/regional_pitch_events/show.en.html.erb
@@ -42,6 +42,15 @@
                 </p>
               <% end %>
             </dd>
+            
+            <dt>Event visibility</dt>
+            <dd>
+              <span class="hint">When "Public", teams can select this event.</span>
+              <br>
+              <span class="hint">When "Private", only you can assign teams to this event.</span>
+              <br>
+              <%= @event.selectable? ? "Public" : "Private" %>
+            </dd>
 
             <dt>Division</dt>
 

--- a/app/views/chapter_ambassador/regional_pitch_events/_form.html.erb
+++ b/app/views/chapter_ambassador/regional_pitch_events/_form.html.erb
@@ -78,6 +78,20 @@
         <%= f.label :event_link, "Event URL (Optional)" %>
         <%= f.url_field :event_link %>
       </div>
+      
+      <div class="field">
+        <label>Event Visibility</label>
+        <p class="hint">
+          Events are public by default and teams can select them from their dashboard.
+          <br>
+          Please change the visibility if you would like the event to be private.
+        </p>
+        <%= f.radio_button :selectable, true %>
+        <%= f.label :selectable_true, "Public - teams can find and select this event" %>
+        <br>
+        <%= f.radio_button :selectable, false %>
+        <%= f.label :selectable_false, "Private - only teams you add will see this event" %>
+      </div>
     </div>
 
     <div class="grid__col-12">

--- a/db/migrate/20260402233018_add_selectable_to_regional_pitch_events.rb
+++ b/db/migrate/20260402233018_add_selectable_to_regional_pitch_events.rb
@@ -1,0 +1,5 @@
+class AddSelectableToRegionalPitchEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regional_pitch_events, :selectable, :boolean, default: true, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2045,7 +2045,8 @@ CREATE TABLE public.regional_pitch_events (
     unofficial boolean DEFAULT true,
     seasons text[] DEFAULT '{}'::text[],
     teams_count integer DEFAULT 0,
-    capacity integer
+    capacity integer,
+    selectable boolean DEFAULT true NOT NULL
 );
 
 
@@ -5457,6 +5458,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260312214123'),
 ('20260312214300'),
 ('20260312214323'),
-('20260331220350');
+('20260331220350'),
+('20260402233018');
 
 

--- a/spec/controllers/student/regional_pitch_events_finder_controller_spec.rb
+++ b/spec/controllers/student/regional_pitch_events_finder_controller_spec.rb
@@ -16,5 +16,16 @@ RSpec.describe Student::RegionalPitchEventsFinderController do
       get :show
       expect(assigns[:regional_events]).to be_empty
     end
+
+    it "does not load non-selectable (closed) events" do
+      student = FactoryBot.create(:student, :submitted, :junior)
+      event = FactoryBot.create(:event, :junior, selectable: false)
+
+      sign_in(student)
+
+      SeasonToggles.select_regional_pitch_event_on!
+      get :show
+      expect(assigns[:regional_events]).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Refs #6118 

Allow RPEs to set as "closed" - they cannot be selected and do not appear on list of available events for students

This PR adds the following:
- Adds `selectable` boolean to `RegionalPitchEvent` - default is true
- Closed events are excluded from the list of events available to students to choose from
- ChAs can update this value on the event form
- Added this to datagrids


Naming note
-  I started with "selectability" and different labels related to that, but I was unsure if it would translate globally. Ended up going with "availability" and open/closed (based on the ticket description). I am open to suggestions or waiting to update based on testing feedback 