### PR TITLE
Send judges an email when bulk-added to an event

### DIFF
--- a/app/services/bulk_data_processors/assign_judges_to_regional_pitch_event.rb
+++ b/app/services/bulk_data_processors/assign_judges_to_regional_pitch_event.rb
@@ -20,8 +20,13 @@ module BulkDataProcessors
         else
           judge_profile.events << regional_pitch_event
 
-          result = "Assigned #{judge_profile.name} to #{regional_pitch_event.name}"
+          EventMailer.invite(
+            "JudgeProfile",
+            judge_profile.id,
+            regional_pitch_event.id
+          ).deliver_later
 
+          result = "Assigned #{judge_profile.name} to #{regional_pitch_event.name}"
         end
 
         results << result

--- a/spec/services/bulk_data_processors/assign_judges_to_regional_pitch_event_spec.rb
+++ b/spec/services/bulk_data_processors/assign_judges_to_regional_pitch_event_spec.rb
@@ -12,12 +12,22 @@ RSpec.describe BulkDataProcessors::AssignJudgesToRegionalPitchEvent do
   let(:judge_2) { FactoryBot.create(:judge) }
   let(:judge_3) { FactoryBot.create(:judge) }
 
+  before do
+    allow(EventMailer).to receive_message_chain(:invite, :deliver_later)
+  end
+
   it "assigns judges to the RPE" do
     assign_judges_to_regional_pitch_event_service.call
 
     expect(regional_pitch_event.judges.map(&:name)).to include(judge_1.name)
     expect(regional_pitch_event.judges.map(&:name)).to include(judge_2.name)
     expect(regional_pitch_event.judges.map(&:name)).to include(judge_3.name)
+  end
+
+  it "makes three calls to send each judge an invite email" do
+    assign_judges_to_regional_pitch_event_service.call
+
+    expect(EventMailer).to have_received(:invite).exactly(3).times
   end
 
   context "when a judge id doesn't exist" do


### PR DESCRIPTION
This will make it so that when judges get added to an event via bulk-uploading, the judges  will receive an event invite email.


