### PR TITLE
Add "judge info" onboarding step to profile debugging section

### DIFF
--- a/app/views/admin/participants/_judge_debugging.html.erb
+++ b/app/views/admin/participants/_judge_debugging.html.erb
@@ -66,6 +66,18 @@
         ) %>
       <% end %>
     </dd>
+
+    <dt>Judge info completed?</dt>
+    <dd>
+      <% if profile.judge_information_completed? %>
+        <%= web_icon("check-circle icon-green", text: "Yes!") %>
+      <% else %>
+        <%= web_icon(
+          "exclamation-circle icon-red",
+          text: "No"
+        ) %>
+      <% end %>
+    </dd>
   </dl>
 </div>
 

--- a/spec/views/admin/participants/_judge_debugging.html.erb_spec.rb
+++ b/spec/views/admin/participants/_judge_debugging.html.erb_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "admin/participants/_judge_debugging.html.erb", type: :view do
       valid_coordinates?: true,
       survey_completed?: true,
       training_completed?: true,
+      judge_information_completed?: true,
       mentor_profile: {},
       browser_name: "Mosiac",
       browser_version: "1.0",


### PR DESCRIPTION
A pretty simple update here to add the new "judge info" onboarding step to the profile debugging section for both admins and chapter ambassadors.

