### PR TITLE
Add open_to_public flag to chapters and clubs

### DIFF
--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -48,7 +48,8 @@ module Admin
         :name,
         :summary,
         :organization_headquarters_location,
-        :visible_on_map
+        :visible_on_map,
+        :open_to_public
       )
     end
 

--- a/app/controllers/admin/clubs_controller.rb
+++ b/app/controllers/admin/clubs_controller.rb
@@ -43,7 +43,8 @@ module Admin
       params.require(:club).permit(
         :id,
         :name,
-        :summary
+        :summary,
+        :open_to_public
       )
     end
 

--- a/app/controllers/chapter_ambassador/public_information_controller.rb
+++ b/app/controllers/chapter_ambassador/public_information_controller.rb
@@ -27,6 +27,7 @@ module ChapterAmbassador
         :summary,
         :primary_account_id,
         :visible_on_map,
+        :open_to_public,
         chapter_links_attributes: [
           :id,
           :_destroy,

--- a/app/controllers/club_ambassador/club_public_information_controller.rb
+++ b/app/controllers/club_ambassador/club_public_information_controller.rb
@@ -25,7 +25,8 @@ module ClubAmbassador
         :name,
         :summary,
         :primary_account_id,
-        :visible_on_map
+        :visible_on_map,
+        :open_to_public
       )
     end
   end

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -45,6 +45,8 @@ class ChaptersGrid
 
   filter(:visible_on_map, :xboolean)
 
+  filter(:open_to_public, :xboolean)
+
   filter :country,
     :enum,
     header: "Country",
@@ -218,6 +220,10 @@ class ChaptersGrid
   end
 
   column :visible_on_map, header: "Visible on map"
+
+  column :open_to_public, header: "Open to Public" do
+    open_to_public? ? "Yes" : "No"
+  end
 
   column :child_safeguarding_policy_and_process, preload: :program_information do
     program_information&.child_safeguarding_policy_and_process.presence || "-"

--- a/app/data_grids/chapters_grid.rb
+++ b/app/data_grids/chapters_grid.rb
@@ -219,9 +219,11 @@ class ChaptersGrid
     FriendlyCountry.new(self).country_name
   end
 
-  column :visible_on_map, header: "Visible on map"
+  column :visible_on_map, header: "Visible on map" do
+    visible_on_map? ? "Yes" : "No"
+  end
 
-  column :open_to_public, header: "Open to Public" do
+  column :open_to_public, header: "Open to public" do
     open_to_public? ? "Yes" : "No"
   end
 

--- a/app/data_grids/clubs_grid.rb
+++ b/app/data_grids/clubs_grid.rb
@@ -62,7 +62,9 @@ class ClubsGrid
     primary_contact&.email.presence || "-"
   end
 
-  column :visible_on_map, header: "Visible on map"
+  column :visible_on_map, header: "Visible on map" do
+    visible_on_map? ? "Yes" : "No"
+  end
 
   column :open_to_public, header: "Open to Public" do
     open_to_public? ? "Yes" : "No"

--- a/app/data_grids/clubs_grid.rb
+++ b/app/data_grids/clubs_grid.rb
@@ -27,6 +27,8 @@ class ClubsGrid
 
   filter(:visible_on_map, :xboolean)
 
+  filter(:open_to_public, :xboolean)
+
   filter(:onboarded,
     :enum,
     select: [
@@ -61,6 +63,10 @@ class ClubsGrid
   end
 
   column :visible_on_map, header: "Visible on map"
+
+  column :open_to_public, header: "Open to Public" do
+    open_to_public? ? "Yes" : "No"
+  end
 
   column :onboarded do
     onboarded? ? "yes" : "no"

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -56,6 +56,8 @@ class Chapter < ActiveRecord::Base
       .where("documents.id IS NULL")
   }
 
+  scope :open_to_public, -> { where(open_to_public: true) }
+
   delegate :seasons_chapter_affiliation_agreement_is_valid_for, to: :legal_contact
 
   def affiliation_agreement

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -30,6 +30,8 @@ class Club < ActiveRecord::Base
   validates :name, presence: true
   validates :summary, length: {maximum: 1000}
 
+  scope :open_to_public, -> { where(open_to_public: true) }
+
   after_update :update_onboarding_status
 
   def assign_address_details(geocoded)

--- a/app/services/chapter_selector.rb
+++ b/app/services/chapter_selector.rb
@@ -41,6 +41,7 @@ class ChapterSelector
   def select_chapters(where:, where_not: {})
     Chapter
       .current
+      .open_to_public
       .joins(legal_contact: :chapter_affiliation_agreement)
       .includes(legal_contact: :chapter_affiliation_agreement)
       .includes(:primary_contact)

--- a/app/services/club_selector.rb
+++ b/app/services/club_selector.rb
@@ -41,6 +41,7 @@ class ClubSelector
   def select_clubs(where:, where_not: {})
     Club
       .current
+      .open_to_public
       .includes(:primary_contact)
       .where(where)
       .where.not(where_not)

--- a/app/views/admin/chapters/show.html.erb
+++ b/app/views/admin/chapters/show.html.erb
@@ -38,6 +38,11 @@
               <%= @chapter.visible_on_map? ?  "Display on map" : "Do not display on map" %>
             </dd>
 
+            <dt>Chapter Privacy</dt>
+            <dd>
+              <%= @chapter.open_to_public? ? "Public" : "Private — invite only" %>
+            </dd>
+
             <dt>Chapter Links</dt>
             <dd>
               <% if @chapter.chapter_links.present? %>

--- a/app/views/admin/clubs/show.html.erb
+++ b/app/views/admin/clubs/show.html.erb
@@ -36,6 +36,16 @@
               </p>
             </dd>
 
+            <dt>Public Map Visibility</dt>
+            <dd>
+              <%= @club.visible_on_map? ? "Display on map" : "Do not display on map" %>
+            </dd>
+
+            <dt>Club Privacy</dt>
+            <dd>
+              <%= @club.open_to_public? ? "Public" : "Private — invite only" %>
+            </dd>
+
             <%= render partial: "admin/chapterables/season_status",
               locals: { chapterable: @club } %>
 

--- a/app/views/chapter_ambassador/public_information/_form.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/_form.en.html.erb
@@ -92,6 +92,24 @@
                 label: false %>
   </div>
 
+  <div>
+    <h3 class="mt-8 mb-4">Chapter Privacy</h3>
+
+    <p class="text-base mb-4">
+      Control whether your chapter appears in the chapter selection list for participants.
+      <br>
+      Private chapters are invite only and will not appear in the chapter selection list.
+    </p>
+
+    <%= f.input :open_to_public,
+      as: :radio_buttons,
+      collection: [
+        ["Public — appears in chapter selection for anyone to join", true],
+        ["Private — invite only, won't appear in chapter selection", false]
+      ],
+      label: false %>
+  </div>
+
   <p class="mt-8">
     <%= f.submit "Save", class: "tw-green-btn" %>
       or

--- a/app/views/chapter_ambassador/public_information/show.en.html.erb
+++ b/app/views/chapter_ambassador/public_information/show.en.html.erb
@@ -43,6 +43,12 @@
             This chapter <%= current_chapter.visible_on_map? ? "is" : "is not" %>
             displayed on the map of chapters on the Technovation website
           </p>
+
+          <p class="font-semibold mt-4">Chapter Privacy</p>
+          <p>
+            This chapter is
+            <%= current_chapter.open_to_public? ? "public — appears in chapter selection for anyone to join" : "private — invite only, won't appear in chapter selection" %>
+          </p>
         </div>
 
         <div class="w-full lg:w-1/3 flex mt-8 mx-auto">

--- a/app/views/club_ambassador/club_public_information/_form.en.html.erb
+++ b/app/views/club_ambassador/club_public_information/_form.en.html.erb
@@ -61,6 +61,24 @@
       label: false %>
   </div>
 
+  <div>
+    <h3 class="mt-8 mb-4">Club Privacy</h3>
+
+    <p class="text-base mb-4">
+      Control whether your club appears in the club selection list for participants.
+      <br>
+      Private clubs are invite only and will not appear in the club selection list.
+    </p>
+
+    <%= f.input :open_to_public,
+      as: :radio_buttons,
+      collection: [
+        ["Public — appears in club selection for anyone to join", true],
+        ["Private — invite only, won't appear in club selection", false]
+      ],
+      label: false %>
+  </div>
+
   <p class="mt-8">
     <%= f.submit "Save", class: "tw-green-btn" %>
       or

--- a/app/views/club_ambassador/club_public_information/show.en.html.erb
+++ b/app/views/club_ambassador/club_public_information/show.en.html.erb
@@ -22,6 +22,12 @@
           This club <%= current_chapterable.visible_on_map? ? "is" : "is not" %>
           displayed on the map of clubs on the Technovation website
         </p>
+
+        <p class="font-semibold mt-4">Club Privacy</p>
+        <p>
+          This club is
+          <%= current_chapterable.open_to_public? ? "public — appears in club selection for anyone to join" : "private — invite only, won't appear in club selection" %>
+        </p>
       </div>
 
       <div class="w-full lg:w-1/3 flex mt-8 mx-auto">

--- a/db/migrate/20260416120000_add_open_to_public_to_chapters.rb
+++ b/db/migrate/20260416120000_add_open_to_public_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddOpenToPublicToChapters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :chapters, :open_to_public, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260416120001_add_open_to_public_to_clubs.rb
+++ b/db/migrate/20260416120001_add_open_to_public_to_clubs.rb
@@ -1,0 +1,5 @@
+class AddOpenToPublicToClubs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :clubs, :open_to_public, :boolean, default: true, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -533,7 +533,8 @@ CREATE TABLE public.chapters (
     primary_account_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    seasons text[] DEFAULT '{}'::text[]
+    seasons text[] DEFAULT '{}'::text[],
+    open_to_public boolean DEFAULT true NOT NULL
 );
 
 
@@ -610,7 +611,8 @@ CREATE TABLE public.clubs (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     onboarded boolean DEFAULT false,
-    seasons text[] DEFAULT '{}'::text[]
+    seasons text[] DEFAULT '{}'::text[],
+    open_to_public boolean DEFAULT true NOT NULL
 );
 
 
@@ -5461,6 +5463,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260312214323'),
 ('20260331220350'),
 ('20260402233018'),
-('20260323193301');
+('20260323193301'),
+('20260416120000'),
+('20260416120001');
 
 

--- a/spec/services/chapter_selector_spec.rb
+++ b/spec/services/chapter_selector_spec.rb
@@ -38,6 +38,19 @@ describe ChapterSelector do
           end
         end
 
+        context "when the los angeles chapter is not open to the public" do
+          before do
+            los_angeles_chapter.update(open_to_public: false)
+          end
+
+          it "does not include the los angeles chapter in the results" do
+            expect(chapter_selector.call).to eq({
+              chapters_in_state_province: [],
+              chapters_in_country: [chicago_chapter]
+            })
+          end
+        end
+
         context "when the account already belongs to the los angeles chapter" do
           before do
             account.chapterable_assignments.delete_all

--- a/spec/services/club_selector_spec.rb
+++ b/spec/services/club_selector_spec.rb
@@ -38,6 +38,19 @@ describe ClubSelector do
           end
         end
 
+        context "when the los angeles club is not open to the public" do
+          before do
+            los_angeles_club.update(open_to_public: false)
+          end
+
+          it "does not include the los angeles club in the results" do
+            expect(club_selector.call).to eq({
+              clubs_in_state_province: [],
+              clubs_in_country: [chicago_club]
+            })
+          end
+        end
+
         context "when the account already belongs to the los angeles club" do
           before do
             account.chapterable_assignments.delete_all


### PR DESCRIPTION
Refs #6122 

Chapters and clubs can now be marked as public or private. Private chapters/clubs are invite-only and will not appear in the chapter/club selection list during registration. All chapters and clubs default to public.

This PR adds the following:
- Add `open_to_public` boolean column to `chapters` and `clubs` (default: `true`)
- Filter private chapters/clubs out of `ChapterSelector` and `ClubSelector` so they don't appear in the selection list
- Update edit form for ambassadors to update this 
- Display access status on admin chapter and club detail pages
- Add `open_to_public` filter and column to chapters and clubs datagrids
- Add tests

This was a tough one to name. Ended up going with `open_to_public` 
I also considered
- `open` or `public` - Seems kind of vague
- `open_membership` - This felt off because we dont really talk about individuals in a chapter being "members" of that chapter
- `open_for_joining`  or `joinable` - this felt misleading because private chapters can be joined, just by invitation
- `open_registration` - This sounds like a deadline
- UI uses "Public / Private" language with "Chapter Privacy" / "Club Privacy" as the section labels for ambassadors