### PR TITLE
Prevent judge-mentor accounts from being assigned to an RPE (via CSV bulk upload) if the mentor is on a team

### DIFF
--- a/app/services/bulk_data_processors/assign_judges_to_regional_pitch_event.rb
+++ b/app/services/bulk_data_processors/assign_judges_to_regional_pitch_event.rb
@@ -15,6 +15,8 @@ module BulkDataProcessors
           result = "Could not find judge with ID: #{judge_id}"
         elsif !judge_profile.current_season?
           result = "#{judge_profile.name} is not a part of the current season"
+        elsif judge_profile.account.mentor_profile&.is_on_team?
+          result = "#{judge_profile.name} is mentoring a team"
         elsif judge_profile.events.include?(regional_pitch_event)
           result = "#{judge_profile.name} has already been assigned to this event"
         else

--- a/spec/factories/judges.rb
+++ b/spec/factories/judges.rb
@@ -140,7 +140,9 @@ FactoryBot.define do
       end
 
       if e.mentor
-        j.account.build_mentor_profile(FactoryBot.attributes_for(:mentor))
+        mentor_profile = j.account.build_mentor_profile(FactoryBot.attributes_for(:mentor))
+
+        mentor_profile.mentor_types << FactoryBot.create(:mentor_type)
       end
 
       if e.onboarded && !j.can_be_marked_onboarded?

--- a/spec/services/bulk_data_processors/assign_judges_to_regional_pitch_event_spec.rb
+++ b/spec/services/bulk_data_processors/assign_judges_to_regional_pitch_event_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe BulkDataProcessors::AssignJudgesToRegionalPitchEvent do
     end
   end
 
+  context "when a judge is also a mentoring a team" do
+    let(:judge_1) { FactoryBot.create(:judge, mentor: true) }
+    let(:team) { FactoryBot.create(:team) }
+
+    before do
+      FactoryBot.create(:team_membership, team:, member: judge_1.account.mentor_profile)
+    end
+
+    it "doesn't add the judge to the RPE" do
+      result = assign_judges_to_regional_pitch_event_service.call
+
+      expect(regional_pitch_event.judges).not_to include(judge_1)
+      expect(result.results).to include("#{judge_1.name} is mentoring a team")
+    end
+  end
+
   context "when a judge is already assigned to this RPE" do
     before do
       judge_1.events << regional_pitch_event


### PR DESCRIPTION
This should prevent judge/mentor combo accounts assigned to a team from being added to an RPE via CSV upload.