### PR TITLE
Only display distinct judges on judges datagrd

### DIFF
--- a/app/data_grids/judges_grid.rb
+++ b/app/data_grids/judges_grid.rb
@@ -16,6 +16,7 @@ class JudgesGrid
       .includes(judge_profile: :events)
       .includes(:mentor_profile)
       .references(:judge_profiles, :regional_pitch_events)
+      .distinct
       .where("judge_profiles.id IS NOT NULL")
   end
 


### PR DESCRIPTION
This will add a `.distinct` clause to this query so only distinct judges will appear on the judges datagrid. This will fix the issue of the same judge appearing multiple times.

Most of our other datagrids are using `distinct` too, so whatever issue is happening here is happening in other datagrids too.


