### PR TITLE
Fix student profile update bug due to parent guardian phone number

### DIFF
--- a/app/models/concerns/parental_consent_phone.rb
+++ b/app/models/concerns/parental_consent_phone.rb
@@ -8,10 +8,10 @@ module ParentalConsentPhone
       if: -> { parent_guardian_phone_number.present? && parent_guardian_phone_country_code.present? }
 
     validate :valid_parent_guardian_phone_number,
-      if: -> { parent_guardian_phone_number.present? || parent_guardian_phone_country_code.present? }
+      if: -> { parent_guardian_phone_number_changed? || parent_guardian_phone_country_code.present? }
 
     validate :parent_guardian_text_message_opt_in_accepted,
-      if: -> { parent_guardian_phone_number.present? || parent_guardian_phone_country_code.present? }
+      if: -> { parent_guardian_phone_number_changed? || parent_guardian_phone_country_code.present? }
 
     before_save :set_parent_guardian_text_message_opted_in_at,
       if: -> { parent_guardian_phone_number.present? && parent_guardian_phone_number_changed? }

--- a/app/views/admin/participants/_student_debugging.html.erb
+++ b/app/views/admin/participants/_student_debugging.html.erb
@@ -4,6 +4,17 @@
   <p class="hint">
     Students must do these things to be eligible to compete
   </p>
+  
+  <dl>
+    <dt>Onboarded</dt>
+    <dd>
+      <% if profile.onboarded? %>
+        <%= web_icon("check-circle icon-green", text: "Yes") %>
+      <% else %>
+        <%= web_icon("exclamation-circle icon-red", text: "No") %>
+      <% end %>
+    </dd>
+  </dl>
 
   <dl>
     <dt>Data Terms</dt>


### PR DESCRIPTION
Refs #6161


This bug recently came to our attention when a student profile could not be updated due to the parent guardian phone number validation. Updated validaton to only run when phone number actually changed. Also added "onboarded" status to the student profile debugging view. 