### PR TITLE
Display distinct events on the events datagrid

### DIFF
--- a/app/data_grids/events_grid.rb
+++ b/app/data_grids/events_grid.rb
@@ -9,6 +9,7 @@ class EventsGrid
     RegionalPitchEvent.current
       .includes(:division, ambassador: :account)
       .references(:accounts)
+      .distinct
   end
 
   column :ambassador_name,


### PR DESCRIPTION
We were having an issue w/ duplicate events appearing on the events datagrid, I couldn't reproduce this locally, but I think adding 'distinct' should address the issue.


