### PR TITLE
Remove phone number from Salesforce

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -99,7 +99,6 @@ module Salesforce
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
           npe01__Preferred_Email__c: "Alternate",
-          OtherPhone: account.phone_number,
           MailingCity: account.city,
           MailingState: account.state_province,
           MailingCountry: account.country, **additional_contact_info

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -152,7 +152,6 @@ RSpec.describe Salesforce::ApiClient do
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
           npe01__Preferred_Email__c: "Alternate",
-          OtherPhone: account.phone_number,
           Birthdate: account.date_of_birth,
           MailingCity: account.city,
           MailingState: account.state_province,
@@ -181,7 +180,6 @@ RSpec.describe Salesforce::ApiClient do
           LastName: account.last_name,
           npe01__AlternateEmail__c: account.email,
           npe01__Preferred_Email__c: "Alternate",
-          OtherPhone: account.phone_number,
           MailingCity: account.city,
           MailingState: account.state_province,
           MailingCountry: account.country


### PR DESCRIPTION
This was causing an error in Salesforce and apparently it's no longer a priority so I'm removing it.