### PR TITLE
Prevent direct access to judge dashboard for ambassadors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ yarn-debug.log*
 .yarn-integrity
 
 claude/*
+vendor/bundle/*
+vendor/cache/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,8 +345,10 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.9)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     normalize-rails (4.1.1)
     noticed (2.9.3)
@@ -370,6 +372,7 @@ GEM
       ruby-rc4
       ttfunk
     pdfkit (0.8.7.3)
+    pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-darwin)
     pg (1.6.2-x86_64-linux)
     phonelib (0.10.16)
@@ -640,6 +643,8 @@ GEM
       zip_kit (~> 6, >= 6.2.0, < 7)
 
 PLATFORMS
+  arm64-darwin
+  arm64-darwin-25
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/app/controllers/judge_controller.rb
+++ b/app/controllers/judge_controller.rb
@@ -4,6 +4,8 @@ class JudgeController < ApplicationController
 
   include Authenticated
 
+  before_action :require_ambassador_can_switch_to_judge
+
   layout "judge"
   helper_method :current_judge,
     :current_profile,
@@ -75,5 +77,16 @@ class JudgeController < ApplicationController
       redirect_to mentor_dashboard_path,
         error: t("controllers.judge.dashboards.show.mentor_on_team_error")
     end
+  end
+
+  def require_ambassador_can_switch_to_judge
+    return if !current_account.authenticated?
+    return if !current_account.ambassador?
+    return if current_account.can_switch_to_judge?
+
+    redirect_to send(
+      "#{current_account.scope_name.sub(/^\w+_r/, "r")}_dashboard_path"
+    ),
+      error: t("controllers.application.unauthorized")
   end
 end

--- a/spec/features/chapter_ambassador/switch_to_judge_spec.rb
+++ b/spec/features/chapter_ambassador/switch_to_judge_spec.rb
@@ -94,6 +94,17 @@ feature "chapter ambassadors switch to judge mode from chapter ambassador dashbo
 
       expect(page).not_to have_link("Judge Mode")
     end
+
+    scenario "chapter ambassadors with a judge profile cannot reach the judge dashboard by URL" do
+      chapter_ambassador = FactoryBot.create(:chapter_ambassador, :approved, :has_judge_profile)
+
+      sign_in(chapter_ambassador)
+
+      visit judge_dashboard_path
+
+      expect(current_path).to eq(chapter_ambassador_dashboard_path)
+      expect(page).to have_content("You don't have permission to go there!")
+    end
   end
 end
 

--- a/spec/features/club_ambassador/switch_to_judge_spec.rb
+++ b/spec/features/club_ambassador/switch_to_judge_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+feature "club ambassadors switch to judge mode from club ambassador dashboard", :js do
+  # `CreateJudgeProfile` (and the factory's `:has_judge_profile` trait) doesn't
+  # cover club ambassadors today; admins set this up manually via the admin UI
+  # (see #5581). Mirror that by creating the judge profile directly on the
+  # account.
+  def give_judge_profile(club_ambassador)
+    club_ambassador.account.create_judge_profile!(
+      company_name: "FactoryBot",
+      job_title: "Engineer"
+    )
+    club_ambassador.account.reload
+    club_ambassador
+  end
+
+  feature "with config on" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ENABLE_CHAPTER_AMBASSADOR_SWITCH_TO_JUDGE", any_args).and_return(true)
+    end
+
+    scenario "a club ambassador with a judge profile can reach the judge dashboard" do
+      club_ambassador = give_judge_profile(FactoryBot.create(:club_ambassador))
+
+      sign_in(club_ambassador)
+
+      expect(club_ambassador.is_a_judge?).to be_truthy
+
+      visit judge_dashboard_path
+      expect(current_path).to eq(judge_dashboard_path)
+      expect(page).to have_text("Judging Rubric")
+    end
+
+    scenario "a club ambassador without a judge profile does not see a judge mode link" do
+      club_ambassador = FactoryBot.create(:club_ambassador)
+
+      sign_in(club_ambassador)
+
+      expect(club_ambassador.is_a_judge?).to be_falsey
+
+      expect(page).not_to have_link("Judge Mode")
+    end
+
+    scenario "club ambassadors without a judge profile cannot browse to judge dashboard" do
+      club_ambassador = FactoryBot.create(:club_ambassador)
+
+      sign_in(club_ambassador)
+
+      visit judge_dashboard_path
+
+      expect(current_path).to eq(club_ambassador_dashboard_path)
+      expect(page).to have_content("You don't have permission to go there!")
+    end
+  end
+
+  feature "with config off" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("ENABLE_CHAPTER_AMBASSADOR_SWITCH_TO_JUDGE", any_args).and_return(false)
+    end
+
+    scenario "club ambassadors with a judge profile do not see judge mode link" do
+      club_ambassador = give_judge_profile(FactoryBot.create(:club_ambassador))
+
+      sign_in(club_ambassador)
+
+      expect(club_ambassador.is_a_judge?).to be_truthy
+      expect(current_path).to eq(club_ambassador_dashboard_path)
+
+      expect(page).not_to have_link("Judge Mode")
+    end
+
+    scenario "club ambassadors without a judge profile do not see a judge mode link" do
+      club_ambassador = FactoryBot.create(:club_ambassador)
+
+      sign_in(club_ambassador)
+
+      expect(club_ambassador.is_a_judge?).to be_falsey
+      expect(current_path).to eq(club_ambassador_dashboard_path)
+
+      expect(page).not_to have_link("Judge Mode")
+    end
+
+    scenario "club ambassadors with a judge profile cannot reach the judge dashboard by URL" do
+      club_ambassador = give_judge_profile(FactoryBot.create(:club_ambassador))
+
+      sign_in(club_ambassador)
+
+      visit judge_dashboard_path
+
+      expect(current_path).to eq(club_ambassador_dashboard_path)
+      expect(page).to have_content("You don't have permission to go there!")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add a guard in `JudgeController` to block ambassadors from direct `/judge/dashboard` access when they cannot switch to judge mode.
- Add feature coverage for chapter and club ambassadors (config on/off) including URL access behavior.
- Include local arm64 dev environment updates (`.gitignore` vendor paths and `Gemfile.lock` platform/gem entries).