### PR TITLE
fix(6070): update participants datagrid search from club stats link

### DIFF
--- a/app/data_grids/accounts_grid.rb
+++ b/app/data_grids/accounts_grid.rb
@@ -524,39 +524,52 @@ class AccountsGrid
 
   filter :name_email,
     header: "Name or Email",
-    filter_group: "more-specific" do |value|
+    filter_group: "more-specific" do |value, scope|
       names = value.strip.downcase.split(" ").map { |n|
         I18n.transliterate(n).gsub("'", "''")
       }
-      fuzzy_search({
-        first_name: names.first,
-        last_name: names.last || names.first,
-        email: names.first
-      }, false) # false enables OR search
+      first_name = names.first
+      last_name = names.last || names.first
+      email = names.first
+
+      scope.where(
+        "(accounts.first_name::text % :first_name) OR " \
+        "(accounts.last_name::text % :last_name) OR " \
+        "(accounts.email::text % :email)",
+        first_name: first_name,
+        last_name: last_name,
+        email: email
+      )
     end
 
   filter :first_name,
     header: "First name (exact spelling)",
-    filter_group: "more-specific" do |value|
-      basic_search({
-        first_name: value
-      })
+    filter_group: "more-specific" do |value, scope|
+      scope.where(
+        "to_tsvector('english', accounts.first_name::text) @@ " \
+        "plainto_tsquery('english', ?::text)",
+        value
+      )
     end
 
   filter :last_name,
     header: "Last name (exact spelling)",
-    filter_group: "more-specific" do |value|
-      basic_search({
-        last_name: value
-      })
+    filter_group: "more-specific" do |value, scope|
+      scope.where(
+        "to_tsvector('english', accounts.last_name::text) @@ " \
+        "plainto_tsquery('english', ?::text)",
+        value
+      )
     end
 
   filter :email,
     header: "Email (exact spelling)",
-    filter_group: "more-specific" do |value|
-      basic_search({
-        email: value
-      })
+    filter_group: "more-specific" do |value, scope|
+      scope.where(
+        "to_tsvector('english', accounts.email::text) @@ " \
+        "plainto_tsquery('english', ?::text)",
+        value
+      )
     end
 
   filter :parent_or_guardian_name,
@@ -564,11 +577,11 @@ class AccountsGrid
     filter_group: "more-specific" do |value, scope|
       scope.includes(:student_profile)
         .references(:student_profiles)
-        .basic_search({
-          student_profiles: {
-            parent_guardian_name: value
-          }
-        })
+        .where(
+          "to_tsvector('english', student_profiles.parent_guardian_name::text) @@ " \
+          "plainto_tsquery('english', ?::text)",
+          value
+        )
     end
 
   filter :parent_or_guardian_email,
@@ -576,11 +589,11 @@ class AccountsGrid
     filter_group: "more-specific" do |value, scope|
       scope.includes(:student_profile)
         .references(:student_profiles)
-        .basic_search({
-          student_profiles: {
-            parent_guardian_email: value
-          }
-        })
+        .where(
+          "to_tsvector('english', student_profiles.parent_guardian_email::text) @@ " \
+          "plainto_tsquery('english', ?::text)",
+          value
+        )
     end
 
   filter :season,

--- a/spec/controllers/admin/participants_controller_spec.rb
+++ b/spec/controllers/admin/participants_controller_spec.rb
@@ -11,6 +11,63 @@ RSpec.describe Admin::ParticipantsController do
   let(:junior_dob) { Division.cutoff_date - junior_division_age.years }
   let(:senior_dob) { Division.cutoff_date - senior_division_age.years }
 
+  describe "GET #index" do
+    context "when arriving from a club's stats overview link (issue #6070)" do
+      render_views
+
+      let(:club) { FactoryBot.create(:club) }
+      let!(:student) do
+        student = FactoryBot.create(
+          :student,
+          :not_assigned_to_chapter,
+          first_name: "Searchable",
+          last_name: "Student"
+        )
+        student.account.update_columns(
+          first_name: "Searchable",
+          last_name: "Student",
+          email: "searchable.student@example.com"
+        )
+        student.chapterable_assignments.create!(
+          account: student.account,
+          chapterable: club,
+          season: Season.current.year,
+          primary: true
+        )
+        student
+      end
+
+      let(:base_params) do
+        {
+          accounts_grid: {
+            chapter: "",
+            club: club.id,
+            scope_names: ["student"],
+            season: [Season.current.year]
+          }
+        }
+      end
+
+      it "returns 200 when filtering by name_email together with the club + scope_names + season filters" do
+        get :index, params: base_params.deep_merge(
+          accounts_grid: {name_email: "Searchable"}
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(student.account.email)
+      end
+
+      it "returns 200 when filtering by first_name (exact spelling) together with the club + scope_names + season filters" do
+        get :index, params: base_params.deep_merge(
+          accounts_grid: {first_name: "Searchable"}
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(student.account.email)
+      end
+    end
+  end
+
   it "reconsiders student's team division on dob change" do
     Timecop.freeze(Division.cutoff_date - 1.day) do
       student = FactoryBot.create(


### PR DESCRIPTION
## Summary
- Replace textacular `fuzzy_search`/`basic_search` in the `AccountsGrid` `name_email`, `first_name`, `last_name`, `email`, `parent_or_guardian_name`, and `parent_or_guardian_email` filters with parameterized PostgreSQL trigram (`%`) and `to_tsvector @@ plainto_tsquery` `WHERE` clauses, so the injected `SELECT … AS "rank<hash>"` / `ORDER BY "rank<hash>"` no longer breaks the eager-loading distinct pagination kicked off by the `Admin > Clubs > Stats` "View Details" link.
- Add admin participants controller specs that arrive with `club + scope_names + season` filters (matching the club stats link) and then apply `name_email` / `first_name`, locking in the regression.

Refs #6070