### PR TITLE
Skip Salesforce contact sync for past-season accounts (#6073)

### DIFF
--- a/app/services/salesforce/api_client.rb
+++ b/app/services/salesforce/api_client.rb
@@ -53,6 +53,8 @@ module Salesforce
     end
 
     def upsert_contact_info
+      return unless account.current_season?
+
       upsert_contact
     end
 

--- a/spec/services/salesforce/api_client_spec.rb
+++ b/spec/services/salesforce/api_client_spec.rb
@@ -234,6 +234,18 @@ RSpec.describe Salesforce::ApiClient do
         salesforce_api_client.upsert_contact_info
       end
     end
+
+    context "when the account is not in the current season" do
+      let(:student_profile) { FactoryBot.create(:student_profile, :past) }
+      let(:account) { student_profile.account }
+      let(:profile_type) { "student" }
+
+      it "does not call upsert! to update contact info in Salesforce" do
+        expect(salesforce_client).not_to receive(:upsert!)
+
+        salesforce_api_client.upsert_contact_info
+      end
+    end
   end
 
   describe "#upsert_program_info" do


### PR DESCRIPTION
Prevent admin and bulk updates from pushing contact changes to Salesforce when the account is not registered for the current season.