### PR TITLE
Update judge dashboard welcome text for issue #6197

### DIFF
--- a/app/views/judge/dashboards/onboarded/rebrand/_quarterfinals_or_semifinals.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_quarterfinals_or_semifinals.en.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-4">
   <% if SeasonToggles.quarterfinals_judging? %>
-    <p>Welcome to the online judging portal for the first round of Technovation Judging!</p>
+    <p>Welcome to the second round of online judging, also known as Semifinals!</p>
   <% elsif SeasonToggles.semifinals_judging? %>
     <p>Welcome to the second round of online judging, also known as Semifinals!</p>
   <% end %>

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Judge certificates" do
     sign_in(judge)
 
     click_link("dashboard-tab")
-    expect(page).to have_content("Welcome to the online judging portal for the first round of Technovation Judging!")
+    expect(page).to have_content("Welcome to the second round of online judging, also known as Semifinals!")
 
     click_link "Your judge certificate"
     expect(page).to have_content("Certificates are currently unavailable.")

--- a/spec/features/judge/starting_scores_spec.rb
+++ b/spec/features/judge/starting_scores_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "starting scores", js: true do
   end
 
   def they_will_see_welcome_text_on_their_dashboard
-    expect(page).to have_content("Welcome to the online judging portal for the first round of Technovation Judging!")
+    expect(page).to have_content("Welcome to the second round of online judging, also known as Semifinals!")
   end
 
   def they_will_see_helper_text_on_their_dashboard


### PR DESCRIPTION
## Summary
- Replace the Quarterfinals judge dashboard welcome line with the copy from issue #6197: "Welcome to the second round of online judging, also known as Semifinals!"
- Update feature specs that assert the Quarterfinals dashboard welcome text.