### PR TITLE
feat(6198): update judge finished dashboard copy when certs off

### DIFF
--- a/app/views/judge/dashboards/onboarded/rebrand/_judging_finished_certs_off.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_judging_finished_certs_off.html.erb
@@ -7,13 +7,13 @@
 </h2>
 
 <p class="mb-3">
-  Thank you for your help scoring and giving valuable feedback to
+  Thank you for your help in scoring and giving valuable feedback to
   Technovation teams.
 </p>
 
 <p class="mb-3">
-  Your judging certificate will be available
-  <%= ImportantDates.certificates_available.strftime("%B %e") %>.
+  Your judging certificate will be available after
+  <%= ImportantDates.certificates_available.to_date.to_fs(:short_ordinal) %>.
 </p>
 
 <p>

--- a/spec/features/judge/certificates_spec.rb
+++ b/spec/features/judge/certificates_spec.rb
@@ -66,7 +66,10 @@ RSpec.feature "Judge certificates" do
     sign_in(judge)
 
     click_link("dashboard-tab")
-    expect(page).to have_content("Thank you for your help scoring and giving valuable feedback to Technovation teams.")
+    expect(page).to have_content("Thank you for your help in scoring and giving valuable feedback to Technovation teams.")
+    expect(page).to have_content(
+      "Your judging certificate will be available after #{ImportantDates.certificates_available.to_date.to_fs(:short_ordinal)}."
+    )
 
     click_link "Your judge certificate"
     expect(page).to have_content("Certificates are currently unavailable.")


### PR DESCRIPTION
## Summary
- Updates onboarded judge dashboard copy when judging is **Finished** and display scores/certs is **off** (`_judging_finished_certs_off`).
- Adds "in" to "Thank you for your help **in** scoring…" and prefixes the certificate date with "**after**".
- Formats the certificate date with `:short_ordinal` via `ImportantDates.certificates_available` (env-driven, e.g. July 2nd).
- Updates `spec/features/judge/certificates_spec.rb` for the finished + certs-off scenario.

Closes #6198

## QA verification (after deploy to QA)
1. Admin (super admin) → **Content & Settings** → **Judging** → **Finished** → **Review** → **Save these settings** (scores/certs off).
2. **Judges** → filter **Fully onboarded** + **Virtual Judges** → **Search** → **View** → **Login as…**
3. On the judge **Dashboard** tab, confirm:
   - "Thank you for your help **in** scoring and giving valuable feedback to Technovation teams."
   - "Your judging certificate will be available **after** &lt;Month Day&gt;**ordinal**" (matches env date, not hardcoded).
   - "Season close" badge and closing paragraph unchanged.