### PR TITLE
feat: enhance team and submission views with regional search capability

### DIFF
--- a/app/controllers/ambassador/team_submissions_controller.rb
+++ b/app/controllers/ambassador/team_submissions_controller.rb
@@ -3,7 +3,7 @@ module Ambassador
     layout "ambassador"
 
     def show
-      @team_submission = if current_ambassador.national_view?
+      @team_submission = if current_ambassador.national_view? || params[:search_in_region].present?
         TeamSubmission.in_region(current_ambassador.chapter)
           .friendly.find(params[:id])
       else

--- a/app/controllers/ambassador/teams_controller.rb
+++ b/app/controllers/ambassador/teams_controller.rb
@@ -5,7 +5,7 @@ module Ambassador
     layout "ambassador"
 
     def show
-      @team = if current_ambassador.national_view?
+      @team = if current_ambassador.national_view? || params[:search_in_region].present?
         Team.in_region(current_ambassador.chapter)
           .find(params.fetch(:id))
       else

--- a/app/views/admin/regional_pitch_events/_registered_judge.html.erb
+++ b/app/views/admin/regional_pitch_events/_registered_judge.html.erb
@@ -4,7 +4,11 @@
       <%= judge.name.presence || "Invited Judge" %>
     <% else %>
       <%= link_to judge.name,
-      send("#{current_scope}_participant_path", judge.account.id),
+      send(
+        "#{current_scope}_participant_path",
+        judge.account.id,
+        **(current_account.chapter_ambassador? ? {search_in_region: 1} : {})
+      ),
       data: { turbo: false } %>
     <% end %>
   </td>

--- a/app/views/admin/regional_pitch_events/_registered_team.html.erb
+++ b/app/views/admin/regional_pitch_events/_registered_team.html.erb
@@ -1,7 +1,11 @@
 <tr id="<%= dom_id(team, :registered) %>">
   <td>
     <%= link_to team.name,
-      send("#{current_scope}_team_path", team),
+      send(
+        "#{current_scope}_team_path",
+        team,
+        **(current_account.chapter_ambassador? ? {search_in_region: 1} : {})
+      ),
       data: { turbo: false } %>
   </td>
   
@@ -11,7 +15,11 @@
   
   <td>
     <%= link_to team.submission.name,
-      send("#{current_scope}_team_submission_path", team.submission),
+      send(
+        "#{current_scope}_team_submission_path",
+        team.submission,
+        **(current_account.chapter_ambassador? ? {search_in_region: 1} : {})
+      ),
       data: { turbo: false} %>
   </td>
   

--- a/spec/controllers/ambassador/team_submissions_controller_spec.rb
+++ b/spec/controllers/ambassador/team_submissions_controller_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Ambassador::TeamSubmissionsController do
+  describe "GET #show" do
+    context "as a chapter ambassador" do
+      let(:chapter_ambassador) do
+        FactoryBot.create(
+          :chapter_ambassador,
+          :not_assigned_to_chapter,
+          national_view: false
+        )
+      end
+      let(:brazil_chapter) do
+        FactoryBot.create(
+          :chapter,
+          :brazil,
+          primary_contact: chapter_ambassador.account
+        )
+      end
+
+      before do
+        chapter_ambassador.chapterable_assignments.create(
+          chapterable: brazil_chapter,
+          account: chapter_ambassador.account,
+          season: Season.current.year,
+          primary: true
+        )
+
+        sign_in(chapter_ambassador)
+      end
+
+      context "when viewing team submissions with `search_in_region` set to a truthy value" do
+        let(:search_in_region) { 1 }
+
+        context "when viewing a team submission in the same region" do
+          let(:team_submission) { FactoryBot.create(:submission, :brazil) }
+
+          before do
+            get :show, params: {
+              id: team_submission.id,
+              search_in_region: search_in_region
+            }
+          end
+
+          it "returns an OK 200 success status code" do
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "when viewing a team submission in a different region" do
+          let(:team_submission) { FactoryBot.create(:submission, :chicago) }
+
+          it "raises an 'ActiveRecord::RecordNotFound' error" do
+            expect {
+              get :show, params: {
+                id: team_submission.id,
+                search_in_region: search_in_region
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/ambassador/teams_controller_spec.rb
+++ b/spec/controllers/ambassador/teams_controller_spec.rb
@@ -60,6 +60,38 @@ RSpec.describe Ambassador::TeamsController do
         end
       end
 
+      context "when viewing teams with `search_in_region` set to a truthy value" do
+        let(:search_in_region) { 1 }
+
+        context "when viewing a team in the same region" do
+          let(:brazil_team) { FactoryBot.create(:team, :brazil) }
+
+          before do
+            get :show, params: {
+              id: brazil_team.id,
+              search_in_region: search_in_region
+            }
+          end
+
+          it "returns an OK 200 success status code" do
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "when viewing a team in a different region" do
+          let(:chicago_team) { FactoryBot.create(:team, :chicago) }
+
+          it "raises an 'ActiveRecord::RecordNotFound' error" do
+            expect {
+              get :show, params: {
+                id: chicago_team.id,
+                search_in_region: search_in_region
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
       context "when a chapter ambassador does not have the 'national view' ability" do
         let(:national_view) { false }
 


### PR DESCRIPTION
- Updated `show` actions in `TeamSubmissionsController` and `TeamsController` to include `search_in_region` parameter for chapter ambassadors.
- Modified links in the registered judge and team views to pass `search_in_region` when applicable.
- Added tests for regional search functionality in both controllers to ensure correct behavior when viewing teams and submissions across regions.


