### PR TITLE
feat(6199): mask judge names and hide locations for chapter ambassadors

### DIFF
--- a/app/helpers/ambassador_helper.rb
+++ b/app/helpers/ambassador_helper.rb
@@ -15,4 +15,42 @@ module AmbassadorHelper
       team.student_chapterables.include?(ambassador.current_chapterable)
     end
   end
+
+  def chapter_ambassador_masked_judge_name(score:, account: (current_account if respond_to?(:current_account)))
+    return score.judge_name unless account&.chapter_ambassador_profile.present?
+
+    judge_account = score.judge_profile&.account
+    return score.judge_name unless judge_account
+
+    first_name = judge_account.first_name.to_s.strip
+    last_initial = judge_account.last_name.to_s.strip.first
+
+    return score.judge_name if first_name.blank?
+
+    [first_name, (last_initial.present? ? "#{last_initial}." : nil)]
+      .compact
+      .join(" ")
+  end
+
+  def chapter_ambassador_can_link_to_judge?(
+    score:,
+    ambassador: (current_ambassador if respond_to?(:current_ambassador)),
+    account: (current_account if respond_to?(:current_account))
+  )
+    return true unless account&.chapter_ambassador_profile.present?
+    return false unless ambassador&.chapter && score.judge_profile
+
+    chapter_judge_ids_for(ambassador).include?(score.judge_profile.id)
+  end
+
+  private
+
+  def chapter_judge_ids_for(ambassador)
+    @chapter_judge_ids_for ||= {}
+    @chapter_judge_ids_for[ambassador.id] ||= RegionalPitchEvent
+      .by_chapter(ambassador.chapter.id)
+      .joins(:judges)
+      .distinct
+      .pluck("judge_profiles.id")
+  end
 end

--- a/app/views/admin/scores/show.en.html.erb
+++ b/app/views/admin/scores/show.en.html.erb
@@ -1,6 +1,7 @@
 <% provide :title, "Review Score" %>
-<% is_privileged = current_account.admin? ||
-                     current_account.chapter_ambassador_profile.present? %>
+<% is_admin = current_account.admin? %>
+<% is_chapter_ambassador = current_account.chapter_ambassador_profile.present? %>
+<% can_view_judge_section = is_admin || is_chapter_ambassador %>
 
 <div class="panel">
   <header class="admin-score-header">
@@ -35,22 +36,27 @@
       %>
     </h4>
 
-    <% if is_privileged %>
+    <% if can_view_judge_section %>
       <h4>
         <span>Judge</span>
-        <%= link_to @score.judge_name,
-                    send("#{current_scope}_participant_path", @score.judge_profile.account_id),
-                    data: { turbo: false }
-        %>
+        <% judge_name = chapter_ambassador_masked_judge_name(score: @score, account: current_account) %>
+        <% if is_admin || chapter_ambassador_can_link_to_judge?(score: @score, account: current_account) %>
+          <%= link_to judge_name,
+                      send("#{current_scope}_participant_path", @score.judge_profile.account_id),
+                      data: { turbo: false }
+          %>
+        <% else %>
+          <%= judge_name %>
+        <% end %>
 
       <%= render partial: "copy_to_clipboard",
         locals: {
-          text_to_copy: @score.judge_name
+          text_to_copy: judge_name
         }
       %>
       </h4>
 
-      <% if current_account.admin? %>
+      <% if is_admin %>
         <h5>
           <span>Judge email address</span>
           <%= @score.judge_profile.email %>
@@ -64,12 +70,12 @@
       <% end %>
     <% end %>
 
-    <h5>
-      <span>Score comes from</span>
-      <%= @score.judge_profile.address_details %>
-    </h5>
+    <% if is_admin %>
+      <h5>
+        <span>Score comes from</span>
+        <%= @score.judge_profile.address_details %>
+      </h5>
 
-    <% if current_account.admin? %>
       <h5>
         <span>Clicked Pitch Video</span>
         <%= @score.clicked_pitch_video? ? "Yes" : "No" %>

--- a/app/views/ambassador/score_details/_scores_table.en.html.erb
+++ b/app/views/ambassador/score_details/_scores_table.en.html.erb
@@ -5,8 +5,13 @@
         <tr class="<%= (current_account.admin? && score.deleted?) ? "background-color--subtle-red" : "" %>">
           <td><%= score.total %> / <%= score.total_possible %></td>
           <td>
-            <%= link_to score.judge_name,
-              send("#{current_scope}_participant_path", id: score.judge_profile.account_id) %>
+            <% judge_name = chapter_ambassador_masked_judge_name(score: score, account: current_account) %>
+            <% if chapter_ambassador_can_link_to_judge?(score: score, account: current_account) %>
+              <%= link_to judge_name,
+                send("#{current_scope}_participant_path", id: score.judge_profile.account_id) %>
+            <% else %>
+              <%= judge_name %>
+            <% end %>
           </td>
           <td class="official-info"><%= score.official? ? "official" : "unofficial" %></td>
 

--- a/app/views/ambassador/score_details/show.en.html.erb
+++ b/app/views/ambassador/score_details/show.en.html.erb
@@ -30,6 +30,7 @@
   </dl>
 
   <% scores = current_account.admin? ? @submission.scores_including_deleted : @submission.scores %>
+  <% hide_incomplete_scores = current_account.chapter_ambassador_profile.present? %>
 
   <% if current_account.is_admin? or SeasonToggles.display_scores? %>
 
@@ -39,11 +40,13 @@
         scores: scores.semifinals.complete %>
     </div>
 
-    <h5>Incomplete Semifinals scores</h5>
-    <div id="incomplete-semifinal-scores">
-      <%= render "ambassador/score_details/scores_table",
-        scores: scores.semifinals.incomplete %>
-    </div>
+    <% unless hide_incomplete_scores %>
+      <h5>Incomplete Semifinals scores</h5>
+      <div id="incomplete-semifinal-scores">
+        <%= render "ambassador/score_details/scores_table",
+          scores: scores.semifinals.incomplete %>
+      </div>
+    <% end %>
 
   <% end %>
 
@@ -53,11 +56,13 @@
       scores: scores.quarterfinals.complete %>
   </div>
 
-  <h5>Incomplete Quarterfinal scores</h5>
-  <div id="incomplete-quarterfinal-scores">
-    <%= render "ambassador/score_details/scores_table",
-      scores: scores.judge_not_deleted.quarterfinals.incomplete %>
-  </div>
+  <% unless hide_incomplete_scores %>
+    <h5>Incomplete Quarterfinal scores</h5>
+    <div id="incomplete-quarterfinal-scores">
+      <%= render "ambassador/score_details/scores_table",
+        scores: scores.judge_not_deleted.quarterfinals.incomplete %>
+    </div>
+  <% end %>
 
   <% if current_account.is_admin? %>
     <h5>Recusals</h5>

--- a/spec/features/admin/view_scores_spec.rb
+++ b/spec/features/admin/view_scores_spec.rb
@@ -76,4 +76,34 @@ RSpec.feature "Admins view scores" do
       ]
     )
   end
+
+  scenario "admin score drilldown shows full judge identity with participant link" do
+    submission = FactoryBot.create(:submission, :junior, :complete)
+    judge = FactoryBot.create(:judge_profile, first_name: "Mira")
+    judge.account.update!(last_name: "Thompson")
+    admin = FactoryBot.create(:admin)
+
+    FactoryBot.create(
+      :submission_score,
+      :complete,
+      team_submission: submission,
+      judge_profile: judge
+    )
+
+    sign_in(admin)
+    visit admin_scores_path
+
+    find("a.view-details").click
+
+    within "#complete-quarterfinal-scores" do
+      expect(page).to have_link("Mira Thompson", href: admin_participant_path(judge.account_id))
+      click_link "View score"
+    end
+
+    within ".admin-score-header" do
+      expect(page).to have_link("Mira Thompson", href: admin_participant_path(judge.account_id))
+      expect(page).to have_content(judge.email)
+      expect(page).to have_content("Score comes from")
+    end
+  end
 end

--- a/spec/features/chapter_ambassador/view_scores_spec.rb
+++ b/spec/features/chapter_ambassador/view_scores_spec.rb
@@ -116,6 +116,99 @@ RSpec.feature "Chapter Ambassador views scores" do
 
       expect(page).to have_content("Semifinals average")
     end
+
+    scenario "score drilldown masks judge name and hides judge profile link when judge is not on chapter RPE" do
+      submission = FactoryBot.create(:submission, :complete)
+      judge = FactoryBot.create(:judge_profile, first_name: "Alice")
+      judge.account.update!(last_name: "Baker")
+
+      submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
+        student.chapterable_assignments.create(
+          chapterable: chapter_ambassador.chapterable,
+          account: student.account,
+          season: Season.current.year,
+          primary: true
+        )
+      end
+
+      FactoryBot.create(
+        :submission_score,
+        :complete,
+        team_submission: submission,
+        judge_profile: judge
+      )
+
+      click_link "Scores"
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find("a.view-details").click
+      end
+
+      within "#complete-quarterfinal-scores" do
+        expect(page).to have_content("Alice B.")
+        expect(page).not_to have_content("Alice Baker")
+        expect(page).not_to have_link("Alice B.", href: chapter_ambassador_participant_path(judge.account_id))
+
+        click_link "View score"
+      end
+
+      within ".admin-score-header" do
+        expect(page).to have_content("Alice B.")
+        expect(page).not_to have_content("Alice Baker")
+        expect(page).not_to have_link("Alice B.", href: chapter_ambassador_participant_path(judge.account_id))
+        expect(page).not_to have_content("Score comes from")
+      end
+    end
+
+    scenario "score drilldown allows judge profile link when judge attends chapter RPE" do
+      submission = FactoryBot.create(:submission, :complete)
+      judge = FactoryBot.create(:judge_profile, first_name: "Lina")
+      judge.account.update!(last_name: "Carver")
+      regional_pitch_event = FactoryBot.create(
+        :regional_pitch_event,
+        ambassador: chapter_ambassador.chapter_ambassador_profile
+      )
+
+      submission.team.students.each do |student|
+        student.chapterable_assignments.destroy_all
+
+        student.chapterable_assignments.create(
+          chapterable: chapter_ambassador.chapterable,
+          account: student.account,
+          season: Season.current.year,
+          primary: true
+        )
+      end
+
+      regional_pitch_event.teams << submission.team
+      regional_pitch_event.judges << judge
+
+      FactoryBot.create(
+        :submission_score,
+        :complete,
+        :live,
+        team_submission: submission,
+        judge_profile: judge
+      )
+
+      click_link "Scores"
+      within_results_page_with("#team_submission_#{submission.id}") do
+        find("a.view-details").click
+      end
+
+      within "#complete-quarterfinal-scores" do
+        expect(page).to have_link("Lina C.", href: chapter_ambassador_participant_path(judge.account_id))
+        expect(page).not_to have_content("Lina Carver")
+
+        click_link "View score"
+      end
+
+      within ".admin-score-header" do
+        expect(page).to have_link("Lina C.", href: chapter_ambassador_participant_path(judge.account_id))
+        expect(page).not_to have_content("Score comes from")
+      end
+    end
   end
 
   context "before scores set to display" do

--- a/spec/system/chapter_ambassador/view_score_details_spec.rb
+++ b/spec/system/chapter_ambassador/view_score_details_spec.rb
@@ -114,11 +114,8 @@ RSpec.describe "viewing score details page" do
           end
         end
 
-        it "displays incomplete quarterfinal scores" do
-          within "#incomplete-quarterfinal-scores" do
-            expect(page).to have_content("30 / 90")
-            expect(page).to have_content("View score")
-          end
+        it "hides incomplete quarterfinal scores" do
+          expect(page).not_to have_css("#incomplete-quarterfinal-scores")
         end
 
         it "does not display complete semifinal scores" do
@@ -222,11 +219,8 @@ RSpec.describe "viewing score details page" do
         end
       end
 
-      it "displays incomplete quarterfinal scores" do
-        within "#incomplete-quarterfinal-scores" do
-          expect(page).to have_content("30 / 90")
-          expect(page).to have_content("View score")
-        end
+      it "hides incomplete quarterfinal scores" do
+        expect(page).not_to have_css("#incomplete-quarterfinal-scores")
       end
 
       it "displays complete semifinal scores" do
@@ -236,11 +230,8 @@ RSpec.describe "viewing score details page" do
         end
       end
 
-      it "displays incomplete semifinal scores" do
-        within "#incomplete-semifinal-scores" do
-          expect(page).to have_content("30 / 90")
-          expect(page).to have_content("View score")
-        end
+      it "hides incomplete semifinal scores" do
+        expect(page).not_to have_css("#incomplete-semifinal-scores")
       end
     end
 

--- a/spec/views/ambassador/score_details/_scores_table.html.erb_spec.rb
+++ b/spec/views/ambassador/score_details/_scores_table.html.erb_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe "ambassador/score_details/_scores_table.html.erb", type: :view do
   before do
+    allow(view).to receive(:chapter_ambassador_can_link_to_judge?)
+      .with(score: score_submission, account: current_account)
+      .and_return(can_link_to_judge)
+
     render partial: "ambassador/score_details/scores_table",
       locals: {scores: scores, current_account: current_account, current_scope: current_scope}
   end
@@ -15,7 +19,12 @@ RSpec.describe "ambassador/score_details/_scores_table.html.erb", type: :view do
       team_name: "Dream Team",
       team_submission_app_name: "Dreamy App",
       judge_name: "Judge Dredd",
-      judge_profile: double("judge_profile", account_id: 333),
+      judge_profile: double(
+        "judge_profile",
+        id: 333,
+        account_id: 333,
+        account: double("judge_account", first_name: "Judge", last_name: "Dredd")
+      ),
       total: 75,
       total_possible: 80,
       official?: score_submission_offical,
@@ -29,9 +38,12 @@ RSpec.describe "ambassador/score_details/_scores_table.html.erb", type: :view do
 
   let(:current_account) {
     instance_double(Account,
-      admin?: current_account_admin)
+      admin?: current_account_admin,
+      chapter_ambassador_profile: chapter_ambassador_profile)
   }
   let(:current_account_admin) { false }
+  let(:chapter_ambassador_profile) { double("chapter_ambassador_profile") }
+  let(:can_link_to_judge) { true }
 
   let(:current_scope) { "chapter_ambassador" }
 
@@ -43,8 +55,22 @@ RSpec.describe "ambassador/score_details/_scores_table.html.erb", type: :view do
       expect(rendered).to have_content("75 / 80")
     end
 
-    it "displays a link to the judge who scored the submission" do
-      expect(rendered).to have_link("Judge Dredd")
+    it "displays the masked judge name" do
+      expect(rendered).to have_content("Judge D.")
+      expect(rendered).not_to have_content("Judge Dredd")
+    end
+
+    it "displays a link to the judge when they are chapter-connected" do
+      expect(rendered).to have_link("Judge D.")
+    end
+
+    context "when the judge is not chapter-connected" do
+      let(:can_link_to_judge) { false }
+
+      it "does not display a link to the judge" do
+        expect(rendered).to have_content("Judge D.")
+        expect(rendered).not_to have_link("Judge D.")
+      end
     end
 
     context "when a score is offical" do
@@ -78,7 +104,13 @@ RSpec.describe "ambassador/score_details/_scores_table.html.erb", type: :view do
 
   context "as an admin" do
     let(:current_account_admin) { true }
+    let(:chapter_ambassador_profile) { nil }
     let(:current_scope) { "admin" }
+
+    it "displays the full judge name and link" do
+      expect(rendered).to have_link("Judge Dredd")
+      expect(rendered).not_to have_content("Judge D.")
+    end
 
     context "when a score is marked as deleted" do
       let(:score_submission_deleted) { true }


### PR DESCRIPTION
## Summary
- Mask judge names as first name plus last initial for chapter ambassadors on score details and review-score pages, with participant links only when the judge is attached to a chapter RPE.
- Hide incomplete semifinal and quarterfinal score sections from chapter ambassadors on the score details page.
- Restrict the judge location row ("Score comes from") and judge email to admins; admins retain full judge identity and existing behavior.

Fixes #6199