### PR TITLE
feat(6196): remove "View our" link from judge between-rounds dashboard

### DIFF
--- a/app/views/judge/dashboards/onboarded/rebrand/_between_rounds.en.html.erb
+++ b/app/views/judge/dashboards/onboarded/rebrand/_between_rounds.en.html.erb
@@ -18,8 +18,8 @@
 
   <p class="text-justify mb-2">
     <span class="font-bold">Semifinals will take place from
-    <%= ImportantDates.semifinals_judging_begins.to_date.to_s(:short_ordinal) %> -
-    <%= ImportantDates.semifinals_judging_ends.to_date.to_s(:short_ordinal) %></span>, the number of scores you finish in both rounds will determine what judge certificate you receive.
+    <%= ImportantDates.semifinals_judging_begins.to_date.to_fs(:short_ordinal) %> -
+    <%= ImportantDates.semifinals_judging_ends.to_date.to_fs(:short_ordinal) %></span>, the number of scores you finish in both rounds will determine what judge certificate you receive.
   </p>
 
   <p class="text-justify mb-2">
@@ -36,7 +36,7 @@
   <p class="text-justify mb-2">
     <span class="font-bold">
       Login after
-      <%= ImportantDates.certificates_available.to_date.to_s(:short_ordinal) %>
+      <%= ImportantDates.certificates_available.to_date.to_fs(:short_ordinal) %>
       to view and download your certificate
     </span>
   </p>
@@ -46,8 +46,4 @@
     <li><span class="font-bold">5-10 submissions:</span> Head Judge</li>
     <li><span class="font-bold">11+ submissions:</span> Judge Advisor</li>
   </ul>
-  
-  <p class="text-justify mt-4">
-    View our <a class="tw-link" href="https://technovationchallenge.org/judge-resources/" target="_blank">Judge Resource page</a> for more information.
-  </p>
 </div>

--- a/spec/views/judge/dashboards/onboarded/rebrand/_between_rounds.html.erb_spec.rb
+++ b/spec/views/judge/dashboards/onboarded/rebrand/_between_rounds.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "judge/dashboards/onboarded/rebrand/_between_rounds.en.html.erb", type: :view do
+  before do
+    allow(ImportantDates).to receive(:semifinals_judging_begins)
+      .and_return(Time.zone.local(2026, 6, 1))
+    allow(ImportantDates).to receive(:semifinals_judging_ends)
+      .and_return(Time.zone.local(2026, 6, 17))
+    allow(ImportantDates).to receive(:certificates_available)
+      .and_return(Time.zone.local(2026, 6, 20))
+    allow(Season).to receive(:current).and_return(double(year: 2026))
+
+    render partial: "judge/dashboards/onboarded/rebrand/between_rounds"
+  end
+
+  it "renders the existing 'You finished quarterfinals!' section" do
+    expect(rendered).to include("You finished quarterfinals!")
+  end
+
+  it "renders the 'What happens next?' section" do
+    expect(rendered).to include("What happens next?")
+  end
+
+  it "renders the 'Judge Levels' section" do
+    expect(rendered).to include("Judge Levels")
+  end
+
+  it "does not render the removed 'View our' Judge Resource page sentence" do
+    expect(rendered).not_to include("View our")
+    expect(rendered).not_to include("Judge Resource page")
+    expect(rendered).not_to include("technovationchallenge.org/judge-resources")
+  end
+end


### PR DESCRIPTION
## Summary
- Removes the trailing "View our [Judge Resource page]" paragraph from the judge dashboard between-rounds view (`app/views/judge/dashboards/onboarded/rebrand/_between_rounds.en.html.erb`), per the latest direction on #6196.
- Migrates 3 deprecated `Date#to_s(:short_ordinal)` calls in the same partial to `to_fs(:short_ordinal)` so the new view spec can render the partial under Rails 7 (matches the existing sister partial `_judging_finished_certs_off.html.erb`).
- Adds a regression view spec at `spec/views/judge/dashboards/onboarded/rebrand/_between_rounds.html.erb_spec.rb` that asserts the removed sentence/link is absent and the surviving sections still render.

Closes #6196.