### PR TITLE
fix(5522): prevent perfect-score alert displaying without a perfect score

### DIFF
--- a/app/javascript/judge/scores/sections/ReviewScore.vue
+++ b/app/javascript/judge/scores/sections/ReviewScore.vue
@@ -205,7 +205,7 @@ export default {
   mounted() {
     if (this.isCompletingTooFast()) {
       this.displayCompletingTooFastAlert();
-    } else if (this.totalScore === this.totalPossibleScore) {
+    } else if (!this.isScoreIncomplete && this.totalScore === this.totalPossibleScore) {
       this.displayPerfectScoreAlert();
     }
   },

--- a/spec/features/judge/scoring_submissions_spec.rb
+++ b/spec/features/judge/scoring_submissions_spec.rb
@@ -38,6 +38,16 @@ RSpec.feature "scoring submissions", js: true do
     and_then_submits_the_score
   end
 
+  scenario "perfect score alert is not shown when navigating to review score without scoring" do
+    given_there_is_a_submission_from_a_beginner_team_that_needs_scoring
+    and_a_judge_is_logged_in
+
+    when_the_judge_starts_a_new_scoring_session
+    and_navigates_directly_to_the_review_score_page
+
+    then_the_perfect_score_alert_is_not_shown
+  end
+
   scenario "when a senior team receives a perfect score" do
     given_there_is_a_submission_from_a_senior_team_that_needs_scoring
     and_a_judge_is_logged_in
@@ -75,6 +85,15 @@ RSpec.feature "scoring submissions", js: true do
   def when_the_judge_starts_a_new_scoring_session
     click_link("Start a new score")
     click_link("Start Score")
+  end
+
+  def and_navigates_directly_to_the_review_score_page
+    execute_script("window.location.hash = '/review-score'")
+    expect(page).to have_content("Total Score")
+  end
+
+  def then_the_perfect_score_alert_is_not_shown
+    expect(page).not_to have_content("You've entered a perfect score")
   end
 
   def and_scores_the_project_details_section_perfectly


### PR DESCRIPTION
## Summary
- On the Review Score page, `ReviewScore.vue`'s `mounted()` hook fired before the AJAX state load completed, causing `totalScore === totalPossibleScore` to evaluate as `0 === 0` — triggering the perfect-score SweetAlert on every page refresh.
- Added `!this.isScoreIncomplete` guard (mirroring the existing "completed too fast" branch) so the alert only fires when all sections are genuinely complete.
- Added a regression spec that navigates to the Review Score view without entering any scores and asserts the alert copy is absent.