### PR TITLE
Fix judge login redirect to JSON endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,6 +74,8 @@ class ApplicationController < ActionController::Base
   end
 
   def save_redirected_path
+    return if request.format.json?
+
     set_cookie(CookieNames::REDIRECTED_FROM, request.fullpath)
   end
 

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -31,7 +31,7 @@ module SignIn
 
     if signin_options[:enable_redirect] == true
       context.redirect_to(
-        (context.remove_cookie(CookieNames::REDIRECTED_FROM) or
+        (safe_html_redirect_path(context.remove_cookie(CookieNames::REDIRECTED_FROM)) or
           context.send(*Array(signin_options[:redirect_to]))),
         success: signin_options[:message]
       )
@@ -39,6 +39,14 @@ module SignIn
   end
 
   private
+
+  def self.safe_html_redirect_path(path)
+    return nil if path.blank?
+    return nil if path.match?(/\.(?:json|xml|csv|pdf|xlsx?)(\?|$)/i)
+
+    path
+  end
+  private_class_method :safe_html_redirect_path
 
   def self.after_signin_path(signin, context)
     last_profile_used = context.remove_cookie(CookieNames::LAST_PROFILE_USED)

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -57,6 +57,36 @@ RSpec.describe SigninsController do
       expect(response).to redirect_to(student_dashboard_path)
     end
 
+    context "REDIRECTED_FROM cookie" do
+      it "ignores a stale JSON redirect and routes to the judge dashboard" do
+        judge = FactoryBot.create(:judge)
+        controller.set_cookie(CookieNames::REDIRECTED_FROM, "/judge/scores.json")
+
+        post :create, params: {
+          account: {
+            email: judge.account.email,
+            password: "secret1234"
+          }
+        }
+
+        expect(response).to redirect_to(judge_dashboard_path)
+      end
+
+      it "honours a valid HTML redirect after login" do
+        student = FactoryBot.create(:student)
+        controller.set_cookie(CookieNames::REDIRECTED_FROM, "/student/teams/1")
+
+        post :create, params: {
+          account: {
+            email: student.email,
+            password: "secret1234"
+          }
+        }
+
+        expect(response).to redirect_to("/student/teams/1")
+      end
+    end
+
     it "sends parent emails for past students registering again" do
       student = FactoryBot.create(
         :onboarded_student,


### PR DESCRIPTION
## Summary
- Guard `save_redirected_path` against JSON-format requests so `/judge/scores.json` is never stored in the redirect cookie
- Sanitize the `REDIRECTED_FROM` cookie in `SignIn.call` so stale JSON paths fall back to the normal dashboard resolver
- Add two regression specs covering the broken and working redirect cases

Closes #6144