### PR TITLE
Fix spacing between Overview and Project Description on judging form

### DIFF
--- a/app/javascript/judge/scores/ScoreStepperItem.vue
+++ b/app/javascript/judge/scores/ScoreStepperItem.vue
@@ -39,7 +39,7 @@
         </div>
       </div>
 
-      <div class="flex justify-between">
+      <div v-if="showSectionProgress || sectionScore" class="flex justify-between">
         <div v-if="showSectionProgress" class="ml-8">
           <SectionProgressIcons :section="sectionName" />
         </div>


### PR DESCRIPTION
## Summary
- The judge Score stepper rendered an empty score/progress row for the "Overview" step (which has no progress icons or score), adding a blank line and an oversized gap above "Project Description".
- Gated that row behind `v-if="showSectionProgress || sectionScore"` in `ScoreStepperItem.vue` so it only renders for steps that have something to show. Spacing is now consistent across all stepper items, and scored sections keep their progress icons and scores.

Closes #5968