### PR TITLE
feat(4522): show "Score deleted" on student scores page when online score removed due to RPE move

### DIFF
--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -4,6 +4,7 @@ module Student
       @all_scores = SubmissionScore.none
       @quarterfinals_scores = SubmissionScore.none
       @semifinals_scores = SubmissionScore.none
+      @deleted_online_scores = SubmissionScore.none
 
       if current_team.submission.present? && SeasonToggles.display_scores?
         @all_scores = current_team.submission.submission_scores.complete
@@ -17,6 +18,13 @@ module Student
 
           @semifinals_scores = @all_scores.semifinals
         end
+
+        @deleted_online_scores = current_team.submission.submission_scores
+          .with_deleted
+          .virtual
+          .complete
+          .where.not(deleted_at: nil)
+          .where(dropped_at: nil)
       end
 
       @certificates = Certificate.none

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -51,7 +51,7 @@
                 <td class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
                   Online
                 </td>
-                <td colspan="2" class="whitespace-nowrap px-3 py-4 text-base italic text-gray-400">
+                <td colspan="2" class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
                   Score deleted
                 </td>
               </tr>

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -42,6 +42,20 @@
                 </td>
               </tr>
             <% end %>
+
+            <% local_assigns.fetch(:deleted_scores, []).sort_by(&:round).reverse.each do |score| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-base font-medium text-gray-900 sm:pl-6">
+                  <%= score.round.titlecase %>
+                </td>
+                <td class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
+                  Online
+                </td>
+                <td colspan="2" class="whitespace-nowrap px-3 py-4 text-base italic text-gray-400">
+                  Score deleted
+                </td>
+              </tr>
+            <% end %>
             </tbody>
           </table>
         </div>

--- a/app/views/student/scores/_scores_and_certificates.html.erb
+++ b/app/views/student/scores/_scores_and_certificates.html.erb
@@ -1,4 +1,4 @@
-<% if current_team.submission.complete? && current_team.submission.scores.complete.any? %>
+<% if current_team.submission.complete? && (current_team.submission.scores.complete.any? || @deleted_online_scores&.any?) %>
   <div class="text-center mt-8 mb-8">
     <p class="mb-4 text-2xl text-tg-magenta uppercase font-bold">
       Congratulations, your team was a <%= current_team.submission.contest_rank %>!

--- a/app/views/student/scores/_scores_overview.html.erb
+++ b/app/views/student/scores/_scores_overview.html.erb
@@ -19,9 +19,10 @@
 </div>
 
 <div id="student-finished-scores" class="mb-10">
-  <% if @all_scores.any? %>
+  <% if @all_scores.any? || @deleted_online_scores&.any? %>
     <%= render "student/scores/scores",
-               scores: @all_scores %>
+               scores: @all_scores,
+               deleted_scores: @deleted_online_scores %>
   <% else %>
     <p>Sorry, there are no available finished scores!</p>
   <% end %>

--- a/app/views/student/scores/_scores_overview.html.erb
+++ b/app/views/student/scores/_scores_overview.html.erb
@@ -1,22 +1,26 @@
-<p class="text-xl text-center mb-8">
-  Thank you for completing the survey and participating in the Technovation program.
-  Find your scores and comments from the judges below!
-</p>
+<% if @all_scores.any? %>
+  <p class="text-xl text-center mb-8">
+    Thank you for completing the survey and participating in the Technovation program.
+    Find your scores and comments from the judges below!
+  </p>
+<% end %>
 
-<div class="bg-energetic-blue rounded w-full lg:w-3/4 mx-auto shadow-md mb-16">
-  <div class="p-8 text-center">
-    <% if @quarterfinals_scores.any? %>
-      <%= render "student/scores/average_score",
-                 scores: @quarterfinals_scores,
-                 round: :quarterfinals %>
-    <% end %>
-    <% if @semifinals_scores.any? %>
-      <%= render "student/scores/average_score",
-                 scores: @semifinals_scores,
-                 round: :semifinals %>
-    <% end %>
+<% if @quarterfinals_scores.any? || @semifinals_scores.any? %>
+  <div class="bg-energetic-blue rounded w-full lg:w-3/4 mx-auto shadow-md mb-16">
+    <div class="p-8 text-center">
+      <% if @quarterfinals_scores.any? %>
+        <%= render "student/scores/average_score",
+                   scores: @quarterfinals_scores,
+                   round: :quarterfinals %>
+      <% end %>
+      <% if @semifinals_scores.any? %>
+        <%= render "student/scores/average_score",
+                   scores: @semifinals_scores,
+                   round: :semifinals %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <div id="student-finished-scores" class="mb-10">
   <% if @all_scores.any? || @deleted_online_scores&.any? %>
@@ -28,6 +32,8 @@
   <% end %>
 </div>
 
-<div class="mb-10">
-  <%= render "student/scores/score_explanation" %>
-</div>
+<% if @all_scores.any? %>
+  <div class="mb-10">
+    <%= render "student/scores/score_explanation" %>
+  </div>
+<% end %>

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe "Students view scores", :js do
     expect(page).to have_selector("#student-finished-scores-table")
     expect(page).to have_content("Score deleted")
     expect(page).not_to have_link("View details")
+    expect(page).not_to have_content("Average Quarterfinals Score")
+    expect(page).not_to have_content("Find your scores and comments from the judges below")
   end
 
   it "view SF scores page if program survey is not completed" do

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe "Students view scores", :js do
     expect(page).to have_selector(:link_or_button, "Complete Survey")
   end
 
+  it "shows 'Score deleted' row when an online score was removed due to RPE move" do
+    submission = FactoryBot.create(:submission, :complete)
+    score = FactoryBot.create(:submission_score, :complete, team_submission: submission)
+    score.destroy
+
+    student = submission.team.students.sample
+    student.account.took_program_survey!
+
+    sign_in(student)
+    visit student_scores_path
+
+    expect(page).to have_selector("#student-finished-scores-table")
+    expect(page).to have_content("Score deleted")
+    expect(page).not_to have_link("View details")
+  end
+
   it "view SF scores page if program survey is not completed" do
     submission = FactoryBot.create(
       :submission,


### PR DESCRIPTION
## Summary
- When a team with a complete online (virtual) score is added to an RPE, the score is soft-deleted and previously vanished silently from the student Scores page. This adds a "Score deleted" row to the Finished Scores table so students/judges can see a score existed and was removed when the team moved to live-event judging.
- Surfaces soft-deleted complete virtual scores via a new `@deleted_online_scores` query in `Student::ScoresController`, gated behind the existing `SeasonToggles.display_scores?`.
- Cleans up the page so it no longer renders an empty average banner or the rubric legend when only a deleted score remains.
- No schema change. Admin score-detail pages already label deleted scores; this closes the gap on the student dashboard.