### PR TITLE
feat(6201): require birthday field in judge registration

### DIFF
--- a/app/javascript/new_registration/components/JudgeStepTwo.vue
+++ b/app/javascript/new_registration/components/JudgeStepTwo.vue
@@ -32,7 +32,6 @@
 
         <p class="italic text-sm -mt-6 mb-8" style="margin-top: -12px;">
           We use date of birth as a way to gain insight into who volunteers to judge.<br>
-          This info is optional.
         </p>
 
         <FormulateInput name="phoneNumber" id="phoneNumber" type="tel"
@@ -118,6 +117,7 @@ export default {
       if (document.getElementById('firstName').value.length === 0 ||
         document.getElementById('lastName').value.length === 0 ||
         !document.getElementById('meetsMinimumAgeRequirement').checked ||
+        document.getElementById('dateOfBirth').value.length === 0 ||
         document.getElementById('judgeSchoolCompanyName').value.length === 0 ||
         document.getElementById('judgeJobTitle').value.length === 0 ||
         (document.getElementById('phoneNumber').value.length > 0 &&
@@ -162,7 +162,7 @@ export default {
     birthdayValidation() {
       const today = DateTime.now().toFormat('MM/dd/yyyy')
 
-      return `judge_age|after:01/01/1900|before:${today}`
+      return `judge_age|required|after:01/01/1900|before:${today}`
     }
   },
   props: {

--- a/app/javascript/new_registration/components/NextButton.vue
+++ b/app/javascript/new_registration/components/NextButton.vue
@@ -1,9 +1,21 @@
 <template>
-  <button @click.prevent="$emit('next')" class="registration-btns">Next</button>
+  <button
+    @click.prevent="$emit('next')"
+    class="registration-btns"
+    :disabled="disabled"
+  >
+    Next
+  </button>
 </template>
 
 <script>
 export default {
-  name: "NextButton"
-}
+  name: "NextButton",
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
 </script>


### PR DESCRIPTION
## Summary
- Make the Birthday field required in judge registration (`JudgeStepTwo.vue`): adds the `required` validation rule and blocks the Next button until a birthday is entered.
- Remove the "This info is optional." helper text.
- Promote `NextButton`'s `disabled` to a declared prop so the step can gate the Next button reliably.

Closes #6201