### PR TITLE
feat(6112): admins can add or remove teams from an RPE

### DIFF
--- a/app/controllers/admin/event_teams_controller.rb
+++ b/app/controllers/admin/event_teams_controller.rb
@@ -1,0 +1,67 @@
+module Admin
+  class EventTeamsController < AdminController
+    include RegionalPitchEvents::AdminAvailableTeams
+
+    def create
+      @event = RegionalPitchEvent.find(params[:event_id])
+      @team = Team.find(params[:team_id])
+
+      AddTeamToRegionalEvent.call(@event, @team)
+
+      @event = RegionalPitchEvent
+        .includes(
+          teams: [
+            :division,
+            :submission
+          ]
+        )
+        .find(params[:event_id])
+      @available_teams = load_available_teams_for_event(@event)
+
+      respond_to do |format|
+        format.html {
+          redirect_to admin_event_path(@event),
+            notice: "#{@team.name} added to #{@event.name}."
+        }
+        format.turbo_stream
+      end
+    end
+
+    def destroy
+      @event = RegionalPitchEvent.find(params[:event_id])
+      @team = Team.find(params[:id])
+
+      if @event.attendees.include?(@team)
+        InvalidateExistingJudgeData.call(@team, removing: true, event: @event)
+
+        @team.memberships.each do |membership|
+          EventMailer.notify_removed(
+            membership.member_type,
+            membership.member_id,
+            @event.id,
+            team_name: @team.name
+          ).deliver_later
+        end
+      end
+
+      @event = RegionalPitchEvent
+        .includes(
+          :judges, :user_invitations,
+          teams: [
+            :division,
+            :submission
+          ]
+        )
+        .find(params[:event_id])
+      @available_teams = load_available_teams_for_event(@event)
+
+      respond_to do |format|
+        format.html {
+          redirect_to admin_event_path(@event),
+            notice: "Team removed"
+        }
+        format.turbo_stream
+      end
+    end
+  end
+end

--- a/app/controllers/admin/regional_pitch_events_controller.rb
+++ b/app/controllers/admin/regional_pitch_events_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class RegionalPitchEventsController < AdminController
     include DatagridController
     include BulkDownloadSubmissionPitchPresentations
+    include RegionalPitchEvents::AdminAvailableTeams
     include RegionalPitchEvents::BulkAddJudgesToRegionalPitchEvent
     include RegionalPitchEvents::BulkAddTeamsToRegionalPitchEvent
 
@@ -29,6 +30,21 @@ module Admin
       @event = RegionalPitchEvent.find(params[:id])
       @event.update(regional_pitch_event_params)
       redirect_to admin_event_path(@event), success: "Changes were saved!"
+    end
+
+    def available_teams
+      @event = RegionalPitchEvent.find(params[:id])
+      @available_teams = load_available_teams_for_event(@event)
+
+      if turbo_frame_request_id == "available-teams-frame"
+        render partial: "admin/regional_pitch_events/available_teams",
+          locals: {event: @event, teams: @available_teams}
+      elsif turbo_frame_request_id == "available-teams-list"
+        render partial: "admin/regional_pitch_events/available_teams_list",
+          locals: {event: @event, teams: @available_teams}
+      else
+        redirect_to admin_event_path(@event)
+      end
     end
 
     private

--- a/app/controllers/concerns/regional_pitch_events/admin_available_teams.rb
+++ b/app/controllers/concerns/regional_pitch_events/admin_available_teams.rb
@@ -1,0 +1,13 @@
+module RegionalPitchEvents::AdminAvailableTeams
+  private
+
+  def load_available_teams_for_event(event)
+    teams = Team.live_event_eligible(event)
+      .includes(:division, submission: :team)
+      .order("teams.name")
+
+    teams = teams.by_query(params[:query]) if params[:query].present?
+
+    teams.paginate(page: params[:page], per_page: 20)
+  end
+end

--- a/app/views/admin/event_teams/create.turbo_stream.erb
+++ b/app/views/admin/event_teams/create.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "available-teams-list" do %>
+  <%= render "admin/regional_pitch_events/available_teams_list", event: @event, teams: @available_teams %>
+<% end %>
+
+<%= turbo_stream.replace "registered-teams-frame" do %>
+  <%= render "admin/regional_pitch_events/registered_teams", event: @event %>
+<% end %>
+
+<%= turbo_stream.replace "registered-judges-frame" do %>
+  <%= render "admin/regional_pitch_events/registered_judges", event: @event %>
+<% end %>

--- a/app/views/admin/event_teams/destroy.turbo_stream.erb
+++ b/app/views/admin/event_teams/destroy.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.replace "available-teams-list" do %>
+  <%= render "admin/regional_pitch_events/available_teams_list", event: @event, teams: @available_teams %>
+<% end %>
+
+<%= turbo_stream.replace "registered-teams-frame" do %>
+  <%= render "admin/regional_pitch_events/registered_teams", event: @event %>
+<% end %>
+
+<%= turbo_stream.replace "registered-judges-frame" do %>
+  <%= render "admin/regional_pitch_events/registered_judges", event: @event %>
+<% end %>

--- a/app/views/admin/regional_pitch_events/_available_team.html.erb
+++ b/app/views/admin/regional_pitch_events/_available_team.html.erb
@@ -15,7 +15,7 @@
       </span>
     <% else %>
       <%= button_to "Add",
-        chapter_ambassador_event_event_teams_path(event, team_id: team.id),
+        send("#{current_scope}_event_event_teams_path", event, team_id: team.id),
         method: :post,
         class: "button" %>
     <% end %>

--- a/app/views/admin/regional_pitch_events/_available_teams.html.erb
+++ b/app/views/admin/regional_pitch_events/_available_teams.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag "available-teams-frame" do %>
   <div class="grid grid--bleed">
     <div class="grid__col-auto" style="overflow-x:auto;">
-      <h5>Available Teams in Your Region</h5>
+      <h5><%= current_account.admin? ? "Available Teams" : "Available Teams in Your Region" %></h5>
 
-      <%= form_with url: available_teams_chapter_ambassador_event_path(@event),
+      <%= form_with url: send("available_teams_#{current_scope}_event_path", @event),
         method: :get,
         data: {
           controller: "search",

--- a/app/views/admin/regional_pitch_events/_available_teams_list.html.erb
+++ b/app/views/admin/regional_pitch_events/_available_teams_list.html.erb
@@ -25,13 +25,13 @@
       <div id="available-teams-pagination">
         <%= will_paginate teams,
           params: {
-            controller: 'chapter_ambassador/regional_pitch_events',
+            controller: "#{current_scope}/regional_pitch_events",
             action: "available_teams", id: event.id } %>
       </div>
     </div>
   <% else %>
     <p>
-      No teams available in your region.
+      <%= current_account.admin? ? "No teams available." : "No teams available in your region." %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/admin/regional_pitch_events/_registered_team.html.erb
+++ b/app/views/admin/regional_pitch_events/_registered_team.html.erb
@@ -48,10 +48,10 @@
     </span>
   </td>
 
-  <% if current_account.chapter_ambassador? %>
+  <% if current_account.chapter_ambassador? || current_account.admin? %>
     <td>
       <div style="display: flex; justify-content: space-between;">
-        <% if event.meets_requirement_to_assign_judges_to_teams? %>
+        <% if current_account.chapter_ambassador? && event.meets_requirement_to_assign_judges_to_teams? %>
           <%= link_to "Manage Judges",
             available_judges_for_team_assignment_chapter_ambassador_event_path(@event, team_id: team.id),
             class: "button",
@@ -61,7 +61,7 @@
         <% end %>
 
         <%= button_to "Remove",
-          chapter_ambassador_event_event_team_path(event, team),
+          send("#{current_scope}_event_event_team_path", event, team),
           method: :delete,
           class: "button button--danger" %>
       </div>

--- a/app/views/admin/regional_pitch_events/_registered_teams.html.erb
+++ b/app/views/admin/regional_pitch_events/_registered_teams.html.erb
@@ -19,7 +19,7 @@
             <% end %>
             <th style="padding-right: 20px;">Presentation Slides</th>
             <th>Status</th>
-            <% if current_account.chapter_ambassador? %>
+            <% if current_account.chapter_ambassador? || current_account.admin? %>
               <th>Actions</th>
             <% end %>
           </tr>

--- a/app/views/admin/regional_pitch_events/show.en.html.erb
+++ b/app/views/admin/regional_pitch_events/show.en.html.erb
@@ -142,6 +142,13 @@
         <% else %>
           <p>Teams cannot be added to events at this time.</p>
         <% end %>
+      <% elsif current_account.admin? %>
+        <%= turbo_frame_tag "available-teams-frame" do %>
+          <%= link_to "Add Teams",
+            available_teams_admin_event_path(@event),
+            class: "button",
+            data: { turbo_frame: "available-teams-frame" } %>
+        <% end %>
       <% end %>
 
       <%= render "admin/regional_pitch_events/registered_teams", event: @event %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,9 @@ Rails.application.routes.draw do
     resources :events,
       controller: :regional_pitch_events,
       only: [:index, :show, :edit, :update] do
+        resources :event_teams, only: [:create, :destroy]
+
+        get :available_teams, on: :member
         get :bulk_download_submission_pitch_presentations
 
         post :bulk_add_judges

--- a/spec/controllers/admin/event_teams_controller_spec.rb
+++ b/spec/controllers/admin/event_teams_controller_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Admin::EventTeamsController do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:event) { FactoryBot.create(:rpe, :senior) }
+  let(:submission) { FactoryBot.create(:team_submission, :senior, :complete) }
+  let(:team) { submission.team }
+
+  before { sign_in(admin) }
+
+  describe "POST #create" do
+    it "adds an eligible team to the event and redirects" do
+      expect {
+        post :create, params: {event_id: event.id, team_id: team.id}
+      }.to change { event.reload.teams.count }.by(1)
+
+      expect(event.reload.teams).to include(team)
+      expect(response).to redirect_to(admin_event_path(event))
+    end
+
+    it "adds the team even when the add-teams season toggle is off" do
+      allow(SeasonToggles)
+        .to receive(:add_teams_to_regional_pitch_event?)
+        .and_return(false)
+
+      expect {
+        post :create, params: {event_id: event.id, team_id: team.id}
+      }.to change { event.reload.teams.count }.by(1)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it "removes the team from the event and redirects" do
+      event.teams << team
+
+      expect {
+        delete :destroy, params: {event_id: event.id, id: team.id}
+      }.to change { event.reload.teams.count }.by(-1)
+
+      expect(event.reload.teams).not_to include(team)
+      expect(response).to redirect_to(admin_event_path(event))
+    end
+  end
+end

--- a/spec/features/admin/view_rpe_details_spec.rb
+++ b/spec/features/admin/view_rpe_details_spec.rb
@@ -47,6 +47,30 @@ RSpec.feature "Admin view rpe details", js: true do
     end
   end
 
+  scenario "Admin can add and remove a team from the RPE" do
+    available_team = FactoryBot.create(:team_submission, :senior, :complete).team
+
+    click_link "View"
+
+    click_link "Add Teams"
+
+    within "##{ActionView::RecordIdentifier.dom_id(available_team, :available)}" do
+      click_button "Add"
+    end
+
+    within "#registered-teams-frame" do
+      expect(page).to have_content(available_team.name)
+    end
+
+    within "##{ActionView::RecordIdentifier.dom_id(available_team, :registered)}" do
+      click_button "Remove"
+    end
+
+    expect(page).not_to have_css(
+      "##{ActionView::RecordIdentifier.dom_id(available_team, :registered)}"
+    )
+  end
+
   xscenario "Viewing a specific RPE displays RPE judge details" do
     rpe_judges = FactoryBot.create_list(:judge, 3)
     rpe_judges.each do |judge|


### PR DESCRIPTION
## Summary
- Adds always-available **Add Teams** / **Remove** controls for admins on the RPE show page (`/admin/events/:id`), so admins no longer have to log in as the Chapter Ambassador to manage an event's teams.
- Admin team management is intentionally **not gated** by the `add_teams_to_regional_pitch_event` season toggle; Chapter Ambassador behavior is unchanged (still toggle-gated).
- Implemented with admin-scoped `event_teams` + `available_teams` routes, an `Admin::EventTeamsController`, a region-agnostic available-teams loader, and `current_scope`-aware shared RPE partials. Reuses the existing `AddTeamToRegionalEvent` / `InvalidateExistingJudgeData` side effects.

## Acceptance criteria
- [x] Admin sees an "Add Teams" control on `/admin/events/:id` and can add an eligible team.
- [x] Admin sees a "Remove" control on each registered team and can remove it.
- [x] Admin add/remove works even when the `add_teams_to_regional_pitch_event` season toggle is OFF.
- [x] Chapter Ambassador behavior is unchanged (still gated by the season toggle).

## Tests
- `spec/controllers/admin/event_teams_controller_spec.rb` — add, add-with-toggle-off, remove (3 examples).
- `spec/features/admin/view_rpe_details_spec.rb` — admin add/remove scenario (js).
- Full run of touched specs: 8 examples, 0 failures (1 pre-existing pending).

## Code review
- Critical 0 / Important 0 / Suggestions 2 / Nits 1. StandardRB + Brakeman clean for the diff.

## Verification
- Captured before/after screenshots and add/remove action GIFs as an admin against a local dev environment; the after-state shows the toggle-disabled bulk panel alongside the working admin Add/Remove controls (proving the ungated behavior).

## Out of scope
- Admin bulk CSV team upload remains toggle-gated; judge management stays Chapter-Ambassador-only.