### PR TITLE
feat(5798): move "Other" to last in coding language dropdown

### DIFF
--- a/app/models/team_submission.rb
+++ b/app/models/team_submission.rb
@@ -18,9 +18,9 @@ class TeamSubmission < ActiveRecord::Base
   ACTIVE_DEVELOPMENT_PLATFORMS_ENUM = {
     "App Inventor" => 0,
     "Thunkable" => 6,
-    "Other" => 5,
     "Scratch" => 8,
-    "Code.org App Lab" => 9
+    "Code.org App Lab" => 9,
+    "Other" => 5
   }
 
   INACTIVE_DEVELOPMENT_PLATFORMS_ENUM = {

--- a/spec/models/team_submission_spec.rb
+++ b/spec/models/team_submission_spec.rb
@@ -185,9 +185,9 @@ RSpec.describe TeamSubmission do
       expect(TeamSubmission::ACTIVE_DEVELOPMENT_PLATFORMS_ENUM).to eq({
         "App Inventor" => 0,
         "Thunkable" => 6,
-        "Other" => 5,
         "Scratch" => 8,
-        "Code.org App Lab" => 9
+        "Code.org App Lab" => 9,
+        "Other" => 5
       })
     end
   end
@@ -226,9 +226,9 @@ RSpec.describe TeamSubmission do
       expect(TeamSubmission::DEVELOPMENT_PLATFORMS).to eq([
         "App Inventor",
         "Thunkable",
-        "Other",
         "Scratch",
-        "Code.org App Lab"
+        "Code.org App Lab",
+        "Other"
       ])
     end
   end


### PR DESCRIPTION
## Summary

- Reorders `ACTIVE_DEVELOPMENT_PLATFORMS_ENUM` in `TeamSubmission` so `"Other"` is the last key in the hash; Ruby preserves insertion order and `development_platform_options` calls `.keys` directly, so this is the only change needed to move "Other" to the bottom of the dropdown.
- New dropdown order: App Inventor → Thunkable → Scratch → Code.org App Lab → **Other**
- No migration needed — the integer enum values for each platform are unchanged.

Closes #5798