### PR TITLE
feat(6156): search RPE judges by email as well as name

### DIFF
--- a/app/models/judge_profile.rb
+++ b/app/models/judge_profile.rb
@@ -46,10 +46,10 @@ class JudgeProfile < ActiveRecord::Base
     if query.present?
       joins(:account)
         .where(
-          "accounts.first_name ILIKE ? OR " \
-          "accounts.last_name ILIKE ?",
-          "%#{query}%",
-          "%#{query}%"
+          "accounts.first_name ILIKE :query OR " \
+          "accounts.last_name ILIKE :query OR " \
+          "accounts.email ILIKE :query",
+          query: "%#{query}%"
         )
     end
   }

--- a/app/views/admin/regional_pitch_events/_available_judges.html.erb
+++ b/app/views/admin/regional_pitch_events/_available_judges.html.erb
@@ -16,7 +16,7 @@
 
         <%=  f.text_field :query,
           value: params[:query],
-          placeholder: "Search judges by name",
+          placeholder: "Search judges by name or email",
           data: {
             action: "input->search#search",
             turbo_submits_with: "Searching..." } %>

--- a/spec/models/judge_profile_spec.rb
+++ b/spec/models/judge_profile_spec.rb
@@ -56,6 +56,42 @@ RSpec.describe JudgeProfile do
     end
   end
 
+  describe ".by_query" do
+    let!(:judge) do
+      FactoryBot.create(:judge).tap do |j|
+        j.account.update_columns(
+          first_name: "Adabelle",
+          last_name: "Lovelaceton",
+          email: "ada.unique@judges.example.com"
+        )
+      end
+    end
+
+    it "matches on first name" do
+      expect(JudgeProfile.by_query("Adabelle")).to include(judge)
+    end
+
+    it "matches on last name" do
+      expect(JudgeProfile.by_query("Lovelaceton")).to include(judge)
+    end
+
+    it "matches on email" do
+      expect(JudgeProfile.by_query("ada.unique")).to include(judge)
+    end
+
+    it "excludes judges that do not match the query" do
+      other = FactoryBot.create(:judge).tap do |j|
+        j.account.update_columns(
+          first_name: "Grace",
+          last_name: "Hopperson",
+          email: "grace@navy.example.com"
+        )
+      end
+
+      expect(JudgeProfile.by_query("ada.unique")).not_to include(other)
+    end
+  end
+
   context "callbacks" do
     let(:judge) { FactoryBot.create(:judge) }
 


### PR DESCRIPTION
## Summary
- Broaden `JudgeProfile.by_query` so the "Available Judges in Your Region" search on the Regional Pitch Event page matches a judge's **email** in addition to first/last name (parameter-bound `ILIKE`, no SQL injection).
- Update the search field placeholder to "Search judges by name or email".
- Add `JudgeProfile.by_query` model specs (first name, last name, email, non-match).

Closes #6156.

## Acceptance criteria
- [x] Searching by part of a judge's email returns that judge (verified in browser on the ChA RPE page: `judge_demo` returned no judges before the fix and the matching judges after).
- [x] Searching by name continues to work (covered by `spec/models/judge_profile_spec.rb`).
- [x] Applies to both the ChA admin RPE page (shared `JudgeProfile.by_query` scope) and the full admin path (the admin judges grid `name_email` filter already matched email).

## Tests
- `spec/models/judge_profile_spec.rb` — passed (20 examples, 0 failures).

## Notes
- The full admin RPE page (`/admin/events/:id`) has no individual judge search box; admins search judges via the admin judges grid, whose filter already matched email. The only name-only judge search was `JudgeProfile.by_query`, fixed here.