### PR TITLE
feat(6201): require birthday for judges

### DIFF
--- a/app/javascript/new_registration/components/JudgeStepTwo.vue
+++ b/app/javascript/new_registration/components/JudgeStepTwo.vue
@@ -25,14 +25,14 @@
 
         <FormulateInput name="dateOfBirth" id="dateOfBirth" type="date" label="Birthday" placeholder="Birthday"
           :validation="birthdayValidation" :validation-messages="{
+            required: 'Birthday is required.',
             after: 'Please enter a valid birthday.',
             before: 'Please enter a valid birthday.'
           }" validation-name="Birthday"
           @keyup="checkValidation" @blur="checkValidation" @change="checkValidation" />
 
         <p class="italic text-sm -mt-6 mb-8" style="margin-top: -12px;">
-          We use date of birth as a way to gain insight into who volunteers to judge.<br>
-          This info is optional.
+          We use date of birth as a way to gain insight into who volunteers to judge.
         </p>
 
         <FormulateInput name="phoneNumber" id="phoneNumber" type="tel"
@@ -118,6 +118,7 @@ export default {
       if (document.getElementById('firstName').value.length === 0 ||
         document.getElementById('lastName').value.length === 0 ||
         !document.getElementById('meetsMinimumAgeRequirement').checked ||
+        document.getElementById('dateOfBirth').value.length === 0 ||
         document.getElementById('judgeSchoolCompanyName').value.length === 0 ||
         document.getElementById('judgeJobTitle').value.length === 0 ||
         (document.getElementById('phoneNumber').value.length > 0 &&
@@ -162,7 +163,7 @@ export default {
     birthdayValidation() {
       const today = DateTime.now().toFormat('MM/dd/yyyy')
 
-      return `judge_age|after:01/01/1900|before:${today}`
+      return `required|judge_age|after:01/01/1900|before:${today}`
     }
   },
   props: {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -634,6 +634,7 @@ class Account < ActiveRecord::Base
     format: {with: /\A[0-9+\-\s]+\z/, message: "can only contain numbers, dashes, and +"}
 
   validates :date_of_birth, presence: true, if: -> { !is_a_judge? && !is_a_mentor? && !is_chapter_ambassador? && !club_ambassador? }
+  validates :date_of_birth, presence: true, if: -> { is_a_judge? && new_record? }
   validates :meets_minimum_age_requirement, inclusion: [true], if: -> { (is_a_judge? || is_a_mentor? || is_chapter_ambassador? || club_ambassador?) && new_record? }
   validates :gender, presence: true, if: -> { not_student? }
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -89,13 +89,35 @@ RSpec.describe Account do
 
     describe "date of birth" do
       context "for judges" do
-        let(:judge) {
-          FactoryBot.create(:judge,
-            account: FactoryBot.build(:account, date_of_birth: date_of_birth))
-        }
+        context "when a new judge doesn't have a date of birth" do
+          let(:judge) {
+            FactoryBot.build(:judge,
+              account: FactoryBot.build(:account, date_of_birth: nil))
+          }
 
-        context "when a judge doesn't have a date of birth" do
-          let(:date_of_birth) { nil }
+          it "is not valid" do
+            expect(judge).not_to be_valid
+          end
+        end
+
+        context "when a new judge has a date of birth" do
+          let(:judge) {
+            FactoryBot.build(:judge,
+              account: FactoryBot.build(:account, date_of_birth: 30.years.ago))
+          }
+
+          it "is valid" do
+            expect(judge).to be_valid
+          end
+        end
+
+        context "when an existing judge doesn't have a date of birth" do
+          let(:judge) { FactoryBot.create(:judge) }
+
+          before do
+            judge.account.update_column(:date_of_birth, nil)
+            judge.account.reload
+          end
 
           it "is valid" do
             expect(judge).to be_valid
@@ -196,6 +218,7 @@ RSpec.describe Account do
             email: "ccara55@example.com",
             password: "abc1239876",
             gender: "Non-binary",
+            date_of_birth: 30.years.ago,
             terms_agreed_at: Time.current,
             judge_profile: JudgeProfile.new(
               job_title: "VIP",

--- a/spec/requests/new_registration_spec.rb
+++ b/spec/requests/new_registration_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "New registration", type: :request do
 
     context "when a judge is registering" do
       let(:profile_type) { "judge" }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth) { (Division.cutoff_date - 25.years) }
       let!(:judge_type) { JudgeType.find_by!(name: "Educator") }
 
       before do


### PR DESCRIPTION
## Summary
- Make the **birthday field required for judges**, following up on #6142.
- Add a `date_of_birth` presence validation for new judge accounts in `app/models/account.rb`, guarded by `new_record?` so existing judge records (and programmatic saves like `suspend!`/CRM syncs) are not broken.
- Make the Birthday field required in the judge registration form (`JudgeStepTwo.vue`): client-side `required` validation, a "Birthday is required." message, Next-button gating, and removal of the "This info is optional." helper text.

## Acceptance criteria
- [x] New judge registration requires a birthday — the Next button stays disabled until a birthday is entered (verified in-browser).
- [x] Server rejects a new judge missing `date_of_birth` — `spec/models/account_spec.rb`.
- [x] "This info is optional" helper text removed from the judge birthday field.
- [x] Existing judges without a birthday remain valid — `spec/models/account_spec.rb`.

## Tests
- `spec/models/account_spec.rb` — 115 examples, 0 failures.
- `spec/requests/new_registration_validation_spec.rb` — 7 examples, 0 failures.

## Code review
Critical 0 / Important 0 / Suggestions 0 / Nits 0.

## Out of scope
- The #6142 over-18 enforcement on the birthday value (only presence/required here).
- Mentors, chapter ambassadors, and club ambassadors (judges-only).

Before/after screenshots and an action GIF were captured locally during verification (`tmp/issue-6201-judge-birthday-required/`).