### PR TITLE
fix: guard accordion init against missing jquery-ui widget

### DIFF
--- a/app/assets/javascripts/mentor.js
+++ b/app/assets/javascripts/mentor.js
@@ -34,5 +34,7 @@ document.addEventListener("turbo:load", function () {
     }
   });
 
-  $(".accordion").accordion();
+  if ($.fn.accordion) {
+    $(".accordion").accordion();
+  }
 });

--- a/app/assets/javascripts/student.js
+++ b/app/assets/javascripts/student.js
@@ -10,9 +10,11 @@
 //= require dropzones
 
 document.addEventListener('turbo:load', function () {
-  $( ".accordion" ).accordion({
-    collapsible: true,
-    active: false,
-    heightStyle: "content",
-  });
+  if ($.fn.accordion) {
+    $( ".accordion" ).accordion({
+      collapsible: true,
+      active: false,
+      heightStyle: "content",
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- `TypeError: $(...).accordion is not a function` was thrown 37 times on `/login` since the Jun 11 deploy when a Turbo Drive navigation from a student or mentor page left a `turbo:load` listener alive on the next page, which loads a different sprockets manifest that does not bundle the jQuery UI accordion widget.
- Added `if ($.fn.accordion)` guards in `student.js` and `mentor.js` so the init call is skipped when the widget is not present.
- No behaviour change on student/mentor pages where the widget is always loaded.

Closes #6242