### PR TITLE
fix(6244): guard submission.screenshots against undefined before ajax load

### DIFF
--- a/app/javascript/judge/scores/pieces/Screenshots.vue
+++ b/app/javascript/judge/scores/pieces/Screenshots.vue
@@ -2,10 +2,10 @@
   <div
     id="screenshots-nav"
     class="flex flex-col lg:flex-row flex-wrap"
-    :data-modal-last="submission.screenshots.length - 1"
+    :data-modal-last="screenshots.length - 1"
   >
     <div
-      v-for="(screenshot, i) in submission.screenshots"
+      v-for="(screenshot, i) in screenshots"
       :key="screenshot.id"
       class="w-full lg:w-1/3 h-64 p-4 flex flex-col justify-center items-center"
     >
@@ -24,7 +24,12 @@ import { mapState } from 'vuex'
 import {getFilestackResizeUrl} from "../../../utilities/filestack-helpers";
 
 export default {
-  computed: mapState(['submission']),
+  computed: {
+    ...mapState(['submission']),
+    screenshots() {
+      return this.submission.screenshots || []
+    },
+  },
   methods: {
     filestackResizeUrl(screenshotUrl) {
       return getFilestackResizeUrl(screenshotUrl, 300)

--- a/app/javascript/judge/scores/store/mutations.js
+++ b/app/javascript/judge/scores/store/mutations.js
@@ -98,6 +98,7 @@ export const resetState = (state) => {
     location: "",
     division: "",
     photo: "",
+    screenshots: [],
   };
   state.score = {
     id: null,

--- a/app/javascript/judge/scores/store/state.js
+++ b/app/javascript/judge/scores/store/state.js
@@ -39,5 +39,6 @@ export default {
     description: "",
     development_platform: "",
     deadline: "",
+    screenshots: [],
   },
 };


### PR DESCRIPTION
## Summary
- Fixes Airbrake TypeError: `Cannot read properties of undefined (reading 'length')` on `/judge/scores/new#/ideation` (27 occurrences since Jun 11)
- Adds a `screenshots` computed property in `Screenshots.vue` defaulting to `[]` so the component is safe during the pre-load window before the async AJAX call populates Vuex
- Initialises `submission.screenshots: []` in `state.js` and `resetState` in `mutations.js` for defence-in-depth

Closes #6244