### PR TITLE
fix(6246): filter browser-extension errors from airbrake-js client

### DIFF
--- a/app/javascript/utilities/utilities.js
+++ b/app/javascript/utilities/utilities.js
@@ -10,14 +10,33 @@ const noopAirbrake = {
 const airbrakeProjectId = process.env.AIRBRAKE_PROJECT_ID;
 const airbrakeProjectKey = process.env.AIRBRAKE_PROJECT_KEY;
 
+const BROWSER_EXTENSION_SCHEMES = [
+  'chrome-extension://',
+  'moz-extension://',
+  'safari-extension://',
+  'safari-web-extension://',
+]
+
+function isBrowserExtensionNotice(notice) {
+  return notice.errors.some((error) =>
+    error.backtrace.some((frame) =>
+      BROWSER_EXTENSION_SCHEMES.some((scheme) => frame.file.startsWith(scheme))
+    )
+  )
+}
+
+function createAirbrakeClient() {
+  const client = new AirbrakeClient({
+    projectId: airbrakeProjectId,
+    projectKey: airbrakeProjectKey,
+    environment: process.env.AIRBRAKE_RAILS_ENV,
+  })
+  client.addFilter((notice) => (isBrowserExtensionNotice(notice) ? null : notice))
+  return client
+}
+
 export const airbrake =
-  airbrakeProjectId && airbrakeProjectKey
-    ? new AirbrakeClient({
-        projectId: airbrakeProjectId,
-        projectKey: airbrakeProjectKey,
-        environment: process.env.AIRBRAKE_RAILS_ENV,
-      })
-    : noopAirbrake;
+  airbrakeProjectId && airbrakeProjectKey ? createAirbrakeClient() : noopAirbrake;
 
 export const isProduction = () => {
   return process.env.HOST_DOMAIN == "my.technovationchallenge.org"


### PR DESCRIPTION
## Summary

- Adds a client-side Airbrake filter in `app/javascript/utilities/utilities.js` that drops JS error notices whose backtrace originates from browser-extension URLs (`chrome-extension://`, `moz-extension://`, `safari-extension://`, `safari-web-extension://`).
- Eliminates the false-positive `TypeError: Cannot redefine property: ethereum` noise from crypto-wallet extensions injecting `inpage.js` into the Airbrake dashboard (63 occurrences, including 4 since the Jun 11 deploy).
- Legitimate application errors are unaffected; the filter only suppresses notices it can positively identify as extension-origin.

Closes #6246