### PR TITLE
fix(6250): enrich Failed to fetch notices with client diagnostics

### DIFF
--- a/app/javascript/utilities/utilities.js
+++ b/app/javascript/utilities/utilities.js
@@ -31,7 +31,26 @@ function createAirbrakeClient() {
     projectKey: airbrakeProjectKey,
     environment: process.env.AIRBRAKE_RAILS_ENV,
   })
-  client.addFilter((notice) => (isBrowserExtensionNotice(notice) ? null : notice))
+  client.addFilter((notice) => {
+    if (isBrowserExtensionNotice(notice)) return null
+
+    // "Failed to fetch" comes from airbrake-js's own delivery fetch failing
+    // (offline / tab closing / ad-blocker) — not from our app code. Attach
+    // context so these entries are diagnosable in Airbrake (issue #6250).
+    const isFailedToFetch = notice.errors.some(
+      (e) => e.type === 'TypeError' && /Failed to fetch/i.test(e.message || '')
+    )
+    if (isFailedToFetch) {
+      notice.params = {
+        ...notice.params,
+        online: navigator.onLine,
+        visibilityState: document.visibilityState,
+        url: window.location.href,
+      }
+    }
+
+    return notice
+  })
   return client
 }
 


### PR DESCRIPTION
## Summary

- `Failed to fetch` TypeErrors in Airbrake are self-referential noise: airbrake-js uses `window.fetch` to deliver its own error reports, and when that fetch fails (offline / tab closing / ad-blocker), the rejection is re-reported by the library's own `unhandledrejection` handler with no context (`Where: <no information>`).
- Our app never calls `window.fetch` directly (it uses jQuery `$.ajax` + axios), so these errors are never from first-party code.
- Extends the existing `addFilter` in `utilities.js` to attach `online`, `visibilityState`, and `url` to these notices so future Airbrake entries are diagnosable rather than blank.

Closes #6250