### PR TITLE
Prevent judges and ambassadors from saving an under-18 birthdate (#6142)

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,22 +2,22 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application";
+import { application } from "./application"
 
-import DateFieldsController from "./date_fields_controller";
-application.register("date-fields", DateFieldsController);
+import DateFieldsController from "./date_fields_controller"
+application.register("date-fields", DateFieldsController)
 
-import LanguageSelectorController from "./language_selector_controller";
-application.register("language-selector", LanguageSelectorController);
+import LanguageSelectorController from "./language_selector_controller"
+application.register("language-selector", LanguageSelectorController)
 
-import ModalController from "./modal_controller";
-application.register("modal", ModalController);
+import MinimumAgeController from "./minimum_age_controller"
+application.register("minimum-age", MinimumAgeController)
 
-import SearchController from "./search_controller";
-application.register("search", SearchController);
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
 
-import Students__ParentalConsentContactToggleController from "./students/parental_consent_contact_toggle_controller";
-application.register(
-  "students--parental-consent-contact-toggle",
-  Students__ParentalConsentContactToggleController
-);
+import SearchController from "./search_controller"
+application.register("search", SearchController)
+
+import Students__ParentalConsentContactToggleController from "./students/parental_consent_contact_toggle_controller"
+application.register("students--parental-consent-contact-toggle", Students__ParentalConsentContactToggleController)

--- a/app/javascript/controllers/minimum_age_controller.js
+++ b/app/javascript/controllers/minimum_age_controller.js
@@ -1,0 +1,103 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Validates the assembled date_of_birth `<select>`s against a minimum age.
+// The year dropdown alone cannot enforce the minimum (a year 18 ago paired
+// with a month/day still to come is under 18), so this checks the full date.
+export default class extends Controller {
+  static values = { minimum: Number };
+
+  connect() {
+    this.selects = Array.from(this.element.querySelectorAll("select"));
+    if (this.selects.length < 3) return;
+
+    this.errorElement = this.buildErrorElement();
+    this.boundValidate = this.validate.bind(this);
+    this.selects.forEach((select) =>
+      select.addEventListener("change", this.boundValidate)
+    );
+    this.validate();
+  }
+
+  disconnect() {
+    if (this.selects) {
+      this.selects.forEach((select) =>
+        select.removeEventListener("change", this.boundValidate)
+      );
+    }
+    this.setSubmitDisabled(false);
+  }
+
+  validate() {
+    const birthdate = this.selectedBirthdate();
+
+    if (birthdate && this.ageOn(new Date(), birthdate) < this.minimumValue) {
+      this.errorElement.style.display = "";
+      this.setSubmitDisabled(true);
+    } else {
+      this.errorElement.style.display = "none";
+      this.setSubmitDisabled(false);
+    }
+  }
+
+  selectedBirthdate() {
+    const year = this.valueForFragment("1i");
+    const month = this.valueForFragment("2i");
+    const day = this.valueForFragment("3i");
+
+    if (!year || !month || !day) return null;
+
+    const birthdate = new Date(year, month - 1, day);
+    if (
+      birthdate.getFullYear() !== year ||
+      birthdate.getMonth() !== month - 1 ||
+      birthdate.getDate() !== day
+    ) {
+      return null;
+    }
+    return birthdate;
+  }
+
+  valueForFragment(fragment) {
+    const select = this.selects.find((element) =>
+      element.name.includes(`(${fragment})`)
+    );
+    return select ? parseInt(select.value, 10) : NaN;
+  }
+
+  ageOn(today, birthdate) {
+    let age = today.getFullYear() - birthdate.getFullYear();
+    const monthDiff = today.getMonth() - birthdate.getMonth();
+    if (
+      monthDiff < 0 ||
+      (monthDiff === 0 && today.getDate() < birthdate.getDate())
+    ) {
+      age -= 1;
+    }
+    return age;
+  }
+
+  setSubmitDisabled(disabled) {
+    const form = this.element.closest("form");
+    if (!form) return;
+    const submit = form.querySelector(
+      'input[type="submit"], button[type="submit"]'
+    );
+    if (submit) submit.disabled = disabled;
+  }
+
+  buildErrorElement() {
+    // Mirror Rails' `.field_with_errors > .error` markup so the message picks
+    // up the app's existing red validation-error styling.
+    const wrapper = document.createElement("div");
+    wrapper.className = "field_with_errors minimum-age-error";
+    wrapper.style.display = "none";
+
+    const message = document.createElement("p");
+    message.className = "error";
+    message.textContent = `You must be at least ${this.minimumValue} years old.`;
+
+    wrapper.appendChild(message);
+    this.element.appendChild(wrapper);
+    return wrapper;
+  }
+}

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -636,6 +636,7 @@ class Account < ActiveRecord::Base
   validates :date_of_birth, presence: true, if: -> { !is_a_judge? && !is_a_mentor? && !is_chapter_ambassador? && !club_ambassador? }
   validates :date_of_birth, presence: true, if: -> { is_a_judge? && new_record? }
   validates :meets_minimum_age_requirement, inclusion: [true], if: -> { (is_a_judge? || is_a_mentor? || is_chapter_ambassador? || club_ambassador?) && new_record? }
+  validate :must_meet_minimum_age_requirement, if: -> { (is_a_judge? || is_chapter_ambassador? || club_ambassador?) && date_of_birth.present? && date_of_birth_changed? }
   validates :gender, presence: true, if: -> { not_student? }
 
   validate -> {
@@ -1211,6 +1212,12 @@ class Account < ActiveRecord::Base
 
   def not_student?
     !student_profile.present?
+  end
+
+  def must_meet_minimum_age_requirement
+    if age && age < 18
+      errors.add(:date_of_birth, "must indicate you are at least 18 years old")
+    end
   end
 
   def create_account_created_activity

--- a/app/views/signups/_basic_profile_fields.html.erb
+++ b/app/views/signups/_basic_profile_fields.html.erb
@@ -9,12 +9,15 @@
   </div>
 
   <% if !a.object.chapter_ambassador? && !a.object.club_ambassador? %>
-    <%= a.input :date_of_birth,
-      as: :date,
-      prompt: true,
-      start_year: f.object.youngest_birth_year,
-      end_year: f.object.oldest_birth_year,
-      input_html: { class: "chosen dob_field" } %>
+    <% dob_wrapper_data = a.object.is_a_judge? ? { controller: "minimum-age", minimum_age_minimum_value: 18 } : {} %>
+    <%= content_tag :div, data: dob_wrapper_data do %>
+      <%= a.input :date_of_birth,
+        as: :date,
+        prompt: true,
+        start_year: f.object.youngest_birth_year,
+        end_year: f.object.oldest_birth_year,
+        input_html: { class: "chosen dob_field" } %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -359,6 +359,84 @@ RSpec.describe Account do
       end
     end
 
+    describe "minimum age on date of birth changes" do
+      context "for a judge" do
+        let(:judge) {
+          FactoryBot.create(:judge,
+            account: FactoryBot.create(:account, date_of_birth: 30.years.ago))
+        }
+
+        it "is invalid when the birthdate is changed to make them younger than 18" do
+          judge.account.date_of_birth = 17.years.ago
+
+          expect(judge.account).not_to be_valid
+          expect(judge.account.errors[:date_of_birth])
+            .to include("must indicate you are at least 18 years old")
+        end
+
+        it "is valid when the birthdate is changed but still 18 or older" do
+          judge.account.date_of_birth = 25.years.ago
+
+          expect(judge.account).to be_valid
+        end
+
+        it "is valid when the birthdate is left unchanged" do
+          expect(judge.account).to be_valid
+        end
+
+        it "is valid when the birthdate is exactly 18 years ago today" do
+          judge.account.date_of_birth = 18.years.ago.to_date
+
+          expect(judge.account).to be_valid
+        end
+
+        it "is invalid when they only turn 18 tomorrow" do
+          judge.account.date_of_birth = (18.years.ago + 1.day).to_date
+
+          expect(judge.account).not_to be_valid
+        end
+      end
+
+      context "for a chapter ambassador" do
+        let(:chapter_ambassador) {
+          FactoryBot.create(:chapter_ambassador,
+            account: FactoryBot.create(:account, date_of_birth: 30.years.ago))
+        }
+
+        it "is invalid when the birthdate is changed to make them younger than 18" do
+          chapter_ambassador.account.date_of_birth = 17.years.ago
+
+          expect(chapter_ambassador.account).not_to be_valid
+        end
+      end
+
+      context "for a club ambassador" do
+        let(:club_ambassador) {
+          FactoryBot.create(:club_ambassador,
+            account: FactoryBot.create(:account, date_of_birth: 30.years.ago))
+        }
+
+        it "is invalid when the birthdate is changed to make them younger than 18" do
+          club_ambassador.account.date_of_birth = 17.years.ago
+
+          expect(club_ambassador.account).not_to be_valid
+        end
+      end
+
+      context "for a mentor (excluded because converted students may be 14+)" do
+        let(:mentor) {
+          FactoryBot.create(:mentor,
+            account: FactoryBot.create(:account, date_of_birth: 30.years.ago))
+        }
+
+        it "stays valid when the birthdate is changed to under 18" do
+          mentor.account.date_of_birth = 15.years.ago
+
+          expect(mentor.account).to be_valid
+        end
+      end
+    end
+
     describe "phone number" do
       it "allows phone numbers with valid characters" do
         account = FactoryBot.create(:account)


### PR DESCRIPTION
## Summary
- Add a server-side `Account` validation requiring judges, chapter ambassadors, and club ambassadors to be at least 18 when their `date_of_birth` is set or changed (closes the profile-edit gap behind #6142).
- Add a `minimum_age` Stimulus controller that enforces the 18+ rule on the shared profile-edit date-of-birth selects (the year dropdown alone didn't account for month/day), showing the app's red validation error and disabling Save.
- Mentors are intentionally excluded because the student→mentor conversion path legitimately allows ages 14+.

## Acceptance criteria
- [x] Judge cannot save a birthdate under 18 (registration or profile edit) — model spec
- [x] Under-18 save surfaces a clear birthdate error — model spec asserts the message
- [x] 18+ judge edits normally; unchanged/legacy birthdate not blocked — model specs
- [x] 18+ floor also applies to chapter/club ambassadors — model specs
- [x] Month/day caught client-side on the profile-edit select (inline error + Save disabled) — browser-verified
- [x] Students and young converted mentors unaffected — mentor spec stays valid at 15

## Tests
- \`spec/models/account_spec.rb\` — 123 examples, 0 failures (1 pre-existing pending)

## Notes
- Browser before/after + action GIF evidence captured locally under \`tmp/issue-6142-judge-birthdate-age/\` (not committed).