### PR TITLE
fix(6142): simplify minimum-age error styling and hook chosen changes

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -210,6 +210,12 @@ select {
   }
 }
 
+.minimum-age-error__message {
+  color: $alert-txt;
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+
 .while-waiting {
   transition: 0.2s opacity;
   opacity: 0;

--- a/app/javascript/controllers/minimum_age_controller.js
+++ b/app/javascript/controllers/minimum_age_controller.js
@@ -12,9 +12,16 @@ export default class extends Controller {
 
     this.errorElement = this.buildErrorElement();
     this.boundValidate = this.validate.bind(this);
-    this.selects.forEach((select) =>
-      select.addEventListener("change", this.boundValidate)
-    );
+    this.jqueryListeners = [];
+    this.selects.forEach((select) => {
+      select.addEventListener("change", this.boundValidate);
+
+      if (window.jQuery) {
+        const $select = window.jQuery(select);
+        $select.on("change.minimumAge", this.boundValidate);
+        this.jqueryListeners.push($select);
+      }
+    });
     this.validate();
   }
 
@@ -22,6 +29,11 @@ export default class extends Controller {
     if (this.selects) {
       this.selects.forEach((select) =>
         select.removeEventListener("change", this.boundValidate)
+      );
+    }
+    if (this.jqueryListeners) {
+      this.jqueryListeners.forEach(($select) =>
+        $select.off("change.minimumAge")
       );
     }
     this.setSubmitDisabled(false);
@@ -86,14 +98,12 @@ export default class extends Controller {
   }
 
   buildErrorElement() {
-    // Mirror Rails' `.field_with_errors > .error` markup so the message picks
-    // up the app's existing red validation-error styling.
     const wrapper = document.createElement("div");
-    wrapper.className = "field_with_errors minimum-age-error";
+    wrapper.className = "minimum-age-error";
     wrapper.style.display = "none";
 
     const message = document.createElement("p");
-    message.className = "error";
+    message.className = "minimum-age-error__message";
     message.textContent = `You must be at least ${this.minimumValue} years old.`;
 
     wrapper.appendChild(message);


### PR DESCRIPTION
## Summary
- Style minimum-age validation errors as plain red text (no highlight bar or icon).
- Listen for Chosen.js `change` events so under-18 birthdates reliably show the error and disable Save on judge profile edit.

## Test plan
- [x] Log in as `judge@judge.com`, open `/judge/profile/edit`, select 2008 / December / 31 — error shows as red text only, Save disabled
- [x] Select a valid 18+ birthdate — error clears, Save re-enabled
- [x] `bundle exec rspec spec/models/account_spec.rb --example "minimum age"` — passed