### PR TITLE
fix(6142): require date of birth and enforce 18+ for judges

### DIFF
--- a/app/javascript/controllers/minimum_age_controller.js
+++ b/app/javascript/controllers/minimum_age_controller.js
@@ -1,8 +1,11 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Validates the assembled date_of_birth `<select>`s against a minimum age.
-// The year dropdown alone cannot enforce the minimum (a year 18 ago paired
-// with a month/day still to come is under 18), so this checks the full date.
+// Validates the assembled date_of_birth `<select>`s when the form is submitted,
+// mirroring the server-side rules (date of birth is required and the judge must
+// be at least the minimum age). On an invalid submit it blocks the submission
+// and shows an inline error in the same `.field_with_errors > .error` markup the
+// rest of the form uses. The Save button stays enabled, consistent with how
+// first/last name validation behaves.
 export default class extends Controller {
   static values = { minimum: Number };
 
@@ -10,33 +13,60 @@ export default class extends Controller {
     this.selects = Array.from(this.element.querySelectorAll("select"));
     if (this.selects.length < 3) return;
 
+    this.form = this.element.closest("form");
+    if (!this.form) return;
+
     this.errorElement = this.buildErrorElement();
-    this.boundValidate = this.validate.bind(this);
-    this.selects.forEach((select) =>
-      select.addEventListener("change", this.boundValidate)
-    );
-    this.validate();
+    this.boundValidateOnSubmit = this.validateOnSubmit.bind(this);
+    this.form.addEventListener("submit", this.boundValidateOnSubmit);
   }
 
   disconnect() {
-    if (this.selects) {
-      this.selects.forEach((select) =>
-        select.removeEventListener("change", this.boundValidate)
-      );
+    if (this.form && this.boundValidateOnSubmit) {
+      this.form.removeEventListener("submit", this.boundValidateOnSubmit);
     }
-    this.setSubmitDisabled(false);
   }
 
-  validate() {
-    const birthdate = this.selectedBirthdate();
+  validateOnSubmit(event) {
+    const message = this.errorMessage();
 
-    if (birthdate && this.ageOn(new Date(), birthdate) < this.minimumValue) {
-      this.errorElement.style.display = "";
-      this.setSubmitDisabled(true);
+    if (message) {
+      // preventDefault blocks the submit; stopImmediatePropagation keeps the
+      // event from bubbling to the document-level jQuery UJS handler, which
+      // would otherwise disable the submit button (via data-disable-with) and
+      // leave it stuck disabled since the form never actually submits.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      this.showError(message);
+      this.errorElement.scrollIntoView({ block: "center", behavior: "smooth" });
     } else {
-      this.errorElement.style.display = "none";
-      this.setSubmitDisabled(false);
+      this.hideError();
     }
+  }
+
+  // Returns the error string to display, or null when the date is valid.
+  errorMessage() {
+    if (!this.allFragmentsSelected()) {
+      return "Date of birth is required.";
+    }
+
+    const birthdate = this.selectedBirthdate();
+    if (birthdate === null) {
+      return "Date of birth is required.";
+    }
+
+    if (this.ageOn(new Date(), birthdate) < this.minimumValue) {
+      return `You must be at least ${this.minimumValue} years old.`;
+    }
+
+    return null;
+  }
+
+  allFragmentsSelected() {
+    return ["1i", "2i", "3i"].every((fragment) => {
+      const select = this.selectForFragment(fragment);
+      return select && select.value !== "";
+    });
   }
 
   selectedBirthdate() {
@@ -57,11 +87,18 @@ export default class extends Controller {
     return birthdate;
   }
 
-  valueForFragment(fragment) {
-    const select = this.selects.find((element) =>
+  selectForFragment(fragment) {
+    return this.selects.find((element) =>
       element.name.includes(`(${fragment})`)
     );
-    return select ? parseInt(select.value, 10) : NaN;
+  }
+
+  valueForFragment(fragment) {
+    const select = this.selectForFragment(fragment);
+    if (!select || select.value === "") return NaN;
+
+    const parsed = parseInt(select.value, 10);
+    return Number.isNaN(parsed) ? NaN : parsed;
   }
 
   ageOn(today, birthdate) {
@@ -76,13 +113,13 @@ export default class extends Controller {
     return age;
   }
 
-  setSubmitDisabled(disabled) {
-    const form = this.element.closest("form");
-    if (!form) return;
-    const submit = form.querySelector(
-      'input[type="submit"], button[type="submit"]'
-    );
-    if (submit) submit.disabled = disabled;
+  showError(message) {
+    this.messageElement.textContent = message;
+    this.errorElement.style.display = "";
+  }
+
+  hideError() {
+    this.errorElement.style.display = "none";
   }
 
   buildErrorElement() {
@@ -92,11 +129,10 @@ export default class extends Controller {
     wrapper.className = "field_with_errors minimum-age-error";
     wrapper.style.display = "none";
 
-    const message = document.createElement("p");
-    message.className = "error";
-    message.textContent = `You must be at least ${this.minimumValue} years old.`;
+    this.messageElement = document.createElement("span");
+    this.messageElement.className = "error";
 
-    wrapper.appendChild(message);
+    wrapper.appendChild(this.messageElement);
     this.element.appendChild(wrapper);
     return wrapper;
   }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -652,9 +652,9 @@ class Account < ActiveRecord::Base
     format: {with: /\A[0-9+\-\s]+\z/, message: "can only contain numbers, dashes, and +"}
 
   validates :date_of_birth, presence: true, if: -> { !is_a_judge? && !is_a_mentor? && !is_chapter_ambassador? && !club_ambassador? }
-  validates :date_of_birth, presence: true, if: -> { is_a_judge? && new_record? }
+  validates :date_of_birth, presence: true, if: -> { is_a_judge? }
   validates :meets_minimum_age_requirement, inclusion: [true], if: -> { (is_a_judge? || is_a_mentor? || is_chapter_ambassador? || club_ambassador?) && new_record? }
-  validate :must_meet_minimum_age_requirement, if: -> { (is_a_judge? || is_chapter_ambassador? || club_ambassador?) && date_of_birth.present? && date_of_birth_changed? }
+  validate :must_meet_minimum_age_requirement, if: -> { (is_a_judge? || is_chapter_ambassador? || club_ambassador?) && date_of_birth.present? }
   validates :gender, presence: true, if: -> { not_student? }
 
   validate -> {

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -119,8 +119,9 @@ RSpec.describe Account do
             judge.account.reload
           end
 
-          it "is valid" do
-            expect(judge).to be_valid
+          it "is not valid" do
+            expect(judge.account).not_to be_valid
+            expect(judge.account.errors[:date_of_birth]).to include("can't be blank")
           end
         end
       end
@@ -394,6 +395,15 @@ RSpec.describe Account do
           judge.account.date_of_birth = (18.years.ago + 1.day).to_date
 
           expect(judge.account).not_to be_valid
+        end
+
+        it "is invalid when a stored under-18 birthdate is left unchanged" do
+          judge.account.update_column(:date_of_birth, 16.years.ago.to_date)
+          judge.account.reload
+
+          expect(judge.account).not_to be_valid
+          expect(judge.account.errors[:date_of_birth])
+            .to include("must indicate you are at least 18 years old")
         end
       end
 


### PR DESCRIPTION
## Summary
Closes #6142. Judges can no longer save a profile (on registration or profile edit) with a missing date of birth or a birthdate that makes them under 18.

- `app/models/account.rb`: date of birth is now required for all judge saves (not just new records), and the 18+ check runs whenever a judge/ambassador DOB is present (removed the `date_of_birth_changed?` guard so a stored under-18 date is also rejected on update).
- `app/javascript/controllers/minimum_age_controller.js`: validates DOB (required + 18+) on Save click, blocks the submit, and shows an inline error using the app's standard `.field_with_errors > .error` styling. Save stays enabled (consistent with first/last-name validation). `stopImmediatePropagation()` keeps jQuery UJS `data-disable-with` from leaving Save stuck disabled when submission is blocked.
- `spec/models/account_spec.rb`: existing-judge-without-DOB is now invalid; added a regression that a stored under-18 birthdate is invalid even when unchanged.

Note: the judge profile edit form already renders the server-side `date_of_birth` error via simple_form's default wrapper (same as first/last name), so no view change was needed.

## Test plan
- [x] `bundle exec rspec spec/models/account_spec.rb` (130 examples, 0 failures)
- [x] `bundle exec rspec spec/models/judge_profile_spec.rb spec/features/registration/judge_spec.rb spec/controllers/chapter_ambassador/mentor_to_judge_conversions_controller_spec.rb spec/features/club_ambassador/switch_to_judge_spec.rb spec/features/chapter_ambassador/switch_to_judge_spec.rb` (43 examples, 0 failures)
- [x] Manual: judge profile edit — empty DOB blocked ("Date of birth is required."), under-18 blocked ("You must be at least 18 years old.", Save stays clickable), valid adult DOB saves.