### PR TITLE
fix(6261): reduce N+1 on admin participant and chapter ambassador pages

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -127,7 +127,7 @@ module Admin
 
     def load_participant_for_show
       Account
-        .includes(
+        .preload(
           :division,
           :background_check,
           :consent_waiver,
@@ -139,7 +139,7 @@ module Admin
             mentor_profile: [
               :expertises,
               {mentor_profile_mentor_types: :mentor_type},
-              {current_teams: {mentors: :account}}
+              :current_teams
             ],
             judge_profile: [
               {judge_profile_judge_types: :judge_type},

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -7,10 +7,10 @@ module Admin
     use_datagrid with: AccountsGrid
 
     def show
-      @account = Account.find(params.fetch(:id))
+      @account = load_participant_for_show
       @teams = Team.current
-      @scores = submission_score
-      @recused_scores = recused_scores
+      @scores = submission_score.includes(team_submission: :team)
+      @recused_scores = recused_scores.includes(team_submission: :team)
       @season_flag = SeasonFlag.new(@account)
       @certificates = @account.current_certificates
       @needed_certificates = DetermineCertificates.new(@account).needed
@@ -123,6 +123,33 @@ module Admin
       else
         false
       end
+    end
+
+    def load_participant_for_show
+      Account
+        .includes(
+          :division,
+          :background_check,
+          :consent_waiver,
+          :current_certificates,
+          :certificates,
+          {chapterable_assignments: [:chapterable, :assignment_by]},
+          {
+            student_profile: [:parental_consent, :media_consent, :parental_consents, :current_teams],
+            mentor_profile: [
+              :expertises,
+              {mentor_profile_mentor_types: :mentor_type},
+              {current_teams: {mentors: :account}}
+            ],
+            judge_profile: [
+              {judge_profile_judge_types: :judge_type},
+              {judge_profile_technical_skills: :technical_skill}
+            ]
+          },
+          :chapter_ambassador_profile,
+          :club_ambassador_profile
+        )
+        .find(params.fetch(:id))
     end
 
     def submission_score

--- a/app/data_grids/chapter_ambassadors_grid.rb
+++ b/app/data_grids/chapter_ambassadors_grid.rb
@@ -3,9 +3,22 @@ class ChapterAmbassadorsGrid
 
   attr_accessor :admin, :allow_state_search
 
+  INDEX_PRELOADS = [
+    :background_check,
+    :mentor_profile,
+    {current_chapter_assignments: {chapterable: [:program_information, {legal_contact: :documents}]}},
+    {chapterable_assignments: :chapterable},
+    {
+      chapter_ambassador_profile: [
+        :volunteer_agreement,
+        {community_connection: {community_connection_availability_slots: :availability_slot}}
+      ]
+    }
+  ].freeze
+
   scope do
     Account
-      .includes(:chapter_ambassador_profile, :chapterable_assignments, :chapters)
+      .joins(:chapter_ambassador_profile)
       .where.not(chapter_ambassador_profiles: {id: nil})
       .order(id: :desc)
   end
@@ -41,7 +54,7 @@ class ChapterAmbassadorsGrid
   end
 
   column :seasons_assigned_to_a_chapter do |account|
-    account.chapterable_assignments.pluck(:season).uniq.sort.join(", ")
+    account.chapterable_assignments.map(&:season).uniq.sort.join(", ")
   end
 
   column :gender, header: "Gender Identity" do
@@ -81,9 +94,9 @@ class ChapterAmbassadorsGrid
   end
 
   column :availability do
-    availability_slots = chapter_ambassador_profile.community_connection&.community_connection_availability_slots
-    if availability_slots&.any?
-      availability_slots.joins(:availability_slot).pluck(:time).join(", ")
+    slots = chapter_ambassador_profile.community_connection&.community_connection_availability_slots
+    if slots&.any?
+      slots.filter_map { |slot| slot.availability_slot&.time }.join(", ")
     else
       "-"
     end
@@ -100,7 +113,7 @@ class ChapterAmbassadorsGrid
   column :remaining_chapter_ambassador_onboarding_tasks,
     preload: [
       chapter_ambassador_profile: [
-        :chapter_volunteer_agreement
+        :volunteer_agreement
       ]
     ] do
     chapter_ambassador_profile.incomplete_onboarding_tasks.to_sentence
@@ -118,7 +131,7 @@ class ChapterAmbassadorsGrid
     preload: [
       :background_check,
       chapter_ambassador_profile: [
-        :chapter_volunteer_agreement
+        :volunteer_agreement
       ]
     ] do
     chapter_ambassador_profile.complete_onboarding_tasks.to_sentence
@@ -352,4 +365,11 @@ class ChapterAmbassadorsGrid
     filter_group: "more-columns",
     multiple: true
   )
+
+  protected
+
+  def append_column_preload(relation)
+    relation = super(relation)
+    relation.preload(*INDEX_PRELOADS)
+  end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1139,7 +1139,7 @@ class Account < ActiveRecord::Base
   end
 
   def current_primary_chapter
-    current_chapter_assignments.find_by(primary: true)&.chapterable
+    primary_chapterable_assignment_from(current_chapter_assignments)&.chapterable
   end
 
   def assigned_to_club?
@@ -1151,7 +1151,7 @@ class Account < ActiveRecord::Base
   end
 
   def current_primary_club
-    current_club_assignments.find_by(primary: true)&.chapterable
+    primary_chapterable_assignment_from(current_club_assignments)&.chapterable
   end
 
   def current_chapterable_assignment
@@ -1159,7 +1159,8 @@ class Account < ActiveRecord::Base
   end
 
   def current_primary_chapterable_assignment
-    current_chapterable_assignments.find_by(primary: true) || ::NullChapterableAccountAssignment.new
+    primary_chapterable_assignment_from(current_chapterable_assignments) ||
+      ::NullChapterableAccountAssignment.new
   end
 
   def last_seasons_primary_chapterable_assignment
@@ -1205,6 +1206,14 @@ class Account < ActiveRecord::Base
   end
 
   private
+
+  def primary_chapterable_assignment_from(assignments)
+    if assignments.loaded?
+      assignments.find(&:primary?)
+    else
+      assignments.find_by(primary: true)
+    end
+  end
 
   def self.survey_reminder_max_times
     2

--- a/spec/performance/admin/chapter_ambassadors_index_benchmark_spec.rb
+++ b/spec/performance/admin/chapter_ambassadors_index_benchmark_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe "Admin::ChapterAmbassadorsController#index performance", type: :request do
+  # Baseline before optimization (local test DB, 5 chapter ambassadors):
+  #   Total SQL queries: 69
+  #   Render time: ~322ms
+  #   Per-row chapterable assignment queries: 30
+  #   Mentor profile queries: 0
+  #
+  # After optimization:
+  #   Total SQL queries: 20
+  #   Render time: ~221ms
+  #   Per-row chapterable assignment queries: 2
+  #   Mentor profile queries: 1
+
+  def count_sql_queries
+    queries = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next if payload[:name] == "SCHEMA"
+      next if payload[:sql].match?(/pg_|sqlite_|SAVEPOINT|RELEASE SAVEPOINT/)
+
+      queries << payload[:sql]
+    end
+
+    elapsed = Benchmark.realtime { yield }
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    {queries: queries, count: queries.size, elapsed: elapsed}
+  end
+
+  def chapterable_assignment_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "chapterable_account_assignments"/)
+    }
+  end
+
+  def mentor_profile_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "mentor_profiles"/)
+    }
+  end
+
+  before do
+    admin = FactoryBot.create(:admin)
+    sign_in(admin)
+
+    FactoryBot.create_list(:chapter_ambassador, 3)
+    FactoryBot.create(:chapter_ambassador, :has_mentor_profile)
+    FactoryBot.create(:chapter_ambassador, :has_mentor_profile)
+  end
+
+  describe "GET /admin/chapter_ambassadors" do
+    it "benchmarks index query count and render time" do
+      result = count_sql_queries do
+        get admin_chapter_ambassadors_path
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Admin chapter_ambassadors#index benchmark ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "Chapterable assignment queries: #{chapterable_assignment_queries(result[:queries])}"
+      puts "Mentor profile queries: #{mentor_profile_queries(result[:queries])}"
+
+      expect(chapterable_assignment_queries(result[:queries])).to be <= 6
+      expect(mentor_profile_queries(result[:queries])).to be <= 2
+      expect(result[:count]).to be <= 45
+    end
+
+    it "preloads associations when rendering grid rows" do
+      grid = ChapterAmbassadorsGrid.new(
+        admin: true,
+        allow_state_search: true,
+        country: [],
+        state_province: []
+      )
+
+      result = count_sql_queries do
+        assets = grid.assets.to_a
+        assets.each { |account| grid.row_for(account) }
+      end
+
+      expect(result[:count]).to be > 0
+      puts "\n--- ChapterAmbassadorsGrid row render ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Chapterable assignment queries: #{chapterable_assignment_queries(result[:queries])}"
+
+      expect(chapterable_assignment_queries(result[:queries])).to be <= 4
+    end
+  end
+end

--- a/spec/performance/admin/participants_show_benchmark_spec.rb
+++ b/spec/performance/admin/participants_show_benchmark_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe "Admin::ParticipantsController#show performance", type: :request do
+  # Baseline before optimization (local test DB):
+  #   Judge — Total SQL: 68, Render: ~3861ms, team_submission/team queries: 28
+  #   Student — Total SQL: 47, Render: ~261ms, chapterable queries: 13
+  #
+  # After optimization:
+  #   Judge — Total SQL: 51, Render: ~287ms, team_submission/team queries: 6
+  #   Student — Total SQL: 39, Render: ~199ms, chapterable queries: 14
+
+  def count_sql_queries
+    queries = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next if payload[:name] == "SCHEMA"
+      next if payload[:sql].match?(/pg_|sqlite_|SAVEPOINT|RELEASE SAVEPOINT/)
+
+      queries << payload[:sql]
+    end
+
+    elapsed = Benchmark.realtime { yield }
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    {queries: queries, count: queries.size, elapsed: elapsed}
+  end
+
+  def team_association_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "(team_submissions|teams)"/)
+    }
+  end
+
+  def chapterable_association_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "(chapterable_account_assignments|chapters|clubs)"/)
+    }
+  end
+
+  before do
+    admin = FactoryBot.create(:admin)
+    sign_in(admin)
+  end
+
+  describe "GET /admin/participants/:id (judge with scores)" do
+    let!(:judge) { FactoryBot.create(:judge, :onboarded) }
+
+    before do
+      8.times do
+        FactoryBot.create(:score, :complete, :quarterfinals, judge_profile: judge)
+      end
+
+      4.times do
+        FactoryBot.create(:score, :complete, :semifinals, judge_profile: judge)
+      end
+
+      2.times do
+        FactoryBot.create(
+          :score,
+          :quarterfinals,
+          judge_profile: judge,
+          judge_recusal: true,
+          judge_recusal_reason: "knows_team"
+        )
+      end
+    end
+
+    it "benchmarks show query count and render time" do
+      result = count_sql_queries do
+        get admin_participant_path(judge.account)
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Admin participants#show benchmark (judge) ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "Team/submission association queries: #{team_association_queries(result[:queries])}"
+
+      expect(team_association_queries(result[:queries])).to be <= 8
+      expect(result[:count]).to be <= 55
+    end
+  end
+
+  describe "GET /admin/participants/:id (student with chapter and team)" do
+    let(:chapter) { FactoryBot.create(:chapter) }
+    let(:co_mentor) { FactoryBot.create(:mentor, :onboarded) }
+    let!(:student) { FactoryBot.create(:student, :onboarded, :on_team, :not_assigned_to_chapter) }
+
+    before do
+      student.chapterable_assignments.create!(
+        account: student.account,
+        chapterable: chapter,
+        season: Season.current.year,
+        primary: true
+      )
+
+      team = student.team
+      TeamRosterManaging.add(team, co_mentor)
+    end
+
+    it "benchmarks show query count and render time" do
+      result = count_sql_queries do
+        get admin_participant_path(student.account)
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Admin participants#show benchmark (student) ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "Chapterable association queries: #{chapterable_association_queries(result[:queries])}"
+
+      expect(chapterable_association_queries(result[:queries])).to be <= 16
+      expect(result[:count]).to be <= 45
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix N+1 queries on `Admin::ParticipantsController#show` by preloading account associations (profiles, chapterable assignments, certificates) and preloading judge score `team_submission`/`team` data.
- Fix N+1 queries on `Admin::ChapterAmbassadorsController#index` via `ChapterAmbassadorsGrid` preloads, replacing per-row `pluck`/`joins` in column renderers, and using in-memory primary-assignment lookup on `Account` when associations are already loaded.
- Fix CI failure in `spec/features/admin/impersonation_spec.rb` by switching show preloads from `includes` to `preload` and dropping the nested `current_teams → mentors` preload (Team’s ordered `through` association generates invalid SQL when eager-loaded).

## Benchmark results (local test DB)

| Page | Total SQL (before → after) | Key metric |
|------|---------------------------|------------|
| Participants `#show` (judge) | 68 → 51 | team/submission queries: 28 → 6 |
| Participants `#show` (student) | 47 → 39 | chapterable queries: 13 → 14 |
| Chapter ambassadors `#index` | 69 → 20 | chapterable assignment queries: 30 → 2 |

## Test plan

- [x] `bundle exec rspec spec/performance/admin/participants_show_benchmark_spec.rb`
- [x] `bundle exec rspec spec/performance/admin/chapter_ambassadors_index_benchmark_spec.rb`
- [x] `bundle exec rspec spec/controllers/admin/participants_controller_spec.rb`
- [x] `bundle exec rspec spec/features/admin/impersonation_spec.rb`

Closes #6261