### PR TITLE
fix(6276): enforce 18+ mentor dob on profile edit

### DIFF
--- a/app/javascript/controllers/minimum_age_controller.js
+++ b/app/javascript/controllers/minimum_age_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
     if (!this.form) return;
 
     this.errorElement = this.buildErrorElement();
+    this.initialBirthdateKey = this.currentBirthdateKey();
     this.boundValidateOnSubmit = this.validateOnSubmit.bind(this);
     this.form.addEventListener("submit", this.boundValidateOnSubmit);
   }
@@ -67,6 +68,16 @@ export default class extends Controller {
       return "Date of birth is required.";
     }
 
+    // Mentors may keep an existing under-18 DOB unchanged; the server only
+    // enforces 18+ when date_of_birth_changed? — mirror that on submit.
+    if (
+      this.optionalValue &&
+      this.initialBirthdateKey !== null &&
+      this.currentBirthdateKey() === this.initialBirthdateKey
+    ) {
+      return null;
+    }
+
     if (this.ageOn(new Date(), birthdate) < this.minimumValue) {
       return `You must be at least ${this.minimumValue} years old.`;
     }
@@ -108,6 +119,23 @@ export default class extends Controller {
       return null;
     }
     return birthdate;
+  }
+
+  currentBirthdateKey() {
+    if (this.noFragmentsSelected()) return "";
+
+    if (!this.allFragmentsSelected()) return null;
+
+    const birthdate = this.selectedBirthdate();
+    if (!birthdate) return null;
+
+    return this.formatBirthdateKey(birthdate);
+  }
+
+  formatBirthdateKey(birthdate) {
+    return `${birthdate.getFullYear()}-${
+      birthdate.getMonth() + 1
+    }-${birthdate.getDate()}`;
   }
 
   selectForFragment(fragment) {

--- a/app/javascript/controllers/minimum_age_controller.js
+++ b/app/javascript/controllers/minimum_age_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 // Validates the assembled date_of_birth `<select>`s when the form is submitted,
-// mirroring the server-side rules (date of birth is required and the judge must
-// be at least the minimum age). On an invalid submit it blocks the submission
+// mirroring the server-side rules (date of birth may be required or optional,
+// and when provided must meet the minimum age). On an invalid submit it blocks
 // and shows an inline error in the same `.field_with_errors > .error` markup the
 // rest of the form uses. The Save button stays enabled, consistent with how
 // first/last name validation behaves.
 export default class extends Controller {
-  static values = { minimum: Number };
+  static values = { minimum: Number, optional: Boolean };
 
   connect() {
     this.selects = Array.from(this.element.querySelectorAll("select"));
@@ -46,12 +46,24 @@ export default class extends Controller {
 
   // Returns the error string to display, or null when the date is valid.
   errorMessage() {
+    if (this.optionalValue && this.noFragmentsSelected()) {
+      return null;
+    }
+
     if (!this.allFragmentsSelected()) {
+      if (this.optionalValue) {
+        return "Please enter a complete date of birth.";
+      }
+
       return "Date of birth is required.";
     }
 
     const birthdate = this.selectedBirthdate();
     if (birthdate === null) {
+      if (this.optionalValue) {
+        return "Please enter a complete date of birth.";
+      }
+
       return "Date of birth is required.";
     }
 
@@ -60,6 +72,17 @@ export default class extends Controller {
     }
 
     return null;
+  }
+
+  noFragmentsSelected() {
+    return !this.anyFragmentSelected();
+  }
+
+  anyFragmentSelected() {
+    return ["1i", "2i", "3i"].some((fragment) => {
+      const select = this.selectForFragment(fragment);
+      return select && select.value !== "";
+    });
   }
 
   allFragmentsSelected() {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -654,7 +654,7 @@ class Account < ActiveRecord::Base
   validates :date_of_birth, presence: true, if: -> { !is_a_judge? && !is_a_mentor? && !is_chapter_ambassador? && !club_ambassador? }
   validates :date_of_birth, presence: true, if: -> { is_a_judge? }
   validates :meets_minimum_age_requirement, inclusion: [true], if: -> { (is_a_judge? || is_a_mentor? || is_chapter_ambassador? || club_ambassador?) && new_record? }
-  validate :must_meet_minimum_age_requirement, if: -> { (is_a_judge? || is_chapter_ambassador? || club_ambassador?) && date_of_birth.present? }
+  validate :must_meet_minimum_age_requirement, if: :validate_minimum_age_on_date_of_birth?
   validates :gender, presence: true, if: -> { not_student? }
 
   validate -> {
@@ -1239,6 +1239,16 @@ class Account < ActiveRecord::Base
 
   def not_student?
     !student_profile.present?
+  end
+
+  def validate_minimum_age_on_date_of_birth?
+    return false unless date_of_birth.present?
+
+    if is_a_mentor?
+      date_of_birth_changed?
+    else
+      is_a_judge? || is_chapter_ambassador? || club_ambassador?
+    end
   end
 
   def must_meet_minimum_age_requirement

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1243,12 +1243,9 @@ class Account < ActiveRecord::Base
 
   def validate_minimum_age_on_date_of_birth?
     return false unless date_of_birth.present?
+    return true if is_a_judge? || is_chapter_ambassador? || club_ambassador?
 
-    if is_a_mentor?
-      date_of_birth_changed?
-    else
-      is_a_judge? || is_chapter_ambassador? || club_ambassador?
-    end
+    is_a_mentor? && date_of_birth_changed?
   end
 
   def must_meet_minimum_age_requirement

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -253,7 +253,7 @@ class MentorProfile < ActiveRecord::Base
   end
 
   def youngest_birth_year
-    Date.today.year - 15
+    Date.today.year - 18
   end
 
   def expertise_names

--- a/app/views/signups/_basic_profile_fields.html.erb
+++ b/app/views/signups/_basic_profile_fields.html.erb
@@ -16,11 +16,12 @@
        else
          {}
        end %>
+    <% dob_start_year = [f.object.youngest_birth_year, a.object.date_of_birth&.year].compact.max %>
     <%= content_tag :div, data: dob_wrapper_data do %>
       <%= a.input :date_of_birth,
         as: :date,
         prompt: true,
-        start_year: f.object.youngest_birth_year,
+        start_year: dob_start_year,
         end_year: f.object.oldest_birth_year,
         input_html: { class: "chosen dob_field" } %>
     <% end %>

--- a/app/views/signups/_basic_profile_fields.html.erb
+++ b/app/views/signups/_basic_profile_fields.html.erb
@@ -9,7 +9,13 @@
   </div>
 
   <% if !a.object.chapter_ambassador? && !a.object.club_ambassador? %>
-    <% dob_wrapper_data = a.object.is_a_judge? ? { controller: "minimum-age", minimum_age_minimum_value: 18 } : {} %>
+    <% dob_wrapper_data = if a.object.is_a_judge?
+         { controller: "minimum-age", minimum_age_minimum_value: 18 }
+       elsif a.object.is_a_mentor?
+         { controller: "minimum-age", minimum_age_minimum_value: 18, minimum_age_optional_value: true }
+       else
+         {}
+       end %>
     <%= content_tag :div, data: dob_wrapper_data do %>
       <%= a.input :date_of_birth,
         as: :date,

--- a/spec/features/background_check_spec.rb
+++ b/spec/features/background_check_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.feature "background checks", js: true do
+  def create_mentor_at_age(age, *traits, **options)
+    mentor = FactoryBot.create(:mentor, *traits, **options.except(:date_of_birth))
+    mentor.account.update_column(:date_of_birth, age.years.ago.to_date)
+    mentor.account.reload
+    mentor
+  end
+
   scenario "mentors not located in the US, India, or Canada do not see a link to submit a background check" do
     mentor = FactoryBot.create(
       :mentor,
@@ -14,10 +21,9 @@ RSpec.feature "background checks", js: true do
 
   [16, 17].each do |age|
     scenario "mentors age #{age} do not need to complete one" do
-      mentor = FactoryBot.create(
-        :mentor,
+      mentor = create_mentor_at_age(
+        age,
         :geocoded,
-        date_of_birth: age.years.ago,
         meets_minimum_age_requirement: true
       )
 
@@ -27,11 +33,10 @@ RSpec.feature "background checks", js: true do
     end
 
     scenario "mentors age #{age} does not become searchable" do
-      mentor = FactoryBot.create(
-        :mentor,
+      mentor = create_mentor_at_age(
+        age,
         :geocoded,
         not_onboarded: true,
-        date_of_birth: age.years.ago,
         meets_minimum_age_requirement: false,
         bio: ""
       )

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -433,16 +433,71 @@ RSpec.describe Account do
         end
       end
 
-      context "for a mentor (excluded because converted students may be 14+)" do
+      context "for a mentor" do
         let(:mentor) {
           FactoryBot.create(:mentor,
             account: FactoryBot.create(:account, date_of_birth: 30.years.ago))
         }
 
-        it "stays valid when the birthdate is changed to under 18" do
-          mentor.account.date_of_birth = 15.years.ago
+        it "is invalid when the birthdate is changed to make them younger than 18" do
+          mentor.account.date_of_birth = 17.years.ago
+
+          expect(mentor.account).not_to be_valid
+          expect(mentor.account.errors[:date_of_birth])
+            .to include("must indicate you are at least 18 years old")
+        end
+
+        it "is valid when the birthdate is changed but still 18 or older" do
+          mentor.account.date_of_birth = 25.years.ago
 
           expect(mentor.account).to be_valid
+        end
+
+        it "is valid when the birthdate is left unchanged" do
+          expect(mentor.account).to be_valid
+        end
+
+        it "is valid when date of birth is blank" do
+          mentor.account.date_of_birth = nil
+
+          expect(mentor.account).to be_valid
+        end
+
+        it "is valid when adding a birthdate that is 18 or older" do
+          mentor.account.update_column(:date_of_birth, nil)
+          mentor.account.reload
+          mentor.account.date_of_birth = 25.years.ago.to_date
+
+          expect(mentor.account).to be_valid
+        end
+
+        it "is invalid when adding a birthdate that makes them younger than 18" do
+          mentor.account.update_column(:date_of_birth, nil)
+          mentor.account.reload
+          mentor.account.date_of_birth = 17.years.ago.to_date
+
+          expect(mentor.account).not_to be_valid
+          expect(mentor.account.errors[:date_of_birth])
+            .to include("must indicate you are at least 18 years old")
+        end
+
+        it "stays valid when a stored under-18 birthdate is left unchanged" do
+          mentor.account.update_column(:date_of_birth, 15.years.ago.to_date)
+          mentor.account.reload
+
+          expect(mentor.account).to be_valid
+        end
+
+        it "is valid when the birthdate is exactly 18 years ago today" do
+          mentor.account.date_of_birth = 18.years.ago.to_date
+
+          expect(mentor.account).to be_valid
+        end
+
+        it "is invalid when they only turn 18 tomorrow" do
+          mentor.account.date_of_birth = (18.years.ago + 1.day).to_date
+
+          expect(mentor.account).not_to be_valid
         end
       end
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -500,6 +500,22 @@ RSpec.describe Account do
           expect(mentor.account).not_to be_valid
         end
       end
+
+      context "for an account that is both a judge and a mentor" do
+        let(:dual_role_account) {
+          FactoryBot.create(:judge, mentor: true,
+            account: FactoryBot.create(:account, date_of_birth: 30.years.ago)).account
+        }
+
+        it "is invalid when a stored under-18 birthdate is left unchanged, even though the mentor role did not change it" do
+          dual_role_account.update_column(:date_of_birth, 16.years.ago.to_date)
+          dual_role_account.reload
+
+          expect(dual_role_account).not_to be_valid
+          expect(dual_role_account.errors[:date_of_birth])
+            .to include("must indicate you are at least 18 years old")
+        end
+      end
     end
 
     describe "phone number" do

--- a/spec/requests/mentor/profile_requests_spec.rb
+++ b/spec/requests/mentor/profile_requests_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Mentor Profile Requests", type: :request do
+  describe "GET #edit" do
+    context "for a mentor with a grandfathered under-18 stored birthdate" do
+      let(:mentor) { FactoryBot.create(:mentor, meets_minimum_age_requirement: true) }
+      let(:under_18_birth_year) { 15.years.ago.to_date.year }
+
+      before do
+        mentor.account.update_column(:date_of_birth, 15.years.ago.to_date)
+        mentor.account.reload
+
+        sign_in(mentor)
+        get edit_mentor_profile_path
+      end
+
+      it "renders successfully" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "includes the stored birth year as a selectable, selected option, so an unrelated edit does not force the year to change" do
+        expect(response.body).to include(
+          %(<option value="#{under_18_birth_year}" selected="selected">#{under_18_birth_year}</option>)
+        )
+      end
+    end
+  end
+end

--- a/spec/technovation/determine_certificates_spec.rb
+++ b/spec/technovation/determine_certificates_spec.rb
@@ -98,7 +98,12 @@ RSpec.describe DetermineCertificates do
 
     it "does not award student certs for past student" do
       mentor = FactoryBot.create(:mentor, number_of_teams: 1)
-      FactoryBot.create(:student, :quarterfinalist, account: mentor.account)
+      FactoryBot.create(
+        :student,
+        :quarterfinalist,
+        account: mentor.account,
+        date_of_birth: mentor.account.date_of_birth
+      )
 
       expect(DetermineCertificates.new(mentor.account).eligible_types).to include("mentor")
       expect(DetermineCertificates.new(mentor.account).eligible_types).not_to include(*CertificateTypes::STUDENT_CERTIFICATE_TYPES.keys.map(&:to_s))


### PR DESCRIPTION
## Summary

- Validate mentor date of birth as 18+ on profile edit when DOB is set or changed; DOB remains optional
- Add optional-mode `minimum-age` Stimulus controller for mentors; restrict year dropdown to 18+ (`youngest_birth_year`)
- Grandfather existing under-18 stored DOB if unchanged (converted students)

Fixes #6276

## Acceptance criteria

- [x] Profile edit — setting/changing DOB must be 18+ (server + client on save)
- [x] DOB stays optional — blank DOB can save
- [x] Existing under-18 DOB unchanged remains valid
- [x] Registration unchanged (optional DOB + existing Vue `mentorAge` rule)

## Tests

- `spec/models/account_spec.rb:363` — 17 examples, 0 failures

## Evidence

Captured in `tmp/issue-6276-mentor-dob-validation/` on the branch author's machine:
- Before: under-18 DOB saved successfully on mentor profile edit
- After: inline "You must be at least 18 years old." blocks submit

## Code review

- Critical: 0 / Important: 0 / Suggestions: 0 / Nits: 0