### PR TITLE
Fix mentor certificate body text for 2026 certificates

### DIFF
--- a/lib/fill_pdfs/mentor.rb
+++ b/lib/fill_pdfs/mentor.rb
@@ -5,7 +5,7 @@ module FillPdfs
     include FillPdfs
 
     def full_text
-      "For their outstanding work as a Technovation Mentor in the #{recipient.season}  season. They supported Technovation Girls participants in finding a problem they were passionate about solving with technology, building the idea, testing it with users, and pitching to industry professionals . All while providing project management support, encouragement and contributing to participant’s sense of belonging in STEM. Their efforts are changing the world through technology."
+      "For their outstanding work as a Technovation Mentor in the #{recipient.season} season. They supported Technovation Girls participants in finding a problem they were passionate about solving with technology, building the idea, testing it with users, and pitching to industry professionals. All while providing project management support, encouragement and contributing to participant's sense of belonging in STEM. Their efforts are changing the world through technology."
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes extra spacing in the mentor certificate body text (`#{season}  season` → `#{season} season`, `professionals .` → `professionals.`)
- Normalizes the curly apostrophe in "participant's" to match other certificate classes (e.g. Coach)

## Acceptance criteria
- [x] Mentor certificate text uses correct spacing and punctuation
- [x] Mentor certificate apostrophe matches other certificate copy

## Tests
- `spec/lib/fill_pdfs_spec.rb` — copy-only change; no logic affected

## Code review
- Critical: 0
- Important: 0
- Suggestions: 0
- Nits: 0

## Files changed
- `lib/fill_pdfs/mentor.rb`

Made with [Cursor](https://cursor.com)