### PR TITLE
Add local postgres connection defaults

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,6 +16,8 @@
 #
 default: &default
   username: postgres
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { "postgres" } %>
+  host: localhost
   adapter: postgresql
   encoding: unicode
   # https://devcenter.heroku.com/articles/postgres-logs-errors#ruby-activerecord-and-prepared-statements
@@ -23,6 +25,7 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("DB_POOL_SIZE") { 5 } %>
+  gssencmode: disable
 
 development:
   <<: *default


### PR DESCRIPTION
## Summary
- Adds default `POSTGRES_PASSWORD`, `host: localhost`, and `gssencmode: disable` to the shared database config for local development.

## Test plan
- [ ] `rails db:migrate` connects successfully with local PostgreSQL

Made with [Cursor](https://cursor.com)