### PR TITLE
chore(6292): tighten ESLint quality gate to catch real bugs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,11 +31,11 @@
                 "varsIgnorePattern": "^_"
             }
         ],
-        "vue/multi-word-component-names": "off",
-        "vue/no-reserved-component-names": "off",
-        "vue/no-unused-components": "off",
-        "vue/require-prop-types": "off",
-        "vue/order-in-components": "off",
-        "vue/require-default-prop": "off"
+        "vue/multi-word-component-names": "error",
+        "vue/no-reserved-component-names": "error",
+        "vue/no-unused-components": "error",
+        "vue/require-prop-types": "error",
+        "vue/order-in-components": "error",
+        "vue/require-default-prop": "error"
     }
 }

--- a/app/javascript/admin/content-settings/components/AdminContentSettings.vue
+++ b/app/javascript/admin/content-settings/components/AdminContentSettings.vue
@@ -16,7 +16,7 @@
           :to="{ name: 'registration' }"
         >
           <button role="button" class="tabs__menu-button">
-            <icon
+            <app-icon
               v-if="judgingEnabled"
               name="exclamation-circle"
               :size="16"
@@ -54,7 +54,7 @@
           :to="{ name: 'teams_and_submissions' }"
         >
           <button role="button" class="tabs__menu-button">
-            <icon
+            <app-icon
               v-if="judgingEnabled"
               name="exclamation-circle"
               :size="16"
@@ -72,7 +72,7 @@
           :to="{ name: 'events' }"
         >
           <button role="button" class="tabs__menu-button">
-            <icon
+            <app-icon
               v-if="judgingEnabled"
               name="exclamation-circle"
               :size="16"
@@ -100,7 +100,7 @@
           :to="{ name: 'scores_and_certificates' }"
         >
           <button role="button" class="tabs__menu-button">
-            <icon
+            <app-icon
               v-if="judgingEnabled"
               name="exclamation-circle"
               :size="16"
@@ -145,14 +145,14 @@
 import Swal from "sweetalert2";
 import { mapGetters } from "vuex";
 
-import Icon from "components/Icon";
+import AppIcon from "components/AppIcon";
 import { isProduction } from "../../../utilities/utilities";
 
 export default {
   name: "AdminContentSettings",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {
@@ -169,6 +169,14 @@ export default {
     };
   },
 
+  computed: {
+    ...mapGetters(["judgingEnabled", "formData", "isSuperAdmin"]),
+
+    currentRoute() {
+      return this.$route.name;
+    },
+  },
+
   created() {
     this.$store
       .dispatch("init")
@@ -180,14 +188,6 @@ export default {
         this.isLoading = false;
         this.hasError = true;
       });
-  },
-
-  computed: {
-    ...mapGetters(["judgingEnabled", "formData", "isSuperAdmin"]),
-
-    currentRoute() {
-      return this.$route.name;
-    },
   },
 
   methods: {

--- a/app/javascript/admin/content-settings/components/Events.vue
+++ b/app/javascript/admin/content-settings/components/Events.vue
@@ -25,7 +25,7 @@
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint user-notice">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, regional pitch events cannot be created
     </div>
 
@@ -52,7 +52,7 @@
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint user-notice">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, regional pitch events cannot be selected
     </div>
 
@@ -73,13 +73,13 @@
 <script>
 import { mapGetters } from "vuex";
 
-import Icon from "components/Icon.vue";
+import AppIcon from "components/AppIcon.vue";
 
 export default {
   name: "EventsSection",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   computed: {

--- a/app/javascript/admin/content-settings/components/Judging.vue
+++ b/app/javascript/admin/content-settings/components/Judging.vue
@@ -10,7 +10,7 @@
         :disabled="!isSuperAdmin"
       />
       <label for="season_toggles_judging_round_off">Off</label>
-      <icon
+      <app-icon
         v-tooltip.right="'Before judging: Judges cannot judge'"
         name="question-circle"
         :size="16"
@@ -26,7 +26,7 @@
         :disabled="!isSuperAdmin"
       />
       <label for="season_toggles_judging_round_qf">Quarterfinals</label>
-      <icon
+      <app-icon
         v-tooltip.right="
           'Judges can now judge either virtually or their assigned submissions'
         "
@@ -44,7 +44,7 @@
         :disabled="!isSuperAdmin"
       />
       <label for="season_toggles_judging_round_between">Between rounds</label>
-      <icon
+      <app-icon
         v-tooltip.right="'Judges now see the &quot;between rounds&quot; screen'"
         name="question-circle"
         :size="16"
@@ -60,7 +60,7 @@
         :disabled="!isSuperAdmin"
       />
       <label for="season_toggles_judging_round_sf">Semifinals</label>
-      <icon
+      <app-icon
         v-tooltip.right="'Judges can now judge semifinals submissions'"
         name="question-circle"
         :size="16"
@@ -76,7 +76,7 @@
         :disabled="!isSuperAdmin"
       />
       <label for="season_toggles_judging_round_finished">Finished</label>
-      <icon
+      <app-icon
         v-tooltip.right="'After judging: judges cannot judge'"
         name="question-circle"
         :size="16"
@@ -94,7 +94,7 @@
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       Enabling judging has affected other season features.
     </div>
   </div>
@@ -104,13 +104,13 @@
 import { mapGetters } from "vuex";
 
 import "components/tooltip.scss";
-import Icon from "components/Icon";
+import AppIcon from "components/AppIcon";
 
 export default {
   name: "JudgingSection",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   computed: {

--- a/app/javascript/admin/content-settings/components/Registration.vue
+++ b/app/javascript/admin/content-settings/components/Registration.vue
@@ -27,7 +27,7 @@
         v-if="isRegistrationClosed(scope)"
         class="notice info hint user-notice"
       >
-        <icon name="exclamation-circle" :size="16" color="00529B" />
+        <app-icon name="exclamation-circle" :size="16" color="00529B" />
         When judging is enabled, {{ `${scope}s` }} cannot sign up
       </div>
     </div>
@@ -37,13 +37,13 @@
 <script>
 import { mapGetters } from "vuex";
 
-import Icon from "components/Icon.vue";
+import AppIcon from "components/AppIcon.vue";
 
 export default {
   name: "RegistrationSection",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   data() {

--- a/app/javascript/admin/content-settings/components/Review.vue
+++ b/app/javascript/admin/content-settings/components/Review.vue
@@ -240,6 +240,10 @@ export default {
     };
   },
 
+  computed: {
+    ...mapGetters(["judgingEnabled", "formData", "isSuperAdmin"]),
+  },
+
   methods: {
     isProduction,
 
@@ -252,10 +256,6 @@ export default {
         return "your local environment";
       }
     },
-  },
-
-  computed: {
-    ...mapGetters(["judgingEnabled", "formData", "isSuperAdmin"]),
   },
 };
 </script>

--- a/app/javascript/admin/content-settings/components/ScoresAndCertificates.vue
+++ b/app/javascript/admin/content-settings/components/ScoresAndCertificates.vue
@@ -25,7 +25,7 @@
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint user-notice">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, scores &amp; certificates cannot be displayed
     </div>
   </div>
@@ -34,13 +34,13 @@
 <script>
 import { mapGetters } from "vuex";
 
-import Icon from "components/Icon.vue";
+import AppIcon from "components/AppIcon.vue";
 
 export default {
   name: "ScoresAndCertificatesSection",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   computed: {

--- a/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
+++ b/app/javascript/admin/content-settings/components/TeamsAndSubmissions.vue
@@ -45,14 +45,14 @@
     </div>
 
     <p class="notice info hint">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       Please note that when the "Forming teams allowed" box is checked, students
       can invite people to register and join their team even if registration is
       closed.
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint user-notice">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, teams cannot be formed
     </div>
 
@@ -79,7 +79,7 @@
     </p>
 
     <div v-if="judgingEnabled" class="notice info hint user-notice">
-      <icon name="exclamation-circle" :size="16" color="00529B" />
+      <app-icon name="exclamation-circle" :size="16" color="00529B" />
       When judging is enabled, submissions cannot be edited
     </div>
   </div>
@@ -88,13 +88,13 @@
 <script>
 import { mapGetters } from "vuex";
 
-import Icon from "components/Icon.vue";
+import AppIcon from "components/AppIcon.vue";
 
 export default {
   name: "TeamsAndSubmissionsSection",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   computed: {

--- a/app/javascript/admin/dashboard/components/DashboardSection.vue
+++ b/app/javascript/admin/dashboard/components/DashboardSection.vue
@@ -3,16 +3,8 @@
 </template>
 
 <script>
-import BarChart from "@appjs/components/BarChart";
-import PieChart from "@appjs/components/PieChart";
-
 export default {
   name: "DashboardSection",
-
-  components: {
-    BarChart,
-    PieChart,
-  },
 
   props: {
     chartEndpoints: {

--- a/app/javascript/admin/dashboard/components/MentorsSection.vue
+++ b/app/javascript/admin/dashboard/components/MentorsSection.vue
@@ -35,9 +35,14 @@
 
 <script>
 import DashboardSection from "./DashboardSection";
+import PieChart from "@appjs/components/PieChart";
 
 export default {
   name: "MentorsSection",
+
+  components: {
+    PieChart,
+  },
 
   extends: DashboardSection,
 

--- a/app/javascript/admin/dashboard/components/StudentsSection.vue
+++ b/app/javascript/admin/dashboard/components/StudentsSection.vue
@@ -35,9 +35,14 @@
 
 <script>
 import DashboardSection from "./DashboardSection";
+import PieChart from "@appjs/components/PieChart";
 
 export default {
   name: "StudentsSection",
+
+  components: {
+    PieChart,
+  },
 
   extends: DashboardSection,
 

--- a/app/javascript/admin/dashboard/components/TopCountriesSection.vue
+++ b/app/javascript/admin/dashboard/components/TopCountriesSection.vue
@@ -19,9 +19,14 @@
 
 <script>
 import DashboardSection from "./DashboardSection";
+import BarChart from "@appjs/components/BarChart";
 
 export default {
   name: "TopCountriesSection",
+
+  components: {
+    BarChart,
+  },
 
   extends: DashboardSection,
 

--- a/app/javascript/chapter_ambassador/events/AttendeeFilter.vue
+++ b/app/javascript/chapter_ambassador/events/AttendeeFilter.vue
@@ -29,11 +29,11 @@
               <slot name="col-2" v-bind="item"></slot>
 
               <td v-show="!isAssigned(item, parentItem)" class="light-opacity">
-                <icon name="check-circle-o" />
+                <app-icon name="check-circle-o" />
               </td>
 
               <td v-show="isAssigned(item, parentItem)">
-                <icon name="check-circle" color="228b22" />
+                <app-icon name="check-circle" color="228b22" />
               </td>
             </tr>
           </tbody>
@@ -48,24 +48,53 @@
 </template>
 
 <script>
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 
 export default {
   name: "AttendeeList",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
-  props: [
-    "parentItem",
-    "childItems",
-    "placeholder",
-    "col2Header",
-    "handleSelection",
-    "handleClose",
-    "isAssigned",
-  ],
+  props: {
+    parentItem: {
+      type: Object,
+      default: null,
+    },
+
+    childItems: {
+      type: Array,
+      default() {
+        return [];
+      },
+    },
+
+    placeholder: {
+      type: String,
+      default: "",
+    },
+
+    col2Header: {
+      type: String,
+      default: "",
+    },
+
+    handleSelection: {
+      type: Function,
+      required: true,
+    },
+
+    handleClose: {
+      type: Function,
+      required: true,
+    },
+
+    isAssigned: {
+      type: Function,
+      required: true,
+    },
+  },
 
   data() {
     return {

--- a/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
+++ b/app/javascript/chapter_ambassador/events/AttendeeSearch.vue
@@ -31,7 +31,7 @@
           />
 
           <div v-show="fetching" class="align-center padding-small">
-            <icon class="spin" name="spinner" />
+            <app-icon class="spin" name="spinner" />
           </div>
 
           <div v-show="!fetching && !items.length" class="padding-small">
@@ -60,11 +60,11 @@
                     v-tooltip="selectionDisabledTooltip"
                     class="light-opacity"
                   >
-                    <icon name="check-circle-o" />
+                    <app-icon name="check-circle-o" />
                   </td>
 
                   <td v-show="item.selected">
-                    <icon name="check-circle" color="228b22" />
+                    <app-icon name="check-circle" color="228b22" />
                   </td>
                 </tr>
               </tbody>
@@ -87,18 +87,25 @@ import axios from "axios";
 import debounce from "lodash/debounce";
 
 import { airbrake } from "utilities/utilities";
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import Attendee from "./Attendee";
 import EventBus from "../../components/EventBus";
 
 export default {
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {
-    addBtnText: String,
-    searchPlaceholder: String,
+    addBtnText: {
+      type: String,
+      default: "",
+    },
+
+    searchPlaceholder: {
+      type: String,
+      default: "",
+    },
     handleSelection: {
       type: Function,
       required: true,

--- a/app/javascript/chapter_ambassador/events/EventForm.vue
+++ b/app/javascript/chapter_ambassador/events/EventForm.vue
@@ -22,7 +22,7 @@
             <input v-model="event.name" type="text" />
           </label>
 
-          <errors :errors="eventErrors.name"></errors>
+          <form-errors :errors="eventErrors.name"></form-errors>
         </div>
 
         <div class="grid__col-sm-6">
@@ -58,7 +58,7 @@
             Beginner division
           </label>
 
-          <errors :errors="eventErrors.division_ids"></errors>
+          <form-errors :errors="eventErrors.division_ids"></form-errors>
         </div>
 
         <div class="grid__col-sm-6">
@@ -67,7 +67,7 @@
             <input v-model="event.city" type="text" />
           </label>
 
-          <errors :errors="eventErrors.city"></errors>
+          <form-errors :errors="eventErrors.city"></form-errors>
         </div>
 
         <div class="grid__col-sm-6">
@@ -76,7 +76,7 @@
             <input v-model="event.venue_address" type="text" />
           </label>
 
-          <errors :errors="eventErrors.venue_address"></errors>
+          <form-errors :errors="eventErrors.venue_address"></form-errors>
         </div>
 
         <div class="grid__col-sm-6">
@@ -85,7 +85,7 @@
             <datetime-input v-model="eventDate" :options="dateOpts" />
           </label>
 
-          <errors :errors="eventErrors.date"></errors>
+          <form-errors :errors="eventErrors.date"></form-errors>
         </div>
 
         <div class="grid__col-6">
@@ -103,7 +103,7 @@
             />
           </label>
 
-          <errors :errors="eventErrors.starts_at"></errors>
+          <form-errors :errors="eventErrors.starts_at"></form-errors>
 
           <label id="event-end-time">
             To
@@ -113,7 +113,7 @@
             />
           </label>
 
-          <errors :errors="eventErrors.ends_at"></errors>
+          <form-errors :errors="eventErrors.ends_at"></form-errors>
         </div>
 
         <div class="grid__col-sm-6">
@@ -127,7 +127,7 @@
             <integer-input v-model="event.capacity" input-name="capacity" />
           </label>
 
-          <errors :errors="eventErrors.capacity"></errors>
+          <form-errors :errors="eventErrors.capacity"></form-errors>
         </div>
 
         <div class="grid__col-12">
@@ -136,7 +136,7 @@
             <input v-model="event.event_link" type="text" />
           </label>
 
-          <errors :errors="eventErrors.event_link"></errors>
+          <form-errors :errors="eventErrors.event_link"></form-errors>
           <p>
             <input
               type="submit"
@@ -156,7 +156,7 @@
 import axios from "axios";
 
 import DatetimeInput from "../../components/DatetimeInput";
-import Errors from "../../components/Errors";
+import FormErrors from "../../components/FormErrors";
 import EventBus from "../../components/EventBus";
 import IntegerInput from "components/IntegerInput";
 
@@ -168,20 +168,47 @@ export default {
   name: "EventForm",
 
   components: {
-    Errors,
+    FormErrors,
     DatetimeInput,
     IntegerInput,
   },
 
-  props: [
-    "postUrl",
-    "beginnerDivisionId",
-    "beginnerDivisionName",
-    "juniorDivisionId",
-    "juniorDivisionName",
-    "seniorDivisionId",
-    "seniorDivisionName",
-  ],
+  props: {
+    postUrl: {
+      type: String,
+      required: true,
+    },
+
+    beginnerDivisionId: {
+      type: [String, Number],
+      required: true,
+    },
+
+    beginnerDivisionName: {
+      type: String,
+      required: true,
+    },
+
+    juniorDivisionId: {
+      type: [String, Number],
+      required: true,
+    },
+
+    juniorDivisionName: {
+      type: String,
+      required: true,
+    },
+
+    seniorDivisionId: {
+      type: [String, Number],
+      required: true,
+    },
+
+    seniorDivisionName: {
+      type: String,
+      required: true,
+    },
+  },
 
   data() {
     return {

--- a/app/javascript/chapter_ambassador/events/EventJudgeList.vue
+++ b/app/javascript/chapter_ambassador/events/EventJudgeList.vue
@@ -11,7 +11,7 @@
       v-if="fetchingList"
       class="grid__col-12 grid--justify-center grid__col--bleed-y"
     >
-      <icon name="spinner" class-name="spin" />
+      <app-icon name="spinner" class-name="spin" />
       Initating judge management...
     </div>
 
@@ -27,7 +27,7 @@
             class="button button--small button--remove-bg"
             @click="exportList"
           >
-            <icon name="download" size="16" />
+            <app-icon name="download" size="16" />
             Export to CSV
           </button>
         </p>
@@ -56,14 +56,14 @@
           >
             <td>
               <div v-if="judge.hovering" class="attendee-list__actions">
-                <icon
+                <app-icon
                   name="remove"
                   size="16"
                   color="ff0000"
                   :handle-click="removeJudge.bind(this, judge)"
                 />
 
-                <icon
+                <app-icon
                   v-if="event.teamListIsTooLong()"
                   name="flag"
                   size="16"
@@ -153,14 +153,35 @@
 </template>
 
 <script>
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import EventBus from "../../components/EventBus";
 
 import JudgeSearch from "./JudgeSearch";
 import AttendeeFilter from "./AttendeeFilter";
 
 export default {
-  props: ["fetchUrl", "saveAssignmentsUrl", "event"],
+  components: {
+    JudgeSearch,
+    AppIcon,
+    AttendeeFilter,
+  },
+
+  props: {
+    fetchUrl: {
+      type: String,
+      required: true,
+    },
+
+    saveAssignmentsUrl: {
+      type: String,
+      required: true,
+    },
+
+    event: {
+      type: Object,
+      required: true,
+    },
+  },
   data() {
     return {
       fetchingList: true,
@@ -322,12 +343,6 @@ export default {
         },
       });
     },
-  },
-
-  components: {
-    JudgeSearch,
-    Icon,
-    AttendeeFilter,
   },
 };
 </script>

--- a/app/javascript/chapter_ambassador/events/EventTeamList.vue
+++ b/app/javascript/chapter_ambassador/events/EventTeamList.vue
@@ -11,7 +11,7 @@
       v-if="fetchingList"
       class="grid__col-12 grid--justify-center grid__col--bleed-y"
     >
-      <icon name="spinner" class-name="spin" />
+      <app-icon name="spinner" class-name="spin" />
       Initating team management...
     </div>
 
@@ -27,7 +27,7 @@
             class="button button--small button--remove-bg"
             @click="exportList"
           >
-            <icon name="download" size="16" />
+            <app-icon name="download" size="16" />
             Export to CSV
           </button>
         </p>
@@ -57,14 +57,14 @@
           >
             <td>
               <div v-if="team.hovering" class="attendee-list__actions">
-                <icon
+                <app-icon
                   name="remove"
                   size="16"
                   color="ff0000"
                   :handle-click="removeTeam.bind(this, team)"
                 />
 
-                <icon
+                <app-icon
                   v-if="event.teamListIsTooLong()"
                   name="gavel"
                   size="16"
@@ -150,7 +150,7 @@
 </template>
 
 <script>
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import EventBus from "../../components/EventBus";
 
 import TeamSearch from "./TeamSearch";
@@ -158,12 +158,27 @@ import AttendeeFilter from "./AttendeeFilter";
 
 export default {
   components: {
-    Icon,
+    AppIcon,
     TeamSearch,
     AttendeeFilter,
   },
 
-  props: ["fetchUrl", "saveAssignmentsUrl", "event"],
+  props: {
+    fetchUrl: {
+      type: String,
+      required: true,
+    },
+
+    saveAssignmentsUrl: {
+      type: String,
+      required: true,
+    },
+
+    event: {
+      type: Object,
+      required: true,
+    },
+  },
   data() {
     return {
       fetchingList: true,

--- a/app/javascript/chapter_ambassador/events/EventsTable.vue
+++ b/app/javascript/chapter_ambassador/events/EventsTable.vue
@@ -50,7 +50,7 @@
           <div class="grid__col-3 text-align--right">
             <div class="grid__cell">
               <template v-if="managingAttendanceEnabled">
-                <icon
+                <app-icon
                   v-tooltip.top-center="editEventTeamsMsg"
                   alt="edit teams"
                   title="Manage teams"
@@ -62,7 +62,7 @@
                   "
                 />
 
-                <icon
+                <app-icon
                   v-tooltip.top-center="editEventJudgesMsg"
                   alt="edit judges"
                   title="Manage judges"
@@ -75,7 +75,7 @@
                 />
               </template>
 
-              <icon
+              <app-icon
                 v-tooltip.top-center="`Print for live event`"
                 alt="print"
                 class-name="events-list__action-item"
@@ -84,7 +84,7 @@
                 :handle-click="goToPrintUrl.bind(this, event)"
               />
 
-              <icon
+              <app-icon
                 v-tooltip.top-center="`Edit event`"
                 alt="edit"
                 class-name="events-list__action-item"
@@ -93,7 +93,7 @@
                 :handle-click="editEvent.bind(this, event)"
               />
 
-              <icon
+              <app-icon
                 v-tooltip.top-center="`Delete event`"
                 alt="remove"
                 class-name="events-list__action-item"
@@ -131,7 +131,7 @@
 </template>
 
 <script>
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import EventBus from "../../components/EventBus";
 
 import Event from "./Event";
@@ -144,18 +144,45 @@ export default {
   components: {
     EventJudgeList,
     EventTeamList,
-    Icon,
+    AppIcon,
   },
 
-  props: [
-    "fetchUrl",
-    "saveAssignmentsUrl",
-    "judgesListUrl",
-    "searchJudgesUrl",
-    "teamsListUrl",
-    "searchTeamsUrl",
-    "manageAttendees",
-  ],
+  props: {
+    fetchUrl: {
+      type: String,
+      required: true,
+    },
+
+    saveAssignmentsUrl: {
+      type: String,
+      required: true,
+    },
+
+    judgesListUrl: {
+      type: String,
+      required: true,
+    },
+
+    searchJudgesUrl: {
+      type: String,
+      required: true,
+    },
+
+    teamsListUrl: {
+      type: String,
+      required: true,
+    },
+
+    searchTeamsUrl: {
+      type: String,
+      required: true,
+    },
+
+    manageAttendees: {
+      type: String,
+      default: "true",
+    },
+  },
 
   data() {
     return {

--- a/app/javascript/chapter_ambassador/events/JudgeSearch.vue
+++ b/app/javascript/chapter_ambassador/events/JudgeSearch.vue
@@ -42,7 +42,17 @@ export default {
     AttendeeSearch,
   },
 
-  props: ["eventBusId", "event"],
+  props: {
+    eventBusId: {
+      type: String,
+      required: true,
+    },
+
+    event: {
+      type: Object,
+      required: true,
+    },
+  },
 
   methods: {
     handleSelection(item) {

--- a/app/javascript/chapter_ambassador/events/TeamSearch.vue
+++ b/app/javascript/chapter_ambassador/events/TeamSearch.vue
@@ -45,7 +45,17 @@ export default {
     AttendeeSearch,
   },
 
-  props: ["eventBusId", "event"],
+  props: {
+    eventBusId: {
+      type: String,
+      required: true,
+    },
+
+    event: {
+      type: Object,
+      required: true,
+    },
+  },
 
   methods: {
     handleSelection(item) {

--- a/app/javascript/components/AppIcon.vue
+++ b/app/javascript/components/AppIcon.vue
@@ -10,13 +10,37 @@
 
 <script>
 export default {
+  name: "AppIcon",
   props: {
-    alt: String,
-    title: String,
-    className: String,
-    name: String,
-    color: String,
-    size: [String, Number],
+    alt: {
+      type: String,
+      default: "",
+    },
+
+    title: {
+      type: String,
+      default: "",
+    },
+
+    className: {
+      type: String,
+      default: "",
+    },
+
+    name: {
+      type: String,
+      default: "",
+    },
+
+    color: {
+      type: String,
+      default: "",
+    },
+
+    size: {
+      type: [String, Number],
+      default: "",
+    },
 
     handleClick: {
       type: Function,

--- a/app/javascript/components/BarChart.vue
+++ b/app/javascript/components/BarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bar-chart">
     <div v-if="loading">
-      <icon class="spin" name="spinner" size="16" />
+      <app-icon class="spin" name="spinner" size="16" />
 
       <span>Loading chart...</span>
     </div>
@@ -14,7 +14,7 @@
 import Chart from "chart.js";
 import chroma from "chroma-js";
 
-import Icon from "./Icon.vue";
+import AppIcon from "./AppIcon.vue";
 import "../utilities/chartjs-plugins";
 import { isEmptyObject } from "../utilities/utilities";
 
@@ -22,7 +22,7 @@ export default {
   name: "BarChart",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/components/DashboardHeader.vue
+++ b/app/javascript/components/DashboardHeader.vue
@@ -67,7 +67,6 @@
 import { createNamespacedHelpers } from "vuex";
 
 import DropDown from "components/DropDown";
-import Icon from "components/Icon";
 
 const { mapGetters } = createNamespacedHelpers("authenticated");
 
@@ -76,7 +75,6 @@ export default {
 
   components: {
     DropDown,
-    Icon,
   },
 
   props: {

--- a/app/javascript/components/DatetimeInput.vue
+++ b/app/javascript/components/DatetimeInput.vue
@@ -8,7 +8,19 @@ import flatpickr from "flatpickr";
 export default {
   name: "FlatpickrInput",
 
-  props: ["value", "options"],
+  props: {
+    value: {
+      type: String,
+      default: "",
+    },
+
+    options: {
+      type: Object,
+      default() {
+        return {};
+      },
+    },
+  },
 
   data() {
     return {

--- a/app/javascript/components/DropDown.vue
+++ b/app/javascript/components/DropDown.vue
@@ -2,7 +2,12 @@
   <div v-click-outside="collapseDropDown" class="drop-down">
     <a @click.stop.prevent="toggleCollapse">
       {{ label }}
-      <icon :title="caretTitle" :name="caretIcon" color="000000" :size="12" />
+      <app-icon
+        :title="caretTitle"
+        :name="caretIcon"
+        color="000000"
+        :size="12"
+      />
     </a>
     <transition name="collapse">
       <div v-show="expanded" class="drop-down__content">
@@ -13,7 +18,7 @@
 </template>
 
 <script>
-import Icon from "components/Icon";
+import AppIcon from "components/AppIcon";
 import ClickOutside from "directives/click-outside";
 
 export default {
@@ -24,7 +29,7 @@ export default {
   },
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/components/FormErrors.vue
+++ b/app/javascript/components/FormErrors.vue
@@ -8,6 +8,12 @@
 
 <script>
 export default {
-  props: ["errors"],
+  name: "FormErrors",
+  props: {
+    errors: {
+      type: Array,
+      default: null,
+    },
+  },
 };
 </script>

--- a/app/javascript/components/IntegerInput.vue
+++ b/app/javascript/components/IntegerInput.vue
@@ -25,7 +25,10 @@ export default {
       default: 0,
     },
 
-    maximum: Number,
+    maximum: {
+      type: Number,
+      default: null,
+    },
   },
 
   data() {

--- a/app/javascript/components/PieChart.vue
+++ b/app/javascript/components/PieChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="pie-chart">
     <div v-if="loading">
-      <icon class="spin" name="spinner" size="16" />
+      <app-icon class="spin" name="spinner" size="16" />
 
       <span>Loading chart...</span>
     </div>
@@ -14,7 +14,7 @@
 import Chart from "chart.js";
 import chroma from "chroma-js";
 
-import Icon from "./Icon.vue";
+import AppIcon from "./AppIcon.vue";
 import "../utilities/chartjs-plugins";
 import { isEmptyObject } from "../utilities/utilities";
 
@@ -22,7 +22,7 @@ export default {
   name: "PieChart",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/components/job_process/template.vue
+++ b/app/javascript/components/job_process/template.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div :class="['status', statusClass]">
-      <icon v-if="showLoading" name="spinner" size="16" class="spin" />
+      <app-icon v-if="showLoading" name="spinner" size="16" class="spin" />
       {{ statusMsg }}
     </div>
 
@@ -13,11 +13,11 @@
 
 <script>
 import { urlHelpers } from "utilities/utilities";
-import Icon from "../Icon";
+import AppIcon from "../AppIcon";
 
 export default {
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/components/job_process_rebrand/template.vue
+++ b/app/javascript/components/job_process_rebrand/template.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col items-center">
     <div :class="['mb-4 p-4 text-2xl ', statusClass]">
-      <icon v-if="showLoading" name="spinner" size="16" class="spin" />
+      <app-icon v-if="showLoading" name="spinner" size="16" class="spin" />
       {{ statusMsg }}
     </div>
 
@@ -15,11 +15,11 @@
 
 <script>
 import { urlHelpers } from "utilities/utilities";
-import Icon from "../Icon";
+import AppIcon from "../AppIcon";
 
 export default {
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/components/rebrand/EnergeticContainer.vue
+++ b/app/javascript/components/rebrand/EnergeticContainer.vue
@@ -14,6 +14,12 @@
 <script>
 export default {
   name: "EnergeticContainer",
-  props: ["heading"],
+
+  props: {
+    heading: {
+      type: String,
+      required: true,
+    },
+  },
 };
 </script>

--- a/app/javascript/dashboard/components/DashboardEvents.vue
+++ b/app/javascript/dashboard/components/DashboardEvents.vue
@@ -2,8 +2,8 @@
   <div class="tabs tabs--vertical tabs--css-only grid">
     <div class="tabs__content grid__col-12 tabs__content--embedded">
       <div class="grid">
-        <div class="grid__col-12">
-          <slot name="scores" />
+        <div class="grid__col-8">
+          <slot name="events" />
         </div>
       </div>
     </div>
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: "Scores",
+  name: "DashboardEvents",
 };
 </script>

--- a/app/javascript/dashboard/components/DashboardEventsRebrand.vue
+++ b/app/javascript/dashboard/components/DashboardEventsRebrand.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <slot name="scores" />
+    <slot name="events" />
   </div>
 </template>
 
 <script>
 export default {
-  name: "Scores",
+  name: "DashboardEventsRebrand",
 };
 </script>

--- a/app/javascript/dashboard/components/DashboardScores.vue
+++ b/app/javascript/dashboard/components/DashboardScores.vue
@@ -2,8 +2,8 @@
   <div class="tabs tabs--vertical tabs--css-only grid">
     <div class="tabs__content grid__col-12 tabs__content--embedded">
       <div class="grid">
-        <div class="grid__col-8">
-          <slot name="events" />
+        <div class="grid__col-12">
+          <slot name="scores" />
         </div>
       </div>
     </div>
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: "Events",
+  name: "DashboardScores",
 };
 </script>

--- a/app/javascript/dashboard/components/DashboardScoresRebrand.vue
+++ b/app/javascript/dashboard/components/DashboardScoresRebrand.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <slot name="scores" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: "DashboardScoresRebrand",
+};
+</script>

--- a/app/javascript/dashboard/components/DashboardSubmission.vue
+++ b/app/javascript/dashboard/components/DashboardSubmission.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: "Submission",
+  name: "DashboardSubmission",
 };
 </script>

--- a/app/javascript/dashboard/components/DashboardSubmissionRebrand.vue
+++ b/app/javascript/dashboard/components/DashboardSubmissionRebrand.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: "Submission",
+  name: "DashboardSubmissionRebrand",
 };
 </script>

--- a/app/javascript/judge/components/GenericJudgingContainer.vue
+++ b/app/javascript/judge/components/GenericJudgingContainer.vue
@@ -40,13 +40,6 @@ import { mapState } from "vuex";
 import { getJudgingRubricLink } from "../../utilities/judge-helpers";
 
 export default {
-  computed: {
-    ...mapState(["submission", "team"]),
-
-    rubricLink() {
-      return getJudgingRubricLink(this.team.division);
-    },
-  },
   name: "GenericJudgingContainer",
   components: {
     TeamInfo,
@@ -54,6 +47,33 @@ export default {
     EnergeticContainer,
     ThickRule,
   },
-  props: ["heading", "section", "nextSection", "prevSection"],
+  props: {
+    heading: {
+      type: String,
+      required: true,
+    },
+
+    section: {
+      type: String,
+      required: true,
+    },
+
+    nextSection: {
+      type: String,
+      default: null,
+    },
+
+    prevSection: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    ...mapState(["submission", "team"]),
+
+    rubricLink() {
+      return getJudgingRubricLink(this.team.division);
+    },
+  },
 };
 </script>

--- a/app/javascript/judge/dashboards/scores/FinishedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/FinishedScoresList.vue
@@ -117,20 +117,6 @@
 import { mapGetters } from "vuex";
 
 export default {
-  computed: {
-    ...mapGetters(["finishedQuarterfinalsScores", "finishedSemifinalsScores"]),
-
-    scores() {
-      switch (this.round) {
-        case "quarterfinals":
-          return this.finishedQuarterfinalsScores;
-        case "semifinals":
-          return this.finishedSemifinalsScores;
-        default:
-          return [];
-      }
-    },
-  },
   props: {
     title: {
       type: String,
@@ -144,6 +130,20 @@ export default {
     scoresEditable: {
       type: Boolean,
       default: true,
+    },
+  },
+  computed: {
+    ...mapGetters(["finishedQuarterfinalsScores", "finishedSemifinalsScores"]),
+
+    scores() {
+      switch (this.round) {
+        case "quarterfinals":
+          return this.finishedQuarterfinalsScores;
+        case "semifinals":
+          return this.finishedSemifinalsScores;
+        default:
+          return [];
+      }
     },
   },
 };

--- a/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
+++ b/app/javascript/judge/dashboards/scores/NotStartedScoresList.vue
@@ -115,10 +115,6 @@
 import { mapGetters } from "vuex";
 
 export default {
-  computed: {
-    ...mapGetters(["notStartedSubmissions"]),
-  },
-
   props: {
     title: {
       type: String,
@@ -132,6 +128,10 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  computed: {
+    ...mapGetters(["notStartedSubmissions"]),
   },
 
   methods: {

--- a/app/javascript/judge/scores/JudgeRecusalPopup.vue
+++ b/app/javascript/judge/scores/JudgeRecusalPopup.vue
@@ -15,10 +15,6 @@ import Swal from "sweetalert2";
 import { mapState } from "vuex";
 
 export default {
-  computed: {
-    ...mapState(["score"]),
-  },
-
   props: {
     cssClass: {
       type: String,
@@ -32,6 +28,10 @@ export default {
       type: Number,
       default: 0,
     },
+  },
+
+  computed: {
+    ...mapState(["score"]),
   },
 
   methods: {

--- a/app/javascript/judge/scores/QuestionSection.vue
+++ b/app/javascript/judge/scores/QuestionSection.vue
@@ -78,27 +78,36 @@ import ScoreEntry from "./ScoreEntry";
 export default {
   name: "QuestionSection",
 
+  components: {
+    ScoreEntry,
+  },
+
+  props: {
+    nextSection: {
+      type: String,
+      default: null,
+    },
+
+    prevSection: {
+      type: String,
+      default: null,
+    },
+
+    section: {
+      type: String,
+      required: true,
+    },
+
+    solo: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
   data() {
     return {
       commentInitiated: false,
     };
-  },
-
-  watch: {
-    commentText() {
-      this.$nextTick(() => {
-        this.$store.commit("setComment", {
-          sectionName: this.section,
-          word_count: this.wordCount,
-        });
-
-        this.debouncedCommentWatcher();
-      });
-    },
-
-    commentStorageKey() {
-      this.initiateComment();
-    },
   },
 
   computed: {
@@ -176,20 +185,31 @@ export default {
     },
   },
 
-  components: {
-    ScoreEntry,
-  },
+  watch: {
+    commentText() {
+      this.$nextTick(() => {
+        this.$store.commit("setComment", {
+          sectionName: this.section,
+          word_count: this.wordCount,
+        });
 
-  props: ["nextSection", "prevSection", "section", "solo"],
+        this.debouncedCommentWatcher();
+      });
+    },
 
-  mounted() {
-    if (this.submission.id) this.initiateComment();
+    commentStorageKey() {
+      this.initiateComment();
+    },
   },
 
   created() {
     this.debouncedCommentWatcher = debounce(() => {
       this.handleCommentChange();
     }, 500);
+  },
+
+  mounted() {
+    if (this.submission.id) this.initiateComment();
   },
 
   methods: {

--- a/app/javascript/judge/scores/ScoreEntry.vue
+++ b/app/javascript/judge/scores/ScoreEntry.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="!questions.length" class="loading">
-    <icon name="spinner" class-name="spin" />
+    <app-icon name="spinner" class-name="spin" />
     <div>Loading questions...</div>
   </div>
 
@@ -62,17 +62,22 @@
 </template>
 
 <script>
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import { mapState } from "vuex";
 
 export default {
-  computed: mapState(["team"]),
-
   components: {
-    Icon,
+    AppIcon,
   },
 
-  props: ["questions"],
+  props: {
+    questions: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  computed: mapState(["team"]),
 
   methods: {
     updateScores(question, score) {

--- a/app/javascript/judge/scores/ScoreStepperItem.vue
+++ b/app/javascript/judge/scores/ScoreStepperItem.vue
@@ -91,6 +91,7 @@ export default {
     sectionScore: {
       type: String,
       required: false,
+      default: "",
     },
     showSectionProgress: {
       type: Boolean,

--- a/app/javascript/judge/scores/SubmissionOverview.vue
+++ b/app/javascript/judge/scores/SubmissionOverview.vue
@@ -20,7 +20,12 @@
         </p>
         <p>
           <span
-            ><icon size="16" name="map-marker" class="inline" color="0075cf" />
+            ><app-icon
+              size="16"
+              name="map-marker"
+              class="inline"
+              color="0075cf"
+            />
             {{ team.location | capitalize }}</span
           >
         </p>
@@ -91,12 +96,18 @@ import { mapState } from "vuex";
 
 import JudgeRecusalPopup from "./JudgeRecusalPopup";
 import JudgeRecusalExceededPopup from "./JudgeRecusalExceededPopup";
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import ThickRule from "../../components/rebrand/ThickRule";
 import { getJudgingRubricLink } from "../../utilities/judge-helpers";
 import { getFilestackResizeUrl } from "../../utilities/filestack-helpers";
 
 export default {
+  components: {
+    AppIcon,
+    JudgeRecusalPopup,
+    JudgeRecusalExceededPopup,
+    ThickRule,
+  },
   data() {
     return {
       devPlatform: null,
@@ -126,12 +137,6 @@ export default {
     maximumNumberOfRecusals() {
       return process.env.JUDGE_MAXIMUM_NUMBER_OF_RECUSALS;
     },
-  },
-  components: {
-    Icon,
-    JudgeRecusalPopup,
-    JudgeRecusalExceededPopup,
-    ThickRule,
   },
 };
 </script>

--- a/app/javascript/judge/scores/TeamInfo.vue
+++ b/app/javascript/judge/scores/TeamInfo.vue
@@ -19,13 +19,18 @@
         </p>
         <p class="mt-4">
           <span
-            ><icon size="20" name="map-marker" class="inline" color="0075cf" />
+            ><app-icon
+              size="20"
+              name="map-marker"
+              class="inline"
+              color="0075cf"
+            />
             {{ team.location | capitalize }}</span
           >
         </p>
         <p>
           <span
-            ><icon size="18" name="file-o" class="inline" color="0075cf" />
+            ><app-icon size="18" name="file-o" class="inline" color="0075cf" />
             <a :href="rubricLink" class="tw-link-magenta" target="_blank"
               >View</a
             >
@@ -42,10 +47,13 @@ import { mapState } from "vuex";
 import { getJudgingRubricLink } from "../../utilities/judge-helpers";
 import { getFilestackResizeUrl } from "../../utilities/filestack-helpers";
 
-import JudgeRecusalPopup from "./JudgeRecusalPopup";
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 
 export default {
+  components: {
+    AppIcon,
+  },
+
   computed: {
     ...mapState(["team", "score", "submission", "deadline"]),
 
@@ -62,11 +70,6 @@ export default {
     filestackResizeUrl() {
       return getFilestackResizeUrl(this.team.photo, 300);
     },
-  },
-
-  components: {
-    Icon,
-    JudgeRecusalPopup,
   },
 };
 </script>

--- a/app/javascript/judge/scores/index.js
+++ b/app/javascript/judge/scores/index.js
@@ -26,7 +26,12 @@ document.addEventListener("turbo:load", () => {
       router,
       store,
 
-      props: ["scoreId"],
+      props: {
+        scoreId: {
+          type: [String, Number],
+          default: null,
+        },
+      },
 
       data: {
         notice: "",

--- a/app/javascript/judge/scores/pieces/BusinessSection.vue
+++ b/app/javascript/judge/scores/pieces/BusinessSection.vue
@@ -7,7 +7,7 @@
         class="text-energetic-blue text-3xl"
         @click="trackBusinessPlanDownload"
       >
-        <Icon name="file-o" class="inline" color="0075cf" />
+        <AppIcon name="file-o" class="inline" color="0075cf" />
         Read the <span>{{ documentType }}</span>
       </a>
     </template>
@@ -20,9 +20,13 @@
 
 <script>
 import { mapState } from "vuex";
-import Icon from "../../../components/Icon";
+import AppIcon from "../../../components/AppIcon";
 
 export default {
+  name: "BusinessSection",
+  components: {
+    AppIcon,
+  },
   computed: {
     ...mapState(["score", "submission", "team"]),
 
@@ -36,9 +40,6 @@ export default {
           return "";
       }
     },
-  },
-  components: {
-    Icon,
   },
   methods: {
     async trackBusinessPlanDownload() {

--- a/app/javascript/judge/scores/pieces/DemoVideoLink.vue
+++ b/app/javascript/judge/scores/pieces/DemoVideoLink.vue
@@ -7,7 +7,7 @@
         :data-modal-fetch="submission.demo_video_url"
         class="text-energetic-blue flex text-3xl"
       >
-        <icon name="play-circle-o" color="0075cf" />
+        <app-icon name="play-circle-o" color="0075cf" />
         Watch the {{ demo_video() }}
       </a>
     </p>
@@ -25,15 +25,15 @@
 <script>
 import { mapState } from "vuex";
 
-import Icon from "../../../components/Icon";
+import AppIcon from "../../../components/AppIcon";
 import { i18n } from "../../../utilities/i18n.js";
 
 export default {
-  computed: mapState(["score", "submission"]),
-
   components: {
-    Icon,
+    AppIcon,
   },
+
+  computed: mapState(["score", "submission"]),
 
   methods: {
     demo_video() {

--- a/app/javascript/judge/scores/pieces/PitchVideoLink.vue
+++ b/app/javascript/judge/scores/pieces/PitchVideoLink.vue
@@ -7,7 +7,7 @@
         :data-modal-fetch="submission.pitch_video_url"
         class="text-energetic-blue flex text-3xl"
       >
-        <Icon name="play-circle-o" color="0075cf" />
+        <AppIcon name="play-circle-o" color="0075cf" />
         Watch the pitch video
       </a>
     </p>
@@ -25,13 +25,13 @@
 <script>
 import { mapState } from "vuex";
 
-import Icon from "../../../components/Icon";
+import AppIcon from "../../../components/AppIcon";
 
 export default {
-  computed: mapState(["score", "submission"]),
-
   components: {
-    Icon,
+    AppIcon,
   },
+
+  computed: mapState(["score", "submission"]),
 };
 </script>

--- a/app/javascript/judge/scores/pieces/SourceCode.vue
+++ b/app/javascript/judge/scores/pieces/SourceCode.vue
@@ -8,7 +8,7 @@
         class="text-energetic-blue text-lg flex"
         @click="trackSourceCodeDownload"
       >
-        <icon name="code" color="0075cf" />
+        <app-icon name="code" color="0075cf" />
         <span class="self-center"
           >{{ submission.source_code_url_label }} (optional)</span
         >
@@ -21,7 +21,7 @@
         class="text-energetic-blue text-lg flex"
         @click="trackSourceCodeDownload"
       >
-        <icon name="code" color="0075cf" />
+        <app-icon name="code" color="0075cf" />
         <span class="self-center"
           >Download the source code for this project (optional)</span
         >
@@ -32,14 +32,15 @@
 
 <script>
 import { mapState } from "vuex";
-import Icon from "../../../components/Icon";
+import AppIcon from "../../../components/AppIcon";
 
 export default {
-  computed: mapState(["score", "submission"]),
-
+  name: "SourceCode",
   components: {
-    Icon,
+    AppIcon,
   },
+
+  computed: mapState(["score", "submission"]),
 
   methods: {
     async trackSourceCodeDownload() {

--- a/app/javascript/judge/scores/pieces/SubmissionScreenshots.vue
+++ b/app/javascript/judge/scores/pieces/SubmissionScreenshots.vue
@@ -24,6 +24,7 @@ import { mapState } from "vuex";
 import { getFilestackResizeUrl } from "../../../utilities/filestack-helpers";
 
 export default {
+  name: "SubmissionScreenshots",
   computed: {
     ...mapState(["submission"]),
     screenshots() {

--- a/app/javascript/judge/scores/routes.js
+++ b/app/javascript/judge/scores/routes.js
@@ -1,28 +1,28 @@
 import VueRouter from "vue-router";
 
-import Overview from "./sections/Overview";
+import OverviewSection from "./sections/OverviewSection";
 import ProjectDetails from "./sections/ProjectDetails";
-import Ideation from "./sections/Ideation";
-import Pitch from "./sections/Pitch";
-import Demo from "./sections/Demo";
-import Entrepreneurship from "./sections/Entrepreneurship";
+import IdeationSection from "./sections/IdeationSection";
+import PitchSection from "./sections/PitchSection";
+import DemoSection from "./sections/DemoSection";
+import EntrepreneurshipSection from "./sections/EntrepreneurshipSection";
 import ReviewScore from "./sections/ReviewScore";
 
 export const routes = [
   { path: "/", redirect: { name: "overview" } },
-  { path: "/overview", name: "overview", component: Overview },
+  { path: "/overview", name: "overview", component: OverviewSection },
   {
     path: "/project-details",
     name: "project_details",
     component: ProjectDetails,
   },
-  { path: "/ideation", name: "ideation", component: Ideation },
-  { path: "/pitch", name: "pitch", component: Pitch },
-  { path: "/demo", name: "demo", component: Demo },
+  { path: "/ideation", name: "ideation", component: IdeationSection },
+  { path: "/pitch", name: "pitch", component: PitchSection },
+  { path: "/demo", name: "demo", component: DemoSection },
   {
     path: "/entrepreneurship",
     name: "entrepreneurship",
-    component: Entrepreneurship,
+    component: EntrepreneurshipSection,
   },
   { path: "/review-score", name: "review-score", component: ReviewScore },
 ];

--- a/app/javascript/judge/scores/sections/DemoSection.vue
+++ b/app/javascript/judge/scores/sections/DemoSection.vue
@@ -8,7 +8,7 @@
     >
       <template #main-content>
         <DemoVideoLink />
-        <Code />
+        <SourceCode />
       </template>
     </GenericJudgingContainer>
   </div>
@@ -19,9 +19,16 @@ import { mapState } from "vuex";
 
 import GenericJudgingContainer from "../../components/GenericJudgingContainer";
 import DemoVideoLink from "../pieces/DemoVideoLink";
-import Code from "../pieces/Code";
+import SourceCode from "../pieces/SourceCode";
 
 export default {
+  name: "DemoSection",
+  components: {
+    GenericJudgingContainer,
+    DemoVideoLink,
+    SourceCode,
+  },
+
   computed: {
     ...mapState(["team", "submission"]),
 
@@ -30,12 +37,6 @@ export default {
         ? "entrepreneurship"
         : "ideation";
     },
-  },
-
-  components: {
-    GenericJudgingContainer,
-    DemoVideoLink,
-    Code,
   },
 };
 </script>

--- a/app/javascript/judge/scores/sections/EntrepreneurshipSection.vue
+++ b/app/javascript/judge/scores/sections/EntrepreneurshipSection.vue
@@ -9,7 +9,7 @@
       next-section="ideation"
     >
       <template #main-content>
-        <business />
+        <BusinessSection />
       </template>
     </GenericJudgingContainer>
   </div>
@@ -18,14 +18,15 @@
 <script>
 import { mapState } from "vuex";
 
-import Business from "../pieces/Business";
+import BusinessSection from "../pieces/BusinessSection";
 import GenericJudgingContainer from "../../components/GenericJudgingContainer";
 
 export default {
-  computed: mapState(["submission", "team"]),
+  name: "EntrepreneurshipSection",
   components: {
-    Business,
+    BusinessSection,
     GenericJudgingContainer,
   },
+  computed: mapState(["submission", "team"]),
 };
 </script>

--- a/app/javascript/judge/scores/sections/IdeationSection.vue
+++ b/app/javascript/judge/scores/sections/IdeationSection.vue
@@ -35,7 +35,7 @@
             target="_blank"
             class="text-energetic-blue"
           >
-            <Icon name="file-o" class="inline text-sm" color="0075cf" />
+            <AppIcon name="file-o" class="inline text-sm" color="0075cf" />
             View the bibliography
           </a>
         </div>
@@ -47,7 +47,7 @@
           Click image to expand. Enlarged images may be pixelated. Please focus
           on the content of the images rather than the photo quality.
         </p>
-        <Screenshots />
+        <SubmissionScreenshots />
       </template>
     </GenericJudgingContainer>
   </div>
@@ -56,11 +56,17 @@
 <script>
 import { mapState } from "vuex";
 import GenericJudgingContainer from "../../components/GenericJudgingContainer";
-import Template from "../../../components/job_process/template";
-import Screenshots from "../pieces/Screenshots";
-import Icon from "../../../components/Icon.vue";
+import SubmissionScreenshots from "../pieces/SubmissionScreenshots";
+import AppIcon from "../../../components/AppIcon.vue";
 
 export default {
+  name: "IdeationSection",
+  components: {
+    AppIcon,
+    GenericJudgingContainer,
+    SubmissionScreenshots,
+  },
+
   computed: {
     ...mapState(["team", "submission"]),
     prevSection() {
@@ -68,13 +74,6 @@ export default {
         ? "entrepreneurship"
         : "demo";
     },
-  },
-
-  components: {
-    Icon,
-    GenericJudgingContainer,
-    Template,
-    Screenshots,
   },
 };
 </script>

--- a/app/javascript/judge/scores/sections/OverviewSection.vue
+++ b/app/javascript/judge/scores/sections/OverviewSection.vue
@@ -2,7 +2,7 @@
   <div>
     <EnergeticContainer heading="Overview">
       <div v-if="!submission.id" class="loading">
-        <icon name="spinner" class-name="spin" />
+        <app-icon name="spinner" class-name="spin" />
         <div>Loading the submission... Happy Judging!</div>
       </div>
       <div v-else>
@@ -14,21 +14,20 @@
 
 <script>
 import { mapState } from "vuex";
-import Icon from "../../../components/Icon";
+import AppIcon from "../../../components/AppIcon";
 
 import EnergeticContainer from "../../../components/rebrand/EnergeticContainer";
 import SubmissionOverview from "../SubmissionOverview";
-import JudgeRecusalPopup from "../JudgeRecusalPopup";
 
 export default {
-  computed: {
-    ...mapState(["team", "score", "submission"]),
-  },
+  name: "OverviewSection",
   components: {
-    Icon,
+    AppIcon,
     EnergeticContainer,
     SubmissionOverview,
-    JudgeRecusalPopup,
+  },
+  computed: {
+    ...mapState(["team", "score", "submission"]),
   },
 };
 </script>

--- a/app/javascript/judge/scores/sections/PitchSection.vue
+++ b/app/javascript/judge/scores/sections/PitchSection.vue
@@ -24,17 +24,18 @@ import GenericJudgingContainer from "../../components/GenericJudgingContainer";
 import PitchVideoLink from "../pieces/PitchVideoLink";
 
 export default {
+  name: "PitchSection",
+  components: {
+    GenericJudgingContainer,
+    PitchVideoLink,
+  },
+
   computed: {
     ...mapState(["team", "submission"]),
 
     nextSection() {
       return this.team.division === "senior" ? "entrepreneurship" : "overall";
     },
-  },
-
-  components: {
-    GenericJudgingContainer,
-    PitchVideoLink,
   },
 };
 </script>

--- a/app/javascript/judge/scores/sections/ProjectDetails.vue
+++ b/app/javascript/judge/scores/sections/ProjectDetails.vue
@@ -30,14 +30,12 @@
 import { mapState } from "vuex";
 
 import GenericJudgingContainer from "../../components/GenericJudgingContainer";
-import Template from "../../../components/job_process/template";
 
 export default {
-  computed: mapState(["submission"]),
-
   components: {
     GenericJudgingContainer,
-    Template,
   },
+
+  computed: mapState(["submission"]),
 };
 </script>

--- a/app/javascript/mentor/DashboardMenu.vue
+++ b/app/javascript/mentor/DashboardMenu.vue
@@ -24,7 +24,7 @@
     >
       Build your Team
       <div v-if="teamPagesActive" slot="subnav" class="tabs-menu__child-menu">
-        <team-menu />
+        <mentor-team />
       </div>
     </tab-link>
 
@@ -77,7 +77,7 @@ const { mapGetters } = createNamespacedHelpers("authenticated");
 import TabLink from "tabs/components/TabLink";
 
 import RegistrationMenu from "registration/DashboardMenu";
-import TeamMenu from "./menus/Team";
+import MentorTeam from "./menus/MentorTeam";
 
 export default {
   name: "DashboardMenu",
@@ -85,7 +85,7 @@ export default {
   components: {
     TabLink,
     RegistrationMenu,
-    TeamMenu,
+    MentorTeam,
   },
 
   mixins: [menuMixin, tooltipsMixin],

--- a/app/javascript/mentor/components/TeamBuilding.vue
+++ b/app/javascript/mentor/components/TeamBuilding.vue
@@ -16,7 +16,7 @@
         v-sticky-sidebar="stickySidebarClasses"
         class="tabs-menu__child-menu"
       >
-        <team-menu />
+        <mentor-team />
       </div>
     </div>
   </div>
@@ -24,7 +24,7 @@
 
 <script>
 import StickySidebar from "directives/sticky-sidebar";
-import TeamMenu from "mentor/menus/Team";
+import MentorTeam from "mentor/menus/MentorTeam";
 
 export default {
   name: "TeamBuilding",
@@ -34,7 +34,7 @@ export default {
   },
 
   components: {
-    TeamMenu,
+    MentorTeam,
   },
 
   props: {

--- a/app/javascript/mentor/menus/MentorTeam.vue
+++ b/app/javascript/mentor/menus/MentorTeam.vue
@@ -71,6 +71,7 @@ const { mapGetters } = createNamespacedHelpers("authenticated");
 import TabLink from "tabs/components/TabLink";
 
 export default {
+  name: "MentorTeam",
   components: {
     TabLink,
   },

--- a/app/javascript/mentor/routes/index.js
+++ b/app/javascript/mentor/routes/index.js
@@ -3,9 +3,9 @@ import VueRouter from "vue-router";
 
 import RegistrationApp from "registration/App";
 import TeamBuilding from "mentor/components/TeamBuilding";
-import Submission from "dashboard/components/Submission";
-import Scores from "dashboard/components/Scores";
-import Events from "dashboard/components/Events";
+import DashboardSubmission from "dashboard/components/DashboardSubmission";
+import DashboardScores from "dashboard/components/DashboardScores";
+import DashboardEvents from "dashboard/components/DashboardEvents";
 
 import store from "../store";
 
@@ -37,9 +37,9 @@ const loadOrRedirect = (to, from, next) => {
 
 export const getRootComponent = () => {
   if (canDisplayScores()) {
-    return Scores;
+    return DashboardScores;
   } else if (anyCurrentTeams()) {
-    return Submission;
+    return DashboardSubmission;
   } else {
     return TeamBuilding;
   }
@@ -114,7 +114,7 @@ export const routes = [
   {
     path: "/submission",
     name: "submission",
-    component: Submission,
+    component: DashboardSubmission,
     props: {
       stickySidebarClasses: ["grid__col-3"],
     },
@@ -127,7 +127,7 @@ export const routes = [
   {
     path: "/events",
     name: "events",
-    component: Events,
+    component: DashboardEvents,
     beforeEnter: loadOrRedirect,
     meta: {
       routeId: "events",
@@ -137,7 +137,7 @@ export const routes = [
   {
     path: "/scores",
     name: "scores",
-    component: Scores,
+    component: DashboardScores,
     props: {
       stickySidebarClasses: ["grid__col-3"],
     },

--- a/app/javascript/new_registration/App.vue
+++ b/app/javascript/new_registration/App.vue
@@ -1,27 +1,27 @@
 <template>
   <div id="home" class="home">
-    <Navbar />
-    <Banner />
+    <RegistrationNavbar />
+    <RegistrationBanner />
     <FormWrapper />
     <div id="thick-rule" class="bg-energetic-blue h-6 my-16"></div>
     <ContactUs />
-    <Footer />
+    <RegistrationFooter />
   </div>
 </template>
 
 <script>
-import Navbar from "./components/Navbar";
-import Banner from "./components/Banner";
-import Footer from "./components/Footer";
+import RegistrationNavbar from "./components/RegistrationNavbar";
+import RegistrationBanner from "./components/RegistrationBanner";
+import RegistrationFooter from "./components/RegistrationFooter";
 import ContactUs from "./components/ContactUs";
 import FormWrapper from "./components/FormWrapper";
 
 export default {
   name: "App",
   components: {
-    Navbar,
-    Banner,
-    Footer,
+    RegistrationNavbar,
+    RegistrationBanner,
+    RegistrationFooter,
     ContactUs,
     FormWrapper,
   },

--- a/app/javascript/new_registration/components/ContainerHeader.vue
+++ b/app/javascript/new_registration/components/ContainerHeader.vue
@@ -10,7 +10,10 @@
 export default {
   name: "ContainerHeader",
   props: {
-    headerText: String,
+    headerText: {
+      type: String,
+      default: "",
+    },
   },
 };
 </script>

--- a/app/javascript/new_registration/components/Header.vue
+++ b/app/javascript/new_registration/components/Header.vue
@@ -1,9 +1,0 @@
-<template>
-  <h1>here is a header</h1>
-</template>
-
-<script>
-export default {
-  name: "Header",
-};
-</script>

--- a/app/javascript/new_registration/components/RegistrationBanner.vue
+++ b/app/javascript/new_registration/components/RegistrationBanner.vue
@@ -5,3 +5,9 @@
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  name: "RegistrationBanner",
+};
+</script>

--- a/app/javascript/new_registration/components/RegistrationFooter.vue
+++ b/app/javascript/new_registration/components/RegistrationFooter.vue
@@ -7,6 +7,7 @@
 
 <script>
 export default {
+  name: "RegistrationFooter",
   data() {
     return {
       currentYear: new Date().getFullYear(),

--- a/app/javascript/new_registration/components/RegistrationHeader.vue
+++ b/app/javascript/new_registration/components/RegistrationHeader.vue
@@ -1,11 +1,9 @@
 <template>
-  <div>
-    <slot name="events" />
-  </div>
+  <h1>here is a header</h1>
 </template>
 
 <script>
 export default {
-  name: "Events",
+  name: "RegistrationHeader",
 };
 </script>

--- a/app/javascript/new_registration/components/RegistrationNavbar.vue
+++ b/app/javascript/new_registration/components/RegistrationNavbar.vue
@@ -127,7 +127,7 @@
 
 <script>
 export default {
-  name: "Navbar",
+  name: "RegistrationNavbar",
   methods: {
     toggleMenu() {
       const menu = document.querySelector(".mobile-menu");

--- a/app/javascript/registration/App.vue
+++ b/app/javascript/registration/App.vue
@@ -77,13 +77,6 @@ export default {
     };
   },
 
-  beforeMount() {
-    let pathname = window.location.pathname;
-    if (pathname === "/signup") {
-      this.isSignup = true;
-    }
-  },
-
   computed: {
     ...mapState(["isReady"]),
 
@@ -118,6 +111,13 @@ export default {
 
       return undefined;
     },
+  },
+
+  beforeMount() {
+    let pathname = window.location.pathname;
+    if (pathname === "/signup") {
+      this.isSignup = true;
+    }
   },
 };
 </script>

--- a/app/javascript/registration/DashboardMenu.vue
+++ b/app/javascript/registration/DashboardMenu.vue
@@ -97,10 +97,6 @@ export default {
     TabLink,
   },
 
-  created() {
-    this.Tooltips = Tooltips;
-  },
-
   computed: {
     ...mapState(["termsAgreed", "termsAgreedDate", "profileChoice"]),
 
@@ -147,6 +143,10 @@ export default {
 
       return "";
     },
+  },
+
+  created() {
+    this.Tooltips = Tooltips;
   },
 };
 </script>

--- a/app/javascript/registration/components/BasicProfile.vue
+++ b/app/javascript/registration/components/BasicProfile.vue
@@ -185,24 +185,6 @@ export default {
     };
   },
 
-  created() {
-    this.debouncedProfileUpdate = debounce((attributes) => {
-      if (this.embedded) {
-        this.saving = true;
-        this.saved = false;
-      }
-
-      this.updateBasicProfile(attributes).then(() => {
-        if (this.embedded) {
-          this.saving = false;
-          this.saved = true;
-        }
-      });
-    }, 500);
-
-    this.getExpertiseOptions();
-  },
-
   computed: {
     ...mapState(["profileChoice"]),
 
@@ -373,6 +355,24 @@ export default {
     referredByOther(value) {
       this.debouncedProfileUpdate({ referredByOther: value });
     },
+  },
+
+  created() {
+    this.debouncedProfileUpdate = debounce((attributes) => {
+      if (this.embedded) {
+        this.saving = true;
+        this.saved = false;
+      }
+
+      this.updateBasicProfile(attributes).then(() => {
+        if (this.embedded) {
+          this.saving = false;
+          this.saved = true;
+        }
+      });
+    }, 500);
+
+    this.getExpertiseOptions();
   },
 
   methods: {

--- a/app/javascript/registration/components/EmailInput.vue
+++ b/app/javascript/registration/components/EmailInput.vue
@@ -18,7 +18,7 @@
 
     <div v-if="emailNeedsValidation" class="text-align--center">
       Checking this email...<br />
-      <icon name="spinner" class="spin" />
+      <app-icon name="spinner" class="spin" />
     </div>
 
     <template v-if="problemsWithInput">
@@ -62,7 +62,7 @@
 <script>
 import { createNamespacedHelpers } from "vuex";
 
-import Icon from "../../components/Icon";
+import AppIcon from "../../components/AppIcon";
 import debounce from "lodash/debounce";
 
 const { mapActions } = createNamespacedHelpers("registration");
@@ -71,7 +71,7 @@ export default {
   name: "EmailInput",
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {

--- a/app/javascript/registration/components/LoginForm.vue
+++ b/app/javascript/registration/components/LoginForm.vue
@@ -32,7 +32,7 @@ import PasswordInput from "./PasswordInput";
 const { mapState, mapGetters } = createNamespacedHelpers("registration");
 
 export default {
-  name: "Login",
+  name: "LoginForm",
 
   components: {
     EmailInput,

--- a/app/javascript/registration/components/RegistrationLocation.vue
+++ b/app/javascript/registration/components/RegistrationLocation.vue
@@ -19,16 +19,10 @@ import LocationForm from "location/components/LocationForm";
 const { mapActions, mapState } = createNamespacedHelpers("registration");
 
 export default {
-  name: "Location",
+  name: "RegistrationLocation",
 
   components: {
     LocationForm,
-  },
-
-  created() {
-    this.debouncedLocationUpdate = debounce((newLocation) => {
-      this.updateLocation(newLocation);
-    }, 500);
   },
 
   computed: {
@@ -45,6 +39,22 @@ export default {
     },
   },
 
+  watch: {
+    locationData(newLocation, oldLocation) {
+      const locationChanged = Object.keys(newLocation).some((key) => {
+        return newLocation[key] !== oldLocation[key];
+      });
+
+      if (locationChanged) this.debouncedLocationUpdate(newLocation);
+    },
+  },
+
+  created() {
+    this.debouncedLocationUpdate = debounce((newLocation) => {
+      this.updateLocation(newLocation);
+    }, 500);
+  },
+
   methods: {
     ...mapActions(["updateLocation"]),
 
@@ -54,16 +64,6 @@ export default {
 
     handleConfirm() {
       this.$router.push({ name: "age" });
-    },
-  },
-
-  watch: {
-    locationData(newLocation, oldLocation) {
-      const locationChanged = Object.keys(newLocation).some((key) => {
-        return newLocation[key] !== oldLocation[key];
-      });
-
-      if (locationChanged) this.debouncedLocationUpdate(newLocation);
     },
   },
 };

--- a/app/javascript/registration/routes/index.js
+++ b/app/javascript/registration/routes/index.js
@@ -3,14 +3,14 @@ import VueRouter from "vue-router";
 
 import store from "../store";
 
-import Location from "../components/Location";
+import RegistrationLocation from "../components/RegistrationLocation";
 
 import AgeVerification from "../components/AgeVerification";
 import ChooseProfile from "../components/ChooseProfile";
 
 import BasicProfile from "../components/BasicProfile";
 
-import Login from "../components/Login";
+import LoginForm from "../components/LoginForm";
 import ChangeEmail from "../components/ChangeEmail";
 import ChangePassword from "../components/ChangePassword";
 
@@ -81,7 +81,7 @@ export const routes = [
   {
     path: "/region",
     name: "location",
-    component: Location,
+    component: RegistrationLocation,
     meta: {
       browserTitle: "Step 2: Region",
     },
@@ -105,7 +105,7 @@ export const routes = [
   {
     path: "/signin",
     name: "login",
-    component: Login,
+    component: LoginForm,
     meta: {
       browserTitle: "Final step: Sign In",
     },

--- a/app/javascript/tabs/components/TabLink.vue
+++ b/app/javascript/tabs/components/TabLink.vue
@@ -7,7 +7,7 @@
     :to="to"
   >
     <button v-tooltip="tooltipContent" :class="buttonClasses">
-      <icon
+      <app-icon
         :name="completedEnabledOrDisabledIcon"
         size="16"
         :color="activeEnabledOrDisabledColor"
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import Icon from "components/Icon";
+import AppIcon from "components/AppIcon";
 
 import { VTooltip } from "v-tooltip";
 
@@ -33,7 +33,7 @@ export default {
   },
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {
@@ -54,11 +54,13 @@ export default {
     },
 
     conditionToComplete: {
+      type: Boolean,
       required: false,
       default: false,
     },
 
     conditionToEnable: {
+      type: Boolean,
       required: false,
       default: false,
     },

--- a/app/javascript/tabs/components/TabLinkRebrand.vue
+++ b/app/javascript/tabs/components/TabLinkRebrand.vue
@@ -7,7 +7,7 @@
   >
     <div class="w-full text-left">
       <button v-tooltip="tooltipContent" class="flex">
-        <icon
+        <app-icon
           :name="completedEnabledOrDisabledIcon"
           size="16"
           :color="activeEnabledOrDisabledColor"
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import Icon from "components/Icon";
+import AppIcon from "components/AppIcon";
 
 import { VTooltip } from "v-tooltip";
 
@@ -35,7 +35,7 @@ export default {
   },
 
   components: {
-    Icon,
+    AppIcon,
   },
 
   props: {
@@ -56,11 +56,13 @@ export default {
     },
 
     conditionToComplete: {
+      type: Boolean,
       required: false,
       default: false,
     },
 
     conditionToEnable: {
+      type: Boolean,
       required: false,
       default: false,
     },

--- a/app/models/friendly_country.rb
+++ b/app/models/friendly_country.rb
@@ -49,8 +49,16 @@ class FriendlyCountry
 
   def result(**options)
     if options[:source] == :country_code
-      country = Carmen::Country.coded(record.address_details)
-      Geocoded.new(OpenStruct.new(country: country.name))
+      country =
+        Carmen::Country.coded(record.address_details) ||
+        Carmen::Country.named(record.address_details)
+
+      Geocoded.new(
+        OpenStruct.new(
+          country: country&.name || record.address_details,
+          country_code: country&.alpha_2_code
+        )
+      )
     elsif result = Geocoder.search(record.address_details).first
       Geocoded.new(result)
     else


### PR DESCRIPTION
## Summary

- Enable all six globally disabled Vue ESLint correctness rules (`vue/no-unused-components`, `vue/require-prop-types`, `vue/require-default-prop`, `vue/order-in-components`, `vue/no-reserved-component-names`, `vue/multi-word-component-names`) as `"error"` in `.eslintrc.json`
- Rules were enabled incrementally (easiest-first), fixing violations after each until lint passed
- Renamed 23 single-word Vue components (files + imports) to satisfy multi-word and reserved-name rules

## Acceptance criteria

- [x] CI `yarn lint` catches Vue correctness issues — `npx eslint 'app/javascript/**/*.{js,vue}'` passes with 0 errors
- [x] All six previously disabled rules are now enforced globally across `app/javascript/`

## Tests

- `npx eslint 'app/javascript/**/*.{js,vue}'` — passed (0 errors, 4 pre-existing warnings)

## Code review

- Critical: 0
- Important: 0
- Suggestions: 1 — `FormWrapper.vue` component name casing warning could be fixed in a follow-up
- Nits: 1 — remaining warnings are pre-existing (v-html, lone template, name-casing)

## Files changed

75 files — `.eslintrc.json` + prop typing, component option reordering, unused component cleanup, and component renames/imports

## Test plan

- [x] Confirm CI `yarn lint` step passes on this branch
- [x] Smoke-test judge scoring flow (renamed section/piece components)
- [x] Smoke-test new registration page (renamed Banner/Footer/Navbar)
- [x] Smoke-test mentor dashboard (renamed DashboardEvents/Scores/Submission)
- [x] Smoke-test registration login/location routes (LoginForm, RegistrationLocation)