### PR TITLE
feat(6209): upgrade smarter_csv to 1.18.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "barnes", "~> 0.0.7"
 gem "bootsnap", require: false
 
 gem "fast_jsonapi", "~> 1.4"
-gem "smarter_csv", "~> 1.0"
+gem "smarter_csv", "~> 1.18.0"
 
 gem "textacular", "~> 5.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,7 +601,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    smarter_csv (1.15.2)
+    smarter_csv (1.18.1)
+      bigdecimal
     spring (4.4.2)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -781,7 +782,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   simple_form (~> 5.0)
   simplecov
-  smarter_csv (~> 1.0)
+  smarter_csv (~> 1.18.0)
   spring (~> 4.4)
   spring-watcher-listen (~> 2.1)
   sprockets (= 3.7.2)


### PR DESCRIPTION
## Summary

- Upgrades `smarter_csv` from 1.15.2 to 1.18.1 (`~> 1.18.0` in Gemfile)
- No application code changes — existing call sites use compatible `SmarterCSV.process` + `SmarterCSV::MissingKeys` API
- Per upstream UPGRADING.md, no code changes required for 1.15 → 1.18

## Acceptance criteria

- [x] Upgrade smarter_csv to current release — lockfile resolves 1.18.1
- [x] No breaking changes for CSV import flows (bulk team/judge upload, contest rank CSV)
- [ ] Existing specs pass — blocked locally (Postgres role config); CI should verify

## Tests

- SmarterCSV 1.18.1 standalone smoke test passed (process + MissingKeys)
- `spec/services/judging/set_contest_rank_from_csv_spec.rb` — pending CI (local DB unavailable)

## Code review

- Critical: 0 / Important: 0 / Suggestions: 0 / Nits: 0

Closes #6209

Made with [Cursor](https://cursor.com)