### PR TITLE
fix(6306): hide deleted scores from student dashboard

### DIFF
--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -4,7 +4,6 @@ module Student
       @all_scores = SubmissionScore.none
       @quarterfinals_scores = SubmissionScore.none
       @semifinals_scores = SubmissionScore.none
-      @deleted_online_scores = SubmissionScore.none
 
       if current_team.submission.present? && SeasonToggles.display_scores?
         @all_scores = current_team.submission.submission_scores.complete
@@ -18,13 +17,6 @@ module Student
 
           @semifinals_scores = @all_scores.semifinals
         end
-
-        @deleted_online_scores = current_team.submission.submission_scores
-          .with_deleted
-          .virtual
-          .complete
-          .where.not(deleted_at: nil)
-          .where(dropped_at: nil)
       end
 
       @certificates = Certificate.none

--- a/app/views/student/scores/_scores.html.erb
+++ b/app/views/student/scores/_scores.html.erb
@@ -42,20 +42,6 @@
                 </td>
               </tr>
             <% end %>
-
-            <% local_assigns.fetch(:deleted_scores, []).sort_by(&:round).reverse.each do |score| %>
-              <tr>
-                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-base font-medium text-gray-900 sm:pl-6">
-                  <%= score.round.titlecase %>
-                </td>
-                <td class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
-                  Online
-                </td>
-                <td colspan="2" class="whitespace-nowrap px-3 py-4 text-base text-gray-500">
-                  Score deleted
-                </td>
-              </tr>
-            <% end %>
             </tbody>
           </table>
         </div>

--- a/app/views/student/scores/_scores_and_certificates.html.erb
+++ b/app/views/student/scores/_scores_and_certificates.html.erb
@@ -1,4 +1,4 @@
-<% if current_team.submission.complete? && (current_team.submission.scores.complete.any? || @deleted_online_scores&.any?) %>
+<% if current_team.submission.complete? && (current_team.submission.scores.complete.any? || current_team.submission.submission_scores.with_deleted.virtual.complete.where.not(deleted_at: nil).where(dropped_at: nil).any?) %>
   <div class="text-center mt-8 mb-8">
     <p class="mb-4 text-2xl text-tg-magenta uppercase font-bold">
       Congratulations, your team was a <%= current_team.submission.contest_rank %>!

--- a/app/views/student/scores/_scores_overview.html.erb
+++ b/app/views/student/scores/_scores_overview.html.erb
@@ -23,10 +23,9 @@
 <% end %>
 
 <div id="student-finished-scores" class="mb-10">
-  <% if @all_scores.any? || @deleted_online_scores&.any? %>
+  <% if @all_scores.any? %>
     <%= render "student/scores/scores",
-               scores: @all_scores,
-               deleted_scores: @deleted_online_scores %>
+               scores: @all_scores %>
   <% else %>
     <p>Sorry, there are no available finished scores!</p>
   <% end %>

--- a/spec/system/student/view_scores_spec.rb
+++ b/spec/system/student/view_scores_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Students view scores", :js do
     expect(page).to have_selector(:link_or_button, "Complete Survey")
   end
 
-  it "shows 'Score deleted' row when an online score was removed due to RPE move" do
+  it "hides deleted scores when an online score was removed due to RPE move" do
     submission = FactoryBot.create(:submission, :complete)
     score = FactoryBot.create(:submission_score, :complete, team_submission: submission)
     score.destroy
@@ -105,8 +105,9 @@ RSpec.describe "Students view scores", :js do
     sign_in(student)
     visit student_scores_path
 
-    expect(page).to have_selector("#student-finished-scores-table")
-    expect(page).to have_content("Score deleted")
+    expect(page).not_to have_content("Score deleted")
+    expect(page).not_to have_selector("#student-finished-scores-table")
+    expect(page).to have_content("Sorry, there are no available finished scores!")
     expect(page).not_to have_link("View details")
     expect(page).not_to have_content("Average Quarterfinals Score")
     expect(page).not_to have_content("Find your scores and comments from the judges below")


### PR DESCRIPTION
# Ship ledger: issue #6306 — Deleted scores are viewable by users

- **Branch:** `fix/6306-hide-deleted-scores`
- **Plan:** `~/.cursor/plans/hide-deleted-student-scores-6306.plan.md`
- **Base:** `origin/qa`

## Stages

| Stage | Status | Timestamp |
|---|---|---|
| 1 Plan | ✅ complete | 2026-07-09T06:52:00Z |
| 2 Plan-approval | ✅ approved — auto-approved | 2026-07-09T06:52:00Z |
| 3 Branch | ✅ complete | 2026-07-09T06:53:00Z |
| 4 Implement | ✅ complete | 2026-07-09T06:55:00Z |
| 5 Diff-approval | ✅ approved — auto-approved | 2026-07-09T06:55:00Z |
| 6 Code review | ✅ complete — Critical 0 / Important 0 / Suggestions 1 / Nits 0 | 2026-07-09T06:58:00Z |
| 7 Verify | ✅ complete — 1 before/after pair, 0 action GIFs | 2026-07-09T06:58:00Z |
| 8 Final report | ✅ complete | 2026-07-09T06:58:00Z |
| 9 Commit | ✅ complete — 06e17e3, f817ec9, 68cecd3 | 2026-07-09T06:59:00Z |
| 10 Push + PR | ⏸ pending | |

## Summary

Removes student-facing visibility of soft-deleted online scores. Students no longer see "Score deleted" rows on the scores dashboard; teams with only deleted scores see the standard empty-state message instead.

## Acceptance criteria

- [x] AC1: Deleted semifinal and quarterfinal scores are not visible to student users on the scores dashboard — [before](01-student-deleted-scores-before.png) / [after](01-student-deleted-scores-after.png)
- [x] AC2: Students with only deleted scores see the empty state rather than deleted-score rows — [before](01-student-deleted-scores-before.png) / [after](01-student-deleted-scores-after.png)
- [x] AC3: Students with active scores continue to see those scores normally — re-ran `spec/system/student/view_scores_spec.rb` (passed, 6 examples)
- [x] AC4: Admin and ambassador score views unchanged — out of scope; no files under admin/ambassador paths modified

## Tests

- `spec/system/student/view_scores_spec.rb` — passed (6 examples)

## Code review

- Critical: 0
- Important: 0
- Suggestions: 1 — inline deleted-score existence query in `_scores_and_certificates.html.erb` could move to a model scope if reused
- Nits: 0

## Files changed

5 files — `app/controllers/student/scores_controller.rb`, `app/views/student/scores/_scores.html.erb`, `app/views/student/scores/_scores_overview.html.erb`, `app/views/student/scores/_scores_and_certificates.html.erb`, `spec/system/student/view_scores_spec.rb`

## Commits

- `06e17e3`: fix(6306): remove deleted online scores query from student controller
- `f817ec93`: fix(6306): remove deleted score rows from student score views
- `68cecd34`: fix(6306): expect hidden deleted scores in student scores spec