### PR TITLE
feat(6277): reduce N+1 on mentor and student scores pages

### DIFF
--- a/app/controllers/mentor/certificates_controller.rb
+++ b/app/controllers/mentor/certificates_controller.rb
@@ -2,8 +2,8 @@ module Mentor
   class CertificatesController < MentorController
 
     def index
-      @current_certificates = current_account.current_appreciation_certificates
-      @previous_certificates = current_account.certificates.mentor_types.previous_certificates
+      @current_certificates = current_account.current_appreciation_certificates.preload(:team)
+      @previous_certificates = current_account.certificates.mentor_types.previous_certificates.preload(:team)
     end
   end
 end

--- a/app/controllers/mentor/scores_controller.rb
+++ b/app/controllers/mentor/scores_controller.rb
@@ -2,7 +2,9 @@ module Mentor
   class ScoresController < MentorController
 
     def index
-      @current_teams = current_mentor.teams.current.order("teams.name")
+      @current_teams = current_mentor.teams.current
+        .order("teams.name")
+        .preload(submission: {submission_scores: {judge_profile: :account}})
     end
 
     def show

--- a/app/controllers/student/scores_controller.rb
+++ b/app/controllers/student/scores_controller.rb
@@ -6,8 +6,11 @@ module Student
       @semifinals_scores = SubmissionScore.none
 
       if current_team.submission.present? && SeasonToggles.display_scores?
-        @all_scores = current_team.submission.submission_scores.complete
-        @quarterfinals_scores = @all_scores.quarterfinals
+        @all_scores = current_team.submission.submission_scores
+          .complete
+          .preload(judge_profile: :account)
+          .to_a
+        @quarterfinals_scores = @all_scores.select(&:quarterfinals?)
 
         if current_team.submission.semifinalist? ||
             current_team.submission.regional_honoree? ||
@@ -15,7 +18,7 @@ module Student
             current_team.submission.finalist? ||
             current_team.submission.grand_prize_winner?
 
-          @semifinals_scores = @all_scores.semifinals
+          @semifinals_scores = @all_scores.select(&:semifinals?)
         end
       end
 

--- a/app/controllers/student_controller.rb
+++ b/app/controllers/student_controller.rb
@@ -19,11 +19,11 @@ class StudentController < ApplicationController
   end
 
   def current_team
-    current_student.team
+    @current_team ||= current_student.team
   end
 
   def current_submission
-    current_team.submission
+    @current_submission ||= current_team.submission
   end
 
   private

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -34,13 +34,14 @@ class Certificate < ApplicationRecord
 
   def self.highest_awarded_student_certs_for_previous_seasons
     past
+      .preload(:team)
       .student_certs_ordered_by_highest_awarded
       .group_by { |cert| cert.season }
       .map { |_, certs| certs.first }
   end
 
   def self.highest_awarded_student_cert_for_current_season
-    current.student_certs_ordered_by_highest_awarded.first
+    current.preload(:team).student_certs_ordered_by_highest_awarded.first
   end
 
   def self.student_certs_ordered_by_highest_awarded

--- a/app/views/mentor/scores/_team_scores_and_certificates.html.erb
+++ b/app/views/mentor/scores/_team_scores_and_certificates.html.erb
@@ -13,7 +13,13 @@
       </div>
 
       <div class="mt-8">
-        <% scores = team.submission.submission_scores.complete %>
+        <% scores = if team.submission.association(:submission_scores).loaded?
+             team.submission.submission_scores.select { |score|
+               score.completed_at.present? && !score.judge_recusal?
+             }
+           else
+             team.submission.submission_scores.complete
+           end %>
 
         <% if scores.any?  %>
           <%= render "scores/finished_scores", team: team, scores: scores %>

--- a/app/views/student/scores/_average_score.html.erb
+++ b/app/views/student/scores/_average_score.html.erb
@@ -1,6 +1,11 @@
+<% score = Array.wrap(scores).first %>
 <h3 class="text-xl text-white">
     Average <%= String(round).titlecase %> Score:
   <span class="text-white">
-      <%= scores.average_score(round) %>/<%= scores.total_possible %>
+      <% if score %>
+        <%= score.team_submission.public_send("#{round}_average_score") %>/<%= score.total_possible %>
+      <% else %>
+        0.0/0.0
+      <% end %>
   </span>
 </h3>

--- a/spec/performance/mentor/certificates_index_benchmark_spec.rb
+++ b/spec/performance/mentor/certificates_index_benchmark_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "Mentor::CertificatesController#index performance", type: :request do
+  # Baseline before optimization (local test DB):
+  #   Total SQL: 37, Render: ~152ms, teams queries: 10
+  #
+  # After optimization:
+  #   Total SQL: 29, Render: ~134ms, teams queries: 2
+
+  def count_sql_queries
+    queries = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next if payload[:name] == "SCHEMA"
+      next if payload[:sql].match?(/pg_|sqlite_|SAVEPOINT|RELEASE SAVEPOINT/)
+
+      queries << payload[:sql]
+    end
+
+    elapsed = Benchmark.realtime { yield }
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    {queries: queries, count: queries.size, elapsed: elapsed}
+  end
+
+  def teams_queries(queries)
+    queries.count { |sql| sql.match?(/FROM "teams"/) }
+  end
+
+  before do
+    SeasonToggles.display_scores_on!
+  end
+
+  describe "GET /mentor/certificates (mentor with current and previous certificates)" do
+    let!(:mentor) { FactoryBot.create(:mentor, :onboarded) }
+
+    before do
+      mentor.account.took_program_survey!
+
+      5.times do
+        team = FactoryBot.create(:team)
+        FactoryBot.create(
+          :certificate,
+          account: mentor.account,
+          team: team,
+          cert_type: :mentor,
+          season: Season.current.year
+        )
+      end
+
+      5.times do |i|
+        team = FactoryBot.create(:team)
+        FactoryBot.create(
+          :certificate,
+          account: mentor.account,
+          team: team,
+          cert_type: :mentor,
+          season: Season.current.year - (i + 1)
+        )
+      end
+    end
+
+    it "benchmarks index query count and render time" do
+      sign_in(mentor)
+
+      result = count_sql_queries do
+        get mentor_certificates_path
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Mentor certificates#index benchmark ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "teams queries: #{teams_queries(result[:queries])}"
+
+      expect(teams_queries(result[:queries])).to be <= 4
+      expect(result[:count]).to be <= 50
+    end
+  end
+end

--- a/spec/performance/mentor/scores_index_benchmark_spec.rb
+++ b/spec/performance/mentor/scores_index_benchmark_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Mentor::ScoresController#index performance", type: :request do
+  # Baseline before optimization (local test DB):
+  #   Total SQL: 66, Render: ~345ms
+  #   team_submissions: 4, submission_scores: 8, judge_profiles/accounts: 28
+  #
+  # After optimization:
+  #   Total SQL: 34, Render: ~213ms
+  #   team_submissions: 1, submission_scores: 1, judge_profiles/accounts: 6
+
+  def count_sql_queries
+    queries = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next if payload[:name] == "SCHEMA"
+      next if payload[:sql].match?(/pg_|sqlite_|SAVEPOINT|RELEASE SAVEPOINT/)
+
+      queries << payload[:sql]
+    end
+
+    elapsed = Benchmark.realtime { yield }
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    {queries: queries, count: queries.size, elapsed: elapsed}
+  end
+
+  def team_submission_queries(queries)
+    queries.count { |sql| sql.match?(/FROM "team_submissions"/) }
+  end
+
+  def submission_score_queries(queries)
+    queries.count { |sql| sql.match?(/FROM "submission_scores"/) }
+  end
+
+  def judge_or_account_queries(queries)
+    queries.count { |sql| sql.match?(/FROM "(judge_profiles|accounts)"/) }
+  end
+
+  before do
+    SeasonToggles.display_scores_on!
+  end
+
+  describe "GET /mentor/scores (mentor with multiple scored teams)" do
+    let!(:mentor) { FactoryBot.create(:mentor, :onboarded) }
+
+    before do
+      mentor.account.took_program_survey!
+
+      4.times do
+        team = FactoryBot.create(:team)
+        TeamRosterManaging.add(team, mentor)
+        submission = FactoryBot.create(:submission, :complete, team: team)
+
+        3.times do
+          FactoryBot.create(:submission_score, :complete, team_submission: submission)
+        end
+      end
+    end
+
+    it "benchmarks index query count and render time" do
+      sign_in(mentor)
+
+      result = count_sql_queries do
+        get mentor_scores_path
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Mentor scores#index benchmark ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "team_submissions queries: #{team_submission_queries(result[:queries])}"
+      puts "submission_scores queries: #{submission_score_queries(result[:queries])}"
+      puts "judge_profiles/accounts queries: #{judge_or_account_queries(result[:queries])}"
+
+      expect(team_submission_queries(result[:queries])).to be <= 4
+      expect(submission_score_queries(result[:queries])).to be <= 4
+      expect(judge_or_account_queries(result[:queries])).to be <= 6
+      expect(result[:count]).to be <= 80
+    end
+  end
+end

--- a/spec/performance/student/scores_index_benchmark_spec.rb
+++ b/spec/performance/student/scores_index_benchmark_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "Student::ScoresController#index performance", type: :request do
+  # Baseline before optimization (local test DB):
+  #   Total SQL: 94, Render: ~341ms
+  #   Per-id judge_profiles/accounts: 16, Certificate team queries: 4
+  #
+  # After optimization:
+  #   Total SQL: 32, Render: ~250ms
+  #   Per-id judge_profiles/accounts: 0, Certificate team queries: 1
+
+  def count_sql_queries
+    queries = []
+    subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      next if payload[:name] == "SCHEMA"
+      next if payload[:sql].match?(/pg_|sqlite_|SAVEPOINT|RELEASE SAVEPOINT/)
+
+      queries << payload[:sql]
+    end
+
+    elapsed = Benchmark.realtime { yield }
+
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    {queries: queries, count: queries.size, elapsed: elapsed}
+  end
+
+  # Per-row N+1 looks like WHERE id = $1 (not IN (...))
+  def per_id_judge_or_account_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "(judge_profiles|accounts)".*WHERE.*"id" = \$1/) &&
+        !sql.include?("auth_token")
+    }
+  end
+
+  def certificate_team_queries(queries)
+    queries.count { |sql|
+      sql.match?(/FROM "teams"/) &&
+        !sql.include?("memberships") &&
+        sql.match?(/"teams"\."id" (IN|=)/)
+    }
+  end
+
+  before do
+    SeasonToggles.display_scores_on!
+  end
+
+  describe "GET /student/scores (student with many scores and previous certificates)" do
+    let!(:submission) { FactoryBot.create(:submission, :complete) }
+    let!(:student) { submission.team.students.sample }
+
+    before do
+      student.account.took_program_survey!
+
+      8.times do
+        FactoryBot.create(:submission_score, :complete, team_submission: submission)
+      end
+
+      4.times do |i|
+        team = FactoryBot.create(:team)
+        FactoryBot.create(
+          :certificate,
+          account: student.account,
+          team: team,
+          cert_type: :participation,
+          season: Season.current.year - (i + 1)
+        )
+      end
+    end
+
+    it "benchmarks index query count and render time" do
+      sign_in(student)
+
+      result = count_sql_queries do
+        get student_scores_path
+      end
+
+      expect(response).to have_http_status(:ok)
+
+      puts "\n--- Student scores#index benchmark ---"
+      puts "Total SQL queries: #{result[:count]}"
+      puts "Render time: #{(result[:elapsed] * 1000).round(1)}ms"
+      puts "Per-id judge_profiles/accounts queries: #{per_id_judge_or_account_queries(result[:queries])}"
+      puts "Certificate team queries: #{certificate_team_queries(result[:queries])}"
+
+      expect(per_id_judge_or_account_queries(result[:queries])).to be <= 2
+      expect(certificate_team_queries(result[:queries])).to be <= 2
+      expect(result[:count]).to be <= 70
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Eager-load associations on `Mentor::ScoresController#index`, `Mentor::CertificatesController#index`, and `Student::ScoresController#index` to eliminate N+1 queries when rendering scores and certificates.
- Add performance benchmark specs with before/after SQL bounds (mentor scores 66→34, mentor certificates teams 10→2, student scores per-id judge/account 16→0).
- Memoize `current_team` / `current_submission` on the student controller to avoid repeated membership lookups during render.

Closes #6277


Made with [Cursor](https://cursor.com)