### PR TITLE
feat(6308): enforce password complexity beyond length

### DIFF
--- a/app/javascript/helpers/passwordComplexity.js
+++ b/app/javascript/helpers/passwordComplexity.js
@@ -1,0 +1,24 @@
+export function passwordMeetsComplexity(password, email = "") {
+  if (!password || password.length < 8) {
+    return false;
+  }
+
+  if (!/[A-Z]/.test(password)) {
+    return false;
+  }
+
+  if (!/[a-z]/.test(password)) {
+    return false;
+  }
+
+  if (!/\d/.test(password)) {
+    return false;
+  }
+
+  const localPart = email.split("@")[0]?.toLowerCase();
+  if (localPart && password.toLowerCase().includes(localPart)) {
+    return false;
+  }
+
+  return true;
+}

--- a/app/javascript/new_registration/components/StepFour.vue
+++ b/app/javascript/new_registration/components/StepFour.vue
@@ -57,7 +57,7 @@
           name="password"
           type="password"
           label="Password"
-          placeholder="At least 8 characters"
+          placeholder="8+ chars with upper, lower, and a number"
           validation="required|min:8,length"
           @keydown="checkValidation"
           @keyup="checkValidation"
@@ -84,6 +84,7 @@
 <script>
 import ContainerHeader from "./ContainerHeader";
 import PreviousButton from "./PreviousButton";
+import { passwordMeetsComplexity } from "../../helpers/passwordComplexity";
 
 export default {
   name: "StepFour",
@@ -137,7 +138,10 @@ export default {
 
       if (
         document.getElementById("email").value.length === 0 ||
-        document.getElementById("password").value.length < 8 ||
+        !passwordMeetsComplexity(
+          document.getElementById("password").value,
+          document.getElementById("email").value
+        ) ||
         validationErrorMessages.some((message) => {
           return (
             message.indexOf("is not a valid email address") >= 0 ||

--- a/app/javascript/registration/components/PasswordInput.vue
+++ b/app/javascript/registration/components/PasswordInput.vue
@@ -6,7 +6,7 @@
       id="password"
       v-model="password"
       autocomplete="new-password"
-      placeholder="Use at least 8 characters"
+      placeholder="8+ chars with upper, lower, and a number"
       name="account[password]"
       :toggle="true"
       :secure-length="8"
@@ -21,6 +21,8 @@
 
 <script>
 import Password from "vue-password-strength-meter";
+
+import { passwordMeetsComplexity } from "../../helpers/passwordComplexity";
 
 export default {
   name: "PasswordValidation",
@@ -45,7 +47,7 @@ export default {
 
   computed: {
     nextStepEnabled() {
-      return this.password.length >= 8;
+      return passwordMeetsComplexity(this.password);
     },
 
     strengthNextStepMsg() {

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -651,6 +651,11 @@ class Account < ActiveRecord::Base
       if: -> { not_admin? && public_registration? }
     }
 
+  validates :password,
+    password_complexity: true,
+    on: :create,
+    if: -> { not_admin? && public_registration? && !inviting_new_admin }
+
   validates :terms_agreed_at,
     presence: true,
     on: :create,
@@ -664,11 +669,21 @@ class Account < ActiveRecord::Base
     }
 
   validates :password,
+    password_complexity: true,
+    on: :update,
+    if: -> { not_admin? && changing_password_or_temporary_password? && !inviting_new_admin }
+
+  validates :password,
     length: {
       minimum: 20,
       on: :update,
       if: -> { !full_admin? && !not_admin? }
     }
+
+  validates :password,
+    password_complexity: true,
+    on: :update,
+    if: -> { !full_admin? && !not_admin? && !inviting_new_admin }
 
   validates :first_name, :last_name,
     presence: true,

--- a/app/models/password.rb
+++ b/app/models/password.rb
@@ -11,7 +11,11 @@ class Password
   attr_reader :account
 
   validates :email, exists: true
-  validate :valid_password
+  validates :password,
+    length: {minimum: 8, if: :resetting}
+  validates :password,
+    password_complexity: {if: :resetting}
+  validate :password_confirmation_matches, if: :resetting
   validate :not_expired
 
   def initialize(attrs = {})
@@ -50,10 +54,8 @@ class Password
     end
   end
 
-  def valid_password
-    if !!resetting and password.to_s.length < 8
-      errors.add(:password, :too_short, count: 8)
-    elsif !!resetting and password != password_confirmation
+  def password_confirmation_matches
+    if password != password_confirmation
       errors.add(:password_confirmation, :doesnt_match)
     end
   end

--- a/app/validators/password_complexity_validator.rb
+++ b/app/validators/password_complexity_validator.rb
@@ -1,0 +1,33 @@
+class PasswordComplexityValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    password = value.to_s
+
+    unless password.match?(/[A-Z]/)
+      record.errors.add(attribute, :missing_uppercase)
+    end
+
+    unless password.match?(/[a-z]/)
+      record.errors.add(attribute, :missing_lowercase)
+    end
+
+    unless password.match?(/\d/)
+      record.errors.add(attribute, :missing_digit)
+    end
+
+    local_part = email_local_part(record)
+    if local_part.present? && password.downcase.include?(local_part)
+      record.errors.add(attribute, :contains_email_local_part)
+    end
+  end
+
+  private
+
+  def email_local_part(record)
+    email = record.email if record.respond_to?(:email)
+    return if email.blank?
+
+    email.to_s.split("@").first.to_s.downcase
+  end
+end

--- a/app/views/admin/signups/new.html.erb
+++ b/app/views/admin/signups/new.html.erb
@@ -7,7 +7,8 @@
 
 <p>
   Make sure you create your password with the generator,
-  and please ensure that it is set to use at least 20 characters.
+  and please ensure that it is set to use at least 20 characters
+  with uppercase, lowercase, and a number.
 </p>
 
 <p>Thank you for your help in keeping our user data secure!</p>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -8,6 +8,11 @@ en:
               not_found: "wasn't found in our database"
             expires_at:
               expired: "has expired"
+            password:
+              missing_uppercase: "must include at least one uppercase letter"
+              missing_lowercase: "must include at least one lowercase letter"
+              missing_digit: "must include at least one number"
+              contains_email_local_part: "cannot contain your email username"
             password_confirmation:
               doesnt_match: "does not match"
 
@@ -30,6 +35,11 @@ en:
             existing_password:
               blank: "is required to change your email address or password"
               invalid: "is incorrect"
+            password:
+              missing_uppercase: "must include at least one uppercase letter"
+              missing_lowercase: "must include at least one lowercase letter"
+              missing_digit: "must include at least one number"
+              contains_email_local_part: "cannot contain your email username"
 
         mentor_invite:
           attributes:

--- a/config/locales/activerecord.es-MX.yml
+++ b/config/locales/activerecord.es-MX.yml
@@ -8,6 +8,11 @@ es-MX:
               not_found: "no se encontró en la base de datos"
             expires_at:
               expired: "ha expirado"
+            password:
+              missing_uppercase: "debe incluir al menos una letra mayúscula"
+              missing_lowercase: "debe incluir al menos una letra minúscula"
+              missing_digit: "debe incluir al menos un número"
+              contains_email_local_part: "no puede contener la parte local de tu correo electrónico"
             password_confirmation:
               doesnt_match: "no corresponde"
 

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -13,7 +13,7 @@ en:
       geocoded: "Postal code -OR- City & State/Province"
       gender: "Gender identity"
       password: "Create a password"
-      password_hint: "Use 8 characters or more"
+      password_hint: "Use 8+ characters with uppercase, lowercase, and a number"
       phone_number: "Phone Number"
       referred_by: "How did you hear about Technovation?"
       referred_by_other: "Please specify"

--- a/config/locales/models.es-MX.yml
+++ b/config/locales/models.es-MX.yml
@@ -9,7 +9,7 @@ es-MX:
       geocoded: "Código postal ó ciudad y estado/provincia"
       gender: "Género"
       password: "Crear una contraseña"
-      password_hint: "Utiliza al menos 8 caracteres"
+      password_hint: "Utiliza al menos 8 caracteres con mayúsculas, minúsculas y un número"
       referred_by: "¿Cómo te enteraste de Technovation?"
       referred_by_other: "Por favor indica cómo"
       state_province: "Estado / Provincia"

--- a/docs/security-password-policy.md
+++ b/docs/security-password-policy.md
@@ -1,0 +1,51 @@
+# Password policy
+
+This document describes the Technovation platform password policy and planned future authentication work.
+
+## Current policy (enforced server-side)
+
+Password complexity is validated on **Account** (registration, profile change, admin first-time setup) and on the **Password** reset form object.
+
+### Regular users (students, mentors, judges, ambassadors, parents)
+
+- Minimum **8 characters**
+- At least one **uppercase** letter
+- At least one **lowercase** letter
+- At least one **digit**
+- Must **not** contain the email local-part (the part before `@`)
+
+### Platform administrators (`temporary_password` status)
+
+- Minimum **20 characters**
+- Same complexity rules as regular users (uppercase, lowercase, digit; no email local-part)
+- Admin onboarding UI recommends generating passwords with password-management software
+
+### What is not enforced
+
+- Special characters are allowed but not required
+- Password strength meters in registration UI are advisory; server validation is authoritative
+- Existing accounts are **not** forced to rotate passwords until their next change or reset
+
+## Implementation
+
+- Validator: `app/validators/password_complexity_validator.rb`
+- Wired on `Account` and `Password` models alongside existing length validations
+- Auto-generated invite passwords for new admins (`inviting_new_admin`) skip complexity validation because they are never user-facing
+
+## Future phase (out of scope)
+
+The following items are **not** implemented in the current stack and are deferred to a later security phase:
+
+### Multi-factor authentication (MFA)
+
+Technovation uses email + password sign-in via `SigninsController` and `has_secure_password`. There is no TOTP, SMS, or WebAuthn flow today. MFA would require new enrollment UX, backup codes, and sign-in flow changes.
+
+### Active Directory / SSO
+
+There is no OmniAuth, SAML, or Azure Entra ID integration. Enterprise SSO would require identity-provider configuration, account linking, and migration strategy for existing local accounts.
+
+### Related issues
+
+- [#6308](https://github.com/Iridescent-CM/technovation-app/issues/6308) — password policy hardening (this work)
+- [#6309](https://github.com/Iridescent-CM/technovation-app/issues/6309) — brute-force / password-spray protection
+- [#6313](https://github.com/Iridescent-CM/technovation-app/issues/6313) — account expiration / deactivation

--- a/spec/controllers/admin/signups_controller_spec.rb
+++ b/spec/controllers/admin/signups_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Admin::SignupsController do
 
       sign_in(student)
 
-      patch :update, params: {account: {password: SecureRandom.hex(10)}}
+      patch :update, params: {account: {password: PasswordHelpers::VALID_ADMIN_PASSWORD}}
       expect(response).to redirect_to(root_path)
     end
 
@@ -33,11 +33,11 @@ RSpec.describe Admin::SignupsController do
 
       sign_in(admin)
 
-      patch :update, params: {account: {password: SecureRandom.hex(9)}}
+      patch :update, params: {account: {password: "abcdefghijabcdefghij"}}
       expect(response).to render_template("admin/signups/new")
       expect(admin.reload.password_digest).to eq(password_digest)
 
-      patch :update, params: {account: {password: SecureRandom.hex(10)}}
+      patch :update, params: {account: {password: PasswordHelpers::VALID_ADMIN_PASSWORD}}
       expect(response).to redirect_to(admin_dashboard_path)
       expect(admin.reload.password_digest).not_to eq(password_digest)
     end
@@ -47,10 +47,10 @@ RSpec.describe Admin::SignupsController do
 
       sign_in(admin)
 
-      patch :update, params: {account: {password: SecureRandom.hex(9)}}
+      patch :update, params: {account: {password: "abcdefghijabcdefghij"}}
       expect(admin.reload.account).not_to be_full_admin
 
-      patch :update, params: {account: {password: SecureRandom.hex(10)}}
+      patch :update, params: {account: {password: PasswordHelpers::VALID_ADMIN_PASSWORD}}
       expect(response).to redirect_to(admin_dashboard_path)
       expect(admin.reload.account).to be_full_admin
     end
@@ -61,10 +61,10 @@ RSpec.describe Admin::SignupsController do
 
       sign_in(admin)
 
-      patch :update, params: {account: {password: SecureRandom.hex(9)}}
+      patch :update, params: {account: {password: "abcdefghijabcdefghij"}}
       expect(admin.reload.admin_invitation_token).to eq(invite_token)
 
-      patch :update, params: {account: {password: SecureRandom.hex(10)}}
+      patch :update, params: {account: {password: PasswordHelpers::VALID_ADMIN_PASSWORD}}
       expect(response).to redirect_to(admin_dashboard_path)
       expect(admin.reload.admin_invitation_token).not_to eq(invite_token)
     end

--- a/spec/controllers/new_registration_controller_spec.rb
+++ b/spec/controllers/new_registration_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe NewRegistrationController do
             chapterAmbassadorJobTitle: "Curator",
             chapterAmbassadorBio: "We live inside a treehouse at the center of the museum, we have been protecting the museum's secrets for generations. We making sure that everyone is safe and happy – without the outside world learning about the museum's secrets.",
             dataTermsAgreedTo: true,
-            password: "123abc*&^"
+            password: PasswordHelpers::VALID_PASSWORD
           }
         }
       end
@@ -66,7 +66,7 @@ RSpec.describe NewRegistrationController do
             meetsMinimumAgeRequirement: true,
             clubAmbassadorJobTitle: "Chef",
             dataTermsAgreedTo: true,
-            password: "123abc*&^"
+            password: PasswordHelpers::VALID_PASSWORD
           }
         }
       end

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe SigninsController do
       post :create, params: {
         account: {
           email: student.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 
@@ -126,7 +126,7 @@ RSpec.describe SigninsController do
       post :create, params: {
         account: {
           email: student.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SigninsController do
         post :create, params: {
           account: {
             email: student.email,
-            password: "secret1234"
+            password: PasswordHelpers::VALID_PASSWORD
           }
         }
 
@@ -31,7 +31,7 @@ RSpec.describe SigninsController do
       post :create, params: {
         account: {
           email: "capitalletters@gmail.com",
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 
@@ -50,7 +50,7 @@ RSpec.describe SigninsController do
       post :create, params: {
         account: {
           email: "dotsigno.red@gmail.com",
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 
@@ -142,7 +142,7 @@ RSpec.describe SigninsController do
         post :create, params: {
           account: {
             email: judge.account.email,
-            password: "secret1234"
+            password: PasswordHelpers::VALID_PASSWORD
           }
         }
 
@@ -156,7 +156,7 @@ RSpec.describe SigninsController do
         post :create, params: {
           account: {
             email: student.email,
-            password: "secret1234"
+            password: PasswordHelpers::VALID_PASSWORD
           }
         }
 
@@ -170,7 +170,7 @@ RSpec.describe SigninsController do
         parent_guardian_email: "parent2@parent2.com",
         account: FactoryBot.create(
           :account,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         )
       )
 
@@ -182,7 +182,7 @@ RSpec.describe SigninsController do
       post :create, params: {
         account: {
           email: student.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :account do
     sequence(:email) { |n| "account-#{n}@example.com" }
-    password { "secret1234" }
+    password { PasswordHelpers::VALID_PASSWORD }
     email_confirmed_at { Time.current }
 
     date_of_birth { Date.today - 31.years }

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     trait :inviting do
       admin_status { :temporary_password }
       skip_existing_password { true }
-      password { SecureRandom.hex(10) }
+      password { PasswordHelpers::VALID_ADMIN_PASSWORD }
     end
 
     trait :super_admin do

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       country { "US" }
       date_of_birth { Division.cutoff_date - (Division::SENIOR_DIVISION_AGE - 1).years }
       sequence(:email) { |n| "factory-student-#{n}@example.com" }
-      password { "secret1234" }
+      password { PasswordHelpers::VALID_PASSWORD }
       not_onboarded { false }
     end
 

--- a/spec/features/account/edit_spec.rb
+++ b/spec/features/account/edit_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Edit account spec" do
       account: FactoryBot.create(
         :account,
         email: "original@email.com",
-        password: "secret1234"
+        password: PasswordHelpers::VALID_PASSWORD
       )
     ))
     visit student_profile_path

--- a/spec/features/account/reset_password_spec.rb
+++ b/spec/features/account/reset_password_spec.rb
@@ -92,6 +92,13 @@ RSpec.feature "Reset your forgotten password" do
     expect(page).to have_css(".error", text: "too short")
 
     fill_in "Create a password", with: "abcdefghij"
+    fill_in "Confirm password", with: "abcdefghij"
+    click_button "Save"
+
+    expect(current_path).to eq(passwords_path)
+    expect(page).to have_css(".error", text: "uppercase")
+
+    fill_in "Create a password", with: "abcdefghij"
     fill_in "Confirm password", with: "zyxwvutsrqp"
     click_button "Save"
 
@@ -104,15 +111,15 @@ RSpec.feature "Reset your forgotten password" do
     account.enable_password_reset!
 
     visit new_password_path(token: account.password_reset_token)
-    fill_in "Create a password", with: "greatnewsecret"
-    fill_in "Confirm password", with: "greatnewsecret"
+    fill_in "Create a password", with: "GreatNewSecret1"
+    fill_in "Confirm password", with: "GreatNewSecret1"
     click_button "Save"
 
     click_link "Logout"
     visit signin_path
 
     fill_in "Email", with: account.email
-    fill_in "Password", with: "greatnewsecret"
+    fill_in "Password", with: "GreatNewSecret1"
     click_button "Sign in"
     expect(current_path).to eq(
       send("#{account.scope_name.sub(/^\w+_chapter_ambassador/, "chapter_ambassador")}_dashboard_path")

--- a/spec/features/admin/judges_export_spec.rb
+++ b/spec/features/admin/judges_export_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "/admin/judges", type: :request do
       post "/signins", params: {
         account: {
           email: admin.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 
@@ -47,7 +47,7 @@ RSpec.describe "/admin/judges", type: :request do
       post "/signins", params: {
         account: {
           email: admin.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 

--- a/spec/features/admin/manage_admins_spec.rb
+++ b/spec/features/admin/manage_admins_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Manage admin accounts" do
     new_admin = Account.temporary_password.last
     visit admin_signup_path(token: new_admin.admin_invitation_token)
 
-    password = SecureRandom.hex(10)
+    password = PasswordHelpers::VALID_ADMIN_PASSWORD
     fill_in "Password", with: password
 
     click_button "Save"

--- a/spec/features/chapter_ambassador/judges_export_spec.rb
+++ b/spec/features/chapter_ambassador/judges_export_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "/chapter_ambassador/judges", type: :request do
       post "/signins", params: {
         account: {
           email: chapter_ambassador.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 
@@ -65,7 +65,7 @@ RSpec.describe "/chapter_ambassador/judges", type: :request do
       post "/signins", params: {
         account: {
           email: chapter_ambassador.email,
-          password: "secret1234"
+          password: PasswordHelpers::VALID_PASSWORD
         }
       }
 

--- a/spec/features/registration/chapter_ambassador_spec.rb
+++ b/spec/features/registration/chapter_ambassador_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Chapter ambassadors registering", :js do
 
     expect(page).to have_content("Set your email and password")
 
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/registration/club_ambassador_spec.rb
+++ b/spec/features/registration/club_ambassador_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Club ambassadors registering", :js do
 
     expect(page).to have_content("Set your email and password")
 
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/registration/judge_spec.rb
+++ b/spec/features/registration/judge_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Judges registering", :js do
     expect(page).to have_content("Set your email and password")
 
     fill_in "Email Address", with: "funshine@test.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/registration/mentor_spec.rb
+++ b/spec/features/registration/mentor_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Mentors registering", :js do
     expect(page).to have_content("Set your email and password")
 
     fill_in "Email Address", with: "cheer@test.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/registration/parent_spec.rb
+++ b/spec/features/registration/parent_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Parents registering", :js do
 
     expect(page).to have_content("Set your email and password")
 
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/registration/student_spec.rb
+++ b/spec/features/registration/student_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Students registering", :js do
     expect(page).to have_content("Set your email and password")
 
     fill_in "Email Address", with: "harmony@test.com"
-    fill_in "Password", with: "secret12345"
+    fill_in "Password", with: "Secret12345"
     click_button "Submit this form"
   end
 end

--- a/spec/features/survey_completion_spec.rb
+++ b/spec/features/survey_completion_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Survey completion" do
 
       # redirect to sign in
       fill_in "Email", with: user.account.email
-      fill_in "Password", with: "secret1234"
+      fill_in "Password", with: PasswordHelpers::VALID_PASSWORD
       click_button "Sign in"
 
       expect(current_path).to eq(send("#{scope}_dashboard_path"))

--- a/spec/requests/new_registration_spec.rb
+++ b/spec/requests/new_registration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "New registration", type: :request do
         dateOfBirth: date_of_birth,
         gender: "Non-binary",
         email: "personxyz@example.com",
-        password: "12345678",
+        password: PasswordHelpers::VALID_PASSWORD,
         dataTermsAgreedTo: true,
         studentParentGuardianName: "Mursmiss Parentente",
         studentParentGuardianEmail: "mrmsparents@example.com",

--- a/spec/requests/new_registration_validation_spec.rb
+++ b/spec/requests/new_registration_validation_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "New registration validation", type: :request do
   end
   let(:profile_type) { "student" }
   let(:date_of_birth) { (Division.cutoff_date - 15.years).to_s }
-  let(:password) { "12345678" }
+  let(:password) { PasswordHelpers::VALID_PASSWORD }
   let(:data_terms_agreed_to) { true }
 
   before do
@@ -91,6 +91,17 @@ RSpec.describe "New registration validation", type: :request do
 
     context "with a password shorter than 8 characters" do
       let(:password) { "short" }
+
+      it "returns unprocessable entity" do
+        register
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["full_error_messages"].join).to match(/password/i)
+      end
+    end
+
+    context "with a password that does not meet complexity requirements" do
+      let(:password) { "12345678" }
 
       it "returns unprocessable entity" do
         register

--- a/spec/requests/student/profile_requests_spec.rb
+++ b/spec/requests/student/profile_requests_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Student Profile Requests", type: :request do
           student_profile: {
             account_attributes: {id: student_account.id,
                                  email: parent_guardian_email_address,
-                                 existing_password: "secret1234"}
+                                 existing_password: PasswordHelpers::VALID_PASSWORD}
           }
         }
       end

--- a/spec/support/password_helpers.rb
+++ b/spec/support/password_helpers.rb
@@ -1,0 +1,8 @@
+module PasswordHelpers
+  VALID_PASSWORD = "Secret1234"
+  VALID_ADMIN_PASSWORD = "ComplexAdminPassword1"
+end
+
+RSpec.configure do |config|
+  config.include PasswordHelpers
+end

--- a/spec/support/request_signin_helper.rb
+++ b/spec/support/request_signin_helper.rb
@@ -7,7 +7,7 @@ module RequestSigninHelper
       profile
     end
 
-    post "/signins", params: {account: {email: signin.email, password: "secret1234"}}
+    post "/signins", params: {account: {email: signin.email, password: PasswordHelpers::VALID_PASSWORD}}
 
     sleep 2
   end

--- a/spec/support/signin_helper.rb
+++ b/spec/support/signin_helper.rb
@@ -12,7 +12,7 @@ module SigninHelper
 
     within "#new_account" do
       fill_in "Email", with: signin.email
-      fill_in "Password", with: signin.account.password || "secret1234"
+      fill_in "Password", with: signin.account.password || PasswordHelpers::VALID_PASSWORD
 
       click_button "Sign in"
     end

--- a/spec/validators/password_complexity_validator_spec.rb
+++ b/spec/validators/password_complexity_validator_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe PasswordComplexityValidator do
+  subject(:validator) { described_class.new(attributes: [:password]) }
+
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :password, :email
+
+      validates :password, password_complexity: true
+    end
+  end
+
+  let(:record) { record_class.new(email: "personxyz@example.com") }
+
+  def validate(password)
+    record.password = password
+    record.valid?
+  end
+
+  it "accepts a password with upper, lower, and digit" do
+    expect(validate("Secret1234")).to be(true)
+    expect(record.errors[:password]).to be_empty
+  end
+
+  it "rejects passwords without an uppercase letter" do
+    expect(validate("secret1234")).to be(false)
+    expect(record.errors.details[:password]).to include(error: :missing_uppercase)
+  end
+
+  it "rejects passwords without a lowercase letter" do
+    expect(validate("SECRET1234")).to be(false)
+    expect(record.errors.details[:password]).to include(error: :missing_lowercase)
+  end
+
+  it "rejects passwords without a digit" do
+    expect(validate("Secretabcd")).to be(false)
+    expect(record.errors.details[:password]).to include(error: :missing_digit)
+  end
+
+  it "rejects passwords containing the email local-part" do
+    expect(validate("PersonxyzSecret1")).to be(false)
+    expect(record.errors.details[:password]).to include(error: :contains_email_local_part)
+  end
+
+  it "skips validation when password is blank" do
+    expect(validate("")).to be(true)
+    expect(record.errors[:password]).to be_empty
+  end
+end


### PR DESCRIPTION
Require uppercase, lowercase, and digit on Account and password reset, reject email local-part matches, and document MFA/AD as a future phase.


