### PR TITLE
feat(6309): add brute-force protection via rack-attack and account lockout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ gem "carmen", "~> 1.1"
 
 gem "indefinite_article", "~> 0.2"
 
+gem "rack-attack", "~> 6.7"
 gem "rack-rewrite", "~> 1.5", require: "rack/rewrite"
 
 gem "browser", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (2.2.23)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-proxy (0.7.7)
       rack
     rack-rewrite (1.5.1)
@@ -763,6 +765,7 @@ DEPENDENCIES
   public_activity (~> 3.0)
   puma (~> 5.6.9)
   pundit (~> 2.0)
+  rack-attack (~> 6.7)
   rack-rewrite (~> 1.5)
   rack-timeout (~> 0.5)
   rails (= 7.2.3.1)

--- a/app/controllers/signins_controller.rb
+++ b/app/controllers/signins_controller.rb
@@ -12,10 +12,18 @@ class SigninsController < ApplicationController
       signin_params.fetch(:email).strip.downcase.delete(".")
     ).first
 
+    if @signin&.locked?
+      flash.now[:error] = t("controllers.signins.create.locked")
+      render :new
+      return
+    end
+
     if !!@signin && !!@signin.authenticate(signin_params.fetch(:password))
       SignIn.call(@signin, self, permanent: params[:remember_me] == "1")
     else
+      account_for_failure = @signin
       @signin = Account.new
+      account_for_failure&.register_failed_attempt!
       flash.now[:error] = t("controllers.signins.create.error")
       render :new
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -590,6 +590,33 @@ class Account < ActiveRecord::Base
   has_secure_token :admin_invitation_token
   has_secure_password
 
+  MAX_FAILED_ATTEMPTS = 10
+  LOCKOUT_PERIOD = 30.minutes
+
+  def locked?
+    return false if locked_at.blank?
+
+    if locked_at <= LOCKOUT_PERIOD.ago
+      reset_failed_attempts!
+      return false
+    end
+
+    true
+  end
+
+  def register_failed_attempt!
+    new_count = failed_attempts + 1
+    attrs = {failed_attempts: new_count}
+    attrs[:locked_at] = Time.current if new_count >= MAX_FAILED_ATTEMPTS
+    update!(attrs)
+  end
+
+  def reset_failed_attempts!
+    return unless failed_attempts.positive? || locked_at.present?
+
+    update!(failed_attempts: 0, locked_at: nil)
+  end
+
   before_validation -> {
     self.email = email.to_s.strip.downcase
 

--- a/app/technovation/sign_in.rb
+++ b/app/technovation/sign_in.rb
@@ -1,5 +1,7 @@
 module SignIn
   def self.call(signin, context, options = {})
+    signin.reset_failed_attempts!
+
     signin_options = {
       message: I18n.translate("controllers.signins.create.success"),
       redirect_to: after_signin_path(signin, context),

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Rack::Attack
+  SIGNINS_LIMIT = 20
+  SIGNINS_PERIOD = 60
+  PASSWORD_RESETS_LIMIT = 5
+  PASSWORD_RESETS_PERIOD = 60
+end
+
+Rack::Attack.cache.store = if Rails.application.config.cache_store == :null_store
+  ActiveSupport::Cache::MemoryStore.new
+else
+  Rails.cache
+end
+
+Rack::Attack.enabled = !Rails.env.test?
+
+if Rails.env.development?
+  Rack::Attack.safelist("allow localhost") do |req|
+    ["127.0.0.1", "::1"].include?(req.ip)
+  end
+end
+
+Rack::Attack.throttle(
+  "signins/ip",
+  limit: Rack::Attack::SIGNINS_LIMIT,
+  period: Rack::Attack::SIGNINS_PERIOD.seconds
+) do |req|
+  req.ip if req.post? && req.path == "/signins"
+end
+
+Rack::Attack.throttle(
+  "password_resets/ip",
+  limit: Rack::Attack::PASSWORD_RESETS_LIMIT,
+  period: Rack::Attack::PASSWORD_RESETS_PERIOD.seconds
+) do |req|
+  req.ip if req.post? && req.path == "/password_resets"
+end
+
+Rack::Attack.throttled_responder = lambda do |_request|
+  [
+    429,
+    {"Content-Type" => "text/plain"},
+    [I18n.t("controllers.rack_attack.throttled")]
+  ]
+end

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -128,10 +128,14 @@ en:
         link: "Reset your password"
         text: "Trouble signing in?"
 
+    rack_attack:
+      throttled: "Too many requests. Please try again later."
+
     signins:
       create:
         success: "Hey! Welcome back!"
         error: "Sorry, we didn't recognize that name and password"
+        locked: "Too many failed sign-in attempts. Try again in 30 minutes."
       destroy:
         success: "You're signed out. See you next time!"
       new:

--- a/config/locales/controllers.es.yml
+++ b/config/locales/controllers.es.yml
@@ -66,10 +66,14 @@ es:
       new:
         link: "Olvidé mi contraseña"
 
+    rack_attack:
+      throttled: "Demasiadas solicitudes. Inténtalo de nuevo más tarde."
+
     signins:
       create:
         success: "¡Hola! ¡Bienvenido!"
         error: "Lo sentimos, no reconocemos ese nombre y contraseña."
+        locked: "Demasiados intentos fallidos de inicio de sesión. Inténtalo de nuevo en 30 minutos."
       destroy:
         success: "Has cerrado sesión. ¡Nos vemos la próxima vez!"
 

--- a/db/migrate/20260713160000_add_lockout_to_accounts.rb
+++ b/db/migrate/20260713160000_add_lockout_to_accounts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLockoutToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    change_table :accounts, bulk: true do |t|
+      t.integer :failed_attempts, null: false, default: 0
+      t.datetime :locked_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -162,7 +162,9 @@ CREATE TABLE public.accounts (
     phone_number character varying,
     no_chapterable_selected boolean,
     no_chapterables_available boolean,
-    force_chapterable_selection boolean DEFAULT false
+    force_chapterable_selection boolean DEFAULT false,
+    failed_attempts integer DEFAULT 0 NOT NULL,
+    locked_at timestamp(6) without time zone
 );
 
 
@@ -5098,6 +5100,7 @@ ALTER TABLE ONLY public.program_information
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260713160000'),
 ('20260402233018'),
 ('20260331220350'),
 ('20260323193301'),

--- a/docs/security-brute-force-protection.md
+++ b/docs/security-brute-force-protection.md
@@ -1,0 +1,37 @@
+# Brute-force and password-spray protection
+
+This app limits repeated authentication attempts at two layers.
+
+## IP throttling (rack-attack)
+
+| Endpoint | Limit |
+|---|---|
+| `POST /signins` | 20 requests per IP per 60 seconds |
+| `POST /password_resets` | 5 requests per IP per 60 seconds |
+
+Exceeded limits return HTTP **429 Too Many Requests** with a generic message.
+
+Counters are stored in `Rails.cache` (Memcached in production). Localhost is safelisted in development only.
+
+## Per-account lockout
+
+| Setting | Value |
+|---|---|
+| Failed attempts before lockout | 10 |
+| Lockout duration | 30 minutes |
+
+After 10 failed password attempts on `POST /signins`, the account is locked. Locked accounts cannot sign in until the lockout window expires. A successful sign-in (via password or any path that calls `SignIn.call`) resets the counter and clears lockout.
+
+Unknown email addresses still receive the generic sign-in error and do not increment any counter.
+
+## Configuration
+
+- Rack::Attack: [`config/initializers/rack_attack.rb`](../config/initializers/rack_attack.rb)
+- Account lockout: [`app/models/account.rb`](../app/models/account.rb) (`MAX_FAILED_ATTEMPTS`, `LOCKOUT_PERIOD`)
+
+## Out of scope (future work)
+
+- MFA / Active Directory
+- CAPTCHA
+- Admin unlock UI or unlock-via-email
+- Cloudflare WAF rules

--- a/spec/controllers/signins_controller_spec.rb
+++ b/spec/controllers/signins_controller_spec.rb
@@ -57,6 +57,83 @@ RSpec.describe SigninsController do
       expect(response).to redirect_to(student_dashboard_path)
     end
 
+    it "increments failed attempts for a wrong password" do
+      student = FactoryBot.create(:student)
+
+      expect {
+        post :create, params: {
+          account: {
+            email: student.email,
+            password: "wrong-password"
+          }
+        }
+      }.to change { student.account.reload.failed_attempts }.by(1)
+
+      expect(response).to render_template(:new)
+      expect(flash.now[:error]).to eq(I18n.t("controllers.signins.create.error"))
+    end
+
+    it "does not increment failed attempts for an unknown email" do
+      post :create, params: {
+        account: {
+          email: "unknown@example.com",
+          password: "wrong-password"
+        }
+      }
+
+      expect(response).to render_template(:new)
+      expect(flash.now[:error]).to eq(I18n.t("controllers.signins.create.error"))
+    end
+
+    it "locks the account after too many failed attempts" do
+      student = FactoryBot.create(:student)
+      student.account.update!(failed_attempts: Account::MAX_FAILED_ATTEMPTS - 1)
+
+      post :create, params: {
+        account: {
+          email: student.email,
+          password: "wrong-password"
+        }
+      }
+
+      expect(student.account.reload.locked?).to be(true)
+      expect(flash.now[:error]).to eq(I18n.t("controllers.signins.create.error"))
+    end
+
+    it "rejects sign-in for a locked account" do
+      student = FactoryBot.create(:student)
+      student.account.update!(
+        failed_attempts: Account::MAX_FAILED_ATTEMPTS,
+        locked_at: 5.minutes.ago
+      )
+
+      post :create, params: {
+        account: {
+          email: student.email,
+          password: "secret1234"
+        }
+      }
+
+      expect(response).to render_template(:new)
+      expect(flash.now[:error]).to eq(I18n.t("controllers.signins.create.locked"))
+      expect(student.account.reload.failed_attempts).to eq(Account::MAX_FAILED_ATTEMPTS)
+    end
+
+    it "resets failed attempts after a successful sign-in" do
+      student = FactoryBot.create(:student)
+      student.account.update!(failed_attempts: 3, locked_at: nil)
+
+      post :create, params: {
+        account: {
+          email: student.email,
+          password: "secret1234"
+        }
+      }
+
+      expect(student.account.reload.failed_attempts).to eq(0)
+      expect(student.account.locked_at).to be_nil
+    end
+
     context "REDIRECTED_FROM cookie" do
       it "ignores a stale JSON redirect and routes to the judge dashboard" do
         judge = FactoryBot.create(:judge)

--- a/spec/models/account_lockout_spec.rb
+++ b/spec/models/account_lockout_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Account, "lockout" do
+  let(:account) { FactoryBot.create(:account, password: "secret1234") }
+
+  describe "#locked?" do
+    it "returns false when locked_at is blank" do
+      expect(account.locked?).to be(false)
+    end
+
+    it "returns true when locked within the lockout period" do
+      account.update!(failed_attempts: Account::MAX_FAILED_ATTEMPTS, locked_at: 5.minutes.ago)
+
+      expect(account.locked?).to be(true)
+    end
+
+    it "clears expired lockouts and returns false" do
+      account.update!(failed_attempts: Account::MAX_FAILED_ATTEMPTS, locked_at: 31.minutes.ago)
+
+      expect(account.locked?).to be(false)
+      expect(account.reload.failed_attempts).to eq(0)
+      expect(account.locked_at).to be_nil
+    end
+  end
+
+  describe "#register_failed_attempt!" do
+    it "increments failed_attempts" do
+      expect {
+        account.register_failed_attempt!
+      }.to change { account.reload.failed_attempts }.by(1)
+    end
+
+    it "locks the account when the threshold is reached" do
+      account.update!(failed_attempts: Account::MAX_FAILED_ATTEMPTS - 1)
+
+      Timecop.freeze do
+        account.register_failed_attempt!
+
+        expect(account.reload.failed_attempts).to eq(Account::MAX_FAILED_ATTEMPTS)
+        expect(account.locked_at).to be_within(1.second).of(Time.current)
+        expect(account.locked?).to be(true)
+      end
+    end
+  end
+
+  describe "#reset_failed_attempts!" do
+    it "clears failed_attempts and locked_at" do
+      account.update!(failed_attempts: 3, locked_at: Time.current)
+
+      account.reset_failed_attempts!
+
+      expect(account.reload.failed_attempts).to eq(0)
+      expect(account.locked_at).to be_nil
+    end
+
+    it "does nothing when already clear" do
+      expect {
+        account.reset_failed_attempts!
+      }.not_to change { account.reload.updated_at }
+    end
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack", type: :request do
+  around do |example|
+    Rack::Attack.cache.store.clear
+    Rack::Attack.enabled = true
+    Timecop.freeze { example.run }
+  ensure
+    Rack::Attack.enabled = false
+    Rack::Attack.cache.store.clear
+  end
+
+  def post_signin(ip: "203.0.113.1")
+    post "/signins",
+      params: {account: {email: "nobody@example.com", password: "wrong"}},
+      env: {"REMOTE_ADDR" => ip}
+  end
+
+  def post_password_reset(ip: "203.0.113.2")
+    post "/password_resets",
+      params: {password_reset: {email: "nobody@example.com"}},
+      env: {"REMOTE_ADDR" => ip}
+  end
+
+  describe "POST /signins IP throttling" do
+    it "allows requests under the limit" do
+      Rack::Attack::SIGNINS_LIMIT.times { post_signin }
+
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the limit is exceeded" do
+      (Rack::Attack::SIGNINS_LIMIT + 1).times { post_signin }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include(I18n.t("controllers.rack_attack.throttled"))
+    end
+  end
+
+  describe "POST /password_resets IP throttling" do
+    it "allows requests under the limit" do
+      Rack::Attack::PASSWORD_RESETS_LIMIT.times { post_password_reset }
+
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the limit is exceeded" do
+      (Rack::Attack::PASSWORD_RESETS_LIMIT + 1).times { post_password_reset }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.body).to include(I18n.t("controllers.rack_attack.throttled"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add rack-attack IP throttling on `POST /signins` (20 req/IP/min) and `POST /password_resets` (5 req/IP/min), returning HTTP 429 when exceeded
- Add per-account failed-attempt lockout (10 failures → 30-minute lock) with counter reset on successful sign-in
- Document thresholds and behavior in `docs/security-brute-force-protection.md`

## Test plan
- [x] `bundle exec rspec spec/models/account_lockout_spec.rb spec/controllers/signins_controller_spec.rb spec/requests/rack_attack_spec.rb` (22 examples, 0 failures)
- [ ] Run `bundle exec rails db:migrate` on QA/staging before deploy
- [ ] Verify locked account shows lockout message and cannot sign in until window expires
- [ ] Verify rapid sign-in attempts from one IP return 429
