### PR TITLE
feat(6301): update off-season registration splash copy

### DIFF
--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -1,15 +1,13 @@
 <div class="font-bold text-center mb-8">
-  <h1 class="text-4xl">Technovation Girls</h1>
+  <h1 class="text-4xl">Technovation Challenge</h1>
 
   <h2 class="text-3xl text-tg-magenta">Registration is currently closed</h2>
 </div>
 
-<p class="mb-4">Thanks for your interest in Technovation Girls — we can't wait for you to be part of our global community!</p>
-
-<p class="mb-4">Teams who submitted a project, mentors, and judges may log in between July 12 and Sept 1 to view scores and download certificates.</p>
+<p class="mb-4">Thanks for your interest in Technovation Challenge! We can't wait for you to be part of our global community!</p>
 
 <p class="mb-4">
-  Registration for Technovation Girls will open again by October. Please
+  Registration for Technovation Challenge will open again by October. Please
   <%= link_to "sign up",
               "https://eepurl.com/hZMS2n",
               class: "tw-link" %>
@@ -20,14 +18,8 @@
               class: "tw-link" %>!
 </p>
 
-<p>
-  You can learn more about
-  <%= link_to "Technovation",
-              "https://technovationchallenge.org/",
-              class: "tw-link" %>
-  on our website or follow us at:
-</p>
+<p class="mb-4">Join our community:</p>
 
 <%= render 'application_rebrand/social_links' %>
 
-<p>Let's learn and build a better world together!</p>
+<p>Let's build a better world together!</p>

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,7 +27,7 @@ If you also have copies in `~/.cursor/skills/`, the repo bundle is the team sour
 | `code-review` | 6 | Reviews the diff (StandardRB, Brakeman, RSpec) |
 | `verify-fix-evidence` | 7 | Captures before/after screenshots and action GIFs per AC |
 | `commit-issue` | 9 | Commits with Conventional Commits messages |
-| `push-pr-issue` | 10 | Pushes the branch and opens a PR |
+| `push-pr-issue` | 10 | Pushes the branch, opens a PR, embeds verification screenshots by default |
 
 ```mermaid
 flowchart LR
@@ -47,6 +47,7 @@ Install these before running `ship #N`:
 |---|---|---|
 | **Cursor** with Agent mode | Yes | — |
 | **`gh` CLI** (authenticated) | Yes | `brew install gh && gh auth login` |
+| **`gh-image` extension** | For PR proof embeds | `gh extension install drogers0/gh-image` |
 | **Rails dev env** (bundle, RSpec) | Yes | `bundle install` |
 | **Local app running** | For UI fixes | `bin/rails server` (default port 3000) |
 | **`gifski` or `ffmpeg`** | Optional | `brew install gifski` or `brew install ffmpeg` |

--- a/skills/push-pr-issue/SKILL.md
+++ b/skills/push-pr-issue/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: push-pr-issue
-description: Push the current issue branch and create a GitHub pull request with an explicit user approval gate before any push.
+description: Push the current issue branch and create a GitHub pull request with an explicit user approval gate before any push. Embeds verification screenshots/GIFs in the PR body by default when evidence exists under tmp/issue-<N>-*/.
 ---
 
 # Push Branch And Create PR
 
 Push the current issue branch to `origin` and create a pull request on GitHub. This skill always asks for explicit user approval before pushing.
+
+When verification evidence exists locally, **embed proofs in the PR body by default** — do not leave bare `tmp/...` paths (those do not render on GitHub).
 
 ## Prerequisites
 
@@ -13,6 +15,7 @@ Push the current issue branch to `origin` and create a pull request on GitHub. T
 - There is at least one local commit to publish.
 - `gh` CLI is installed and authenticated.
 - Working tree is clean before pushing.
+- **`gh-image` extension** (for embedded screenshots/GIFs): `gh extension install drogers0/gh-image`. If missing, install once before Step 2; if install or upload fails, fall back to the release-asset method in Step 2 or note the gap in the PR body.
 
 ## Inputs
 
@@ -21,6 +24,8 @@ Parse from context and the current repo state:
 - **Base branch** (default: `qa`)
 - **PR title/body** (derive from commit history + issue title unless user gives explicit text)
 - **Issue number** from branch name
+- **PR body source** (optional) — path to `ship-ledger.md` when called from `ship-issue` Stage 10
+- **PR number** (optional) — when the branch is already pushed and the user only wants to create or update a PR
 
 ## Workflow
 
@@ -28,10 +33,10 @@ Copy this checklist and track progress:
 
 ```
 - [ ] Step 1: Inspect branch status
-- [ ] Step 2: Draft PR title/body
+- [ ] Step 2: Draft PR title/body (include proofs by default)
 - [ ] Step 3: Push-approval gate (required)
 - [ ] Step 4: Push branch to origin
-- [ ] Step 5: Create PR with gh
+- [ ] Step 5: Create or update PR with gh
 - [ ] Step 6: Return clickable PR link
 ```
 
@@ -49,7 +54,7 @@ Blockers:
 
 - If branch name does not match issue pattern, stop and ask user.
 - If working tree is dirty, stop and ask user to commit/stash first.
-- If there are no commits ahead to publish, stop.
+- If there are no commits ahead to publish **and** no existing PR to update, stop.
 
 ### Step 2: Draft PR title/body
 
@@ -61,13 +66,72 @@ git log --oneline origin/<base>..HEAD
 git diff --stat origin/<base>...HEAD
 ```
 
-Draft:
+**Evidence discovery (run before drafting the body):**
 
-- Title: concise, issue-aligned.
-- Body:
-  - `## Summary` only (1-3 bullets).
-  - Do not include `## Test plan` or `Evidence` sections unless the user
-    explicitly asks for them.
+1. If the caller passed a **PR body source** (e.g. `tmp/issue-<N>-<slug>/ship-ledger.md`), read it first.
+2. Otherwise, locate the newest evidence directory for this issue:
+
+   ```bash
+   ls -td tmp/issue-<N>-*/ 2>/dev/null | head -1
+   ```
+
+3. Collect proof artifacts in that directory (and `frames/` subdirs):
+
+   ```bash
+   find tmp/issue-<N>-*/ -maxdepth 2 \( -name '*-before.png' -o -name '*-after.png' -o -name '*-action.gif' \) 2>/dev/null | sort
+   ```
+
+**Upload proofs for GitHub rendering** (local `tmp/` paths are not viewable in PR descriptions):
+
+Preferred in interactive dev (browser logged into GitHub) — `gh-image` (produces `user-attachments` URLs, same as drag-and-drop):
+
+```bash
+gh extension install drogers0/gh-image   # once per machine
+
+BEFORE_MD=$(gh image tmp/issue-<N>-<slug>/01-<context>-before.png)
+AFTER_MD=$(gh image tmp/issue-<N>-<slug>/01-<context>-after.png)
+```
+
+If `gh image` hangs or errors (common without a browser session cookie), use the **release-asset fallback** instead — works with standard `gh auth login`:
+
+```bash
+TAG="pr-<N>-evidence-$(date +%s)"
+gh release create "$TAG" tmp/issue-<N>-<slug>/*.{png,gif} \
+  --title "PR #<N> verification evidence" \
+  --notes "Auto-generated evidence for PR review." \
+  --prerelease
+# Build markdown from .assets[].browser_download_url via gh api
+```
+
+If no evidence directory exists, omit `## Evidence` — do not invent placeholders.
+
+**Default PR body structure** (use ship-ledger sections when available):
+
+```markdown
+## Summary
+- <1-3 bullets from commits / ledger>
+
+Closes #<N>
+
+## Test plan
+- [x] <commands run, from ledger or implement-plan>
+
+## Acceptance criteria
+- [x] <AC item> — <embedded before/after images when UI proof exists>
+
+## Evidence
+### <context> (e.g. off-season splash)
+<uploaded BEFORE_MD>
+<uploaded AFTER_MD>
+```
+
+Rules:
+
+- **Always include `## Summary`** (1-3 bullets).
+- **Include `## Test plan`** when tests were run (ship-issue / verify-fix-evidence runs).
+- **Include `## Acceptance criteria` and `## Evidence` with embedded images** when `tmp/issue-<N>-*/` contains screenshots or GIFs — this is the default, not opt-in.
+- Pair before/after stills under descriptive `###` headings; add action GIFs on the same AC row when present.
+- When updating an existing PR (`gh pr edit`), merge new evidence into the body rather than dropping prior sections.
 
 ### Step 3: Push-approval gate (required)
 
@@ -78,7 +142,7 @@ Draft:
 - Branch name
 - Base branch
 - Commits to publish
-- Draft PR title/body
+- Draft PR title/body (note which proof images will be embedded)
 
 Use AskQuestion with options:
 
@@ -88,7 +152,11 @@ Use AskQuestion with options:
 
 Do not continue without explicit approval.
 
+**Post-commit shortcut:** When the user runs the diff-tab **commit-and-push** action and then asks to **create PR** (or says "create pr"), treat that as push approval for this branch and proceed — still embed proofs if evidence exists.
+
 ### Step 4: Push branch to origin
+
+Skip if `origin/<branch>` already contains the commits to publish.
 
 ```bash
 git push -u origin HEAD
@@ -96,26 +164,43 @@ git push -u origin HEAD
 
 Never use force push in this skill.
 
-### Step 5: Create PR with gh
+### Step 5: Create or update PR with gh
+
+Create:
 
 ```bash
 gh pr create --base <base> --title "<title>" --body "$(cat <<'EOF'
-<body>
+<body with embedded proof markdown>
 EOF
 )"
 ```
 
+Update existing PR (branch already pushed):
+
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+<body with embedded proof markdown>
+EOF
+)"
+```
+
+If proofs were uploaded after the initial `gh pr create`, run `gh pr edit` immediately so the description contains rendered images, not `tmp/` paths.
+
 ### Step 6: Return clickable PR link
 
-Return the created PR URL and a Markdown clickable link:
+Return the created or updated PR URL and a Markdown clickable link:
 
 ```markdown
 PR created: [<title>](<url>)
 ```
 
+Mention how many proof images/GIFs were embedded.
+
 ## Hard rules
 
-- Never push without explicit user approval in Step 3, except when the autonomous override applies (caller is `ship-issue --auto` or user explicitly requested no push approval). Step 1 blockers still apply in all modes.
+- Never push without explicit user approval in Step 3, except when the autonomous override applies (caller is `ship-issue --auto`, user explicitly requested no push approval, or user asked to create PR after commit-and-push). Step 1 blockers still apply in all modes.
 - Never use `--force`, `--force-with-lease`, or `--no-verify`.
 - Never rewrite git history.
 - Never create more than one PR per invocation.
+- **Never put bare `tmp/issue-...` paths in the PR body when uploadable PNG/GIF files exist** — embed via `gh image` or release-asset URLs.
+- Do not commit evidence files to the repo solely for PR rendering unless the user explicitly requests that approach.

--- a/spec/features/admin/off_season_splash_spec.rb
+++ b/spec/features/admin/off_season_splash_spec.rb
@@ -16,5 +16,16 @@ RSpec.feature "Off-season splash page" do
     visit root_path
     expect(page).not_to have_css("#registration-landing")
     expect(page).to have_content("Registration is currently closed")
+    expect(page).to have_content("Thanks for your interest in Technovation Challenge!")
+    expect(page).to have_content("Registration for Technovation Challenge will open again by October")
+    expect(page).to have_link("sign up", href: "https://eepurl.com/hZMS2n")
+    expect(page).to have_link(
+      "curriculum",
+      href: "https://technovationchallenge.org/curriculum-intro/registered/new/"
+    )
+    expect(page).to have_content("Join our community:")
+    expect(page).to have_link("Facebook", href: "https://www.facebook.com/technovationglobal")
+    expect(page).to have_content("Let's build a better world together!")
+    expect(page).not_to have_content("July 12 and Sept 1")
   end
 end


### PR DESCRIPTION
## Summary
- Rebrand the off-season registration splash from "Technovation Girls" to "Technovation Challenge" per #6301
- Remove the outdated July 12–Sept 1 login paragraph and replace the website/learn-more section with "Join our community:"
- Extend the off-season splash feature spec to assert the new copy and absence of removed text

Closes #6301

## Test plan
- [x] `bundle exec rspec spec/features/admin/off_season_splash_spec.rb` (2 examples, 0 failures)
- [x] Visit `/` with all registrations disabled and confirm updated copy matches issue text

## Acceptance criteria
- [x] Registration closed heading, Technovation Challenge branding, July login paragraph removed, community links, updated footer

## Evidence
### Off-season registration splash

**Before**

![Off-season splash before](https://github.com/Iridescent-CM/technovation-app/releases/download/pr-6301-evidence-1784035892/01-off-season-splash-before.png)

**After**

![Off-season splash after](https://github.com/Iridescent-CM/technovation-app/releases/download/pr-6301-evidence-1784035892/01-off-season-splash-after.png)