### PR TITLE
feat(6294): extend bundle measurement for per-layout gzip sizes

### DIFF
--- a/perf/scripts/compare-baselines.js
+++ b/perf/scripts/compare-baselines.js
@@ -18,6 +18,7 @@ console.log("")
 
 compareRoleFiles(baselineA, baselineB)
 compareBundles(baselineA, baselineB)
+compareLayouts(baselineA, baselineB)
 
 function compareRoleFiles(dirA, dirB) {
   const roles = [
@@ -77,6 +78,46 @@ function compareBundles(dirA, dirB) {
   for (const pack of packs) {
     printDelta("  ", pack, "KB", a[pack] ?? 0, b[pack] ?? 0, true)
   }
+}
+
+function compareLayouts(dirA, dirB) {
+  const fileA = path.join(dirA, "bundles.json")
+  const fileB = path.join(dirB, "bundles.json")
+  if (!fs.existsSync(fileA) || !fs.existsSync(fileB)) {
+    console.log("[layouts] missing bundles.json in one baseline — skip")
+    return
+  }
+
+  const layoutsA = JSON.parse(fs.readFileSync(fileA, "utf8")).layouts
+  const layoutsB = JSON.parse(fs.readFileSync(fileB, "utf8")).layouts
+
+  if (!layoutsA || !layoutsB) {
+    console.log("[layouts] missing layouts in one baseline — skip")
+    return
+  }
+
+  const layouts = [...new Set([...Object.keys(layoutsA), ...Object.keys(layoutsB)])].sort()
+
+  console.log("[layouts] transferred gzip KB")
+  for (const layout of layouts) {
+    printDelta(
+      "  ",
+      layout,
+      "gzip KB",
+      layoutsA[layout]?.total_gzip_kb ?? 0,
+      layoutsB[layout]?.total_gzip_kb ?? 0,
+      true
+    )
+    printDelta(
+      "  ",
+      layout,
+      "raw KB",
+      layoutsA[layout]?.total_kb ?? 0,
+      layoutsB[layout]?.total_kb ?? 0,
+      true
+    )
+  }
+  console.log("")
 }
 
 function printDelta(prefix, label, metric, before, after, lowerIsBetter = false) {

--- a/perf/scripts/extract-bundles.js
+++ b/perf/scripts/extract-bundles.js
@@ -3,6 +3,7 @@
 
 const fs = require("fs")
 const path = require("path")
+const zlib = require("zlib")
 
 const TRACKED_PACKS = [
   "application",
@@ -12,42 +13,134 @@ const TRACKED_PACKS = [
   "admin"
 ]
 
-const statsPath = process.argv[2] || "stats.json"
-const outPath = process.argv[3]
-
-if (!fs.existsSync(statsPath)) {
-  console.error(`extract-bundles: missing ${statsPath} — run shakapacker --json first`)
-  process.exit(1)
+const LAYOUT_PACKS = {
+  application: ["application"],
+  judge: ["application", "application_rebrand", "judge"],
+  mentor: ["application", "application_rebrand"],
+  admin: ["application", "admin"],
+  new_registration: ["application", "new_registration"],
+  submissions: ["application", "submissions", "application_rebrand"]
 }
 
-const stats = JSON.parse(fs.readFileSync(statsPath, "utf8"))
-const bytesByPack = Object.fromEntries(TRACKED_PACKS.map((p) => [p, 0]))
+function extractBundles(
+  stats,
+  { outputPath, outputDir = "public/packs", statsFile = "stats.json" } = {}
+) {
+  const bytesByPack = Object.fromEntries(TRACKED_PACKS.map((p) => [p, 0]))
 
-for (const asset of stats.assets || []) {
-  const pack = packFromAssetName(asset.name)
-  if (pack) {
-    bytesByPack[pack] += asset.size || 0
+  for (const asset of stats.assets || []) {
+    const pack = packFromAssetName(asset.name)
+    if (pack) {
+      bytesByPack[pack] += asset.size || 0
+    }
   }
+
+  const kbByPack = Object.fromEntries(
+    Object.entries(bytesByPack).map(([pack, bytes]) => [pack, round1(bytes / 1024)])
+  )
+
+  const assetSizeByName = buildAssetSizeIndex(stats)
+  const layouts = computeLayouts(stats, assetSizeByName, outputDir)
+
+  const output = {
+    generated_at: new Date().toISOString(),
+    stats_file: statsFile,
+    packs_kb: kbByPack,
+    layouts
+  }
+
+  const json = JSON.stringify(output, null, 2) + "\n"
+
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+    fs.writeFileSync(outputPath, json)
+  }
+
+  return output
 }
 
-const kbByPack = Object.fromEntries(
-  Object.entries(bytesByPack).map(([pack, bytes]) => [pack, round1(bytes / 1024)])
-)
-
-const output = {
-  generated_at: new Date().toISOString(),
-  stats_file: statsPath,
-  packs_kb: kbByPack
+function buildAssetSizeIndex(stats) {
+  const index = {}
+  for (const asset of stats.assets || []) {
+    if (asset.name) {
+      index[normalizeAssetName(asset.name)] = asset.size || 0
+    }
+  }
+  return index
 }
 
-const json = JSON.stringify(output, null, 2) + "\n"
+function normalizeAssetName(name) {
+  return path.basename(name)
+}
 
-if (outPath) {
-  fs.mkdirSync(path.dirname(outPath), { recursive: true })
-  fs.writeFileSync(outPath, json)
-  console.log(`extract-bundles: wrote ${outPath}`)
-} else {
-  process.stdout.write(json)
+function entrypointAssets(stats, packName) {
+  const entry = stats.entrypoints?.[packName]
+  if (!entry?.assets) return []
+
+  return entry.assets.map((asset) => {
+    if (typeof asset === "string") return normalizeAssetName(asset)
+    return normalizeAssetName(asset.name)
+  })
+}
+
+function computeLayouts(stats, assetSizeByName, outputDir) {
+  const layouts = {}
+
+  for (const [layout, packs] of Object.entries(LAYOUT_PACKS)) {
+    const uniqueAssets = new Set()
+
+    for (const pack of packs) {
+      for (const assetName of entrypointAssets(stats, pack)) {
+        uniqueAssets.add(assetName)
+      }
+    }
+
+    let jsBytes = 0
+    let cssBytes = 0
+    let jsGzipBytes = 0
+    let cssGzipBytes = 0
+    let chunkCount = 0
+
+    for (const assetName of uniqueAssets) {
+      const size = assetSizeByName[assetName] || 0
+      const gzipSize = gzipSizeForAsset(assetName, outputDir)
+
+      if (assetName.endsWith(".js")) {
+        jsBytes += size
+        jsGzipBytes += gzipSize
+        chunkCount++
+      } else if (assetName.endsWith(".css")) {
+        cssBytes += size
+        cssGzipBytes += gzipSize
+        chunkCount++
+      }
+    }
+
+    layouts[layout] = {
+      packs,
+      js_kb: round1(jsBytes / 1024),
+      css_kb: round1(cssBytes / 1024),
+      total_kb: round1((jsBytes + cssBytes) / 1024),
+      js_gzip_kb: round1(jsGzipBytes / 1024),
+      css_gzip_kb: round1(cssGzipBytes / 1024),
+      total_gzip_kb: round1((jsGzipBytes + cssGzipBytes) / 1024),
+      chunk_count: chunkCount
+    }
+  }
+
+  return layouts
+}
+
+function gzipSizeForAsset(assetName, outputDir) {
+  const filePath = path.join(outputDir, assetName)
+  if (!fs.existsSync(filePath)) return 0
+
+  try {
+    const content = fs.readFileSync(filePath)
+    return zlib.gzipSync(content).length
+  } catch {
+    return 0
+  }
 }
 
 function packFromAssetName(name) {
@@ -61,4 +154,31 @@ function packFromAssetName(name) {
 
 function round1(n) {
   return Math.round(n * 10) / 10
+}
+
+module.exports = {
+  extractBundles,
+  LAYOUT_PACKS,
+  TRACKED_PACKS,
+  packFromAssetName,
+  round1
+}
+
+if (require.main === module) {
+  const statsPath = process.argv[2] || "stats.json"
+  const outPath = process.argv[3]
+
+  if (!fs.existsSync(statsPath)) {
+    console.error(`extract-bundles: missing ${statsPath} — run shakapacker --json first`)
+    process.exit(1)
+  }
+
+  const stats = JSON.parse(fs.readFileSync(statsPath, "utf8"))
+  const output = extractBundles(stats, { outputPath: outPath, statsFile: statsPath })
+
+  if (!outPath) {
+    process.stdout.write(JSON.stringify(output, null, 2) + "\n")
+  } else {
+    console.log(`extract-bundles: wrote ${outPath}`)
+  }
 }

--- a/spec/javascript/perf/extract-bundles.spec.js
+++ b/spec/javascript/perf/extract-bundles.spec.js
@@ -1,0 +1,143 @@
+import { createRequire } from "module";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { extractBundles } = require("../../../perf/scripts/extract-bundles.js");
+
+const FIXTURE_STATS = {
+  entrypoints: {
+    application: {
+      assets: [
+        { name: "packs/application.js" },
+        { name: "packs/vendors-abc123.js" },
+      ],
+    },
+    application_rebrand: {
+      assets: [{ name: "packs/application_rebrand.css" }],
+    },
+    judge: {
+      assets: [{ name: "packs/judge.js" }, { name: "packs/vendors-abc123.js" }],
+    },
+    admin: {
+      assets: [{ name: "packs/admin.js" }, { name: "packs/vendors-abc123.js" }],
+    },
+    new_registration: {
+      assets: [{ name: "packs/new_registration.js" }],
+    },
+    submissions: {
+      assets: [{ name: "packs/submissions.js" }],
+    },
+  },
+  assets: [
+    { name: "packs/application.js", size: 10240 },
+    { name: "packs/vendors-abc123.js", size: 51200 },
+    { name: "packs/judge.js", size: 8192 },
+    { name: "packs/admin.js", size: 6144 },
+    { name: "packs/application_rebrand.css", size: 4096 },
+    { name: "packs/new_registration.js", size: 20480 },
+    { name: "packs/submissions.js", size: 16384 },
+  ],
+};
+
+describe("extract-bundles", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  function writeAsset(name, content) {
+    const filePath = path.join(tempDir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+
+  function runExtract() {
+    return extractBundles(FIXTURE_STATS, {
+      outputDir: tempDir,
+      statsFile: "fixture-stats.json",
+    });
+  }
+
+  it("preserves packs_kb for tracked entry packs", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    writeAsset("application.js", "application pack");
+
+    const output = runExtract();
+
+    expect(output.packs_kb.application).toBe(10);
+    expect(output.packs_kb.judge).toBe(8);
+    expect(output.packs_kb.admin).toBe(6);
+  });
+
+  it("attributes vendor chunks to layouts via entrypoint asset unions", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    writeAsset("application.js", "application pack");
+    writeAsset("vendors-abc123.js", "shared vendor chunk");
+    writeAsset("judge.js", "judge pack");
+    writeAsset("application_rebrand.css", "rebrand styles");
+
+    const output = runExtract();
+    const judge = output.layouts.judge;
+
+    expect(judge.packs).toEqual([
+      "application",
+      "application_rebrand",
+      "judge",
+    ]);
+    expect(judge.total_kb).toBe(72);
+    expect(judge.js_kb).toBe(68);
+    expect(judge.css_kb).toBe(4);
+    expect(judge.chunk_count).toBe(4);
+  });
+
+  it("counts shared vendor chunks once per layout", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    writeAsset("application.js", "application pack");
+    writeAsset("vendors-abc123.js", "shared vendor chunk");
+    writeAsset("admin.js", "admin pack");
+
+    const output = runExtract();
+
+    expect(output.layouts.application.total_kb).toBe(60);
+    expect(output.layouts.admin.total_kb).toBe(66);
+  });
+
+  it("reports gzip transferred sizes smaller than raw sizes", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    const repeated = "console.log('bundle optimization measurement');\n".repeat(
+      200
+    );
+    writeAsset("application.js", repeated);
+    writeAsset("vendors-abc123.js", repeated);
+
+    const output = runExtract();
+    const application = output.layouts.application;
+
+    expect(application.total_gzip_kb).toBeGreaterThan(0);
+    expect(application.total_gzip_kb).toBeLessThan(application.total_kb);
+    expect(application.js_gzip_kb).toBeLessThan(application.js_kb);
+  });
+
+  it("writes bundles.json when outputPath is provided", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    const outPath = path.join(tempDir, "bundles.json");
+    writeAsset("application.js", "application pack");
+
+    extractBundles(FIXTURE_STATS, {
+      outputPath: outPath,
+      outputDir: tempDir,
+      statsFile: "fixture-stats.json",
+    });
+
+    const written = JSON.parse(fs.readFileSync(outPath, "utf8"));
+    expect(written.layouts.application).toBeDefined();
+    expect(written.packs_kb).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `perf/scripts/extract-bundles.js` to report total transferred (gzip) JS/CSS per layout, including deduped vendor chunks from webpack entrypoints
- Updates `perf/scripts/compare-baselines.js` to diff per-layout gzip/raw KB (gracefully skips when `layouts` is missing)
- Adds vitest coverage for layout mapping, vendor-chunk dedup, gzip sizing, and JS/CSS split

Phase 1 (measurement prerequisite) for #6294. Lazy-load and cleanup phases are follow-up PRs.

Part of #6294

## Test plan

- [x] `yarn vitest run spec/javascript/perf/extract-bundles.spec.js` — 5/5 passed

## Acceptance criteria

- [x] `extract-bundles.js` reports total transferred JS/CSS per layout (gzip), including vendor chunks
- [x] Packs mapped to layouts via `LAYOUT_PACKS` from actual layout composition
- [x] Vendor/shared chunks counted once per layout
- [x] `packs_kb` backward compatibility preserved
- [x] `compare-baselines.js` diffs per-layout transferred sizes
- [x] Unit tests cover layout mapping, dedup, gzip, JS/CSS split

## Code review

- Critical: 0 | Important: 0 | Suggestions: 0 | Nits: 0

## Files changed

- `perf/scripts/extract-bundles.js`
- `perf/scripts/compare-baselines.js`
- `spec/javascript/perf/extract-bundles.spec.js`

## Commits

- `458bdd2`: feat(6294): extend extract-bundles for layout gzip sizes
- `273eb0a`: feat(6294): compare per-layout transferred bundle sizes
- `7330818`: feat(6294): add extract-bundles unit tests

## Note

Baseline capture (`yarn perf:bundle` + Lighthouse → `perf/baselines/<date>-bundle-opt-before/`) is an operational step for a perf environment and is not included in this PR. Run after merge to establish the before baseline for Phase 2+ comparisons.