### PR TITLE
feat(6302): add pardon our dust banner to dashboards

### DIFF
--- a/app/javascript/controllers/dismissible_banner_controller.js
+++ b/app/javascript/controllers/dismissible_banner_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = {
+    storageKey: { type: String, default: "pardon_our_dust_banner_dismissed" },
+  };
+
+  connect() {
+    if (localStorage.getItem(this.storageKeyValue) === "true") {
+      this.element.remove();
+      return;
+    }
+
+    this.element.style.display = "";
+  }
+
+  dismiss() {
+    localStorage.setItem(this.storageKeyValue, "true");
+    this.element.remove();
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application";
 import DateFieldsController from "./date_fields_controller";
 application.register("date-fields", DateFieldsController);
 
+import DismissibleBannerController from "./dismissible_banner_controller";
+application.register("dismissible-banner", DismissibleBannerController);
+
 import LanguageSelectorController from "./language_selector_controller";
 application.register("language-selector", LanguageSelectorController);
 

--- a/app/views/application/_pardon_our_dust_banner.html.erb
+++ b/app/views/application/_pardon_our_dust_banner.html.erb
@@ -1,0 +1,40 @@
+<div
+  class="border border-gray-200 border-l-4 border-l-energetic-blue bg-blue-50 mb-6 mx-4 lg:mx-auto lg:max-w-screen-xl"
+  style="display: none"
+  data-controller="dismissible-banner"
+  data-dismissible-banner-storage-key-value="pardon_our_dust_banner_dismissed"
+  role="region"
+  aria-label="Site announcement"
+>
+  <div class="flex items-start gap-3 p-4">
+    <div class="flex-shrink-0 pt-0.5">
+      <svg class="h-5 w-5 text-energetic-blue" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+      </svg>
+    </div>
+
+    <div class="flex-1 min-w-0 text-sm text-energetic-blue">
+      <p class="font-semibold">Pardon our dust!</p>
+      <p class="mt-1">
+        Technovation's refreshed brand and broadened mission are live at technovation.org.
+        Your curriculum and competition resources stay right here.
+      </p>
+      <p class="mt-2">
+        <%= link_to "See what's new →",
+          "https://www.technovation.org/",
+          class: "tw-link font-medium",
+          target: "_blank",
+          rel: "noopener noreferrer" %>
+      </p>
+    </div>
+
+    <button
+      type="button"
+      class="flex-shrink-0 text-gray-500 hover:text-gray-700 text-xl leading-none p-1"
+      data-action="dismissible-banner#dismiss"
+      aria-label="Dismiss announcement"
+    >
+      &times;
+    </button>
+  </div>
+</div>

--- a/app/views/chapter_ambassador/dashboards/show.en.html.erb
+++ b/app/views/chapter_ambassador/dashboards/show.en.html.erb
@@ -1,3 +1,7 @@
+<% content_for :notifications do %>
+  <%= render "application/pardon_our_dust_banner" %>
+<% end %>
+
 <% if current_chapter.present? &&
   ( !current_ambassador.onboarded? || !current_chapter.onboarded? ) %>
     <%= render "chapter_ambassador/profiles/welcome_message_with_required_steps" %>

--- a/app/views/club_ambassador/dashboards/show.en.html.erb
+++ b/app/views/club_ambassador/dashboards/show.en.html.erb
@@ -1,3 +1,7 @@
+<% content_for :notifications do %>
+  <%= render "application/pardon_our_dust_banner" %>
+<% end %>
+
 <% if current_chapterable.present? &&
       (!current_ambassador.onboarded? || !current_chapterable.onboarded?) %>
   <%= render "club_ambassador/profiles/welcome_message_with_required_steps" %>

--- a/app/views/judge/dashboards/show.en.html.erb
+++ b/app/views/judge/dashboards/show.en.html.erb
@@ -1,3 +1,7 @@
+<% content_for :notifications do %>
+  <%= render "application/pardon_our_dust_banner" %>
+<% end %>
+
 <% if !current_judge.email_confirmed? %>
   <%= render "completion_steps/rebrand/confirm_changed_email", profile: current_judge %>
 <% else %>

--- a/app/views/mentor/dashboards/show.html.erb
+++ b/app/views/mentor/dashboards/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :notifications do %>
+  <%= render "application/pardon_our_dust_banner" %>
+<% end %>
+
 <div class="container mx-auto flex flex-col lg:flex-row justify-around gap-6 w-full lg:w-3/4">
   <%= render "mentor/dashboards/side_nav" %>
 

--- a/app/views/student/dashboards/show.html.erb
+++ b/app/views/student/dashboards/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :notifications do %>
+  <%= render "application/pardon_our_dust_banner" %>
+<% end %>
+
 <% if not current_student.email_confirmed? %>
   <%= render "completion_steps/rebrand/confirm_changed_email", profile: current_student %>
 <% else %>

--- a/spec/features/pardon_our_dust_banner_spec.rb
+++ b/spec/features/pardon_our_dust_banner_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.feature "Pardon our dust banner", js: true do
+  scenario "student sees banner on dashboard, can dismiss it, and it stays hidden on revisit" do
+    student = FactoryBot.create(:student, :onboarded)
+    sign_in(student)
+
+    page.execute_script("localStorage.removeItem('pardon_our_dust_banner_dismissed')")
+    visit student_dashboard_path
+
+    expect(page).to have_css("[aria-label='Site announcement']")
+    expect(page).to have_text("Pardon our dust!")
+    expect(page).to have_text("Technovation's refreshed brand and broadened mission are live at technovation.org.")
+    expect(page).to have_link("See what's new →", href: "https://www.technovation.org/")
+
+    find("[aria-label='Dismiss announcement']").click
+
+    expect(page).not_to have_css("[aria-label='Site announcement']")
+
+    visit student_dashboard_path
+
+    expect(page).not_to have_css("[aria-label='Site announcement']")
+    expect(page).not_to have_text("Pardon our dust!")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a dismissible “Pardon our dust!” info banner below the green header on student, mentor, judge, chapter ambassador, and club ambassador dashboards
- Banner uses issue copy with a “See what's new →” link to https://www.technovation.org/; dismiss state persists in localStorage per browser
- Includes feature spec for student dashboard visibility, CTA, and dismiss persistence

Fixes #6302

## Acceptance criteria
- [x] Banner on all five participant dashboards
- [x] Positioned in `:notifications` slot below green header
- [x] Issue copy + CTA link (new tab)
- [x] Blue info styling with dismiss control
- [x] Dismissible; stays hidden after dismiss on revisit
- [x] Admin/public homepage unchanged

## Tests
- `bundle exec rspec spec/features/pardon_our_dust_banner_spec.rb` — passed (1 example)

## Code review
- Critical: 0
- Important: 1 (pre-dismiss flash — fixed with `display:none` until Stimulus connect)
- Suggestions: 4
- Nits: 2