### PR TITLE
chore(6294): Phase 5 bundle optimization verify & sign-off

### DIFF
--- a/perf/scripts/extract-bundles.js
+++ b/perf/scripts/extract-bundles.js
@@ -132,15 +132,24 @@ function computeLayouts(stats, assetSizeByName, outputDir) {
 }
 
 function gzipSizeForAsset(assetName, outputDir) {
-  const filePath = path.join(outputDir, assetName)
-  if (!fs.existsSync(filePath)) return 0
+  // Webpack emits packs under public/packs/js|css/; fixtures may use a flat dir.
+  const candidates = [
+    path.join(outputDir, assetName),
+    path.join(outputDir, "js", assetName),
+    path.join(outputDir, "css", assetName)
+  ]
 
-  try {
-    const content = fs.readFileSync(filePath)
-    return zlib.gzipSync(content).length
-  } catch {
-    return 0
+  for (const filePath of candidates) {
+    if (!fs.existsSync(filePath)) continue
+
+    try {
+      return zlib.gzipSync(fs.readFileSync(filePath)).length
+    } catch {
+      return 0
+    }
   }
+
+  return 0
 }
 
 function packFromAssetName(name) {

--- a/spec/javascript/perf/extract-bundles.spec.js
+++ b/spec/javascript/perf/extract-bundles.spec.js
@@ -125,6 +125,21 @@ describe("extract-bundles", () => {
     expect(application.js_gzip_kb).toBeLessThan(application.js_kb);
   });
 
+  it("resolves gzip sizes from public/packs/js and css subdirectories", () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
+    const repeated = "console.log('bundle optimization measurement');\n".repeat(
+      200
+    );
+    writeAsset("js/application.js", repeated);
+    writeAsset("js/vendors-abc123.js", repeated);
+
+    const output = runExtract();
+    const application = output.layouts.application;
+
+    expect(application.total_gzip_kb).toBeGreaterThan(0);
+    expect(application.total_gzip_kb).toBeLessThan(application.total_kb);
+  });
+
   it("writes bundles.json when outputPath is provided", () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "extract-bundles-"));
     const outPath = path.join(tempDir, "bundles.json");


### PR DESCRIPTION
## Summary
- Document Phase 5 before/after Lighthouse + layout gzip for the #6294 lazy-load work (`perf/6294-signoff.md`)
- Fix `extract-bundles.js` so gzip sizes resolve under `public/packs/js/` and `public/packs/css/` (Phase 1 previously reported `0` gzip)
- Add vitest coverage for the subdirectory gzip path

Closes #6294

## Test plan
- [x] `yarn vitest run spec/javascript/perf/extract-bundles.spec.js` (6/6)
- [x] `yarn perf:baseline` for public / mentor / judge / admin (before `9a344f01d` + after `905a9090e`)
- [x] `yarn perf:bundle` + `yarn perf:compare` before/after

## Acceptance criteria
- [x] Lighthouse baselines for public, mentor, judge, admin (before + after)
- [x] Bundle report with per-layout gzip (before + after)
- [x] Sign-off doc with LCP + gzip tables and exceptions
- [x] Phase 4 pack split documented as deferred

## Perf results (Phase 5 sign-off)

Local Lighthouse (desktop, simulated throttling, median of 5 runs) + layout transferred gzip from `yarn perf:bundle`.

Before: `9a344f01d` (pre–#6330 lazy-load). After: `905a9090e` (includes #6330).

| Page | LCP before | LCP after | LCP Δ | Score before | Score after |
|------|------------|-----------|-------|--------------|-------------|
| `/` | 1715 ms | 1742 ms | +27 ms | 0.92 | 0.91 |
| `/signup` | 1755 ms | 1763 ms | +8 ms | 0.91 | 0.91 |
| `/mentor/dashboard` | 854 ms | 985 ms | +131 ms | 0.99 | 0.97 |
| `/judge/dashboard` | 1407 ms | 1107 ms | −300 ms | 0.94 | 0.96 |
| `/admin/participants` | 1152 ms | 1111 ms | −41 ms | 0.94 | 0.94 |

| Layout | Gzip before | Gzip after | Gzip Δ |
|--------|-------------|------------|--------|
| application | 648.8 KB | 263.0 KB | **−385.8 KB (−59%)** |
| mentor | 667.9 KB | 282.0 KB | **−385.9 KB (−58%)** |
| judge | 721.0 KB | 335.5 KB | **−385.5 KB (−53%)** |
| admin | 805.7 KB | 278.1 KB | **−527.6 KB (−66%)** |
| new_registration | 717.6 KB | 332.0 KB | **−385.6 KB (−54%)** |
| submissions | 772.0 KB | 289.3 KB | **−482.7 KB (−63%)** |

Lazy-load of filestack / chart.js / password meter cuts initial transferred JS by ~0.4–0.5 MB gzip on every layout. LCP is flat-to-improved on judge/admin; mentor stays sub-1s (noise +131 ms). Phase 4 registration pack split deferred.

