### PR TITLE
fix(6333): defer filestack init for turbo head merge

### DIFF
--- a/app/helpers/filestack_helper.rb
+++ b/app/helpers/filestack_helper.rb
@@ -4,4 +4,23 @@ module FilestackHelper
   def enable_filestack!
     controller.needs_filestack!
   end
+
+  # Turbo-safe replacement for filestack-rails' filestack_js_init_tag.
+  # Security options are not configured in this app; v3 init matches the gem's {cname: ...} output.
+  def filestack_js_deferred_init_tag
+    config = Rails.application.config.filestack_rails
+    client_name = config.client_name
+    init_call = "filestack.init(#{config.api_key.to_json}, #{{cname: config.cname}.to_json})"
+    javascript_tag(<<~JS)
+      (function () {
+        function initFilestack() { window.#{client_name} = #{init_call}; }
+        if (typeof filestack !== "undefined") {
+          initFilestack();
+        } else {
+          var s = document.querySelector('script[src*="filestack"]');
+          (s || window).addEventListener("load", initFilestack);
+        }
+      })();
+    JS
+  end
 end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -16,7 +16,7 @@
     <%= csrf_meta_tags %>
 
     <%= filestack_js_include_tag %>
-    <%= filestack_js_init_tag %>
+    <%= filestack_js_deferred_init_tag %>
 
     <%= javascript_include_tag 'admin', 'data-turbo-track' => true %>
     <%= javascript_pack_tag("application", "admin", data: { turbo_track: :reload }) %>

--- a/app/views/layouts/ambassador.html.erb
+++ b/app/views/layouts/ambassador.html.erb
@@ -24,7 +24,7 @@
     <%= csrf_meta_tags %>
 
     <%= filestack_js_include_tag %>
-    <%= filestack_js_init_tag %>
+    <%= filestack_js_deferred_init_tag %>
 
     <%= javascript_include_tag 'chapter_ambassador', 'data-turbo-track' => true %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <%= yield :css %>
 
     <%= filestack_js_include_tag %>
-    <%= filestack_js_init_tag %>
+    <%= filestack_js_deferred_init_tag %>
 
     <%= javascript_include_tag determine_manifest,
       'data-turbo-track' => true %>

--- a/app/views/layouts/application_rebrand.html.erb
+++ b/app/views/layouts/application_rebrand.html.erb
@@ -27,7 +27,7 @@
 
     <% if needs_filestack? %>
       <%= filestack_js_include_tag %>
-      <%= filestack_js_init_tag %>
+      <%= filestack_js_deferred_init_tag %>
     <% end %>
 
     <%= javascript_include_tag determine_manifest,

--- a/app/views/layouts/chapter_ambassador.html.erb
+++ b/app/views/layouts/chapter_ambassador.html.erb
@@ -24,7 +24,7 @@
     <%= csrf_meta_tags %>
 
     <%= filestack_js_include_tag %>
-    <%= filestack_js_init_tag %>
+    <%= filestack_js_deferred_init_tag %>
 
     <%= javascript_include_tag 'chapter_ambassador',
       'data-turbo-track' => true %>

--- a/app/views/layouts/submissions.html.erb
+++ b/app/views/layouts/submissions.html.erb
@@ -28,7 +28,7 @@
 
     <% if needs_filestack? %>
       <%= filestack_js_include_tag %>
-      <%= filestack_js_init_tag %>
+      <%= filestack_js_deferred_init_tag %>
     <% end %>
 
     <%= javascript_include_tag determine_manifest,

--- a/spec/helpers/filestack_helper_spec.rb
+++ b/spec/helpers/filestack_helper_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe FilestackHelper, type: :helper do
+  describe "#filestack_js_deferred_init_tag" do
+    subject(:tag) { filestack_js_deferred_init_tag }
+
+    it "returns a script tag" do
+      expect(tag).to start_with("<script>")
+      expect(tag).to end_with("</script>")
+    end
+
+    it "does not reference filestack.init at parse time" do
+      expect(tag).to include('typeof filestack !== "undefined"')
+      expect(tag).to include("function initFilestack()")
+      expect(tag).not_to match(/\A<script>\s*var filestack_client = filestack\.init/m)
+    end
+
+    it "assigns the configured client name after load" do
+      client_name = Rails.application.config.filestack_rails.client_name
+
+      expect(tag).to include("window.#{client_name} = filestack.init")
+      expect(tag).to include('addEventListener("load", initFilestack)')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `filestack_js_deferred_init_tag` helper that waits for the Filestack CDN script before calling `filestack.init()`
- Swap all layout `filestack_js_init_tag` calls to the deferred helper
- Add helper spec and browser verification on student team page

Closes #6333

## Test plan
- [x] `bundle exec rspec spec/helpers/filestack_helper_spec.rb spec/views/filestack_upload_partials_spec.rb` (5 examples, 0 failures)
- [x] Turbo-navigated to `/student/teams/1` as student — no `filestack is not defined` error; `filestack_client` initialized
- [x] Clicked "Change Image" on team Summary tab — Filestack picker opened

## Acceptance criteria
- [x] Turbo navigation to Filestack pages no longer throws `ReferenceError` — before: `tmp/issue-6333-filestack-turbo-init/01-turbo-nav-team-page-before.png`, after: `01-turbo-nav-team-page-after.png`
- [x] Filestack picker still initializes and works — before/after stills + `02-picker-opens-action.gif` in evidence dir
- [x] `needs_filestack?` gating unchanged — upload partial specs pass

## Evidence
Verification artifacts captured locally under `tmp/issue-6333-filestack-turbo-init/` (gh-image upload timed out during PR creation).