### PR TITLE
feat(6304): add admin manual award buttons for letters of recognition

### DIFF
--- a/app/models/certificate_recipient.rb
+++ b/app/models/certificate_recipient.rb
@@ -50,6 +50,28 @@ class CertificateRecipient
   end
 
   def description
+    if letter_type?
+      letter_description
+    else
+      certificate_description
+    end
+  end
+
+  def letter_type?
+    CertificateTypes::LETTER_OF_RECOGNITION_TYPES.key?(@certificate_type.to_sym)
+  end
+
+  def letter_description
+    role = @certificate_type.to_s.sub("_letter", "").humanize.titleize
+
+    if @team.present?
+      "Letter of Recognition (#{role}) for #{@team.name}"
+    else
+      "Letter of Recognition (#{role})"
+    end
+  end
+
+  def certificate_description
     title = @certificate_type.to_s.humanize.titleize
 
     if @team.present?

--- a/app/views/admin/participants/_certificates.en.html.erb
+++ b/app/views/admin/participants/_certificates.en.html.erb
@@ -129,4 +129,57 @@
       <div class="grid__col-1"></div>
     <% end %>
   </div>
+
+  <h5 class="reset">Manually award letters of recognition:</h5>
+
+  <div class="grid">
+    <% if account.mentor_profile.present? %>
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
+        <%= hidden_field_tag :account_id, account.id %>
+        <%= hidden_field_tag :certificate_type, :mentor_letter %>
+
+        <h6 class="reset">Mentor letter</h6>
+        <p>
+          <%= submit_tag 'Award', class: "button" %>
+        </p>
+      <% end %>
+      <div class="grid__col-1"></div>
+    <% end %>
+
+    <% if account.judge_profile.present? %>
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
+        <%= hidden_field_tag :account_id, account.id %>
+
+        <h6 class="reset">Judge letter</h6>
+        <p>
+          <%= select_tag :certificate_type,
+              options_for_select(CertificateTypes::LETTER_OF_RECOGNITION_TYPES.slice(
+                :bronze_judge_letter, :silver_judge_letter, :gold_judge_letter
+              ).keys.map { |t|
+                [t.to_s.sub("_letter", "").humanize.titleize, t]
+              }),
+              prompt: "Select type",
+              required: true,
+              class: "chosen" %>
+        </p>
+        <p>
+          <%= submit_tag 'Award', class: "button" %>
+        </p>
+      <% end %>
+      <div class="grid__col-1"></div>
+    <% end %>
+
+    <% if account.ambassador? %>
+      <%= form_tag(admin_certificates_path, class: 'grid__col-3') do %>
+        <%= hidden_field_tag :account_id, account.id %>
+        <%= hidden_field_tag :certificate_type, :ambassador_letter %>
+
+        <h6 class="reset">Ambassador letter</h6>
+        <p>
+          <%= submit_tag 'Award', class: "button" %>
+        </p>
+      <% end %>
+      <div class="grid__col-1"></div>
+    <% end %>
+  </div>
 </div>

--- a/spec/models/certificate_recipient_spec.rb
+++ b/spec/models/certificate_recipient_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe CertificateRecipient do
 
     expect(a).to eq(b)
   end
+
+  it "describes letter types as letters of recognition" do
+    account = FactoryBot.create(:judge).account
+
+    recipient = CertificateRecipient.new(:bronze_judge_letter, account)
+
+    expect(recipient.description).to eq("Letter of Recognition (Bronze Judge)")
+  end
 end

--- a/spec/views/admin/participants/_certificates.en.html.erb_spec.rb
+++ b/spec/views/admin/participants/_certificates.en.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "admin/participants/_certificates.en.html.erb", type: :view do
+  let(:account) { FactoryBot.create(:judge).account }
+  let(:certificates) { [] }
+  let(:needed_certificates) { [] }
+
+  before do
+    assign(:certificates, certificates)
+    assign(:needed_certificates, needed_certificates)
+    render partial: "admin/participants/certificates", locals: {account: account}
+  end
+
+  it "shows manual letter award controls for judges" do
+    expect(rendered).to have_content("Manually award letters of recognition")
+    expect(rendered).to have_content("Judge letter")
+    expect(rendered).to have_select("certificate_type", with_options: ["Bronze Judge", "Silver Judge", "Gold Judge"])
+  end
+
+  context "when the account is a mentor" do
+    let(:account) { FactoryBot.create(:mentor).account }
+
+    it "shows a mentor letter award form" do
+      expect(rendered).to have_content("Mentor letter")
+      expect(rendered).to have_field("certificate_type", type: "hidden", with: "mentor_letter")
+    end
+  end
+
+  context "when the account is an ambassador" do
+    let(:account) { FactoryBot.create(:chapter_ambassador).account }
+
+    it "shows an ambassador letter award form" do
+      expect(rendered).to have_content("Ambassador letter")
+      expect(rendered).to have_field("certificate_type", type: "hidden", with: "ambassador_letter")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a "Manually award letters of recognition" section to the admin participant certificates panel, mirroring the existing certificate award forms
- Mentors, judges (bronze/silver/gold), and ambassadors can now have letters generated on demand via `CertificateJob`
- Fixes `CertificateRecipient#description` to say "Letter of Recognition" for letter types (consistent with `Certificate#description`)

## Test plan
- [ ] Open an admin participant page for a mentor, judge, or ambassador
- [ ] Confirm "Manually award letters of recognition" section appears below certificate forms
- [ ] Award a letter and verify it appears under current certificates after the job completes
- [ ] Run `bundle exec rspec spec/models/certificate_recipient_spec.rb spec/views/admin/participants/_certificates.en.html.erb_spec.rb`

## Acceptance criteria
- [x] Admins can manually generate letters of recognition for mentor, judge, and ambassador accounts
- [x] Letter award uses the same pipeline as certificates (`Admin::CertificatesController#create` → `CertificateJob`)