### PR TITLE
Align pardon our dust banner width with flash messages

### DIFF
--- a/app/views/application/_pardon_our_dust_banner.html.erb
+++ b/app/views/application/_pardon_our_dust_banner.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="border border-gray-200 border-l-4 border-l-energetic-blue bg-blue-50 mb-6 mx-4 lg:mx-auto lg:max-w-screen-xl"
+  class="w-4/5 mx-auto my-4 border border-gray-200 border-l-4 border-l-energetic-blue bg-blue-50"
   style="display: none"
   data-controller="dismissible-banner"
   data-dismissible-banner-storage-key-value="pardon_our_dust_banner_dismissed"


### PR DESCRIPTION
## Summary
- Match the pardon our dust banner width to the common flash/error banner (`w-4/5`, centered) so it stays consistent across viewports

## Test plan
- [x] Load a participant dashboard and confirm the banner aligns with flash message width