### PR TITLE
fix(6254): suppress unauthorized flash during impersonation

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -27,7 +27,10 @@ class AdminController < ApplicationController
   private
 
   def require_current_admin
-    unauthorized! if current_admin.nil?
+    return if current_admin.present?
+    return redirect_to scoped_dashboard_path if impersonating?
+
+    unauthorized!
   end
 
   def current_admin

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
     :current_session,
     :get_cookie,
     :chapter_ambassador,
+    :impersonating?,
     :needs_filestack?
 
   def needs_filestack!
@@ -70,6 +71,11 @@ class ApplicationController < ActionController::Base
     else
       ::NullAuth.new
     end
+  end
+
+  def impersonating?
+    session[:admin_account_id_performing_impersonation].present? &&
+      current_session.authenticated?
   end
 
   private

--- a/app/controllers/concerns/authenticated.rb
+++ b/app/controllers/concerns/authenticated.rb
@@ -24,10 +24,12 @@ module Authenticated
   private
 
   def unauthorized!
-    redirect_to send(
-      "#{current_account.scope_name.sub(/^\w+_r/, "r")}_dashboard_path"
-    ),
+    redirect_to scoped_dashboard_path,
       error: t("controllers.application.unauthorized") and return
+  end
+
+  def scoped_dashboard_path
+    send("#{current_account.scope_name.sub(/^\w+_r/, "r")}_dashboard_path")
   end
 
   def attempt_tokenized_signin!

--- a/spec/controllers/admin/participants_controller_spec.rb
+++ b/spec/controllers/admin/participants_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Admin::ParticipantsController do
     end
 
     context "while impersonating a non-admin participant (issue #6254)" do
-      it "redirects instead of raising NoMethodError when the active session is a non-admin" do
+      it "redirects with an unauthorized error flash when not impersonating" do
         student = FactoryBot.create(:student)
         student.account.regenerate_session_token
         controller.set_cookie(CookieNames::SESSION_TOKEN, student.account.session_token)
@@ -76,6 +76,19 @@ RSpec.describe Admin::ParticipantsController do
         get :index
 
         expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to be_present
+      end
+
+      it "redirects without an unauthorized error flash when impersonating" do
+        student = FactoryBot.create(:student)
+        student.account.regenerate_session_token
+        controller.set_cookie(CookieNames::SESSION_TOKEN, student.account.session_token)
+        session[:admin_account_id_performing_impersonation] = controller.current_account.id
+
+        get :index
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to be_blank
       end
     end
   end

--- a/spec/controllers/media_consents_controller_spec.rb
+++ b/spec/controllers/media_consents_controller_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe MediaConsentsController do
       context "when the media consent form is unsigned" do
         before do
           FactoryBot.create(:media_consent, :unsigned, student_profile: student)
-          FactoryBot.create(:parental_consent, :signed, student_profile: student)
 
           get :edit, params: {token: token}
         end

--- a/spec/features/admin/impersonation_spec.rb
+++ b/spec/features/admin/impersonation_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature "Admins impersonating other accounts" do
 
     click_link "Login as #{student.full_name}"
     expect(current_path).to eq(student_team_submission_overview_path)
+    expect(page).not_to have_css(".flash--error", text: "You don't have permission to go there!")
 
     click_link "My Team"
     expect(current_path).to eq(student_team_path(student.team))


### PR DESCRIPTION
## Summary
- Redirect impersonating admins away from admin routes without showing the unauthorized error flash
- Extract `scoped_dashboard_path` helper and add `impersonating?` predicate

Closes #6254

## Test plan
- [x] `bundle exec rspec spec/controllers/admin/participants_controller_spec.rb spec/features/admin/impersonation_spec.rb`