### PR TITLE
fix(6334): update off-season waitlist signup link

### DIFF
--- a/app/views/application/_off_season_splash.en.html.erb
+++ b/app/views/application/_off_season_splash.en.html.erb
@@ -9,7 +9,7 @@
 <p class="mb-4">
   Registration for Technovation Challenge will open again by October. Please
   <%= link_to "sign up",
-              "https://eepurl.com/hZMS2n",
+              "https://eepurl.com/jB3Rxc",
               class: "tw-link" %>
   to receive a reminder email when registration opens.
   You can start working on your next project now by checking out the

--- a/spec/features/admin/off_season_splash_spec.rb
+++ b/spec/features/admin/off_season_splash_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Off-season splash page" do
     expect(page).to have_content("Registration is currently closed")
     expect(page).to have_content("Thanks for your interest in Technovation Challenge!")
     expect(page).to have_content("Registration for Technovation Challenge will open again by October")
-    expect(page).to have_link("sign up", href: "https://eepurl.com/hZMS2n")
+    expect(page).to have_link("sign up", href: "https://eepurl.com/jB3Rxc")
     expect(page).to have_link(
       "curriculum",
       href: "https://technovationchallenge.org/curriculum-intro/registered/new/"


### PR DESCRIPTION
## Summary
- Replace dead Mailchimp short URL on the off-season splash "sign up" link with the current waitlist URL (`https://eepurl.com/jB3Rxc`)
- Update feature spec assertion to match the new href

Closes #6334

## Test plan
- [x] `bundle exec rspec spec/features/admin/off_season_splash_spec.rb` (2 examples, 0 failures)

## Acceptance criteria
- [x] Clicking "sign up" on the platform home page (registration closed) redirects to the current Mailchimp waitlist page instead of a 404
- [x] Link resolves to `https://technovation.us4.list-manage.com/subscribe?u=b10254bbb5db780d1af913317&id=7f6c126eb7`
