### PR TITLE
chore(6343): bump deploy workflow actions to node 24

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,7 +41,7 @@ jobs:
       prev_tag: ${{ steps.version.outputs.prev_tag }}
     steps:
       - name: Verify actor has write access
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel(
@@ -49,7 +49,7 @@ jobs:
             if (!["admin", "maintain", "write"].includes(data.permission))
               core.setFailed(`Deploy blocked: ${context.actor} lacks write access (${data.permission})`);
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.deploy_ref }}
           fetch-depth: 0
@@ -62,7 +62,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Require green CircleCI build on target commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const ref = "${{ steps.resolve.outputs.sha }}";
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60   # Heroku build (blocking push) + up to 30 min release-phase poll + smoke test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.guard.outputs.sha }}
           fetch-depth: 0
@@ -211,7 +211,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v7` and `actions/github-script@v7` → `@v9` in `deploy-production.yml`
- Both actions run natively on Node 24, eliminating the Node 20 deprecation warnings on GitHub-hosted runners

Closes #6343

## Test plan
- [ ] Run deploy workflow with `dry_run: true` and confirm no Node 20 deprecation warnings in the `guard` job annotations
- [ ] Confirm `guard` job steps (permission check, checkout, CircleCI status check) still pass